### PR TITLE
--no-cache option to `bundle install` was not doing anything

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -223,7 +223,7 @@ module Bundler
       Bundler.ui.be_quiet! if opts[:quiet]
 
       Installer.install(Bundler.root, Bundler.definition, opts)
-      Bundler.load.cache if Bundler.root.join("vendor/cache").exist?
+      Bundler.load.cache if Bundler.root.join("vendor/cache").exist? && !options[:no_cache]
 
       if Bundler.settings[:path]
         relative_path = Bundler.settings[:path]


### PR DESCRIPTION
The `--no-cache` option for `bundle install` was not actually preventing the cache from being updated. It looks like the original commit got clobbered in a merge perhaps -- refer to commits 4601dde and e4287d2. Thanks!
