### PR TITLE
Changed the output of gem build to verbose

### DIFF
--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -41,7 +41,7 @@ module Bundler
 
     def build_gem
       file_name = nil
-      sh("gem build '#{spec_path}'") { |out, code|
+      sh("gem build '#{spec_path}' -V") { |out, code|
         raise out unless out[/Successfully/]
         file_name = File.basename(built_gem_path)
         FileUtils.mkdir_p(File.join(base, 'pkg'))


### PR DESCRIPTION
Changed the output of gem build to verbose.
The new RubyGems version won't give any response when you run gem build ...
