### PR TITLE
gitignore Gemfile.lock

### DIFF
--- a/lib/bundler/templates/newgem/gitignore.tt
+++ b/lib/bundler/templates/newgem/gitignore.tt
@@ -1,3 +1,4 @@
 pkg/*
 *.gem
 .bundle
+Gemfile.lock


### PR DESCRIPTION
Yehuda says Gemfile.lock should not be checked in for new gems: http://yehudakatz.com/2010/12/16/clarifying-the-roles-of-the-gemspec-and-gemfile/
