### PR TITLE
Improve Rakefile locating code in GemHelper

### DIFF
--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -5,7 +5,7 @@ require 'thor'
 module Bundler
   class GemHelper
     def self.install_tasks(opts = nil)
-      dir = caller.find{|c| /Rakefile:/}[/^(.*?)\/Rakefile:/, 1]
+      dir = File.dirname(Rake.application.rakefile_location)
       self.new(dir, opts && opts[:name]).install
     end
 


### PR DESCRIPTION
GemHelper currently uses regular expressions to trawl through the caller list and find the project directory which Rake was called on. This may be made more robust by using Rake.application.rakefile_location instead (which happens to trawl through backtraces as well, but may change in the future).
