### PR TITLE
Less as default

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -45,7 +45,7 @@ module Bundler
 
         if have_groff? && root !~ %r{^file:/.+!/META-INF/jruby.home/.+}
           groff   = "groff -Wall -mtty-char -mandoc -Tascii"
-          pager   = ENV['MANPAGER'] || ENV['PAGER'] || 'more'
+          pager   = ENV['MANPAGER'] || ENV['PAGER'] || 'less'
 
           Kernel.exec "#{groff} #{root}/#{command} | #{pager}"
         else


### PR DESCRIPTION
Clean Ubuntu 10.10 hasn’t `$PAGER` and `$MANPAGER` variables, so `bundle help` will use `more`. `more` is confused for new users, because it have different controls and `less` is more standard (when I exec `man ls` it will use `less`).
So, I think, it’s better to use `less`. If some OS didn’t have `less`, I can add detection by `whereis` and use `less` only if it in system.
