### PR TITLE
Ignore gemfile lock

### DIFF
--- a/lib/bundler/templates/newgem/gitignore.tt
+++ b/lib/bundler/templates/newgem/gitignore.tt
@@ -1,3 +1,4 @@
 pkg/*
 *.gem
 .bundle
+Gemfile.lock


### PR DESCRIPTION
Best practice is to ignore the Gemfile.lock when using bundler with a rubygem. This simply adds the Gemfile.lock to .gitignore when using `bundle gem`.
