### PR TITLE
Fixes #1459. autoclean won't remove used bins.

### DIFF
--- a/lib/bundler/endpoint_specification.rb
+++ b/lib/bundler/endpoint_specification.rb
@@ -42,6 +42,17 @@ module Bundler
       end
     end
 
+    # needed for bundle clean
+    def bindir
+      if @remote_specification
+        @remote_specification.bindir
+      elsif _local_specification
+        _local_specification.bindir
+      else
+        super
+      end
+    end
+
     def _local_specification
       eval(File.read(local_specification_path)) if @loaded_from && File.exists?(local_specification_path)
     end

--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -18,7 +18,7 @@ module Bundler
         if spec
           path = download_gem_from_uri(spec, uri)
           s = Bundler.rubygems.spec_from_gem(path)
-          spec.__swap__(s) if spec.is_a?(RemoteSpecification)
+          spec.__swap__(s)
         end
       end
 

--- a/spec/install/gems/dependency_api_spec.rb
+++ b/spec/install/gems/dependency_api_spec.rb
@@ -281,4 +281,26 @@ describe "gemcutter's dependency API" do
     gembin "rackup"
     out.should == "1.0.0"
   end
+
+  it "installs the bins when using --path and uses autoclean" do
+    gemfile <<-G
+      source "#{source_uri}"
+      gem "rack"
+    G
+
+    bundle "install --path vendor/bundle", :artifice => "endpoint"
+
+    vendored_gems("bin/rackup").should exist
+  end
+
+  it "installs the bins when using --path and uses bundle clean" do
+    gemfile <<-G
+      source "#{source_uri}"
+      gem "rack"
+    G
+
+    bundle "install --path vendor/bundle --no-clean", :artifice => "endpoint"
+
+    vendored_gems("bin/rackup").should exist
+  end
 end


### PR DESCRIPTION
the automatic clean run after `bundle install` will now not remove gem binaries that are from gems in the Gemfile.
