### PR TITLE
Sorted requirements (Fixes rubygems 1.x vs 1.6 requirements sort order bugs)

### DIFF
--- a/lib/bundler/dependency.rb
+++ b/lib/bundler/dependency.rb
@@ -75,6 +75,7 @@ module Bundler
         # rubygems 1.5 + 1.6 compatibility requires us sorting this by hand
         reqs = requirement.requirements.map { |a| Gem::Requirement.new a.join(' ') }
         reqs.sort!
+        reqs.reverse!
         reqs.map! { |r| r.to_s }
         out << " (#{reqs.join(', ')})"
       end


### PR DESCRIPTION
This fixes the bug where Gemfile.lock appears to be changed as users with different versions of RubyGems boot bundler applications.

Sorry, I said I was going to send this through a while ago, but well, stuff happens....

Plz 2 release <3
