### PR TITLE
No platform for mac or linux - similar to #1050

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -57,6 +57,8 @@ module Bundler
 
   WINDOWS = RbConfig::CONFIG["host_os"] =~ %r!(msdos|mswin|djgpp|mingw)!
   FREEBSD = RbConfig::CONFIG["host_os"] =~ /bsd/
+  MAC     = RbConfig::CONFIG["host_os"] =~ /darwin/
+  LINUX   = RbConfig::CONFIG["host_os"] =~ /linux/
   NULL    = WINDOWS ? "NUL" : "/dev/null"
 
   # Internal errors, should be rescued

--- a/lib/bundler/dependency.rb
+++ b/lib/bundler/dependency.rb
@@ -16,6 +16,8 @@ module Bundler
       :mri_18   => Gem::Platform::RUBY,
       :mri_19   => Gem::Platform::RUBY,
       :rbx      => Gem::Platform::RUBY,
+      :mac      => Gem::Platform::RUBY,
+      :linux    => Gem::Platform::RUBY,
       :jruby    => Gem::Platform::JAVA,
       :mswin    => Gem::Platform::MSWIN,
       :mingw    => Gem::Platform::MINGW,
@@ -104,6 +106,14 @@ module Bundler
 
     def rbx?
       ruby? && defined?(RUBY_ENGINE) && RUBY_ENGINE == "rbx"
+    end
+
+    def mac?
+      Bundler::MAC && Gem::Platform.local.os == "darwin"
+    end
+
+    def linux?
+      Bundler::LINUX && Gem::Platform.local.os == "linux"
     end
 
     def jruby?

--- a/man/gemfile.5.ronn
+++ b/man/gemfile.5.ronn
@@ -125,6 +125,10 @@ There are a number of `Gemfile` platforms:
     _mri_ `AND` version 1.9
   * `rbx`:
     Same as _ruby_, but only Rubinius (not MRI)
+  * `mac`:
+    Mac OS X
+  * `linux`:
+    Linux
   * `jruby`:
     JRuby
   * `mswin`:


### PR DESCRIPTION
- added Bundler::MAC and Bundler::LINUX constants based on RbConfig
- added :mac and :linux platforms to Bundler::Dependency::PLATFORM_MAP
- updated docs
