### PR TITLE
Hidden gemspec

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -22,7 +22,7 @@ module Bundler
 
     def gemspec(opts = nil)
       path              = opts && opts[:path] || '.'
-      name              = opts && opts[:name] || '*'
+      name              = opts && opts[:name] || '{,*}'
       development_group = opts && opts[:development_group] || :development
       path              = File.expand_path(path, Bundler.default_gemfile.dirname)
       gemspecs = Dir[File.join(path, "#{name}.gemspec")]

--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -14,7 +14,7 @@ module Bundler
     def initialize(base, name = nil)
       Bundler.ui = UI::Shell.new(Thor::Shell::Color.new)
       @base = base
-      gemspecs = name ? [File.join(base, "#{name}.gemspec")] : Dir[File.join(base, "*.gemspec")]
+      gemspecs = name ? [File.join(base, "#{name}.gemspec")] : Dir[File.join(base, "{,*}.gemspec")]
       raise "Unable to determine name from existing gemspec. Use :name => 'gemname' in #install_tasks to manually set it." unless gemspecs.size == 1
       @spec_path = gemspecs.first
       @gemspec = Bundler.load_gemspec(@spec_path)

--- a/lib/bundler/source.rb
+++ b/lib/bundler/source.rb
@@ -266,7 +266,7 @@ module Bundler
       attr_writer   :name
       attr_accessor :version
 
-      DEFAULT_GLOB = "{,*/}*.gemspec"
+      DEFAULT_GLOB = "{,*,*/*}.gemspec"
 
       def initialize(options)
         @options = options


### PR DESCRIPTION
Here are the changes to support a hidden `.gemspec` file. I used `grep` to look though all the source code and adjusted each case where gemspec files were being globed. Three files were effected. I then ran the specs and nothing broke. So that's a good sign.

The next step of course is to write some specs to make sure Bundler works with a hidden gemspec file. But looking over the specs I'm not exactly sure how to do it , in particular I'm not sure how to build a sample project to test against. Hopefully someone with more intimate knowledge of Bundler can finish this off?
