### PR TITLE
When using --standalone, place the setup.rb file relative to the gem install path, rather than the working directory

### DIFF
--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -124,8 +124,9 @@ module Bundler
     end
 
     def generate_standalone(groups)
-      standalone_path = Bundler.settings[:path]
-      bundler_path = File.join(standalone_path, "bundler")
+      bundler_path = File.expand_path(File.join(Bundler.rubygems.gem_path, "..", "..", "bundler"))
+      bundler_setup_file = File.join(bundler_path, "setup.rb")
+      Bundler.ui.debug "Generating standlone include file #{bundler_setup_file}"
       FileUtils.mkdir_p(bundler_path)
 
       paths = []
@@ -145,8 +146,7 @@ module Bundler
         end
       end
 
-
-      File.open File.join(bundler_path, "setup.rb"), "w" do |file|
+      File.open bundler_setup_file, "w" do |file|
         file.puts "path = File.expand_path('..', __FILE__)"
         paths.each do |path|
           file.puts %{$:.unshift File.expand_path("\#{path}/#{path}")}


### PR DESCRIPTION
For issue #1643 I am running bundler from the root of my project. There are several subdirectories with their own Gemfiles. For each subdirectory, I run:

  bundle install --gemfile=path/to/Gemfile --standalone

This installs the gems into path/to/vendor/bundle/ruby.

However the setup.rb file is created at vendor/bundle/bundler/setup.rb, in the project root. I would like this file to be located at path/to/vendor/bundle/bundler/setup.rb. This patch provides the desired behavior. Thanks!
