### PR TITLE
Keep relative paths relative in the Gemfile.lock when using Source::Path

### DIFF
--- a/lib/bundler/source.rb
+++ b/lib/bundler/source.rb
@@ -276,7 +276,8 @@ module Bundler
         @allow_remote = false
 
         if options["path"]
-          @path = Pathname.new(options["path"]).expand_path(Bundler.root)
+          @path = Pathname.new(options["path"])
+          @path = @path.expand_path(Bundler.root) unless @path.relative? and @path.to_s =~ %r{^..}
         end
 
         @name = options["name"]


### PR DESCRIPTION
This is so that I could, say, work with my co-workers with all of us using a development copy of some code that is set up relative to our project e.g.

```
gem 'some-gem', :path => '../some_gem'
```

Bundler would previously Gemfile.lock this to:

```
PATH
  remote: /code/some_gem
```

..which is correct for my system but may be incorrect for the others.

This patch makes it become:

```
PATH
  remote: ../some_gem
```

Which works for everyone regardless of how their disk is setup.
