### PR TITLE
Get rid of warning in ruby 1.9.3

### DIFF
--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -123,7 +123,7 @@ module Bundler
         if executables.include? File.basename(caller.first.split(':').first)
           return
         end
-        opts = reqs.last.is_a?(Hash) ? reqs.pop : {}
+        reqs.pop if reqs.last.is_a?(Hash)
 
         unless dep.respond_to?(:name) && dep.respond_to?(:requirement)
           dep = Gem::Dependency.new(dep, reqs)


### PR DESCRIPTION
This removes "warning: assigned but unused variable - opts" on ruby 1.9.3
The 'opts' variable is never used in the code.
