### PR TITLE
Fixed deprecation warnings in `bundle viz`

### DIFF
--- a/lib/bundler/graph.rb
+++ b/lib/bundler/graph.rb
@@ -40,9 +40,9 @@ module Bundler
             @relations[dependency.name] += child_dependencies.map(&:name).to_set
             tmp += child_dependencies
 
-            @node_options[dependency.name] = {:label => _make_label(dependency, :node)}
+            @node_options[dependency.name] = _make_label(dependency, :node)
             child_dependencies.each do |c_dependency|
-              @edge_options["#{dependency.name}_#{c_dependency.name}"] = {:label => _make_label(c_dependency, :edge)}
+              @edge_options["#{dependency.name}_#{c_dependency.name}"] = _make_label(c_dependency, :edge)
             end
           end
           parent_dependencies = tmp
@@ -58,8 +58,8 @@ module Bundler
           relations[group.to_s].add(dependency)
           @relations[group.to_s].add(dependency.name)
 
-          @node_options[group.to_s] ||= {:label => _make_label(group, :node)}
-          @edge_options["#{group}_#{dependency.name}"] = {:label => _make_label(dependency, :edge)}
+          @node_options[group.to_s] ||= _make_label(group, :node)
+          @edge_options["#{group}_#{dependency.name}"] = _make_label(dependency, :edge)
         end
       end
       @groups = relations.keys
@@ -84,7 +84,7 @@ module Bundler
       else
         raise ArgumentError, "2nd argument is invalid"
       end
-      label
+      label.nil? ? {} : { :label => label }
     end
 
     class GraphVizClient
@@ -109,7 +109,7 @@ module Bundler
 
       def run
         @groups.each do |group|
-          g.add_node(
+          g.add_nodes(
             group,
             {:style     => 'filled',
              :fillcolor => '#B9B9D5',
@@ -121,11 +121,11 @@ module Bundler
         @relations.each do |parent, children|
           children.each do |child|
             if @groups.include?(parent)
-              g.add_node(child, {:style => 'filled', :fillcolor => '#B9B9D5'}.merge(@node_options[child]))
-              g.add_edge(parent, child, {:constraint => false}.merge(@edge_options["#{parent}_#{child}"]))
+              g.add_nodes(child, {:style => 'filled', :fillcolor => '#B9B9D5'}.merge(@node_options[child]))
+              g.add_edges(parent, child, {:constraint => false}.merge(@edge_options["#{parent}_#{child}"]))
             else
-              g.add_node(child, @node_options[child])
-              g.add_edge(parent, child, @edge_options["#{parent}_#{child}"])
+              g.add_nodes(child, @node_options[child])
+              g.add_edges(parent, child, @edge_options["#{parent}_#{child}"])
             end
           end
         end


### PR DESCRIPTION
Newer versions of ruby-graphviz also warn about nil options.
So I decided to clear out the :label option if it's nil.

This also has a nice side effect, DRYing up the code a bit.
