### PR TITLE
Fix which stderr (Issue #1321)

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -206,7 +206,7 @@ module Bundler
 
       path = bundle_path
       path = path.parent until path.exist?
-      sudo_present = !(`which sudo` rescue '').empty?
+      sudo_present = !(`which sudo 2>/dev/null` rescue '').empty?
 
       @checked_for_sudo = true
       @requires_sudo = settings.allow_sudo? && !File.writable?(path) && sudo_present


### PR DESCRIPTION
bundler checks for sudo availability by using which.
Depending on the platform or distribution, which output an
error message on stderr in case sudo is not found.

This fix redirect stderr to /dev/null. Agreed this is a *nixish way to
fix it, but as on other platforms (Windows) which does not exists anyway
...
