### PR TITLE
1 0 stable

### DIFF
--- a/lib/bundler/source.rb
+++ b/lib/bundler/source.rb
@@ -558,7 +558,7 @@ module Bundler
         if allow_git_ops?
           out = %x{git #{command}}
 
-          if $? != 0
+          if $?.exitstatus != 0
             raise GitError, "An error has occurred in git when running `git #{command}`. Cannot complete bundling."
           end
           out


### PR DESCRIPTION
Small change to get the correct exit value from git. The git method was checking the value of $? (a Process::Status object) for the exit value of the git command instead of $?.exitstatus
