### PR TITLE
JRuby bug workaround

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -253,6 +253,7 @@ module Bundler
         ENV["GEM_HOME"] = bundle_path.to_s
       end
 
+      FileUtils.mkdir_p bundle_path.to_s
       Gem.clear_paths
     end
 


### PR DESCRIPTION
Here's a workaround that resolves this issue with JRuby: http://github.com/carlhuda/bundler/issues#issue/602

JRuby is monkeypatching RubyGems so the Gem.path behavior is different and expects all directories in Gem.path to exist. This workaround creates GEM_HOME so it's included in Gem.path on JRuby.

It looks like a fix for this problem won't exist until JRuby 1.5.4, so this works around it for existing JRuby users in the interim.
