### PR TITLE
eval gemspec in containing directory

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -29,7 +29,7 @@ module Bundler
 
       case gemspecs.size
       when 1
-        spec = Gem::Specification.load(gemspecs.first)
+        spec = Bundler.load_gemspec(gemspecs.first)
         raise InvalidOption, "There was an error loading the gemspec at #{gemspecs.first}." unless spec
         gem spec.name, :path => path
         group(development_group) do


### PR DESCRIPTION
Here's a proposed fix for issue #947 (bundler evaluates the .gemspec in the current directory instead of the directory containing the .gemspec).  I don't know whether it was intended to use Gem::Specification.load in one place and Bundler.load_gemspec in others, since they do have subtly different behavior, but load_gemspec seems a lot better.

Note: I have not created a test for this change.  The change didn't break any existing tests and I couldn't find tests for the dsl functionality.  I'd be happy to add tests around this change, but I think I need someone to point me in the right direction.
