### PR TITLE
Git ident configs in specs helpers

### DIFF
--- a/spec/support/builders.rb
+++ b/spec/support/builders.rb
@@ -487,6 +487,8 @@ module Spec
         Dir.chdir(path) do
           `git init`
           `git add *`
+          `git config user.email "lol@wut.com"`
+          `git config user.name "lolwut"`
           `git commit -m 'OMG INITIAL COMMIT'`
         end
       end


### PR DESCRIPTION
Newer versions of git (I have 1.7.5.1 on my machine) abort if there isn't identity configuration (user.name and user.email) set. So I added it.
