### PR TITLE
rake tasks should respect bundle_cmd as well

### DIFF
--- a/lib/bundler/capistrano.rb
+++ b/lib/bundler/capistrano.rb
@@ -7,6 +7,5 @@ require 'bundler/deployment'
 Capistrano::Configuration.instance(:must_exist).load do
   after "deploy:update_code", "bundle:install"
   Bundler::Deployment.define_task(self, :task, :except => { :no_release => true })
-  bundle_cmd     = context.fetch(:bundle_cmd, "bundle")
-  set :rake, "#{bundle_cmd} exec rake"
+  set :rake, "#{fetch(:bundle_cmd, "bundle")} exec rake"
 end


### PR DESCRIPTION
I didn't see any specs for this, but it is just a rather simple change.

This effects things like "cap deploy:migrate" which execute in the context of a rake task.
