### PR TITLE
Bundler.setup(:group) clears previously bundled load paths with no way to re-load them

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -99,12 +99,10 @@ module Bundler
         # Load all groups, but only once
         @setup = load.setup
       else
-        # Figure out which groups haven't been loaded yet
-        unloaded = groups - (@completed_groups || [])
-        # Record groups that are now loaded
+        # Record groups that should now be loaded
         @completed_groups = groups | (@completed_groups || [])
-        # Load any groups that are not yet loaded
-        unloaded.any? ? load.setup(*unloaded) : load
+        # Load all groups that should be loaded
+        load.setup(*@completed_groups)
       end
     end
 

--- a/spec/install/gems/groups_spec.rb
+++ b/spec/install/gems/groups_spec.rb
@@ -43,6 +43,17 @@ describe "bundle install with gem sources" do
         out = run("require 'thin'; puts THIN")
         out.should == '1.0'
       end
+
+      it "sets up multiple groups paths if Bundler.setup call is repeated" do
+        out = run(<<-R, :emo).split
+          require 'thin'; puts THIN
+          Bundler.setup(:default)
+          require 'rack'; puts RACK
+          Bundler.setup(:emo)
+          require 'activesupport'; puts ACTIVESUPPORT
+        R
+        out.should == ['1.0', '1.0.0', '2.3.5']
+      end
     end
 
     describe "installing --without" do


### PR DESCRIPTION
If you call Bundler.setup(:group) then call it again with a different group (e.g. :test), the load path from the first call gets wiped. Since setup() caches what it has previously loaded, calling Bundler.setup(:group) again will have no effect.

Not sure how to set github labels for this but i've tested on 1.0.7 (current stable) and 1.1pre (current master), it's a bug in both versions.
