### PR TITLE
Fixes for Capistrano requirement when using vlad & Rake::FetchError

### DIFF
--- a/lib/bundler/deployment.rb
+++ b/lib/bundler/deployment.rb
@@ -1,7 +1,7 @@
 module Bundler
   class Deployment
     def self.define_task(context, task_method = :task, opts = {})
-      if context.is_a?(Capistrano::Configuration)
+      if defined?(Capistrano) && context.is_a?(Capistrano::Configuration)
         context_name = "capistrano"
         role_default = "{:except => {:no_release => true}}"
       else
@@ -9,7 +9,7 @@ module Bundler
         role_default = "[:app]"
       end
 
-      roles = context.fetch(:bundle_roles, nil)
+      roles = context.fetch(:bundle_roles, false)
       opts[:roles] = roles if roles
 
       context.send :namespace, :bundle do


### PR DESCRIPTION
Sometime between 1.0.3 and 1.0.7 vlad deployment broke.  Added a check for "Capistrano" and resolved the FetchError by defaulting :default_roles to false.
