### PR TITLE
Implement `to_ary` to avoid calls to method_missing

### DIFF
--- a/lib/bundler/lazy_specification.rb
+++ b/lib/bundler/lazy_specification.rb
@@ -58,9 +58,11 @@ module Bundler
 
   private
 
-    def method_missing(method, *args, &blk)
-      return super if method == :to_ary
+    def to_ary
+      nil
+    end
 
+    def method_missing(method, *args, &blk)
       raise "LazySpecification has not been materialized yet (calling :#{method} #{args.inspect})" unless @specification
 
       return super unless respond_to?(method)


### PR DESCRIPTION
The following code is calls method missing and emits annoying warnings when -d is used:

``` ruby

class Item
  def method_missing(name, *args)
    p "method_missing(#{name})"
    super
  end
end

p [[Item.new]].flatten
```

We can silence these warnings by implementing a `to_ary` that returns nil:

``` ruby

class Item
  def method_missing(name, *args)
    p "method_missing(#{name})"
    super
  end

  private
  def to_ary
    nil
  end
end

p [[Item.new]].flatten
```

According to [ruby spec](https://github.com/rubyspec/rubyspec/blob/master/core/array/flatten_spec.rb#L105) it's OK for `to_ary` to return nil, and it will just be ignored.  We can also see that the [ruby implementation agrees](https://github.com/ruby/ruby/blob/trunk/array.c#L3687-3693).

This patch adds `to_ary` for two reasons:
- Avoiding expensive calls to method_missing
- Silencing warnings when -d is enabled.

Thanks!
