### PR TITLE
Avoid passing RUBYOPT changes in with_clean_env block.

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -195,6 +195,10 @@ module Bundler
     def with_clean_env
       with_original_env do
         ENV.delete_if { |k,_| k[0,7] == 'BUNDLE_' }
+        if ENV.has_key? 'RUBYOPT'
+          ENV['RUBYOPT'] = ENV['RUBYOPT'].sub '-rbundler/setup', ''
+          ENV['RUBYOPT'] = ENV['RUBYOPT'].sub "-I#{File.expand_path('..', __FILE__)}", ''
+        end
         yield
       end
     end

--- a/spec/runtime/with_clean_env_spec.rb
+++ b/spec/runtime/with_clean_env_spec.rb
@@ -15,10 +15,10 @@ describe "Bundler.with_env helpers" do
   end
 
   around do |example|
-    bundle_path = Bundler::ORIGINAL_ENV['BUNDLE_PATH']
+    env = Bundler::ORIGINAL_ENV.dup
     Bundler::ORIGINAL_ENV['BUNDLE_PATH'] = "./Gemfile"
     example.run
-    Bundler::ORIGINAL_ENV['BUNDLE_PATH'] = bundle_path
+    Bundler::ORIGINAL_ENV.replace env
   end
 
   describe "Bundler.with_clean_env" do
@@ -29,6 +29,18 @@ describe "Bundler.with_env helpers" do
       Bundler.with_clean_env do
         `echo $BUNDLE_PATH`.strip.should_not == './Gemfile'
       end
+    end
+
+    it "should not pass RUBYOPT changes" do
+      lib_path = File.expand_path('../../../lib', __FILE__)
+      Bundler::ORIGINAL_ENV['RUBYOPT'] = " -I#{lib_path} -rbundler/setup"
+
+      Bundler.with_clean_env do
+        `echo $RUBYOPT`.strip.should_not include '-rbundler/setup'
+        `echo $RUBYOPT`.strip.should_not include "-I#{lib_path}"
+      end
+
+      Bundler::ORIGINAL_ENV['RUBYOPT'].should == " -I#{lib_path} -rbundler/setup"
     end
 
     it "should not change ORIGINAL_ENV" do


### PR DESCRIPTION
Restoring the original ENV generally restored the RUBYOPT changes, but certain
use cases leak through. This commit ensures that the ENV is truely clean by
always checking for RUBYOPT changes and zapping them if they do exist.

This commit fixes #1604 (second attempt)
