### PR TITLE
capistrano: use :release_path, not :current_release

### DIFF
--- a/lib/bundler/deployment.rb
+++ b/lib/bundler/deployment.rb
@@ -40,12 +40,12 @@ module Bundler
           bundle_gemfile = context.fetch(:bundle_gemfile, "Gemfile")
           bundle_without = [*context.fetch(:bundle_without, [:development, :test])].compact
 
-          args = ["--gemfile #{File.join(context.fetch(:current_release), bundle_gemfile)}"]
+          args = ["--gemfile #{File.join(context.fetch(:release_path), bundle_gemfile)}"]
           args << "--path #{bundle_dir}" unless bundle_dir.to_s.empty?
           args << bundle_flags.to_s
           args << "--without #{bundle_without.join(" ")}" unless bundle_without.empty?
 
-          run "cd #{context.fetch(:current_release)} && #{bundle_cmd} install #{args.join(' ')}"
+          run "cd #{context.fetch(:release_path)} && #{bundle_cmd} install #{args.join(' ')}"
         end
       end
     end


### PR DESCRIPTION
This commit fixes the following generated command where a bogus
`releases/ls` directory is assumed due to the use of `:current_release`.

```
failed: "sh -c 'cd MY_DEPLOY_DIR/releases/ls && bundle install --gemfile MY_DEPLOY_DIR/releases/ls/Gemfile --path MY_DEPLOY_DIR/shared/bundle --deployment --quiet --without development test'" on MY_HOST_NAME
```

I am using capistrano (2.6.0) and bundler (1.0.15) under ruby 1.9.2p180.
