### PR TITLE
bundle clean --force

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -19,6 +19,7 @@ module Bundler
     default_task :install
     class_option "no-color", :type => :boolean, :banner => "Disable colorization in output"
     class_option "verbose",  :type => :boolean, :banner => "Enable verbose output mode", :aliases => "-V"
+    class_option "force",    :type => :boolean, :banner => "Force", :aliases => "-f"
 
     def help(cli = nil)
       case cli
@@ -540,9 +541,9 @@ module Bundler
 
     desc "clean", "Cleans up unused gems in your bundler directory"
     def clean
-      clean_output = Bundler.load.clean
+      clean_output = Bundler.load.clean(options[:force])
       if !clean_output
-        Bundler.ui.error "Can only use bundle clean when --path is set"
+        Bundler.ui.error "Can only use bundle clean when --path is set or use --force"
       end
     end
 

--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -119,8 +119,8 @@ module Bundler
       end
     end
 
-    def clean
-      return false if Bundler.settings[:path] == nil
+    def clean(force = false)
+      return false if !force && Bundler.settings[:path] == nil
 
       gem_bins             = Dir["#{Gem.dir}/bin/*"]
       git_dirs             = Dir["#{Gem.dir}/bundler/gems/*"]

--- a/spec/other/clean_spec.rb
+++ b/spec/other/clean_spec.rb
@@ -197,6 +197,18 @@ describe "bundle clean" do
 
     bundle :clean
 
-    out.should == "Can only use bundle clean when --path is set"
+    out.should == "Can only use bundle clean when --path is set or use --force"
+  end
+
+  it "does not display an error when used without --path and with --force" do
+    install_gemfile <<-G
+      source "file://#{gem_repo1}"
+
+      gem "rack", "1.0.0"
+    G
+
+    bundle :clean, :force => true
+
+    out.should_not == "Can only use bundle clean when --path is set or use --force"
   end
 end


### PR DESCRIPTION
I added `--force` command line option so that I could clean my rvm gemsets and this can also be used in other cases.
