### PR TITLE
Access rubygems.org via https by default when using :rubygems in Gemfile

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -92,7 +92,7 @@ module Bundler
     def source(source, options = {})
       case source
       when :gemcutter, :rubygems, :rubyforge then
-        @rubygems_source.add_remote "http://rubygems.org"
+        @rubygems_source.add_remote "https://rubygems.org"
         return
       when String
         @rubygems_source.add_remote source


### PR DESCRIPTION
I'm partial to using `source :rubygems` syntax in my Gemfile to denote a source but noticed that it was using http instead of https, this brings the https changes in sync with those made in #1562 and #1522
