### PR TITLE
Load RubyGems plugins

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -217,6 +217,7 @@ module Bundler
       Bundler.settings.without = opts[:without] unless opts[:without].empty?
       Bundler.ui.be_quiet! if opts[:quiet]
 
+      Gem.load_plugins
       Installer.install(Bundler.root, Bundler.definition, opts)
       Bundler.load.cache if Bundler.root.join("vendor/cache").exist? && !options["no-cache"]
 
@@ -265,6 +266,7 @@ module Bundler
       end
 
       opts = {"update" => true, "local" => options[:local]}
+      Gem.load_plugins
       Installer.install Bundler.root, Bundler.definition, opts
       Bundler.load.cache if Bundler.root.join("vendor/cache").exist?
       Bundler.ui.confirm "Your bundle is updated! " +


### PR DESCRIPTION
My use case is [gem-ctags](https://github.com/tpope/gem-ctags), my own gem which automatically invokes [ctags](http://ctags.sourceforge.net/) on installed gems. It works great on `gem install`, but doesn't fire on `bundle install`, and the difference is that Bundler skips loading RubyGems plugins.

My strategy here is to invoke `Gem.load_plugins` inside `bundler/cli`, which is basically equivalent to where RubyGems itself does it: `rubygems/gem_runner`. I don't claim to fully understand the implications of doing it here (or, indeed, doing it all), but it seems benign enough. `Bundler.setup` never loads this file, so there's no risk of accidentally tainting the pristine environment with additional gems.
