### PR TITLE
Fix for loss of inherited bits (setgid, others) in git source gems

### DIFF
--- a/lib/bundler/source.rb
+++ b/lib/bundler/source.rb
@@ -656,10 +656,9 @@ module Bundler
 
       def checkout
         unless File.exist?(path.join(".git"))
-          FileUtils.mkdir_p(path.dirname)
           FileUtils.rm_rf(path)
+          FileUtils.mkdir_p(path)
           git %|clone --no-checkout "#{cache_path}" "#{path}"|
-          File.chmod((0777 & ~File.umask), path)
         end
         Dir.chdir(path) do
           git %|fetch --force --quiet --tags "#{cache_path}"|


### PR DESCRIPTION
Pull request #1148 fixed improper parent directory umask via a method which clobbered any inherited bits from the parent directory. FileUtils.mkdir_p will abide by umask and inherit bits properly, and git clone has no issue cloning into an existing directory so long as it's empty.
