### PR TITLE
silence stderr on a spec

### DIFF
--- a/spec/other/gem_helper_spec.rb
+++ b/spec/other/gem_helper_spec.rb
@@ -118,7 +118,7 @@ describe "Bundler::GemHelper tasks" do
           `git config user.name "name"`
           `git remote add origin file://#{gem_repo1}`
           `git commit -a -m "initial commit"`
-          sys_exec("git push origin master")
+          sys_exec("git push origin master", true)
           `git commit -a -m "another commit"`
         }
         @helper.release_gem


### PR DESCRIPTION
just a minor fix

Was seeing this in my stderr stream using git 1.7.1:

```
$ rspec spec/other/gem_helper_spec.rb
Run filtered excluding {:sudo=>true}
..........To file:///Users/bozo/code/fork/bundler/tmp/gems/remote1
* [new branch]      master -> master
.

Finished in 9.82 seconds
11 examples, 0 failures
```

Could also change the line in question to `git push -q ...`
