### PR TITLE
newgem should require the version file

### DIFF
--- a/lib/bundler/templates/newgem/lib/newgem.rb.tt
+++ b/lib/bundler/templates/newgem/lib/newgem.rb.tt
@@ -1,3 +1,5 @@
+require "<%=config[:name]%>/version"
+
 <%- config[:constant_array].each_with_index do |c,i| -%>
 <%= '  '*i %>module <%= c %>
 <%- end -%>

--- a/spec/other/newgem_spec.rb
+++ b/spec/other/newgem_spec.rb
@@ -21,4 +21,8 @@ describe "bundle gem" do
     bundled_app("test-gem/lib/test-gem/version.rb").read.should =~ /module Test\n  module Gem/
     bundled_app("test-gem/lib/test-gem.rb").read.should =~ /module Test\n  module Gem/
   end
+
+  it "requires the version file" do
+    bundled_app("test-gem/lib/test-gem.rb").read.should =~ /require "test-gem\/version"/
+  end
 end


### PR DESCRIPTION
the version constant is not only important for the gemspec, but should
also be required by the main gem file by default.
