### PR TITLE
Add simple cache to Bundler.load_gemspec

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -230,6 +230,11 @@ module Bundler
     end
 
     def load_gemspec(file)
+      @gemspec_cache ||= {}
+      @gemspec_cache[File.expand_path(file)] ||= load_gemspec_uncached(file)
+    end
+
+    def load_gemspec_uncached(file)
       path = Pathname.new(file)
       # Eval the gemspec from its parent directory
       Dir.chdir(path.dirname.to_s) do


### PR DESCRIPTION
In some projects, for example those with 10s of local gemspecs, use of `git ls-files` for spec.files, or specs requiring significant source to get at a spec.version; this change to cache load_gemspec results in notable performance gains.

The cache also avoids loading these same gemspecs repeatedly with different LOAD_PATH values.

This came up originally in #1481 (\cc @sunaku, @tenderlove).  Only a sub-case (specs from rubygems) of that original issue was dealt with before it was closed (#1567).  There also, @indirect suggests "[caching] seems like a good plan eventually"

Perhaps this is actually easy enough, safe enough (I find no spec regressions) and suitable for 1.1?
