### PR TITLE
Allow bypassing branch check for local overrides

### DIFF
--- a/lib/bundler/source.rb
+++ b/lib/bundler/source.rb
@@ -717,7 +717,7 @@ module Bundler
         path = Pathname.new(path)
         path = path.expand_path(Bundler.root) unless path.relative?
 
-        unless options["branch"]
+        unless options["branch"] || Bundler.settings['local_override_require_branch'] == 'false'
           raise GitError, "Cannot use local override for #{name} at #{path} because " \
             ":branch is not specified in Gemfile. Specify a branch or check " \
             "`bundle config --delete` to remove the local override"


### PR DESCRIPTION
Local overrides serve the purpose of making it easier to work with
multiple related repositories locally.

The current behaviour requires a branch name to be specified in the
Gemfile when working with local overrides. This makes sense as a quick
check as long as nothing else makes sure bundler is using the expected
refs in repositories we depend on.

I am working on an external tool that watches and displays the current
state of multiple related repositories. This tool uses bundler to check
and display the state a repository is in, but it is also supposed to
make it easier to quickly switch between, e.g., feature-branches in
various repositories. In this context having to manually edit the
Gemfile and add/change branch references rather defeats the purpose. The
tool itself is supposed to watch and make sure we use the correct
references from outside of bundler. Having bundler itself do a similar
check (that also requires manual editing of Ruby code) blocks the
intended workflow.

When discussing this with @josevalim he suggested to allow adding a flag
to the bundler settings in order to turn this check off.

The attached patch does just that.
