### PR TITLE
Add user.name and user.email from git config to newgem gemspec template

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -479,8 +479,12 @@ module Bundler
       constant_name = name.split('_').map{|p| p.capitalize}.join
       constant_name = constant_name.split('-').map{|q| q.capitalize}.join('::') if constant_name =~ /-/
       constant_array = constant_name.split('::')
+      git_author_name = `git config user.name`.chomp
+      git_author_email = `git config user.email`.chomp
+      author_name = git_author_name.empty? ? "TODO: Write your name" : git_author_name
+      author_email = git_author_email.empty? ? "TODO: Write your email address" : git_author_email
       FileUtils.mkdir_p(File.join(target, 'lib', name))
-      opts = {:name => name, :constant_name => constant_name, :constant_array => constant_array}
+      opts = {:name => name, :constant_name => constant_name, :constant_array => constant_array, :author_name => author_name, :author_email => author_email}
       template(File.join("newgem/Gemfile.tt"),               File.join(target, "Gemfile"),                opts)
       template(File.join("newgem/Rakefile.tt"),              File.join(target, "Rakefile"),               opts)
       template(File.join("newgem/gitignore.tt"),             File.join(target, ".gitignore"),             opts)

--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -5,8 +5,8 @@ require "<%=config[:name]%>/version"
 Gem::Specification.new do |s|
   s.name        = <%=config[:name].inspect%>
   s.version     = <%=config[:constant_name]%>::VERSION
-  s.authors     = ["TODO: Write your name"]
-  s.email       = ["TODO: Write your email address"]
+  s.authors     = ["<%= config[:author_name] %>"]
+  s.email       = ["<%= config[:author_email] %>"]
   s.homepage    = ""
   s.summary     = %q{TODO: Write a gem summary}
   s.description = %q{TODO: Write a gem description}


### PR DESCRIPTION
Every time generating new gem with `bundle gem gem-name` I need to edit `.gemspec` file and type there my name and email. Again and again. It's weird a bit, really. 
But there is no difference what to edit: default stub or your git name/email, if you really do not need this.
