### PR TITLE
Fixed help message wording.

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -157,7 +157,7 @@ module Bundler
     method_option "full-index", :tpye => :boolean, :banner =>
       "Use the rubygems modern index instead of the API endpoint"
     method_option "clean", :type => :boolean, :default => true, :banner =>
-      "Run bundle clean automatically after clean"
+      "Run bundle clean automatically after install"
     def install
       opts = options.dup
       if opts[:without]
@@ -254,7 +254,7 @@ module Bundler
     method_option "local", :type => :boolean, :banner =>
       "Do not attempt to fetch gems remotely and use the gem cache instead"
     method_option "clean", :type => :boolean, :default => true, :banner =>
-      "Run bundle clean automatically after clean"
+      "Run bundle clean automatically after update"
     def update(*gems)
       sources = Array(options[:source])
 


### PR DESCRIPTION
Help for `bundle update` and `bundle install` had incorrect wording for
the `clean` option.
