### PR TITLE
Don't display the "fatal error" warning for illformed Rubygem requirements

### DIFF
--- a/bin/bundle
+++ b/bin/bundle
@@ -23,7 +23,7 @@ rescue SystemExit => e
   exit e.status
 rescue Exception => e
   unless e.is_a?(ArgumentError) && e.message =~ /Illformed requirement/
-    # don't display the standard error if Rubygems finds an unparseable gem requirement 
+    # don't display the standard error if Rubygems finds an unparseable gem requirement
     Bundler.ui.error "Unfortunately, a fatal error has occurred. " +
       "Please report this error to the Bundler issue tracker at " +
       "https://github.com/carlhuda/bundler/issues so that we can fix it. Thanks!"


### PR DESCRIPTION
Right now, if a developer makes a mistake in their Gemfile (for instance, entering ">~ 3.1" rather than "~> 3.1"), Rubygems raises an ArgumentError.  Bundler passes that error along, but also adds a red-colored message asking users to report the problem on Github:

```
Unfortunately, a fatal error has occurred. Please report this error to the Bundler issue tracker at https://github.com/carlhuda/bundler/issues so that we can fix it. Thanks!
/Users/ahkoppel2/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems/requirement.rb:98:in `parse': Illformed requirement [">~ 3.1.1"] (ArgumentError)
```

The "fatal error" message (raised in [bin/bundle](https://github.com/carlhuda/bundler/blob/master/bin/bundle#L24)) probably shouldn't be raised in this case, since the error was caused and has to be fixed by the user.  This small pull request skips that warning if it detects this particular Rubygems error message (which has been the same since at least 2009, according to [blame](https://github.com/rubygems/rubygems/blame/master/lib/rubygems/requirement.rb)).

For reference, the relevant method in Rubygems is [here](https://github.com/rubygems/rubygems/blob/master/lib/rubygems/requirement.rb#L91); I've also submitted a pull request to [raise a specific error class](https://github.com/rubygems/rubygems/pull/215) so that Bundler wouldn't need to do text comparison on the error message, on the off chance it ever changes.

Thanks for the great work!

Alex

Complete backtrace: 

```
Unfortunately, a fatal error has occurred. Please report this error to the Bundler issue tracker at https://github.com/carlhuda/bundler/issues so that we can fix it. Thanks!
/Users/ahkoppel2/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems/requirement.rb:98:in `parse': Illformed requirement [">~ 3.1.1"] (ArgumentError)
    from /Users/ahkoppel2/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems/requirement.rb:123:in `block in initialize'
    from /Users/ahkoppel2/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems/requirement.rb:123:in `map!'
    from /Users/ahkoppel2/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems/requirement.rb:123:in `initialize'
    from /Users/ahkoppel2/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems/requirement.rb:61:in `new'
    from /Users/ahkoppel2/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems/requirement.rb:61:in `create'
    from /Users/ahkoppel2/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems/dependency.rb:50:in `initialize'
    from /Users/ahkoppel2/.rvm/gems/ruby-1.9.2-p180/gems/bundler-1.1.rc/lib/bundler/dependency.rb:28:in `initialize'
    from /Users/ahkoppel2/.rvm/gems/ruby-1.9.2-p180/gems/bundler-1.1.rc/lib/bundler/dsl.rb:60:in `new'
    from /Users/ahkoppel2/.rvm/gems/ruby-1.9.2-p180/gems/bundler-1.1.rc/lib/bundler/dsl.rb:60:in `gem'
    from /Users/ahkoppel2/Sites/project_name/Gemfile:3:in `evaluate'
    from /Users/ahkoppel2/.rvm/gems/ruby-1.9.2-p180/gems/bundler-1.1.rc/lib/bundler/dsl.rb:7:in `instance_eval'
    from /Users/ahkoppel2/.rvm/gems/ruby-1.9.2-p180/gems/bundler-1.1.rc/lib/bundler/dsl.rb:7:in `evaluate'
    from /Users/ahkoppel2/.rvm/gems/ruby-1.9.2-p180/gems/bundler-1.1.rc/lib/bundler/definition.rb:17:in `build'
    from /Users/ahkoppel2/.rvm/gems/ruby-1.9.2-p180/gems/bundler-1.1.rc/lib/bundler.rb:144:in `definition'
    from /Users/ahkoppel2/.rvm/gems/ruby-1.9.2-p180/gems/bundler-1.1.rc/lib/bundler/cli.rb:219:in `install'
    from /Users/ahkoppel2/.rvm/gems/ruby-1.9.2-p180/gems/bundler-1.1.rc/lib/bundler/vendor/thor/task.rb:22:in `run'
    from /Users/ahkoppel2/.rvm/gems/ruby-1.9.2-p180/gems/bundler-1.1.rc/lib/bundler/vendor/thor/invocation.rb:118:in `invoke_task'
    from /Users/ahkoppel2/.rvm/gems/ruby-1.9.2-p180/gems/bundler-1.1.rc/lib/bundler/vendor/thor.rb:263:in `dispatch'
    from /Users/ahkoppel2/.rvm/gems/ruby-1.9.2-p180/gems/bundler-1.1.rc/lib/bundler/vendor/thor/base.rb:386:in `start'
    from /Users/ahkoppel2/.rvm/gems/ruby-1.9.2-p180/gems/bundler-1.1.rc/bin/bundle:13:in `<top (required)>'
    from /Users/ahkoppel2/.rvm/gems/ruby-1.9.2-p180/bin/bundle:19:in `load'
    from /Users/ahkoppel2/.rvm/gems/ruby-1.9.2-p180/bin/bundle:19:in `<main>'
```
