### PR TITLE
Move require 'bundler' up before the begin ... rescue ... end.

### DIFF
--- a/bin/bundle
+++ b/bin/bundle
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
+require 'bundler'
 begin
-  require 'bundler'
   # Check if an older version of bundler is installed
   $:.each do |path|
     if path =~ %r'/bundler-0.(\d+)' && $1.to_i < 9


### PR DESCRIPTION
This means that Bundler::BundlerError will be defined before the rescue clause is set up, and (at least on MagLev), this allows us to optimize it - we know the Class object id before the rescue clause is set up and can mark the stack with a more specific clause.
