### PR TITLE
Speed up resolution 

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -50,12 +50,14 @@ module Bundler
           @locked_specs   = SpecSet.new([])
           @locked_sources = []
         end
+        @lockfile_exists = true
       else
         @unlock         = {}
         @platforms      = []
         @locked_deps    = []
         @locked_specs   = SpecSet.new([])
         @locked_sources = []
+        @lockfile_exists = false
       end
 
       @unlock[:gems] ||= []
@@ -148,7 +150,7 @@ module Bundler
           end
 
           # Run a resolve against the locally available gems
-          last_resolve.merge Resolver.resolve(expanded_dependencies, index, source_requirements, last_resolve)
+          last_resolve.merge Resolver.resolve(expanded_dependencies, index, source_requirements, last_resolve, !@lockfile_exists)
         end
       end
     end

--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -124,9 +124,9 @@ module Bundler
     # ==== Returns
     # <GemBundle>,nil:: If the list of dependencies can be resolved, a
     #   collection of gemspecs is returned. Otherwise, nil is returned.
-    def self.resolve(requirements, index, source_requirements = {}, base = [])
+    def self.resolve(requirements, index, source_requirements = {}, base = [], sort = true)
       base = SpecSet.new(base) unless base.is_a?(SpecSet)
-      resolver = new(index, source_requirements, base)
+      resolver = new(index, source_requirements, base, sort)
       result = catch(:success) do
         resolver.start(requirements)
         raise resolver.version_conflict
@@ -135,13 +135,14 @@ module Bundler
       SpecSet.new(result)
     end
 
-    def initialize(index, source_requirements, base)
+    def initialize(index, source_requirements, base, sort)
       @errors               = {}
       @stack                = []
       @base                 = base
       @index                = index
       @missing_gems         = Hash.new(0)
       @source_requirements  = source_requirements
+      @sort                 = sort
     end
 
     def debug
@@ -174,11 +175,13 @@ module Bundler
       #   1) Is this gem already activated?
       #   2) Do the version requirements include prereleased gems?
       #   3) Sort by number of gems available in the source.
-      reqs = reqs.sort_by do |a|
-        [ activated[a.name] ? 0 : 1,
-          a.requirement.prerelease? ? 0 : 1,
-          @errors[a.name]   ? 0 : 1,
-          activated[a.name] ? 0 : search(a).size ]
+      if @sort
+        reqs = reqs.sort_by do |a|
+          [ activated[a.name] ? 0 : 1,
+            a.requirement.prerelease? ? 0 : 1,
+            @errors[a.name]   ? 0 : 1,
+            activated[a.name] ? 0 : search(a).size ]
+        end
       end
 
       debug { "Activated:\n" + activated.values.map { |a| "  #{a.name} (#{a.version})" }.join("\n") }


### PR DESCRIPTION
In response to the issue [Bundler::Resolver.resolve is time consuming](http://github.com/carlhuda/bundler/issues#issue/789)

This branch makes Resolver sorting optional and disables sorting if the specs were loaded from the lock file. I'm not sure if this has other implications, but the specs all pass and the resolution time is much faster with my Gemfile.
