### PR TITLE
Convert group symbol name2

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -93,6 +93,8 @@ module Bundler
     end
 
     def setup(*groups)
+      groups.map! { |g| g.to_sym }
+
       if groups.empty?
         # Load all groups, but only once
         @setup ||= load.setup


### PR DESCRIPTION
Otherwise this is broken:
`Bundler.require(:default, Rails.env)`
