### PR TITLE
RSpec 2.0.0.beta21 introduced some deprecation warnings

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,8 +25,8 @@ begin
 
   desc "Run specs"
   RSpec::Core::RakeTask.new do |t|
-    t.spec_opts  = %w(-fs --color)
-    t.warning    = true
+    t.rspec_opts  = %w(-fs --color)
+    t.ruby_opts = %w(-w)
   end
   task :spec => :build
 
@@ -52,8 +52,8 @@ begin
   %w(master REL_1_3_5 REL_1_3_6).each do |rg|
     desc "Run specs with Rubygems #{rg}"
     RSpec::Core::RakeTask.new("spec_gems_#{rg}") do |t|
-      t.spec_opts  = %w(-fs --color)
-      t.warning    = true
+      t.rspec_opts  = %w(-fs --color)
+      t.ruby_opts = %w(-w)
     end
 
     task "rubygems_#{rg}" do
@@ -77,8 +77,8 @@ begin
 
     desc "Run specs on Ruby #{ruby}"
     RSpec::Core::RakeTask.new("spec_ruby_#{ruby}") do |t|
-      t.spec_opts  = %w(-fs --color)
-      t.warning    = true
+      t.rspec_opts  = %w(-fs --color)
+      t.ruby_opts = %w(-w)
       #t.ruby_cmd   = ruby_cmd
     end
 


### PR DESCRIPTION
I'm not sure if you already want to fix these (because it looks like the new code only works with beta21 or better), but given that deprecation support is broken in RSpec right now you might want to include this anyway.
