### PR TITLE
Fix for issue #1127: Properly display installation location as a relative

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -223,8 +223,7 @@ module Bundler
       Bundler.load.cache if Bundler.root.join("vendor/cache").exist? && !options["no-cache"]
 
       if Bundler.settings[:path]
-        relative_path = Bundler.settings[:path]
-        relative_path = "./" + relative_path unless relative_path[0] == ?/
+        relative_path = File.expand_path(Bundler.settings[:path]).sub(/^#{File.expand_path('.')}/, '.')
         Bundler.ui.confirm "Your bundle is complete! " +
           "It was installed into #{relative_path}"
       else


### PR DESCRIPTION
This fixes [Issue 1127](https://github.com/carlhuda/bundler/issues/1127) by accounting for the fact that Windows path names do not start with `/` at the top.
