### PR TITLE
Requirements list

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -32,11 +32,11 @@ module Bundler
         spec = Gem::Specification.load(gemspecs.first)
         gem spec.name, :path => path
         spec.runtime_dependencies.each do |dep|
-          gem dep.name, dep.requirement.to_s
+          gem dep.name, *dep.requirement.as_list
         end
         group(development_group) do
           spec.development_dependencies.each do |dep|
-            gem dep.name, dep.requirement.to_s
+            gem dep.name, *dep.requirement.as_list
           end
         end
       when 0

--- a/spec/install/gemspec_spec.rb
+++ b/spec/install/gemspec_spec.rb
@@ -22,6 +22,22 @@ describe "bundle install from an existing gemspec" do
     should_be_installed "bar-dev 1.0.0", :groups => :development
   end
 
+  it "should handle a list of requirements" do
+    build_gem "baz", "1.0", :to_system => true
+    build_gem "baz", "1.1", :to_system => true
+
+    build_lib("foo", :path => tmp.join("foo")) do |s|
+      s.write("Gemfile", "source :rubygems\ngemspec")
+      s.add_dependency "baz", ">= 1.0", "< 1.1"
+    end
+    install_gemfile <<-G
+      source "file://#{gem_repo2}"
+      gemspec :path => '#{tmp.join("foo")}'
+    G
+
+    should_be_installed "baz 1.0"
+  end
+
   it "should raise if there are no gemspecs available" do
     build_lib("foo", :path => tmp.join("foo"), :gemspec => false)
 


### PR DESCRIPTION
This fixes the "gemspec" DSL command to support a list of requirements from the .gemspec file, such as this:

```
gem.add_dependency "foo", ">= 1.0", "< 1.1"
```
