### PR TITLE
Fix for Issue #744

### DIFF
--- a/lib/bundler/source.rb
+++ b/lib/bundler/source.rb
@@ -276,7 +276,8 @@ module Bundler
         @allow_remote = false
 
         if options["path"]
-          @path = Pathname.new(options["path"]).expand_path(Bundler.root)
+          @path = Pathname.new(options["path"])
+          @path = @path.expand_path(Bundler.root) unless @path.relative?
         end
 
         @name = options["name"]
@@ -326,8 +327,10 @@ module Bundler
       def load_spec_files
         index = Index.new
 
-        if File.directory?(path)
-          Dir["#{path}/#{@glob}"].each do |file|
+        expanded_path = path.expand_path
+
+        if File.directory?(expanded_path)
+          Dir["#{expanded_path}/#{@glob}"].each do |file|
             spec = Bundler.load_gemspec(file)
             if spec
               spec.loaded_from = file.to_s
@@ -344,14 +347,14 @@ module Bundler
               s.platform = Gem::Platform::RUBY
               s.summary  = "Fake gemspec for #{@name}"
               s.relative_loaded_from = "#{@name}.gemspec"
-              if path.join("bin").exist?
-                binaries = path.join("bin").children.map{|c| c.basename.to_s }
+              if expanded_path.join("bin").exist?
+                binaries = expanded_path.join("bin").children.map{|c| c.basename.to_s }
                 s.executables = binaries
               end
             end
           end
         else
-          raise PathError, "The path `#{path}` does not exist."
+          raise PathError, "The path `#{expanded_path}` does not exist."
         end
 
         index

--- a/spec/install/path_spec.rb
+++ b/spec/install/path_spec.rb
@@ -37,7 +37,7 @@ describe "bundle install with explicit source paths" do
   it "expands paths" do
     build_lib "foo"
 
-    relative_path = lib_path('foo-1.0').relative_path_from(Pathname.new("~").expand_path)
+    relative_path = lib_path('foo-1.0').relative_path_from(Pathname.new('~').expand_path)
 
     install_gemfile <<-G
       gem 'foo', :path => "~/#{relative_path}"

--- a/spec/lock/flex_spec.rb
+++ b/spec/lock/flex_spec.rb
@@ -375,7 +375,7 @@ describe "the lockfile format" do
     G
   end
 
-  it "stores relative paths when the path is provided in a relative fashion" do
+  it "stores relative paths when the path is provided in a relative fashion and in Gemfile dir" do
     build_lib "foo", :path => bundled_app('foo')
 
     install_gemfile <<-G
@@ -386,6 +386,31 @@ describe "the lockfile format" do
     lockfile_should_be <<-G
       PATH
         remote: foo
+        specs:
+          foo (1.0)
+
+      GEM
+        specs:
+
+      PLATFORMS
+        #{generic(Gem::Platform.local)}
+
+      DEPENDENCIES
+        foo
+    G
+  end
+
+  it "stores relative paths when the path is provided in a relative fashion and is above Gemfile dir" do
+    build_lib "foo", :path => bundled_app(File.join('..', 'foo'))
+
+    install_gemfile <<-G
+      path "../foo"
+      gem "foo"
+    G
+
+    lockfile_should_be <<-G
+      PATH
+        remote: ../foo
         specs:
           foo (1.0)
 


### PR DESCRIPTION
Keep relative paths relative in the Gemfile.lock when using Source::Path

Improved solution from @parndt and fixed "expands path" spec.
