### PR TITLE
Only format error backtrace if stdout is TTY

### DIFF
--- a/lib/bundler/setup.rb
+++ b/lib/bundler/setup.rb
@@ -2,12 +2,16 @@ require 'bundler/shared_helpers'
 
 if Bundler::SharedHelpers.in_bundle?
   require 'bundler'
-  begin
+  if STDOUT.tty?
+    begin
+      Bundler.setup
+    rescue Bundler::BundlerError => e
+      puts "\e[31m#{e.message}\e[0m"
+      puts e.backtrace.join("\n") if ENV["DEBUG"]
+      exit e.status_code
+    end
+  else
     Bundler.setup
-  rescue Bundler::BundlerError => e
-    puts "\e[31m#{e.message}\e[0m"
-    puts e.backtrace.join("\n") if ENV["DEBUG"]
-    exit e.status_code
   end
 
   # Add bundler to the load path after disabling system gems


### PR DESCRIPTION
`bundle/setup` shadows the original `Bundler::BundlerError` in order to print out a nicer message to stdout. This is a pain for servers that aren't connected to a terminal like passenger or pow. The exception that bubbles is an uninformative `SystemExit` error.

We can preserve the original error message and trace if stdout is not a TTY.
