### PR TITLE
An attempt on reintroducing Gem::Specification#add_bundler_dependencies

### DIFF
--- a/lib/bundler/rubygems_ext.rb
+++ b/lib/bundler/rubygems_ext.rb
@@ -70,17 +70,17 @@ module Gem
     end
 
     def add_bundler_dependencies(*groups)
-      Bundler.ui.warn "#add_bundler_dependencies is deprecated and will " \
-        "be removed in Bundler 1.0. Instead, please use the #gemspec method " \
-        "in your Gemfile, which will pull in any dependencies specified in " \
-        "your gemspec"
-
       groups = [:default] if groups.empty?
-      Bundler.definition.dependencies.each do |dep|
-        if dep.groups.include?(:development)
-          self.add_development_dependency(dep.name, dep.requirement.to_s)
-        elsif (dep.groups & groups).any?
-          self.add_dependency(dep.name, dep.requirement.to_s)
+      path = File.dirname(caller.first.match(/(.*):/)[1])
+      Bundler.with_clean_env do
+        gemfile = File.join path, 'Gemfile'
+        lockfile = gemfile + '.lock'
+        Bundler::Definition.build(gemfile, lockfile, nil).dependencies.each do |dep|
+          if dep.groups.include? :development
+            add_development_dependency dep.name, dep.requirement.to_s
+          elsif (dep.groups & groups).any?
+            add_dependency dep.name, dep.requirement.to_s
+          end
         end
       end
     end


### PR DESCRIPTION
This implementation will dynamically load the Gemfile inside the path of the gemspec file and add all dependencies from that Gemfile. This will not dirty the current environment when the gemspec is loaded e.g. from Git.

This is somehow a follow-up to #1086 as I think that this feature is really needed, when dependencies should be completely mangaged by Bundler.

I open to any objections to revive this feature and safe it from deprecation and I'd also like to see any suggestions to make this change better.
