### PR TITLE
don't install development or test groups to production with capistrano task

### DIFF
--- a/lib/bundler/capistrano.rb
+++ b/lib/bundler/capistrano.rb
@@ -5,7 +5,7 @@
 require 'bundler/deployment'
 
 Capistrano::Configuration.instance(:must_exist).load do
-  after "deploy:update_code", "bundle:install"
+  after "deploy:update_code", "bundle:install --without development --without test"
 
   Bundler::Deployment.define_task(self, :task, :except => { :no_release => true })
 end


### PR DESCRIPTION
It seems like there isn't a benefit to installing these groups to the machine you are deploying to. In fact, it usually causes problems for me as I like to use autotest-fsevent which will only install on OS X and throw errors during my deploy.
