### PR TITLE
Dependency type bug

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -81,6 +81,7 @@ module Bundler
       # add_development_dependency in a gemspec that's loaded with the gemspec
       # directive, the lockfile dependencies and resolved dependencies end up
       # with a mismatch on #type.
+      # Test coverage to catch a regression on this is in gemspec_spec.rb
       @dependencies.each do |d|
         if ld = @locked_deps.find { |l| l.name == d.name }
           ld.instance_variable_set(:@type, d.type)

--- a/spec/install/gemspec_spec.rb
+++ b/spec/install/gemspec_spec.rb
@@ -110,6 +110,27 @@ describe "bundle install from an existing gemspec" do
     should_be_installed "bar-dev 1.0.0", :groups => :dev
   end
 
+  it "should match a lockfile even if the gemspec defines development dependencies" do
+    build_lib("foo", :path => tmp.join("foo")) do |s|
+      s.write("Gemfile", "source 'file://#{gem_repo1}'\ngemspec")
+      s.add_dependency "actionpack", "=2.3.2"
+      s.add_development_dependency "rake", '=0.8.7'
+    end
+
+    Dir.chdir(tmp.join("foo")) do
+      bundle "install"
+      # This should really be able to rely on $stderr, but, it's not written
+      # right, so we can't. In fact, this is a bug negation test, and so it'll
+      # ghost pass in future, and will only catch a regression if the message
+      # doesn't change. Exit codes should be used correctly (they can be more
+      # than just 0 and 1).
+      output = bundle("install --deployment")
+      output.should_not match(/You have added to the Gemfile/)
+      output.should_not match(/You have deleted from the Gemfile/)
+      output.should_not match(/install in deployment mode after changing/)
+    end
+  end
+
   it "should evaluate the gemspec in its directory" do
     build_lib("foo", :path => tmp.join("foo"))
     File.open(tmp.join("foo/foo.gemspec"), "w") do |s|


### PR DESCRIPTION
As described in the comments and so on, this is a bug occurring in 1.1 and 1.0, whereby the lockfile contains insufficient information to make Gem::Dependency#== match when the deployment mode checks to see if the lockfile resolve and the gemfile resolve match.

This means users receive an unexpected and otherwise unresolvable error that looks like this:

https://gist.github.com/605252169609bfe8081d

This patch also needs backporting to a bugfix release in 1.0. It's affecting our production deployments, and could easily affect others.

The only reason this /might/ be less common is that people with deployable applications often do not also publish those applications as importable gems. The behavior is incorrect, regardless of the leading use case.

Thanks!
