### PR TITLE
gems provide "executables", they are rarely also "binaries"

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -61,8 +61,8 @@ Bundler 0.9 removes the following Bundler 0.8 Gemfile APIs:
    via `bundle install /path/to/bundle`. Bundler will remember
    where you installed the dependencies to on a particular
    machine for future installs, loads, setups, etc.
-5. `bin_path`: Bundler no longer generates binaries in the root
-   of your app. You should use `bundle exec` to execute binaries
+5. `bin_path`: Bundler no longer generates executables in the root
+   of your app. You should use `bundle exec` to execute executables
    in the current context.
 
 ### Gemfile Changes

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -347,7 +347,7 @@ module Bundler
         exit 126
       rescue Errno::ENOENT
         Bundler.ui.error "bundler: command not found: #{ARGV.first}"
-        Bundler.ui.warn  "Install missing gem binaries with `bundle install`"
+        Bundler.ui.warn  "Install missing gem executables with `bundle install`"
         exit 127
       end
     end

--- a/lib/bundler/source.rb
+++ b/lib/bundler/source.rb
@@ -362,9 +362,9 @@ module Bundler
               s.relative_loaded_from = "#{@name}.gemspec"
               s.authors  = ["no one"]
               if expanded_path.join("bin").exist?
-                binaries = expanded_path.join("bin").children
-                binaries.reject!{|p| File.directory?(p) }
-                s.executables = binaries.map{|c| c.basename.to_s }
+                executables = expanded_path.join("bin").children
+                executables.reject!{|p| File.directory?(p) }
+                s.executables = executables.map{|c| c.basename.to_s }
               end
             end
           end

--- a/spec/other/exec_spec.rb
+++ b/spec/other/exec_spec.rb
@@ -101,7 +101,7 @@ describe "bundle exec" do
     bundle "exec foobarbaz", :exitstatus => true
     exitstatus.should eq(127)
     out.should include("bundler: command not found: foobarbaz")
-    out.should include("Install missing gem binaries with `bundle install`")
+    out.should include("Install missing gem executables with `bundle install`")
   end
 
   it "errors nicely when the argument is not executable" do
@@ -115,7 +115,7 @@ describe "bundle exec" do
     out.should include("bundler: not executable: ./foo")
   end
 
-  describe "with gem binaries" do
+  describe "with gem executables" do
     describe "run from a random directory" do
       before(:each) do
         install_gemfile <<-G


### PR DESCRIPTION
Something with +x in Unix is an "executable" file. Sometimes it is binary, sometimes it is not. Ruby scripts like rails are executables, not binaries. Also gem specs have an spec.executables attribute for them (though they have a spec.bindir).

This patch normalizes this terminology in code and messages.
