### PR TITLE
amend Rake 0.9 support

### DIFF
--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -2,15 +2,10 @@ $:.unshift File.expand_path('../vendor', __FILE__)
 require 'thor'
 require 'bundler'
 
-begin
-  # Support Rake > 0.8.7
-  require 'rake/dsl_definition'
-  include Rake::DSL
-rescue LoadError
-end
-
 module Bundler
   class GemHelper
+    include Rake::DSL if defined? Rake::DSL
+
     def self.install_tasks(opts = {})
       dir = opts[:dir] || Dir.pwd
       self.new(dir, opts[:name]).install


### PR DESCRIPTION
The original commit for Rake 0.9 support ([6c3123a](https://github.com/carlhuda/bundler/commit/6c3123a)) was problematic: the top level <code>include Rake::DSL</code> pollutes Object with the methods 'task', 'file', etc., which is what Rake 0.9 intended to correct. Also, requiring a private Rake header (dsl_definition.rb) is asking for trouble.

[Update] This pull request passes all working specs.

The relevant section of the Rake's ChangeLog:

```
* *Incompatible* *change*: Rake DSL commands ('task', 'file', etc.) are
  no longer private methods in Object. If you need to call 'task :xzy' inside
  your class, include Rake::DSL into the class. The DSL is still available at
  the top level scope (via the top level object which extends Rake::DSL).
```
