### PR TITLE
jgeiger

### DIFF
--- a/lib/bundler/capistrano.rb
+++ b/lib/bundler/capistrano.rb
@@ -17,13 +17,13 @@ Capistrano::Configuration.instance(:must_exist).load do
       variable to specifiy which one it should use.
 
         set :bundle_gemfile,      fetch(:latest_release)+"/Gemfile"
-        set :bundle_dir,          fetch(:shared_path)+"/bundle"
+        set :bundle_dir,          fetch(:shared_path)+"/bundled_gems"
         set :bundle_flags,       "--deployment --quiet"
         set :bundle_without,      [:development, :test]
         set :bundle_cmd,          "bundle" # e.g. change to "/opt/ruby/bin/bundle"
     DESC
     task :install, :except => { :no_release => true } do
-      bundle_dir     = fetch(:bundle_dir, "#{fetch(:shared_path)}/bundle")
+      bundle_dir     = fetch(:bundle_dir, "#{fetch(:shared_path)}/bundled_gems")
       bundle_without = [*fetch(:bundle_without, [:development, :test])].compact
       bundle_flags   = fetch(:bundle_flags, "--deployment --quiet")
       bundle_gemfile = (fetch(:bundle_gemfile, nil) || fetch(:latest_release)+"/Gemfile")


### PR DESCRIPTION
If you're using a non-standard capistrano deploy method, say a variation on github's git deploy method where you have a current and shared directory, the deploy task will fail. This change allows you to set the Gemfile location so you're not stuck.

Line 29 is wonky because for some reason the fetch below would ALWAYS force the latest_release to run even when bundle_gemfile was set. The small hack gets around that.

```
fetch(:bundle_gemfile, fetch(:latest_release)+"/Gemfile")
```

So now a user can use the setting below and have the bundle properly installed.
    set :bundle_gemfile, "#{fetch(:current_path)}/Gemfile"

The second change just sets the capistrano task to follow the shared path as stated in the changelog.
