### PR TITLE
Search $PATH for a binary rather than shelling out to `which`

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -229,7 +229,7 @@ module Bundler
 
       path = bundle_path
       path = path.parent until path.exist?
-      sudo_present = !(`which sudo` rescue '').empty?
+      sudo_present = which "sudo"
       bin_dir = Pathname.new(Bundler.system_bindir)
       bin_dir = bin_dir.parent until bin_dir.exist?
 
@@ -243,6 +243,17 @@ module Bundler
         sudo "mkdir -p '#{path}'" unless File.exist?(path)
       else
         FileUtils.mkdir_p(path)
+      end
+    end
+
+    def which(binary)
+      if File.executable? binary
+        binary
+      else
+        path = ENV['PATH'].split(File::PATH_SEPARATOR).find { |path|
+          File.executable? File.join(path, binary)
+        }
+        path && File.expand_path(binary, path)
       end
     end
 


### PR DESCRIPTION
I'm trying to speed up startup time for `rake environment` (on rails).  Creating subshells came up on my list, so I'm trying to eliminate them.

This patch changes Bundler to search the `PATH` environment variable rather than shelling out to `which`.  The function isn't 100% perfect as it doesn't handle "./sudo" the same way the shell does, but our input for this function is known so I don't think it matters.
