### PR TITLE
Fix rescue clause

### DIFF
--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -133,7 +133,7 @@ module Bundler
       begin
         Bundler.ui.debug "Fetching from: #{uri}"
         response = @@connection.request(uri)
-      rescue SocketError, Timeout, Net::HTTP::Persistent::Error
+      rescue SocketError, Timeout::Error, Net::HTTP::Persistent::Error
         raise Bundler::HTTPError, "Network error while fetching #{uri}"
       end
 


### PR DESCRIPTION
This rescue clause rescues `Timeout`, but the #timeout method raises a `Timeout::Error`, and `Timeout::Error.new === Timeout => false`, so that event isn't actually rescued. I might be misinterpreting what you are trying to accomplish, though, so please enlighten me, if I'm wrong :)
