### PR TITLE
Path bug

### DIFF
--- a/lib/bundler/source.rb
+++ b/lib/bundler/source.rb
@@ -324,7 +324,7 @@ module Bundler
       alias == eql?
 
       def name
-        File.basename(@path.to_s)
+        File.basename(path.expand_path(Bundler.root).to_s)
       end
 
       def load_spec_files


### PR DESCRIPTION
Currently Source::Paths are only considered equal if they have the same basename. This basename is generated from either a relative or absolute path depending on how the Path was created. This fails for:

```
Path.new(:path => '.').should == Path.new(:path => "/absolute/path/to/same/directory")
```

The basepaths are different and so the Paths are not equal.

This showed up as a bug when using a gemspec. During parsing the LockfileParser loads the source with an absolute path. The Dsl on the other hand loads it with a relative path. Definition then considers them different and gives an error like:

```
You have modified your Gemfile in development but did not check
the resulting snapshot (Gemfile.lock) into version control

You have added to the Gemfile:
* source: source at /absolute/path/to/delayed_job_groups_mongoid

You have deleted from the Gemfile:
* source: source at .

You have changed in the Gemfile:
* delayed_job_groups_mongoid from `source at /absolute/path/to/delayed_job_groups_mongoid` to `no specified source`
```

You can replicate this bug with

```
$ git clone git://github.com/opsb/delayed_job_groups_mongoid.git
$ git checkout path_bug
$ bundle install --deployment
```

The commit updates Path#name to always use an absolute path. This allows Path#eql? to compare absolute and relative paths correctly.
