### PR TITLE
Add initial commit for new gem

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -493,7 +493,7 @@ module Bundler
         template(File.join("newgem/bin/newgem.tt"),          File.join(target, 'bin', name),              opts)
       end
       Bundler.ui.info "Initializating git repo in #{target}"
-      Dir.chdir(target) { `git init`; `git add .` }
+      Dir.chdir(target) { `git init`; `git add .`; `git commit -m 'initial commit'` }
     end
 
     def self.source_root


### PR DESCRIPTION
After `bundle gem name` bundler calls `git init` and `git add .`, maybe time to add `git commit -m 'initial commit'`? Too long line that everybody always write.
