### PR TITLE
Allow :platforms option on #gem method in Gemfile

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -57,6 +57,10 @@ module Bundler
         options[:group] = group
       end
 
+      if platform = options[:platforms] || options[:platform]
+        options[:platforms] = platform
+      end
+
       _deprecated_options(options)
       _normalize_options(name, version, options)
 


### PR DESCRIPTION
This is a fix for carlhuda/bundler#590 where this does nothing:

```
gem 'fastercsv', :platforms => :ruby_18
```

But this works:

```
platforms :ruby_18 do
  gem 'fastercsv'
end
```

There is already a test for this change from carlhuda/bundler@4030ac4.
