### PR TITLE
Minor: set predefined homepage in gemspec template

### DIFF
--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -6,7 +6,7 @@ Gem::Specification.new do |gem|
   gem.email         = [<%=config[:email].inspect%>]
   gem.description   = %q{TODO: Write a gem description}
   gem.summary       = %q{TODO: Write a gem summary}
-  gem.homepage      = ""
+  gem.homepage      = "https://github.com/#{author_name}/#{config[:name]}"
 
   gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.files         = `git ls-files`.split("\n")


### PR DESCRIPTION
Better than old `http://rubygems.org/gems/config[:name]` homepage and new empty one. IMO.

:octocat:
