### PR TITLE
- say "git" not "version control"

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -202,7 +202,7 @@ module Bundler
         unless Bundler.default_lockfile.exist?
           flag = opts[:deployment] ? '--deployment' : '--frozen'
           raise ProductionError, "The #{flag} flag requires a Gemfile.lock. Please make " \
-                                 "sure you have checked your Gemfile.lock into version control " \
+                                 "sure you have checked your Gemfile.lock into git " \
                                  "before deploying."
         end
 

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -239,7 +239,7 @@ module Bundler
       changes = false
 
       msg = "You have modified your Gemfile in development but did not check\n" \
-            "the resulting snapshot (Gemfile.lock) into version control"
+            "the resulting snapshot (Gemfile.lock) into git"
 
       added =   []
       deleted = []


### PR DESCRIPTION
It took me lots of time and some confusion trying to fight bundler each time it insisted I needed to have Gemfile.lock checked into version control.

The problem was for this particular project, I use svn. Turns out, when bundler says "version control" it means "git" 

This pull request changes the output to be implicit about the requirement to use git. If nothing else, knowing bundler pines for only git  would have saved me some frustration and could hopefully save others from the same. :)

My workarounds for this issue are a crappy; I can either hand-mangle the Gemfile.lock myself (bleh) or run 'rm .bundle/config Gemfile.lock' each time I update the Gemfile. 
