### PR TITLE
make --standalone respect --path

### DIFF
--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -91,8 +91,8 @@ module Bundler
     end
 
     def generate_standalone(groups)
-      path = Bundler.settings[:path]
-      bundler_path = File.join(path, "bundler")
+      standalone_path = Bundler.settings[:path]
+      bundler_path = File.join(standalone_path, "bundler")
       FileUtils.mkdir_p(bundler_path)
 
       paths = []
@@ -108,7 +108,7 @@ module Bundler
 
         spec.require_paths.each do |path|
           full_path = File.join(spec.full_gem_path, path)
-          paths << Pathname.new(full_path).relative_path_from(Bundler.root.join("bundle/bundler"))
+          paths << Pathname.new(full_path).relative_path_from(Bundler.root.join(bundler_path))
         end
       end
 

--- a/spec/install/gems/standalone_spec.rb
+++ b/spec/install/gems/standalone_spec.rb
@@ -142,6 +142,20 @@ describe "bundle install --standalone" do
       err.should =~ /no such file to load.*spec/
     end
 
+    it "allows --path to change the location of the standalone bundle" do
+      bundle "install --standalone --path path/to/bundle"
+
+      ruby <<-RUBY, :no_lib => true, :expect_err => false
+        $:.unshift File.expand_path("path/to/bundle")
+        require "bundler/setup"
+
+        require "actionpack"
+        puts ACTIONPACK
+      RUBY
+
+      out.should == "2.3.2"
+    end
+
     it "allows remembered --without to limit the groups used in a standalone" do
       bundle "install --without test"
       bundle "install --standalone"


### PR DESCRIPTION
The paths generated in setup.rb are relative to the hard coded bundle path `bundle`, so if `--path` is specified, the load paths will be all out of whack.

This fix will allow you to generate a standalone bundle at any path relative to Bundler.root
