### PR TITLE
Run the bundle install earlier in a Capistrano deployment

### DIFF
--- a/lib/bundler/capistrano.rb
+++ b/lib/bundler/capistrano.rb
@@ -5,7 +5,7 @@
 require 'bundler/deployment'
 
 Capistrano::Configuration.instance(:must_exist).load do
-  after "deploy:update_code", "bundle:install"
+  after "deploy:finalize_update", "bundle:install"
   Bundler::Deployment.define_task(self, :task, :except => { :no_release => true })
   set :rake, lambda { "#{fetch(:bundle_cmd, "bundle")} exec rake" }
 end


### PR DESCRIPTION
Run the bundle install earlier in a Capistrano deployment to give other tasks a stable, common hook to use.

See this Capistrano patch for background.
https://github.com/capistrano/capistrano/pull/35
