### PR TITLE
Typo in section on Updating a Gem Without Modifying the Gemfile

### DIFF
--- a/rationale.html
+++ b/rationale.html
@@ -308,7 +308,7 @@
             It will, however, update dependencies of other gems if necessary. For instance, if the
             latest version of <code>rack-cache</code> specifies a dependency on <code>rack >=
             1.2.2</code>, bundler will update <code>rack</code> to <code>1.2.2</code> even though
-            you have not asked bundler to update <code>rails</code>. If bundler needs to update a
+            you have not asked bundler to update <code>rack</code>. If bundler needs to update a
             gem that another gem depends on, it will let you know after the update has completed.
           </p>
           <p>


### PR DESCRIPTION
When discussing the example of how `bundle update rack-cache` will update its dependency `rack` if there's a newer version, the documentation currently states "bundler will update rack to 1.2.2 even though you have not asked bundler to update rails.", when it should instead refer to "rack".
