### PR TITLE
Prevent making useless symbols.

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -161,9 +161,7 @@ module Bundler
     def install
       opts = options.dup
       if opts[:without]
-        opts[:without].map!{|g| g.split(" ") }
-        opts[:without].flatten!
-        opts[:without].map!{|g| g.to_sym }
+        opts[:without] = opts[:without].map{|g| g.tr(' ', ':') }
       end
 
       # Can't use Bundler.settings for this because settings needs gemfile.dirname


### PR DESCRIPTION
Groups are concatenated with ':' in Bundler::Settings#without=,
and splited by ':' in Bundler::Settings#without. So
- to_sym in Bundler::CLI#install is useless
- :-separated list is also allowed.
