### PR TITLE
Fix file permissions after git checkout.

### DIFF
--- a/lib/bundler/source.rb
+++ b/lib/bundler/source.rb
@@ -633,6 +633,7 @@ module Bundler
           FileUtils.mkdir_p(path.dirname)
           FileUtils.rm_rf(path)
           git %|clone --no-checkout "#{cache_path}" "#{path}"|
+          File.chmod((0777 & ~File.umask), path)
         end
         Dir.chdir(path) do
           git %|fetch --force --quiet --tags "#{cache_path}"|


### PR DESCRIPTION
We found in shared user spaces all files were abiding by the umask except for the parent repo folder for git sources on first checkout. These were being set to owner only. 

This change will do everything as before but make sure permissions match the users umask so that future actions run by different users are not problematic.
