### PR TITLE
Don't hose existing load paths if Bundle.setup is called multiple times

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -111,8 +111,7 @@ module Bundler
         unloaded = groups - @completed_groups
         # Record groups that are now loaded
         @completed_groups = groups
-        # Load any groups that are not yet loaded
-        unloaded.any? ? load.setup(*unloaded) : load
+        unloaded.any? ? load.setup(*groups) : load
       end
     end
 

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -25,6 +25,7 @@ describe "Bundler.setup" do
     before(:each) do
       install_gemfile <<-G
         source "file://#{gem_repo1}"
+        gem "yard"
         gem "rack", :group => :test
       G
     end
@@ -57,6 +58,24 @@ describe "Bundler.setup" do
       RUBY
       err.should eq("")
       out.should eq("1.0.0")
+    end
+
+    it "leaves :default available if setup is called twice" do
+      ruby <<-RUBY
+        require 'rubygems'
+        require 'bundler'
+        Bundler.setup(:default)
+        Bundler.setup(:default, :test)
+
+        begin
+          require 'yard'
+          puts "WIN"
+        rescue LoadError
+          puts "FAIL"
+        end
+      RUBY
+      err.should eq("")
+      out.should match("WIN")
     end
   end
 


### PR DESCRIPTION
Don't hose existing load paths if Bundle.setup is called multiple times with a different set of groups.

This fixes #1230.
