### PR TITLE
redirect stderr to /dev/null to avoid unwanted output.

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -206,7 +206,7 @@ module Bundler
 
       path = bundle_path
       path = path.parent until path.exist?
-      sudo_present = !(`which sudo 2> /dev/null` rescue '').empty?
+      sudo_present = !(`which sudo 2> #{Bundler::NULL}` rescue '').empty?
 
       @checked_for_sudo = true
       @requires_sudo = settings.allow_sudo? && !File.writable?(path) && sudo_present

--- a/spec/support/sudo.rb
+++ b/spec/support/sudo.rb
@@ -1,7 +1,7 @@
 module Spec
   module Sudo
     def self.present?
-      @which_sudo ||= (`which sudo 2> /dev/null`.chomp rescue '')
+      @which_sudo ||= (`which sudo`.chomp rescue '')
       !@which_sudo.empty?
     end
 


### PR DESCRIPTION
On some platforms the sudo present test outputs unwanted spam on the console. For example this happens under jruby from a cygwin prompt on windows.

This small change redirects stderr while keeping stdout output intact.
