### PR TITLE
--without documentation patch

### DIFF
--- a/groups.html
+++ b/groups.html
@@ -29,7 +29,7 @@
               Install all dependencies, except
               those in specified groups
             </div>
-            <pre class='sunburst'>$ bundle install --without test&#x000A;</pre>
+            <pre class='sunburst'>$ bundle install --without &quot;test development&quot;&#x000A;</pre>
           </div>
           <div class="bullet">
             <div class="description">


### PR DESCRIPTION
One-line doc patch, so no tests are included.

I tried three different ways of excluding multiple groups before i just downloaded the source and figured out that you do it with the quoted, space-separated approach.  I updated the example on the web page to hopefully save another person a half-hour of time.
