### PR TITLE
fixes #1445. Fix fetcher output.

### DIFF
--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -83,8 +83,9 @@ module Bundler
 
       query_list = gem_names - full_dependency_list
       # only display the message on the first run
-      if full_dependency_list.empty?
+      if !@fetching_first_print
         Bundler.ui.info "Fetching dependency information from the API at #{@remote_uri}", false
+        @fetching_first_print = true
       else
         Bundler.ui.info ".", false
       end
@@ -92,6 +93,7 @@ module Bundler
       Bundler.ui.debug "Query List: #{query_list.inspect}"
       if query_list.empty?
         Bundler.ui.info "\n"
+        @fetching_first_print = false
         return {@remote_uri => last_spec_list}
       end
 

--- a/spec/install/gems/dependency_api_spec.rb
+++ b/spec/install/gems/dependency_api_spec.rb
@@ -192,6 +192,29 @@ describe "gemcutter's dependency API" do
     should_be_installed "back_deps 1.0"
   end
 
+  it "prints API output properly with back deps" do
+    build_repo2 do
+      build_gem "back_deps" do |s|
+        s.add_dependency "foo"
+      end
+      FileUtils.rm_rf Dir[gem_repo2("gems/foo-*.gem")]
+    end
+
+    gemfile <<-G
+      source "#{source_uri}"
+      source "#{source_uri}/extra"
+      gem "back_deps"
+    G
+
+    bundle :install, :artifice => "endpoint_extra"
+
+    output = <<OUTPUT
+Fetching dependency information from the API at http://localgemserver.test/.
+Fetching dependency information from the API at http://localgemserver.test/extra/
+OUTPUT
+    out.should include(output)
+  end
+
   it "does not fetch every specs if the index of gems is large when doing back deps" do
     build_repo2 do
       build_gem "back_deps" do |s|


### PR DESCRIPTION
Fixes the multiple fetcher ouput. If there are unmet deps like in the example @indirect gave, we need to print twice since we could be fetching from multiple sources and need to reprint the source.

There are unmet deps in the example do to gems that were yanked but are still referenced.
