### PR TITLE
Lazy specification to ary

### DIFF
--- a/lib/bundler/lazy_specification.rb
+++ b/lib/bundler/lazy_specification.rb
@@ -59,6 +59,8 @@ module Bundler
   private
 
     def method_missing(method, *args, &blk)
+      return super if method == :to_ary
+
       raise "LazySpecification has not been materialized yet (calling :#{method} #{args.inspect})" unless @specification
 
       return super unless respond_to?(method)


### PR DESCRIPTION
Was getting errors from LazySpecification under 1.9.2 when #to_ary was called by Array#flatten.
