### PR TITLE
Cause a generated gemspec to fall back from `git ls-files` to filespecs

### DIFF
--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -13,8 +13,15 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = <%=config[:name].inspect%>
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  if File.directory?("#{File.dirname __FILE__}/.git") &&
+     system('git status > /dev/null 2>&1')
+    s.files       = `git ls-files`.split("\n")
+    s.test_files  = `git ls-files -- {test,spec,features}/*`.split("\n")
+    s.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  else
+    s.files       = Dir.glob('**/*')
+    s.test_files  = Dir.glob('{test,spec,features}/**/*')
+    s.executables = Dir.glob('bin/*').map{ |f| File.basename(f) }
+  end
   s.require_paths = ["lib"]
 end


### PR DESCRIPTION
This is desirable because installed gems are not contained in a repo. When a Bundler-generated gemspec is loaded, irrelevant error messages pertaining to a missing Git repo appear on the user’s console.

We check for the presence of a ‘.git’ directory before invoking `git status` in order to avoid confusing Windows machines with “/dev/null” and “2>&1”.
