### PR TITLE
Performance fix for MRI 1.9

### DIFF
--- a/lib/bundler/index.rb
+++ b/lib/bundler/index.rb
@@ -101,10 +101,15 @@ module Bundler
       end
     end
 
-    def same_version?(a, b)
-      regex = /^(.*?)(?:\.0)*$/
-
-      a.to_s[regex, 1] == b.to_s[regex, 1]
+    if RUBY_VERSION < '1.9'
+      def same_version?(a, b)
+        regex = /^(.*?)(?:\.0)*$/
+        a.to_s[regex, 1] == b.to_s[regex, 1]
+      end
+    else
+      def same_version?(a, b)
+        a == b
+      end
     end
 
     def spec_satisfies_dependency?(spec, dep)


### PR DESCRIPTION
I did some testing to cut time for `bundle install` runs, and this is one of the low hanging fruits fur Ruby 1.9.

Commit text:
MRI 1.9 is considerably faster when directly comparing Gem::Version,
while 1.8 is faster with the regex method.

Tested with:
ruby 1.9.2p0 (2010-08-18 revision 29036) [x86_64-linux]
ruby 1.8.7 (2010-08-16 patchlevel 302) [x86_64-linux]
Rubygems 1.8.5

Test program: https://gist.github.com/1067157

Timings:
1.9 without the change: ~12 sec
1.9 with the change: ~6 sec
1.8 always: ~19 sec
