### PR TITLE
Dependency api basic auth

### DIFF
--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -58,8 +58,10 @@ module Bundler
       case response
       when Net::HTTPRedirection
         Bundler.ui.debug("HTTP Redirection")
-        uri = URI.parse(response["location"])
-        fetch(uri, counter + 1)
+        new_uri = URI.parse(response["location"])
+        new_uri.user = uri.user
+        new_uri.password = uri.password
+        fetch(new_uri, counter + 1)
       when Net::HTTPSuccess
         Bundler.ui.debug("HTTP Success")
         response.body

--- a/lib/bundler/vendor/net/http/persistent.rb
+++ b/lib/bundler/vendor/net/http/persistent.rb
@@ -348,6 +348,10 @@ class Net::HTTP::Persistent
       req.add_field(*pair)
     end
 
+    if uri.user or uri.password
+      req.basic_auth uri.user, uri.password
+    end
+
     req.add_field 'Connection', 'keep-alive'
     req.add_field 'Keep-Alive', @keep_alive
 

--- a/spec/install/gems/dependency_api_spec.rb
+++ b/spec/install/gems/dependency_api_spec.rb
@@ -89,4 +89,19 @@ describe "gemcutter's dependency API" do
     bundle :install, :artifice => "endpoint_redirect"
     out.should match(/Too many redirects/)
   end
+
+  it "passes basic authentication details" do
+    uri = URI.parse(source_uri)
+    uri.user = "hello"
+    uri.password = "there"
+
+    gemfile <<-G
+      source "#{uri}"
+      gem "rack"
+    G
+
+    bundle :install, :artifice => "endpoint_basic_authentication"
+    out.should include("Fetching dependency information from the API at #{uri}")
+    should_be_installed "rack 1.0.0"
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require 'fileutils'
 require 'rubygems'
 require 'bundler'
 require 'rspec'
+require 'uri'
 
 # Require the correct version of popen for the current platform
 if RbConfig::CONFIG['host_os'] =~ /mingw|mswin/

--- a/spec/support/artifice/endpoint_basic_authentication.rb
+++ b/spec/support/artifice/endpoint_basic_authentication.rb
@@ -1,0 +1,13 @@
+require File.expand_path("../endpoint", __FILE__)
+
+Artifice.deactivate
+
+class EndpointBasicAuthentication < Endpoint
+  before do
+    unless env["HTTP_AUTHORIZATION"]
+      halt 401, "Authentication info not supplied"
+    end
+  end
+end
+
+Artifice.activate_with(EndpointBasicAuthentication)


### PR DESCRIPTION
Given a source such as `http://foo:bar@gems.com`, the basic auth info
needs to be passed on so, if the source is not an API endpoint, it
will return 404 instead of 401. The fetcher will then fall back to
fetching the full specs as expected instead of bailing.
