### PR TITLE
Ruby 2.0 (trunk ruby) is not Ruby 1.9

### DIFF
--- a/lib/bundler/dependency.rb
+++ b/lib/bundler/dependency.rb
@@ -87,7 +87,7 @@ module Bundler
     end
 
     def ruby_19?
-      ruby? && RUBY_VERSION >= "1.9"
+      ruby? && RUBY_VERSION >= "1.9" && RUBY_VERSION < "2.0"
     end
 
     def mri?
@@ -99,7 +99,7 @@ module Bundler
     end
 
     def mri_19?
-      mri? && RUBY_VERSION >= "1.9"
+      mri? && RUBY_VERSION >= "1.9" && RUBY_VERSION < "2.0"
     end
 
     def rbx?


### PR DESCRIPTION
Bundler treats trunk ruby as Ruby 1.9, when that is not true.  This will make bundler return false for Ruby 2.0.
