### PR TITLE
Warn about excluding a previously excluded group from a local config file

### DIFF
--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -62,6 +62,9 @@ module Bundler
     end
 
     def without=(array)
+      if @local_config.key?(key_for(:without)) && !array
+        Bundler.ui.warn "Groups '#{self[:without]}' excluded because of a local configuration file!"
+      end
       self[:without] = (array.empty? ? nil : array.join(":")) if array
     end
 

--- a/spec/install/gems/groups_spec.rb
+++ b/spec/install/gems/groups_spec.rb
@@ -100,6 +100,13 @@ describe "bundle install with gem sources" do
           should_not_be_installed "activesupport 2.3.5"
         end
 
+        it "warns about excluding a previously excluded group because of a local configuration file" do
+          bundle :install, :without => "emo"
+          out.should_not match(/Groups.*emo.*excluded/)
+          bundle :install
+          out.should match(/Groups.*emo.*excluded/)
+        end
+
         it "does not say it installed gems from the excluded group" do
           bundle :install, :without => "emo"
           out.should_not include("activesupport")


### PR DESCRIPTION
This was the second time I was tripped by the behavior "If you run bundle install later, without any flag, bundler will remember that you last called bundle install --without production, and use that flag again."

For the principle of least surprise, I added a warning that will be shown when the without option is active, because of a local configuration file and not because of a command line parameter.

Test and code in the commit (I ran the rspec tests on 1.8.7 with a fairly old set of gems; I did not test it in travis).
