### PR TITLE
only clear search cache on conflict

### DIFF
--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -334,12 +334,13 @@ module Bundler
       length = @stack.length
       @stack << requirement.name
       retval = catch(requirement.name) do
-        # clear the search cache since the catch means we couldn't meet the
-        # requirement we need with the current constraints on search
-        clear_search_cache
         # try to resolve the next option
         resolve(reqs, activated)
       end
+
+      # clear the search cache since the catch means we couldn't meet the
+      # requirement we need with the current constraints on search
+      clear_search_cache
 
       # Since we're doing a lot of throw / catches. A push does not necessarily match
       # up to a pop. So, we simply slice the stack back to what it was before the catch


### PR DESCRIPTION
d737c128e68bd47e8631ca8105d8c38f1a7ebb68 introduced a pretty bad performance regression in resolving our rather large Gemfile -- ~4-5 seconds up to 27(!) seconds to do `bundle show activerecord`.  I bisected the problem down to these lines.

I think this patch reflects the original intent of the code -- if we reach the code below the catch() block, we've hit a conflict, so clear the cache.  If we throw :success, the clear_search_cache code will never be hit.
