### PR TITLE
Fix proxy env

### DIFF
--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -7,7 +7,7 @@ module Bundler
 
     def initialize(remote_uri)
       @remote_uri = remote_uri
-      @@connection ||= Net::HTTP::Persistent.new
+      @@connection ||= Net::HTTP::Persistent.new nil, :ENV
     end
 
     # fetch a gem specification


### PR DESCRIPTION
Use ENV['http_proxy'] or ENV['HTTP_PROXY'] on Net::HTTP::Persistent connections.
