### PR TITLE
Fix uninitialized variable warning

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -99,10 +99,11 @@ module Bundler
         # Load all groups, but only once
         @setup = load.setup
       else
+        @completed_groups ||= []
         # Figure out which groups haven't been loaded yet
-        unloaded = groups - (@completed_groups || [])
+        unloaded = groups - @completed_groups
         # Record groups that are now loaded
-        @completed_groups = groups | (@completed_groups || [])
+        @completed_groups = groups | @completed_groups
         # Load any groups that are not yet loaded
         unloaded.any? ? load.setup(*unloaded) : load
       end


### PR DESCRIPTION
This fixes a simple uninitialized variable warning.
