### PR TITLE
Check clean before build on rake tasks

### DIFF
--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -24,18 +24,22 @@ module Bundler
 
     def install
       desc "Build #{name}-#{version}.gem into the pkg directory"
-      task 'build' do
+      task 'build' => :check_clean do
         build_gem
       end
 
       desc "Build and install #{name}-#{version}.gem into system gems"
-      task 'install' do
+      task 'install' => :check_clean do
         install_gem
       end
 
       desc "Create tag #{version_tag} and build and push #{name}-#{version}.gem to Rubygems"
-      task 'release' do
+      task 'release' => :check_clean do
         release_gem
+      end
+
+      task "check_clean" do
+        check_clean
       end
     end
 
@@ -66,6 +70,11 @@ module Bundler
         git_push
         rubygem_push(built_gem_path)
       }
+    end
+
+    def check_clean
+      out, _ = sh_with_code("git status --porcelain")
+      raise "Not clean status. Commit your changes before building a gem" unless out.strip.empty?
     end
 
     protected


### PR DESCRIPTION
I am building a library, a rdoc template.

To automatic load the template, rdoc sources call Gem.find_files, that if I am not wrong, it look for that files in the files from the specifications.

The default rake tasks that bundler install when running "bundle gem my_new_gem", uses "git ls-files", that shows only commited files, inside the gemspec. OK. Thats cool.

The problem if that, if I don't commit some files, the builded gem is inconsistent, as it doesn't have the uncommited changes.

Big problems could be if the gem is release before commiting the changes (Not usual but can occur).

This pull-request, and a :check_clean dependency task in rake, that abort "rake build", "rake install" and "rake release".

The :check_clean rake task checks if the are changes, and abort if something is uncommited.
