### PR TITLE
Better vim integration when using bundle open gem_name

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -398,9 +398,12 @@ module Bundler
     def open(name)
       editor = [ENV['BUNDLER_EDITOR'], ENV['VISUAL'], ENV['EDITOR']].find{|e| !e.nil? && !e.empty? }
       if editor
-        command = "#{editor} #{locate_gem(name)}"
-        success = system(command)
-        Bundler.ui.info "Could not run '#{command}'" unless success
+        gem_path = locate_gem(name)
+        Dir.chdir(gem_path) do
+          command = "#{editor} #{gem_path}"
+          success = system(command)
+          Bundler.ui.info "Could not run '#{command}'" unless success
+        end
       else
         Bundler.ui.info("To open a bundled gem, set $EDITOR or $BUNDLER_EDITOR")
       end


### PR DESCRIPTION
This is relevant when using vim, vi, or MacVim as your BUNDLE_EDITOR.
You'll notice that if you do a bundle open and then try
to use PeepOpen, or vim's built-in :edit, vim will think that you are still
in the directory that you called bundle open from, rather than
the gem src, and it will think you want to open a file from your
project. 

This is easily demonstrated by issuing the bundle open gem_name command and
then issuing :pwd from inside vim. That pwd is where vim will search for files you 
want to edit.

By doing a Dir.chdir() around the call to the editor this ensures
that we are in the right directory when vim is opened, so the it's :pwd is set properly and it's edit
commands work properly, then we will be returned to our project
directory by the time that bundle open is finished, so everything
works seamlessly.
