### PR TITLE
Don't crash on directories inside :path gem's bin/

### DIFF
--- a/lib/bundler/source.rb
+++ b/lib/bundler/source.rb
@@ -350,8 +350,9 @@ module Bundler
               s.summary  = "Fake gemspec for #{@name}"
               s.relative_loaded_from = "#{@name}.gemspec"
               if expanded_path.join("bin").exist?
-                binaries = expanded_path.join("bin").children.map{|c| c.basename.to_s }
-                s.executables = binaries
+                binaries = expanded_path.join("bin").children
+                binaries.reject! &:directory?
+                s.executables = binaries.map{|c| c.basename.to_s }
               end
             end
           end


### PR DESCRIPTION
Rails 2.3 has a performance/ directory inside of bin/. When I add
    gem 'rails', '2.3.11', :path => 'vendor/rails/railties'
to my Gemfile and run
    bundle update
I get 
    Using rails (2.3.11) from source at vendor/rails/railties /Users/epall/.rvm/rubies/ruby-1.8.7-p330/lib/ruby/site_ruby/1.8/rubygems/installer.rb:374:in `gets': Is a directory - /Users/epall/Dropbox/code/tracks/vendor/rails/railties/bin/performance (Errno::EISDIR)

I traced this down to Bundler::Source's generation of Gem::Specifications when dealing with gems loaded using the :path argument and fixed it.

See http://pastie.org/1614164 for full error message.
