### PR TITLE
Prompt instead of exiting on file collision in `bundle gem`

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -455,11 +455,6 @@ module Bundler
     desc "gem GEM_NAME", "Creates a skeleton for creating a rubygem"
     def gem(name)
       target = File.join(Dir.pwd, name)
-      if File.exist?(name)
-        Bundler.ui.error "File already exists at #{File.join(Dir.pwd, name)}"
-        exit 1
-      end
-
       constant_name = name.split('_').map{|p| p.capitalize}.join
       constant_name = constant_name.split('-').map{|q| q.capitalize}.join('::') if constant_name =~ /-/
       constant_array = constant_name.split('::')


### PR DESCRIPTION
This allows a user to run `bundle gem` over an existing project. On collision, the user will be prompted with the standard [Ynaqdh] overwrite options (Yes, no, all, quit, diff, help). This functionality comes for free thanks to thor. All I had to do was remove the exit to make it work.
