### PR TITLE
Hack to to workaround "not in gzip format" error while resolving gem dependencies.

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -4,6 +4,7 @@ require 'pathname'
 require 'yaml'
 require 'bundler/rubygems_ext'
 require 'bundler/version'
+require 'bunder/fix_gzip_error'
 
 module Bundler
   ORIGINAL_ENV = ENV.to_hash

--- a/lib/bundler/fix_gzip_error.rb
+++ b/lib/bundler/fix_gzip_error.rb
@@ -1,0 +1,20 @@
+require 'gem/package/tar_input'
+
+# monkey patch that clears the problem where bundler 
+# barfs out saying "not in gzip format" whilst reading 
+# gemspecs from inside a gem.  silly that this works, 
+# but it does :)
+class Gem::Package::TarInput
+  
+  # there's probably a more focused way to do this, 
+  # where poking at one particular attribute in the
+  # entry takes care of the problem we've seen.  If
+  # anyone would like to troubleshoot that, that'd 
+  # be welcome.  
+  def zipped_stream_with_gzip_fix(entry)
+    entry.inspect
+    zipped_stream_without_gzip_fix(entry)
+  end
+  alias_method_chain :zipped_stream, :gzip_fix
+  
+end


### PR DESCRIPTION
See http://github.com/carlhuda/bundler/issues/issue/281/
