### PR TITLE
fixes rake 0.9.2 WARNING

### DIFF
--- a/lib/bundler/vlad.rb
+++ b/lib/bundler/vlad.rb
@@ -4,6 +4,8 @@
 # include the vlad:bundle:install task in your vlad:deploy task.
 require 'bundler/deployment'
 
+include Rake::DSL if defined? Rake::DSL
+
 namespace :vlad do
   Bundler::Deployment.define_task(Rake::RemoteTask, :remote_task, :roles => :app)
 end


### PR DESCRIPTION
by adding the include we could get rid of 

WARNING: Global access to Rake DSL methods is deprecated.  Please include
    ...  Rake::DSL into classes and modules which use the Rake DSL methods.

when using bundler vlad tasks
