### PR TITLE
Bundler resolver blows up with many available versions

### DIFF
--- a/spec/resolver/many_versions_spec.rb
+++ b/spec/resolver/many_versions_spec.rb
@@ -1,0 +1,39 @@
+require "spec_helper"
+
+describe "Resolving with many available versions" do
+  it 'resolves in reasonable number of steps' do
+    dep 'root'
+
+    # Example of how this blows up the resolver.
+    #
+    # m   n        calls
+    # 1   1             5
+    # 2   2            21
+    # 3   3           152
+    # 4   4          1630
+    # 5   5         22668
+    # 6   6        382607
+    # m   n           ??
+
+    # Not sure what sould make a good unit test really...  Just
+    # illustrating that this index triggers a recursive explosion.
+    m = n = 5
+    @index = a_worst_case_index(m, n)
+    @resolver = Bundler::Resolver.new(@index, {}, Bundler::SpecSet.new([]))
+    class << @resolver
+      # replaced by rspec so we can count calls to #resolve
+      def resolve_tic; end
+      def resolve(*args)
+        resolve_tic
+        super(*args)
+      end
+    end
+
+    @resolver.should_receive(:resolve_tic).at_most(22000).times
+
+    catch(:success) do
+      @resolver.start(make_deps)
+    end.should be
+  end
+end
+  


### PR DESCRIPTION
I've seen Bundler's resolver blow up (takes a very long time, but does complete) in a production situation where we have a moderate number of dependencies (say 10-20) where some of these have many versions available in the repository (three gems have at least 40 available versions).

I think I've reproduced this situation in a unit test.  It's not a very good test, but it serves to illustrate the problem.

I don't (yet...?) have a solution to the resolver algorithm.  Would be a fun problem if I can find the time.
