### PR TITLE
Fix for issue #1014 (color escape sequences displaying for bundle --help)

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -46,7 +46,7 @@ module Bundler
 
         if have_groff? && root !~ %r{^file:/.+!/META-INF/jruby.home/.+}
           groff   = "groff -Wall -mtty-char -mandoc -Tascii"
-          pager   = ENV['MANPAGER'] || ENV['PAGER'] || 'less'
+          pager   = ENV['MANPAGER'] || ENV['PAGER'] || 'less -R'
 
           Kernel.exec "#{groff} #{root}/#{command} | #{pager}"
         else


### PR DESCRIPTION
Fix for issue #1014 (color escape sequences displaying for bundle --help)
