### PR TITLE
allow unsetting config options with the --unset param

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -413,9 +413,11 @@ module Bundler
       end
     end
 
-    desc "config NAME [VALUE]", "retrieve or set a configuration value"
+    desc "config NAME [VALUE]", "retrieve, set, or unset a configuration value"
+    method_option "unset", :type => :array, :banner => "Unset configuration options."
+    method_option "local", :type => :boolean, :banner => "Used with --unset, unset the value for the local application."
     long_desc <<-D
-      Retrieves or sets a configuration value. If only parameter is provided, retrieve the value. If two parameters are provided, replace the
+      Retrieves, sets, or unsets a configuration value. If only parameter is provided, retrieve the value. If two parameters are provided, replace the
       existing value with the newly provided one.
 
       By default, setting a configuration value sets it for all projects
@@ -429,6 +431,23 @@ module Bundler
       values = ARGV.dup
       values.shift # remove config
       values.shift # remove the name
+
+      if options[:unset]
+        Array(options[:unset]).each do |key|
+          locations = Bundler.settings.locations(key)
+
+          if options[:local] && locations[:local]
+            Bundler.settings.unset(key)
+            Bundler.ui.info "You have unset #{key} for your application."
+          elsif locations[:global]
+            Bundler.settings.unset_global(key)
+            Bundler.ui.info "You have unset the system value for #{key}."
+          else
+            Bundler.ui.info "#{key} is not set. Configuration unchanged."
+          end
+        end
+        return
+      end
 
       unless name
         Bundler.ui.confirm "Settings are listed in order of priority. The top value will be used.\n"

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -19,6 +19,14 @@ module Bundler
       @local_config.delete(key_for(key))
     end
 
+    def unset(key)
+      unset_key(key, @local_config, local_config_file)
+    end
+
+    def unset_global(key)
+      unset_key(key, @global_config, global_config_file)
+    end
+
     def set_global(key, value)
       set_key(key, value, @global_config, global_config_file)
     end
@@ -33,6 +41,7 @@ module Bundler
     end
 
     def locations(key)
+      key = key_for(key)
       locations = {}
 
       locations[:local]  = @local_config[key] if @local_config.key?(key)
@@ -97,10 +106,23 @@ module Bundler
       unless hash[key] == value
         hash[key] = value
         hash.delete(key) if value.nil?
-        FileUtils.mkdir_p(file.dirname)
-        File.open(file, "w") { |f| f.puts hash.to_yaml }
+        write_config_file(hash, file)
       end
       value
+    end
+
+    def unset_key(key, hash, file)
+      key = key_for(key)
+
+      if hash[key]
+        hash.delete(key)
+        write_config_file(hash, file)
+      end
+    end
+
+    def write_config_file(hash, file)
+      FileUtils.mkdir_p(file.dirname)
+      File.open(file, "w") { |f| f.puts hash.to_yaml }
     end
 
     def global_config_file


### PR DESCRIPTION
This addresses https://github.com/carlhuda/bundler/issues/867, providing an --unset=foo option, along with a --local option to unset options in the local config (because the issue's main problem was the auto-remembering of some settings for the app).

It also fixes a bug with Bundler.settings.locations, which didn't work at all because it wasn't using key_for, so the contextual output of config was never being output (e.g. "This will override the system value you are currently setting." etc.).
