### PR TITLE
name and requirement methods are needed, so define them to avoid method_missing

### DIFF
--- a/lib/bundler/dep_proxy.rb
+++ b/lib/bundler/dep_proxy.rb
@@ -21,6 +21,14 @@ module Bundler
       @dep.type
     end
 
+    def name
+      @dep.name
+    end
+
+    def requirement
+      @dep.requirement
+    end
+
     def to_s
       "#{name} (#{requirement}) #{__platform}"
     end


### PR DESCRIPTION
We know from the `to_s` method that `name` and `requirement` are needed, so we may as well define them and avoid the extra method_missing dispatch.  Also defining these methods avoids `method_missing` during `rake environment`.
