### PR TITLE
documentation

### DIFF
--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -17,4 +17,8 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
+
+  # specify any dependencies here; for example:
+  # s.add_development_dependency 'rspec'
+  # s.add_runtime_dependency 'rest-client'
 end


### PR DESCRIPTION
As Bundler stands, there's a comment in Gemfile telling people not to put their gem dependencies in there, but there's no comment in the gemspec giving an example of the format. This patch adds comments in the gemspec with an example of the format. MINASWAN.
