### PR TITLE
Force "gem build" to use Verbose mode

### DIFF
--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -39,7 +39,7 @@ module Bundler
 
     def build_gem
       file_name = nil
-      sh("gem build #{spec_path}") { |out, code|
+      sh("gem build -V #{spec_path}") { |out, code|
         raise out unless out[/Successfully/]
         file_name = File.basename(built_gem_path)
         FileUtils.mkdir_p(File.join(base, 'pkg'))


### PR DESCRIPTION
Prior to this change, I was getting an empty exception raised for any Bundler-installed Rake tasks:

<pre>$ rake build --trace
(in /Users/tsigo/Code/ruby/will_paginate_renderers)
** Invoke build (first_time)
** Execute build
rake aborted!

/Users/tsigo/.rvm/gems/ree-1.8.7-2010.02/gems/bundler-1.0.2/lib/bundler/gem_helper.rb:43:in `build_gem'
/Users/tsigo/.rvm/gems/ree-1.8.7-2010.02/gems/bundler-1.0.2/lib/bundler/gem_helper.rb:141:in `call'
/Users/tsigo/.rvm/gems/ree-1.8.7-2010.02/gems/bundler-1.0.2/lib/bundler/gem_helper.rb:141:in `sh_with_code'
/Users/tsigo/.rvm/gems/ree-1.8.7-2010.02/gems/bundler-1.0.2/lib/bundler/gem_helper.rb:137:in `chdir'
/Users/tsigo/.rvm/gems/ree-1.8.7-2010.02/gems/bundler-1.0.2/lib/bundler/gem_helper.rb:137:in `sh_with_code'
/Users/tsigo/.rvm/gems/ree-1.8.7-2010.02/gems/bundler-1.0.2/lib/bundler/gem_helper.rb:131:in `sh'
/Users/tsigo/.rvm/gems/ree-1.8.7-2010.02/gems/bundler-1.0.2/lib/bundler/gem_helper.rb:42:in `build_gem'
/Users/tsigo/.rvm/gems/ree-1.8.7-2010.02/gems/bundler-1.0.2/lib/bundler/gem_helper.rb:26:in `install'
/Users/tsigo/.rvm/gems/ree-1.8.7-2010.02/gems/rake-0.8.7/lib/rake.rb:636:in `call'
/Users/tsigo/.rvm/gems/ree-1.8.7-2010.02/gems/rake-0.8.7/lib/rake.rb:636:in `execute'
/Users/tsigo/.rvm/gems/ree-1.8.7-2010.02/gems/rake-0.8.7/lib/rake.rb:631:in `each'
/Users/tsigo/.rvm/gems/ree-1.8.7-2010.02/gems/rake-0.8.7/lib/rake.rb:631:in `execute'
/Users/tsigo/.rvm/gems/ree-1.8.7-2010.02/gems/rake-0.8.7/lib/rake.rb:597:in `invoke_with_call_chain'
/Users/tsigo/.rvm/rubies/ree-1.8.7-2010.02/lib/ruby/1.8/monitor.rb:242:in `synchronize'
/Users/tsigo/.rvm/gems/ree-1.8.7-2010.02/gems/rake-0.8.7/lib/rake.rb:590:in `invoke_with_call_chain'
/Users/tsigo/.rvm/gems/ree-1.8.7-2010.02/gems/rake-0.8.7/lib/rake.rb:583:in `invoke'
/Users/tsigo/.rvm/gems/ree-1.8.7-2010.02/gems/rake-0.8.7/lib/rake.rb:2051:in `invoke_task'
/Users/tsigo/.rvm/gems/ree-1.8.7-2010.02/gems/rake-0.8.7/lib/rake.rb:2029:in `top_level'
/Users/tsigo/.rvm/gems/ree-1.8.7-2010.02/gems/rake-0.8.7/lib/rake.rb:2029:in `each'
/Users/tsigo/.rvm/gems/ree-1.8.7-2010.02/gems/rake-0.8.7/lib/rake.rb:2029:in `top_level'
/Users/tsigo/.rvm/gems/ree-1.8.7-2010.02/gems/rake-0.8.7/lib/rake.rb:2068:in `standard_exception_handling'
/Users/tsigo/.rvm/gems/ree-1.8.7-2010.02/gems/rake-0.8.7/lib/rake.rb:2023:in `top_level'
/Users/tsigo/.rvm/gems/ree-1.8.7-2010.02/gems/rake-0.8.7/lib/rake.rb:2001:in `run'
/Users/tsigo/.rvm/gems/ree-1.8.7-2010.02/gems/rake-0.8.7/lib/rake.rb:2068:in `standard_exception_handling'
/Users/tsigo/.rvm/gems/ree-1.8.7-2010.02/gems/rake-0.8.7/lib/rake.rb:1998:in `run'
/Users/tsigo/.rvm/gems/ree-1.8.7-2010.02/gems/rake-0.8.7/bin/rake:31
/usr/local/bin/rake:19:in `load'
/usr/local/bin/rake:19</pre>


For whatever reason, the gem command that's currently on my system (v1.3.7) returns absolutely nothing without enabling verbose mode, regardless of success/failure.

System info:

<pre>$ rvm info

ree-1.8.7-2010.02:

  system:
    uname:       "Darwin pride.home 10.4.0 Darwin Kernel Version 10.4.0: Fri Apr 23 18:28:53 PDT 2010; root:xnu-1504.7.4~1/RELEASE_I386 i386"
    bash:        "/bin/bash => GNU bash, version 3.2.48(1)-release (x86_64-apple-darwin10.0)"
    zsh:         "/bin/zsh => zsh 4.3.9 (i386-apple-darwin10.0)"

  rvm:
    version:      "rvm 1.0.8 by Wayne E. Seguin (wayneeseguin@gmail.com) [http://rvm.beginrescueend.com/]"

  ruby:
    interpreter:  "ruby"
    version:      "1.8.7"
    date:         "2010-04-19"
    platform:     "i686-darwin10.4.0"
    patchlevel:   "2010-04-19 patchlevel 253"
    full_version: "ruby 1.8.7 (2010-04-19 patchlevel 253) [i686-darwin10.4.0], MBARI 0x6770, Ruby Enterprise Edition 2010.02"

  homes:
    gem:          "/Users/tsigo/.rvm/gems/ree-1.8.7-2010.02"
    ruby:         "/Users/tsigo/.rvm/rubies/ree-1.8.7-2010.02"

  binaries:
    ruby:         "/Users/tsigo/.rvm/rubies/ree-1.8.7-2010.02/bin/ruby"
    irb:          "/Users/tsigo/.rvm/rubies/ree-1.8.7-2010.02/bin/irb"
    gem:          "/Users/tsigo/.rvm/rubies/ree-1.8.7-2010.02/bin/gem"
    rake:         "/usr/local/bin/rake"

  environment:
    PATH:         "/usr/local/bin:/usr/local/sbin:/Users/tsigo/.rvm/gems/ree-1.8.7-2010.02/bin:/Users/tsigo/.rvm/gems/ree-1.8.7-2010.02@global/bin:/Users/tsigo/.rvm/rubies/ree-1.8.7-2010.02/bin:/Users/tsigo/.rvm/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/X11/bin:/Users/tsigo/bin"
    GEM_HOME:     "/Users/tsigo/.rvm/gems/ree-1.8.7-2010.02"
    GEM_PATH:     "/Users/tsigo/.rvm/gems/ree-1.8.7-2010.02:/Users/tsigo/.rvm/gems/ree-1.8.7-2010.02@global"
    BUNDLE_PATH:  "/Users/tsigo/.rvm/gems/ree-1.8.7-2010.02"
    MY_RUBY_HOME: "/Users/tsigo/.rvm/rubies/ree-1.8.7-2010.02"
    IRBRC:        "/Users/tsigo/.rvm/rubies/ree-1.8.7-2010.02/.irbrc"
    RUBYOPT:      ""
    gemset:       ""</pre>
