### PR TITLE
Generate static groups for  Bundle.require when creating a standalone bundle.

### DIFF
--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -129,12 +129,15 @@ module Bundler
       FileUtils.mkdir_p(bundler_path)
 
       paths = []
-
+      groups = groups.map {|g| g.to_sym}
       if groups.empty?
         specs = Bundler.definition.requested_specs
+        standalone_groups = Bundler.definition.groups
       else
-        specs = Bundler.definition.specs_for groups.map { |g| g.to_sym }
+        specs = Bundler.definition.specs_for groups
+        standalone_groups = groups
       end
+      standalone_groups -= Bundler.settings.without
 
       specs.each do |spec|
         next if spec.name == "bundler"
@@ -150,6 +153,16 @@ module Bundler
         file.puts "path = File.expand_path('..', __FILE__)"
         paths.each do |path|
           file.puts %{$:.unshift File.expand_path("\#{path}/#{path}")}
+        end
+      end
+
+      File.open File.join(bundler_path, "require.rb"), "w" do |file|
+        file.puts "require 'bundler/setup'"
+        Bundler.definition.dependencies.each do |dep|
+          next unless (dep.groups & standalone_groups).any? && dep.current_platform?
+          Array(dep.autorequire || dep.name).each do |requirement|
+            file.puts "require '#{requirement}'"
+          end
         end
       end
     end

--- a/spec/support/builders.rb
+++ b/spec/support/builders.rb
@@ -75,6 +75,10 @@ module Spec
           s.write "lib/rack/test.rb", "RACK_TEST = '1.0'"
         end
 
+        build_gem "therubyracer", "0.9.9" do |s|
+          s.write "lib/v8.rb", "THERUBYRACER = '0.9.9'"
+        end
+
         build_gem "platform_specific" do |s|
           s.platform = Gem::Platform.local
           s.write "lib/platform_specific.rb", "PLATFORM_SPECIFIC = '1.0.0 #{Gem::Platform.local}'"
@@ -115,6 +119,11 @@ module Spec
 
         build_gem "multiple_versioned_deps" do |s|
           s.add_dependency "weakling", ">= 0.0.1", "< 0.1"
+        end
+
+        build_gem "multiple_requires" do |s|
+          s.write "lib/multi/one.rb", "MULTI_ONE = 1"
+          s.write "lib/multi/two.rb", "MULTI_TWO = 2"
         end
 
         build_gem "not_released", "1.0.pre"


### PR DESCRIPTION
For every group we create a file that requires all of the code for its gems.
So, for example if you have the following Gemfile:

```
gem "abc"

group :foo do
  gem "xyz"
  gem "zzz"
end
```

The standalone will generate

```
bundler/setup/default.rb
bundler/setup/foo.rb
```

so that when you call Bundler.require(:default, :foo), it will load
those files which contain a listing of requires for that group.

As I see it, there is still some work to be done in standalone because all dependency information is lost at runtime, but that's a separate bit of work.
