### PR TITLE
Fix for spaces in the pathname when releasing gems.

### DIFF
--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -39,7 +39,7 @@ module Bundler
 
     def build_gem
       file_name = nil
-      sh("gem build #{spec_path}") { |out, code|
+      sh("gem build '#{spec_path}'") { |out, code|
         raise out unless out[/Successfully/]
         file_name = File.basename(built_gem_path)
         FileUtils.mkdir_p(File.join(base, 'pkg'))
@@ -51,7 +51,7 @@ module Bundler
 
     def install_gem
       built_gem_path = build_gem
-      out, _ = sh_with_code("gem install #{built_gem_path}")
+      out, _ = sh_with_code("gem install '#{built_gem_path}'")
       raise "Couldn't install gem, run `gem install #{built_gem_path}' for more detailed output" unless out[/Successfully installed/]
       Bundler.ui.confirm "#{name} (#{version}) installed"
     end
@@ -68,7 +68,7 @@ module Bundler
 
     protected
     def rubygem_push(path)
-      out, _ = sh("gem push #{path}")
+      out, _ = sh("gem push '#{path}'")
       raise "Gem push failed due to lack of RubyGems.org credentials." if out[/Enter your RubyGems.org credentials/]
       Bundler.ui.confirm "Pushed #{name} #{version} to rubygems.org"
     end


### PR DESCRIPTION
As my way of saying "Thanks!" for how amazingly helpful Bundler is for gem development (esp.  <code>rake release</code>), found that a few <code>gem</code> system calls required quoting during the release process so I'm submitting a pull.  Hope this helps!

Here's the troublesome path (with a single space in it).

<code>slif:~/Documents/Personal Data/projects/elasticity(master)$</code>

Rob
