### PR TITLE
Reduce invocation of `git ls-files` and remove ksh/bash-ism.

### DIFF
--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -8,9 +8,9 @@ Gem::Specification.new do |gem|
   gem.summary       = %q{TODO: Write a gem summary}
   gem.homepage      = ""
 
-  gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.files         = `git ls-files`.split("\n")
-  gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
+  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
+  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = <%=config[:name].inspect%>
   gem.require_paths = ["lib"]
   gem.version       = <%=config[:constant_name]%>::VERSION


### PR DESCRIPTION
This also removes shell brace expasion which is a ksh/bash extension
that does not work with POSIX sh.
