### PR TITLE
Fix Dependency.mswin?

### DIFF
--- a/lib/bundler/dependency.rb
+++ b/lib/bundler/dependency.rb
@@ -108,7 +108,7 @@ module Bundler
     end
 
     def mswin?
-      # w0t?
+      !!(RBConfig::CONFIG["host_os"] =~ /mswin/)
     end
   end
 end


### PR DESCRIPTION
Currently Dependency.mswin? always returns false as it isn't implemented. 

This is my best guess as to what it should be. Feedback appreciated. 
