### PR TITLE
Make locking the Gemfile optional on $ bundle check

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -94,6 +94,8 @@ module Bundler
       "Use the specified gemfile instead of Gemfile"
     method_option "path", :type => :string, :banner =>
       "Specify a different path than the system default ($BUNDLE_PATH or $GEM_HOME). Bundler will remember this value for future installs on this machine"
+    method_option "lock", :type => :boolean, :default => true, :banner =>
+      "Lock the Gemfile"
     def check
       ENV['BUNDLE_GEMFILE'] = File.expand_path(options[:gemfile]) if options[:gemfile]
 
@@ -112,7 +114,7 @@ module Bundler
         Bundler.ui.warn "Install missing gems with `bundle install`"
         exit 1
       else
-        Bundler.load.lock
+        Bundler.load.lock if options[:lock]
         Bundler.ui.info "The Gemfile's dependencies are satisfied"
       end
     end

--- a/spec/other/check_spec.rb
+++ b/spec/other/check_spec.rb
@@ -23,7 +23,7 @@ describe "bundle check" do
     out.should == "The Gemfile's dependencies are satisfied"
   end
 
-  it "creates a Gemfile.lock if one did not exist" do
+  it "creates a Gemfile.lock by default if one did not exist" do
     install_gemfile <<-G
       source "file://#{gem_repo1}"
       gem "rails"
@@ -34,6 +34,19 @@ describe "bundle check" do
     bundle "check"
 
     bundled_app("Gemfile.lock").should exist
+  end
+
+  it "does not create a Gemfile.lock if --no-lock was passed" do
+    install_gemfile <<-G
+      source "file://#{gem_repo1}"
+      gem "rails"
+    G
+
+    FileUtils.rm("Gemfile.lock")
+
+    bundle "check --no-lock"
+
+    bundled_app("Gemfile.lock").should_not exist
   end
 
   it "prints a generic error if the missing gems are unresolvable" do


### PR DESCRIPTION
Currently `bundle check` locks the Gemfile. According to @indirect this
behaviour is intentional (see
https://twitter.com/#!/indirect/status/186493694013210624).

I am working on a CLI monitoring tool that makes it easier to work with
cross-repository changes on projects that are split up into several
repositories.

This tool is supposed to display status information such as out-of-date
bundler Gemfiles etc. To do so it watches the filesystem and queries for
information on demand. Using `bundle check` to do so currently leads to
highly confusing side-effects because suddenly the git working directory
might be dirty - having changed the Gemfile.lock - because `bundle
check` has been run in the background.

This patch adds a boolean method option `--[no-]lock` to `bundle check`
that defaults to `true` in order to not change the current behaviour but
make it possible for users to turn it off.

Sidenote: apparently the same behaviour also applies to `bundle show`.
Am I the only one who finds this highly confusing?
