### PR TITLE
Explicitely mention what options are accepted

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -185,7 +185,8 @@ module Bundler
     def _normalize_options(name, version, opts)
       _normalize_hash(opts)
 
-      invalid_keys = opts.keys - %w(group groups git github path name branch ref tag require submodules platform platforms type)
+      valid_keys = %w(group groups git github path name branch ref tag require submodules platform platforms type)
+      invalid_keys = opts.keys - valid_keys
       if invalid_keys.any?
         plural = invalid_keys.size > 1
         message = "You passed #{invalid_keys.map{|k| ':'+k }.join(", ")} "
@@ -194,6 +195,8 @@ module Bundler
         else
           message << "as an option for gem '#{name}', but it is invalid."
         end
+
+        message << " Valid options are: #{valid_keys.join(", ")}"
         raise InvalidOption, message
       end
 


### PR DESCRIPTION
I was trying to specify a commit in my Gemfile, but couldn't remember the exact option. I tried :commit, :sha, and Bundler was unhelpful. It told me those options were invalid, but didn't tell me what options _were_ valid. This commit fixes that.

Specs ran perfectly well after this change.
