### PR TITLE
Use specified gemfile when running bundle exec'd rake

### DIFF
--- a/lib/bundler/capistrano.rb
+++ b/lib/bundler/capistrano.rb
@@ -7,5 +7,5 @@ require 'bundler/deployment'
 Capistrano::Configuration.instance(:must_exist).load do
   after "deploy:update_code", "bundle:install"
   Bundler::Deployment.define_task(self, :task, :except => { :no_release => true })
-  set :rake, lambda { "#{fetch(:bundle_cmd, "bundle")} exec rake" }
+  set :rake, lambda { "#{fetch(:bundle_cmd, "bundle")} --gemfile #{File.join(context.fetch(:current_release), bundle_gemfile)} exec rake" }
 end


### PR DESCRIPTION
If you use :bundle_gemfile to specify a non-standard Gemfile it cause the rake command to fail.
