### PR TITLE
Incorrect ENV vars display during "bundle config" command

### DIFF
--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -62,7 +62,7 @@ module Bundler
     end
 
     def without=(array)
-      unless array.empty? && without.empty?
+      unless array.empty?
         self[:without] = array.join(":")
       end
     end


### PR DESCRIPTION
Steps to reproduce:

```
$ export BUNDLE_WITHOUT=production
$ bundle config
without
Set via $BUNDLE_BUNDLE_WITHOUT: "production"
```

I think it should looks like this:
    without
    Set via BUNDLE_WITHOUT: "production"

I think my Bundler, ruby, RVM and other settings have no sense this case.
