### PR TITLE
Add #ungem to DSL. 

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -89,6 +89,22 @@ module Bundler
       @dependencies << dep
     end
 
+    def ungem(name, *args)
+      if name.is_a?(Symbol)
+        raise GemfileError, %{You need to specify gem names as Strings. Use 'ungem "#{name.to_s}"' instead.}
+      end
+      
+      options = Hash === args.last ? args.pop : {}
+      version = args || [">= 0"]
+
+      _deprecated_options(options)
+      _normalize_options(name, version, options)
+
+      dep = Dependency.new(name, version, options)
+      
+      @dependencies.reject! { |d| dep =~ d }
+    end
+
     def source(source, options = {})
       case source
       when :gemcutter, :rubygems, :rubyforge then


### PR DESCRIPTION
The use case for this is when you use, for example, #gemspec but then have a dependency issue with a particular version of Ruby. This allows one to still use #gemspec, but exempt a requirement.

NOTE: The implementation is just an online "quick edit" designed by looking at #gem and figuring how it should probably work. I have not tested it. It might need to be refined as well, to take dependency type into account as I am not sure if it should or not.
