### PR TITLE
When requiring a gem that contains a dash the original exception is swallowed

### DIFF
--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -74,7 +74,7 @@ module Bundler
               Kernel.require namespaced_file
             rescue LoadError
               REGEXPS.find { |r| r =~ e.message }
-              raise if dep.autorequire || $1.gsub('-', '/') != namespaced_file
+              raise e if dep.autorequire || $1.gsub('-', '/') != namespaced_file
             end
           else
             REGEXPS.find { |r| r =~ e.message }


### PR DESCRIPTION
We just had an issue with `Bundler.require` in one of our gems. This one contains a dash but it's not namespaced and `Bundlder.require` raised a `LoadError` complaining about **gem/name** being not found.

The thing is, the "real" error was a typo in one of the required files (one file tried to require something wrong and it failed with a `LoadError` exception). This was next to impossible to catch because the exception that is raised in this case is the second `LoadError` (the **gem/name** not found one) instead of the original **another_gem not found**.

I've patched `require` to re-raise the original exception in this case. I think it's more logical but I can see where you'd sometimes want to be warned about the namespaced version not found. I don't know how to handle this case properly but as-is it doesn't break anything, a `LoadError` is still raised and it's just a matter of displaying the correct information.
