### PR TITLE
Man pages for pull request #1159

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -440,7 +440,7 @@ module Bundler
       IRB.start
     end
     
-    desc "benchmark [GROUP]", "Displays the time taken for each each gem to be loaded into the environment"
+    desc "benchmark [GROUP]", "Displays the time taken for each gem to be loaded into the environment"
     def benchmark(group = nil)
       Bundler.ui.debug!
       Bundler.ui.debug "Gem require times as included by bundle:"

--- a/man/bundle-benchmark.ronn
+++ b/man/bundle-benchmark.ronn
@@ -1,0 +1,20 @@
+bundle-benchmark(1) -- Display the time taken for each gem to be loaded
+=======================================================================
+
+## SYNOPSIS
+
+`bundle benchmark` [group]
+
+## DESCRIPTION
+
+This command loads all your required dependencies as per Bundler.setup, and
+displays the total time spent in requiring each gem and its dependencies.
+
+Use this command to track down problems with excessive boot time in your 
+application, or to optimize specific groups in your Gemfile for fast setup.
+
+## GROUP OPTION
+
+To test the load times for gems in a specific group, pass the group as an
+argument to `bundle benchmark`. Omitting this option loads all dependencies
+in your Gemfile.

--- a/man/bundle.ronn
+++ b/man/bundle.ronn
@@ -66,6 +66,9 @@ We divide `bundle` subcommands into primary commands and utilities.
 
 * `bundle viz(1)`:
   Generate a visual representation of your dependencies
+  
+* `bundle benchmark(1)`:
+  Display the time taken for each each gem to be loaded into the environment
 
 * `bundle init(1)`:
   Generate a simple `Gemfile`, placed in the current directory

--- a/man/index.txt
+++ b/man/index.txt
@@ -4,3 +4,4 @@ bundle-update      bundle-update.1
 bundle-package     bundle-package.1
 bundle-exec        bundle-exec.1
 bundle-config      bundle-config.1
+bundle-benchmark   bundle-benchmark.1


### PR DESCRIPTION
This adds documentation for the bundle CLI benchmark utility I added (pull request #1159). Might be excessive, so leave out bundle-benchmark.ronn if necessary.
