### PR TITLE
User path from environment variable

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -142,7 +142,11 @@ module Bundler
     end
 
     def user_bundle_path
-      Pathname.new(Bundler.rubygems.user_home).join(".bundler")
+      if ENV['BUNDLE_USER_PATH']
+        Pathname.new(ENV['BUNDLE_USER_PATH']).join('bundler')
+      else
+        Pathname.new(Gem.user_home).join(".bundler")
+      end
     end
 
     def home


### PR DESCRIPTION
Set `BUNDLE_USER_PATH` to avoid using `$HOME`.

In some scenarios (i.e., NFS) having bundler use the home directory is not desirable since NFS tends to be slow with git, and squashing root access causes issues with the build proces (moving files will cause a lot of error messages).

This patch enables using the `BUNDLE_USER_PATH` environment variable so that bundler will use `${BUNDLE_USER_PATH}/builder` instead of `~/.builder`.
