### PR TITLE
1 0 stable

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -482,7 +482,7 @@ module Bundler
       author_name = git_author_name.empty? ? "TODO: Write your name" : git_author_name
       author_email = git_author_email.empty? ? "TODO: Write your email address" : git_author_email
       FileUtils.mkdir_p(File.join(target, 'lib', name))
-      opts = {:name => name, :constant_name => constant_name, :constant_array => constant_array, :author_name => author_name, :author_email => author_email}
+      opts = {:name => name, :constant_name => constant_name, :constant_array => constant_array, :author_name => author_name, :author_email => author_email, :version => "0.0.1"}
       template(File.join("newgem/Gemfile.tt"),               File.join(target, "Gemfile"),                opts)
       template(File.join("newgem/Rakefile.tt"),              File.join(target, "Rakefile"),               opts)
       template(File.join("newgem/gitignore.tt"),             File.join(target, ".gitignore"),             opts)

--- a/spec/other/gem_helper_spec.rb
+++ b/spec/other/gem_helper_spec.rb
@@ -87,6 +87,7 @@ describe "Bundler::GemHelper tasks" do
         end
         proc { @helper.install_gem }.should raise_error
       end
+
     end
 
     describe 'release' do
@@ -130,6 +131,46 @@ describe "Bundler::GemHelper tasks" do
           `git commit -a -m "another commit"`
         }
         @helper.release_gem
+      end
+    end
+
+    describe 'version' do
+      before :each do
+        @app = bundled_app("test")
+        @helper = Bundler::GemHelper.new(@app.to_s)
+        @helper.reload_version
+      end
+
+      it "is correct initially" do
+        @helper.gemspec.version.version.should == '0.0.1'
+      end
+
+      it "can be set with arbirary number" do
+        mock_confirm_message "Version set to 2.3.4.rc5"
+        @helper.update_to("2.3.4.rc5")
+        @helper.reload_version
+        @helper.gemspec.version.version.should == '2.3.4.rc5'
+      end
+
+      it "bumps patch" do
+        mock_confirm_message "Version set to 0.0.2"
+        @helper.update_to(@helper.bump_patch)
+        @helper.reload_version
+        @helper.gemspec.version.version.should == '0.0.2'
+      end
+
+      it "bumps minor" do
+        mock_confirm_message "Version set to 0.1.0"
+        @helper.update_to(@helper.bump_minor)
+        @helper.reload_version
+        @helper.gemspec.version.version.should == '0.1.0'
+      end
+
+      it "bumps major" do
+        mock_confirm_message "Version set to 1.0.0"
+        @helper.update_to(@helper.bump_major)
+        @helper.reload_version
+        @helper.gemspec.version.version.should == '1.0.0'
       end
     end
   end


### PR DESCRIPTION
Add four new rake tasks for version management a-la Jeweler:

rake version:bump:major    # Bumps major version to 1.0.0
rake version:bump:minor    # Bumps minor version to 0.1.0
rake version:bump:patch    # Bumps patch version to 0.0.2
rake version:set[version]  # Sets version to [version]
