### PR TITLE
Use the same ruby to run subprocesses as is running rake.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
 $:.unshift File.expand_path("../lib", __FILE__)
+require 'rubygems'
 require 'bundler/gem_tasks'
 
 def safe_task(&block)
@@ -12,8 +13,8 @@ end
 namespace :spec do
   desc "Ensure spec dependencies are installed"
   task :deps do
-    sh "gem list ronn | (grep 'ronn' 1> /dev/null) || gem install ronn --no-ri --no-rdoc"
-    sh "gem list rspec | (grep 'rspec (2.' 1> /dev/null) || gem install rspec --no-ri --no-rdoc"
+    sh "#{Gem.ruby} -S gem list ronn | (grep 'ronn' 1> /dev/null) || #{Gem.ruby} -S gem install ronn --no-ri --no-rdoc"
+    sh "#{Gem.ruby} -S gem list rspec | (grep 'rspec (2.' 1> /dev/null) || #{Gem.ruby} -S gem install rspec --no-ri --no-rdoc"
   end
 end
 
@@ -135,7 +136,7 @@ begin
       roff = "lib/bundler/man/#{basename}"
 
       file roff => ["lib/bundler/man", ronn] do
-        sh "ronn --roff --pipe #{ronn} > #{roff}"
+        sh "#{Gem.ruby} -S ronn --roff --pipe #{ronn} > #{roff}"
       end
 
       file "#{roff}.txt" => roff do
@@ -171,7 +172,7 @@ begin
 
       desc "Install CI dependencies"
       task :deps do
-        sh "gem list ci_reporter | (grep 'ci_reporter' 1> /dev/null) || gem install ci_reporter --no-ri --no-rdoc"
+        sh "#{Gem.ruby} -S gem list ci_reporter | (grep 'ci_reporter' 1> /dev/null) || #{Gem.ruby} -S gem install ci_reporter --no-ri --no-rdoc"
       end
       task :deps => "spec:deps"
     end


### PR DESCRIPTION
For implementations like Rubinius that can run from a source directory without
installing and which do not overwrite gem binary wrappers in system
directories, it is possible to invoke the Rakefile with eg 'rbx -S rake spec'
while the system Ruby is on PATH as 'ruby' and 'gem'. This results in the
system Ruby running the rake subprocesses instead of Rubinius as intended.

These changes use Gem.ruby, which returns the path to the Ruby implementation
running rake and use -S to search for the gem bin wrapper on PATH. Rubinius
prepends distinguished directories when processing -S so that gems installed
into Rubinius are found first.

The explicit requiring of rubygems may be controversial. Evan said it was ok
but the rest of the changes stand on their own if it's desirable to remove the
require.
