### PR TITLE
Bundler::Settings.without= works wrong

### DIFF
--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -62,7 +62,7 @@ module Bundler
     end
 
     def without=(array)
-      unless array.empty? && without.empty?
+      unless array.empty?
         self[:without] = array.join(":")
       end
     end


### PR DESCRIPTION
Bundler just ignores "without" parameter set anywhere except command line. This happens because of Bundler::Settings.without= function:

```
def without=(array)
  unless array.empty? && without.empty?
    self[:without] = array.join(":")
  end
end
```

"unless array.empty? && without.empty?" is the same as "if !array.empty? || !without.empty?"
Because of "|| !without.empty?" this string "self[:without] = array.join(":")" will be evaluated each time and other existing settings will be ignored and re-written with empty values.

Steps to reproduce:
    $ export BUNDLE_WITHOUT=production
    $ bundle install
This will install all gems including production group and will re-write any BUNDLE_WITHOUT parameter in .bundle/config file to empty string.

This solution also fixes this ticket
http://github.com/carlhuda/bundler/issues/issue/645
