### PR TITLE
Information on what gem bundler has started to install, to ease debugging

### DIFF
--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -63,8 +63,10 @@ module Bundler
           Bundler.ui.info ""
           generate_bundler_executable_stubs(spec) if Bundler.settings[:bin]
           FileUtils.rm_rf(Bundler.tmp)
-        rescue Exception
-          puts "Error: '#{$!.message}', when installing #{spec.name}"
+        rescue Exception => e
+          Bundler.ui.warn "#{e.class}: #{e.message}"
+          Bundler.ui.error "An error (#{e.message}) occured while installing #{spec.name} (#{spec.version})"
+          Bundler.ui.error "Bundler can not continue. Try manually installing the gem, to determine if this is a Bundler specfic issue or issue with the gem itself"
           raise
         end
       end


### PR DESCRIPTION
When something goes wrong with a gem bundler currently gives output like this:

....

```
Installing somegem
Undefined some_method for NilClass
```

A user might believe that the problem happened when trying to install somegem, and blame the issue on bundler when "gem install somegem" is successful.

In fact, what has happened is Bundler has successfully installed somegem, but has failed on the _next gem in the list_. However, figuring out the next gem in the list is non-trivial for a non Bundler developer to figure out.

This pull outputs the following line _before_ starting processing on the current gem.

Thus, the output from the failure above would look like:

```
  Currently processing 'somegem'...
Installing somegem

  Currently processing 'bad_gem'
Undefined some_method for NilClass
```

With this change a user can identify that 'bad_gem' is the gem with errors, and try to 'gem install bad_gem' (to see if the error is bundler specific, or something with the gem / Rubygems)
