### PR TITLE
ronn man-page output workaround for "..."

### DIFF
--- a/man/gemfile.5.ronn
+++ b/man/gemfile.5.ronn
@@ -202,7 +202,7 @@ the `.gemspec`.
     | |-actionpack.gemspec    [actionpack gem located here]
     |~activesupport
     | |-activesupport.gemspec [activesupport gem located here]
-    ...
+    |...
 
 To install a gem located in a git repository, bundler changes to
 the directory containing the gemspec, runs `gem build name.gemspec`


### PR DESCRIPTION
Gemfile.5 has an example with "..." in a preformatted block.
Apparently ronn doesn't escape this properly and man will then
complain about an undefined ".." macro and the "..." is missing the manpage output.

This just adds a "|" in front of the "..." so this doesn't look like a macro to man.

Please also merge this to 1.1-stable or wherever relevant.
Thanks.
