### PR TITLE
added all_specs to RubygemsIntegration::Transitional

### DIFF
--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -265,6 +265,10 @@ module Bundler
       def stub_rubygems(specs)
         stub_source_index170(specs)
       end
+
+      def all_specs
+        Gem.source_index.to_a.map { |x| x[1] }
+      end
     end
 
   end


### PR DESCRIPTION
bundler 1.0.13 & rubygems 1.7.2 issues annoying Deprecation warning when calling 'all_specs' .

rubygems 1.7.2 does not respond_to? :all=, so traps to RubygemsIntegration::Transitional - which calls Gem.source_index.all_gems.values.

two tests fail, but I don't think they are significant:

1) bundle install with git sources catches git errors and spits out useful output
Failure/Error: err.should include("fatal: The remote end hung up unexpectedly")
expected "fatal: repository 'omgomg' does not exist" to include "fatal: The remote end hung up unexpectedly"

2) bundle help simply outputs the txt file when there is no groff on the path
Failure/Error: out.should =~ /BUNDLE-INSTALL/
expected: /BUNDLE-INSTALL/
got: "" (using =~)
Diff:
@@ -1,2 +1 @@
-/BUNDLE-INSTALL/
