### PR TITLE
Fix which stderr - Issue 1321

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -208,7 +208,6 @@ module Bundler
       path = path.parent until path.exist?
       sudo_present = in_path("sudo") 
 
-
       @checked_for_sudo = true
       @requires_sudo = settings.allow_sudo? && !File.writable?(path) && sudo_present
     end


### PR DESCRIPTION
Attempting to fix issue #1321 in a more platform agnostic way : which does not exist on all platforms, and thus must not be used.

A local ruby implementation of `which` is used here.
