### PR TITLE
Use http_proxy setting from gemrc if present

### DIFF
--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -43,7 +43,12 @@ module Bundler
     def initialize(remote_uri)
       @remote_uri = remote_uri
       @has_api    = true # will be set to false if the rubygems index is ever fetched
-      @@connection ||= Net::HTTP::Persistent.new nil, :ENV
+      proxy_config = case Gem.configuration[:http_proxy]
+                       when String then URI.parse Gem.configuration[:http_proxy]
+                       when :no_proxy then nil
+                       else :ENV
+                     end
+      @@connection ||= Net::HTTP::Persistent.new nil, proxy_config
     end
 
     # fetch a gem specification


### PR DESCRIPTION
Since bundler 1.1 the http_proxy setting from the gemrc file is not used anymore when fetching remote gems. Instead bundler always sticks to the http_proxy environment var.

This patch favors the proxy settings from the ruby gems configuration over the environment variables if present.
