### PR TITLE
warning: `*' interpreted as argument prefix

### DIFF
--- a/lib/bundler/vendor/thor/util.rb
+++ b/lib/bundler/vendor/thor/util.rb
@@ -155,7 +155,7 @@ class Thor
       rescue Exception => e
         $stderr.puts "WARNING: unable to load thorfile #{path.inspect}: #{e.message}"
         if debug
-          $stderr.puts *e.backtrace
+          $stderr.puts(*e.backtrace)
         else
           $stderr.puts e.backtrace.first
         end


### PR DESCRIPTION
Fix "warning: `*' interpreted as argument prefix" (see https://github.com/carlhuda/bundler/issues/1268)
