### PR TITLE
Allow spaces in %RUBYDIR% (specially useful for Windows).

### DIFF
--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -219,7 +219,7 @@ module Bundler
       rubyopt = [ENV["RUBYOPT"]].compact
       if rubyopt.empty? || rubyopt.first !~ /-rbundler\/setup/
         rubyopt.unshift "-rbundler/setup"
-        rubyopt.unshift "-I#{File.expand_path('../..', __FILE__)}"
+        rubyopt.unshift "\"-I#{File.expand_path('../..', __FILE__)}\""
         ENV["RUBYOPT"] = rubyopt.join(' ')
       end
     end


### PR DESCRIPTION
(I meant %RUBYDIR%, not %RUBY_OPT% :)

See http://stackoverflow.com/questions/6375063/bundle-exec-rspec-spec-invalid-switch-in-rubyopt-f-runtimeerror.
