### PR TITLE
avoid modifying frozen array (fixes `bundle install --without` on kiji)

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -152,10 +152,10 @@ module Bundler
       opts = options.dup
       opts[:without] ||= []
       if opts[:without].size == 1
-        opts[:without].map!{|g| g.split(" ") }
+        opts[:without] = opts[:without].map{|g| g.split(" ") }
         opts[:without].flatten!
       end
-      opts[:without].map!{|g| g.to_sym }
+      opts[:without] = opts[:without].map{|g| g.to_sym }
 
       # Can't use Bundler.settings for this because settings needs gemfile.dirname
       ENV['BUNDLE_GEMFILE'] = File.expand_path(opts[:gemfile]) if opts[:gemfile]


### PR DESCRIPTION
`bundler/cli.rb` modifies a frozen array. This causes problems on kiji, which enforces frozen semantics more strictly.

See https://github.com/twitter/rubyenterpriseedition187-248/issues/2
