### PR TITLE
bundle help fails when run from an in-jar gem in jruby

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -42,7 +42,7 @@ module Bundler
       if manpages.include?(command)
         root = File.expand_path("../man", __FILE__)
 
-        if have_groff?
+        if have_groff? && root !~ %r{^file:/.+!/META-INF/jruby.home/.+}
           groff   = "groff -Wall -mtty-char -mandoc -Tascii"
           pager   = ENV['MANPAGER'] || ENV['PAGER'] || 'more'
 


### PR DESCRIPTION
pull request for

http://github.com/carlhuda/bundler/issues/issue/680/#comment_411653

"bundle help" passes a helpfile path to groff, which fails when bundler is distributed as a gem inside jruby-complete.jar, because helpfile pathnames are of the form file:/path/to/jruby-complete.jar!/META-INF/jruby.home/path/to/helpfile , which groff can't use

this patch against 1-0-stable detects when bundler is in-jar, and reverts to printing plaintext helpfiles

patch above only works for jruby master : it relies on fix for http://jira.codehaus.org/browse/JRUBY-4921 which is not in released jruby-1.5.2, but will be in jruby-1.6

this is ok, since running rest of bundler in-jar with jruby also relies on fix for jruby-4921
