### PR TITLE
The --deployment flag requires a Gemfile.lock. Please make sure you have checked your Gemfile.lock into version control before deploying.

### DIFF
--- a/lib/bundler/deployment.rb
+++ b/lib/bundler/deployment.rb
@@ -45,7 +45,7 @@ module Bundler
           if current_release.to_s.empty?
             raise error_type.new("Cannot detect current release path - make sure you have deployed at least once.")
           end
-          args = ["--gemfile #{File.join(current_release, bundle_gemfile)}"]
+          args = ["--gemfile #{bundle_gemfile}"]
           args << "--path #{bundle_dir}" unless bundle_dir.to_s.empty?
           args << bundle_flags.to_s
           args << "--without #{bundle_without.join(" ")}" unless bundle_without.empty?


### PR DESCRIPTION
The original command that is created seemed to have a path issue. I made a fix for it.

The command looked like this:
<code>
cd test/releases/20120327132342 && bundle install --gemfile test/releases/20120327132342/Gemfile --path test/shared/bundle --deployment --quiet --without development test
</code>
Here the Gemfile could not be found, because we are looking in the wrong path

with the patch it looks like this and works:
<code>
cd test/releases/20120327132342 && bundle install --gemfile Gemfile --path test/shared/bundle --deployment --quiet --without development test
</code>
