### PR TITLE
Remove default version on `gem` method calls since it was never being evaluated

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -52,7 +52,7 @@ module Bundler
       end
 
       options = Hash === args.last ? args.pop : {}
-      version = args || [">= 0"]
+      version = args
 
       _deprecated_options(options)
       _normalize_options(name, version, options)


### PR DESCRIPTION
The `args` local variable is always an array so the line never evals past the `||`.
