### PR TITLE
gem specification platform is already Gem::Platform::RUBY

### DIFF
--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -5,7 +5,6 @@ require "<%=config[:name]%>/version"
 Gem::Specification.new do |s|
   s.name        = <%=config[:name].inspect%>
   s.version     = <%=config[:constant_name]%>::VERSION
-  s.platform    = Gem::Platform::RUBY
   s.authors     = ["TODO: Write your name"]
   s.email       = ["TODO: Write your email address"]
   s.homepage    = ""


### PR DESCRIPTION
There's no need for this line as it's already the [default in RubyGems](https://github.com/rubygems/rubygems/blob/master/lib/rubygems/specification.rb#L99)
