### PR TITLE
Rubygems 1.8.5 expects SpecSet to act like an array.

### DIFF
--- a/lib/bundler/spec_set.rb
+++ b/lib/bundler/spec_set.rb
@@ -1,19 +1,16 @@
 require 'tsort'
+require 'forwardable'
 
 module Bundler
   class SpecSet
+    extend Forwardable
     include TSort, Enumerable
+
+    def_delegators :@specs, :<<, :length, :add, :remove
+    def_delegators :sorted, :each
 
     def initialize(specs)
       @specs = specs.sort_by { |s| s.name }
-    end
-
-    def each
-      sorted.each { |s| yield s }
-    end
-
-    def length
-      @specs.length
     end
 
     def for(dependencies, skip = [], check = false, match_current_platform = false)
@@ -66,6 +63,10 @@ module Bundler
       @lookup = nil
       @sorted = nil
       value
+    end
+
+    def sort!
+      self
     end
 
     def to_a


### PR DESCRIPTION
RubyGems expects that SpecSet acts like an array, presumably because when working outside of bundler the set is an Array.

For example, when trying to generate_index, this causes the following error:

```
undefined method `<<' for #<Bundler::SpecSet:0x7ff9eb37b558>
    /home/cmeiklejohn/.rvm/rubies/ree-1.8.7-head/lib/ruby/site_ruby/1.8/rubygems/specification.rb:307:in `add_spec'
    /home/cmeiklejohn/.rvm/rubies/ree-1.8.7-head/lib/ruby/site_ruby/1.8/rubygems/specification.rb:322:in `add_specs'
    /home/cmeiklejohn/.rvm/rubies/ree-1.8.7-head/lib/ruby/site_ruby/1.8/rubygems/specification.rb:321:in `each'
    /home/cmeiklejohn/.rvm/rubies/ree-1.8.7-head/lib/ruby/site_ruby/1.8/rubygems/specification.rb:321:in `add_specs'
    /home/cmeiklejohn/.rvm/rubies/ree-1.8.7-head/lib/ruby/site_ruby/1.8/rubygems/indexer.rb:129:in `build_indicies'
    /home/cmeiklejohn/.rvm/rubies/ree-1.8.7-head/lib/ruby/site_ruby/1.8/rubygems/indexer.rb:456:in `generate_index'
```

Also, when examining the rubygems code, it assume it can call add, << and remove on the SpecSet.  See (add_spec and remove_spec).

This patch uses Forwardable to delegate the expected methods down to the inner array within SpecSet.

Also, is 1-0-stable the correct place to be making this fix, or should I be making the fix on master?
