### PR TITLE
Ensure the gemspec template will work on windows, and only run `git ls-files` once.

### DIFF
--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -9,8 +9,8 @@ Gem::Specification.new do |gem|
   gem.homepage      = ""
 
   gem.files         = `git ls-files`.split($\)
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
-  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
+  gem.executables   = (gem.files & Dir["bin/*"]).map { |f| File.basename(f) }
+  gem.test_files    = (gem.files & Dir["{test,spec,features}/{**/}*"])
   gem.name          = <%=config[:name].inspect%>
   gem.require_paths = ["lib"]
   gem.version       = <%=config[:constant_name]%>::VERSION


### PR DESCRIPTION
- Ensure the gemspec template will run on Windows systems by splitting Strings with `$\` instead of `"\n"`.
- Only run `git ls-files` once, in order to get the complete file-listing. Then intersect the file-listing with `Dir[]` calls, to extract `bin` files or test files. This should reduce the overhead of evaluating gemspecs generated by Bundler.
