### PR TITLE
bundler root path should be escaped

### DIFF
--- a/lib/bundler/source.rb
+++ b/lib/bundler/source.rb
@@ -435,7 +435,7 @@ module Bundler
       end
 
       def relative_path
-        if path.to_s.match(%r{^#{Bundler.root.to_s}})
+        if path.to_s.match(%r{^#{Regexp.escape Bundler.root.to_s}})
           return path.relative_path_from(Bundler.root)
         end
         path


### PR DESCRIPTION
I don't know how to write a test for this, but if you create a rails application under a directory that has regular expression characters in it, bundler will break.

```
Unfortunately, a fatal error has occurred. Please report this error to the Bundler issue tracker at https://github.com/carlhuda/bundler/issues so that we can fix it. Please include the full output of the command, your Gemfile and Gemfile.lock. Thanks!
/Users/aaron/.rvm/gems/ruby-1.9.3-p125/gems/bundler-1.1.1/lib/bundler/source.rb:422:in `relative_path': empty char-class: /^\/Users\/aaron\/git\/foo[]bar\/lolwut/ (RegexpError)
    from /Users/aaron/.rvm/gems/ruby-1.9.3-p125/gems/bundler-1.1.1/lib/bundler/source.rb:308:in `to_lock'
    from /Users/aaron/.rvm/gems/ruby-1.9.3-p125/gems/bundler-1.1.1/lib/bundler/definition.rb:254:in `block in to_lock'
    from /Users/aaron/.rvm/gems/ruby-1.9.3-p125/gems/bundler-1.1.1/lib/bundler/definition.rb:252:in `each'
    from /Users/aaron/.rvm/gems/ruby-1.9.3-p125/gems/bundler-1.1.1/lib/bundler/definition.rb:252:in `to_lock'
    from /Users/aaron/.rvm/gems/ruby-1.9.3-p125/gems/bundler-1.1.1/lib/bundler/definition.rb:233:in `lock'
    from /Users/aaron/.rvm/gems/ruby-1.9.3-p125/gems/bundler-1.1.1/lib/bundler/environment.rb:39:in `lock'
    from /Users/aaron/.rvm/gems/ruby-1.9.3-p125/gems/bundler-1.1.1/lib/bundler/installer.rb:59:in `run'
    from /Users/aaron/.rvm/gems/ruby-1.9.3-p125/gems/bundler-1.1.1/lib/bundler/installer.rb:12:in `install'
    from /Users/aaron/.rvm/gems/ruby-1.9.3-p125/gems/bundler-1.1.1/lib/bundler/cli.rb:220:in `install'
    from /Users/aaron/.rvm/gems/ruby-1.9.3-p125/gems/bundler-1.1.1/lib/bundler/vendor/thor/task.rb:22:in `run'
    from /Users/aaron/.rvm/gems/ruby-1.9.3-p125/gems/bundler-1.1.1/lib/bundler/vendor/thor/invocation.rb:118:in `invoke_task'
    from /Users/aaron/.rvm/gems/ruby-1.9.3-p125/gems/bundler-1.1.1/lib/bundler/vendor/thor.rb:263:in `dispatch'
    from /Users/aaron/.rvm/gems/ruby-1.9.3-p125/gems/bundler-1.1.1/lib/bundler/vendor/thor/base.rb:386:in `start'
    from /Users/aaron/.rvm/gems/ruby-1.9.3-p125/gems/bundler-1.1.1/bin/bundle:13:in `<top (required)>'
    from /Users/aaron/.rvm/gems/ruby-1.9.3-p125/bin/bundle:19:in `load'
    from /Users/aaron/.rvm/gems/ruby-1.9.3-p125/bin/bundle:19:in `<main>
```

This pull request escapes the directory name before it's used in a regexp.
