### PR TITLE
Bundler should check :branch for local overrides on runtime

### DIFF
--- a/spec/install/git_spec.rb
+++ b/spec/install/git_spec.rb
@@ -156,7 +156,7 @@ describe "bundle install with git sources" do
     end
   end
 
-  describe "when specifying local" do
+  describe "when specifying local override" do
     it "uses the local repository instead of checking a new one out" do
       # We don't generate it because we actually don't need it
       # build_git "rack", "0.8"
@@ -241,7 +241,7 @@ describe "bundle install with git sources" do
       lockfile1.should_not == lockfile0
     end
 
-    it "explodes if given path does not exist" do
+    it "explodes if given path does not exist on install" do
       build_git "rack", "0.8"
 
       install_gemfile <<-G
@@ -254,7 +254,7 @@ describe "bundle install with git sources" do
       out.should =~ /Cannot use local override for rack-0.8 because #{Regexp.escape(lib_path('local-rack').to_s)} does not exist/
     end
 
-    it "explodes if branch is not given" do
+    it "explodes if branch is not given on install" do
       build_git "rack", "0.8"
       FileUtils.cp_r("#{lib_path('rack-0.8')}/.", lib_path('local-rack'))
 
@@ -268,7 +268,7 @@ describe "bundle install with git sources" do
       out.should =~ /because :branch is not specified in Gemfile/
     end
 
-    it "explodes on different branches" do
+    it "explodes on different branches on install" do
       build_git "rack", "0.8"
 
       FileUtils.cp_r("#{lib_path('rack-0.8')}/.", lib_path('local-rack'))
@@ -287,7 +287,7 @@ describe "bundle install with git sources" do
       out.should =~ /is using branch another but Gemfile specifies master/
     end
 
-    it "explodes on invalid revision" do
+    it "explodes on invalid revision on install" do
       build_git "rack", "0.8"
 
       build_git "rack", "0.8", :path => lib_path('local-rack') do |s|


### PR DESCRIPTION
_Note: I actually would like to bypass :branch checking by default, as I mentioned in Issue #1810._

As the specified behavior (checking :branch by default) stands, there's a bug in that once you've run bundle install/update with the proper :branch option, you can remove the :branch option and it'll still use the override without complaints.

The bug also manifests itself if you set both :ref and :branch, and then change the :branch to a different branch after bundle install.

If users expect the enforcement of :branch options, then the :branch must be checked on runtime.

This pull request provides the failing specs.
