### PR TITLE
Stop LazySpec#method_missing from generating so many objects

### DIFF
--- a/lib/bundler/lazy_specification.rb
+++ b/lib/bundler/lazy_specification.rb
@@ -59,12 +59,11 @@ module Bundler
   private
 
     def method_missing(method, *args, &blk)
-      if Gem::Specification.new.respond_to?(method)
-        raise "LazySpecification has not been materialized yet (calling :#{method} #{args.inspect})" unless @specification
-        @specification.send(method, *args, &blk)
-      else
-        super
-      end
+      raise "LazySpecification has not been materialized yet (calling :#{method} #{args.inspect})" unless @specification
+
+      return super unless respond_to?(method)
+
+      @specification.send(method, *args, &blk)
     end
 
   end


### PR DESCRIPTION
LazySpec#method_missing creates a new instance of Gem::Specification, then throws it away on every call. Let's reuse respond_to? and be kinder to our garbage collector.
