### PR TITLE
Constant Namespace Problem with Ruby 1.9.2 and Rubygems 1.5

### DIFF
--- a/lib/bundler/ui.rb
+++ b/lib/bundler/ui.rb
@@ -55,7 +55,7 @@ module Bundler
       end
     end
 
-    class RGProxy < Gem::SilentUI
+    class RGProxy < ::Gem::SilentUI
       def initialize(ui)
         @ui = ui
       end


### PR DESCRIPTION
I'm assuming this has to do with 1.8.7 vs 1.9.1 vs 1.9.2's difference in how they look up constant namespaces.

I'm not sure if this is the 100% backwards-compatible fix for this problem.  Please let me know if there's anything else I can do.

Exact error was: `class:UI': uninitialized constant Gem::SilentUI (NameError)
