### PR TITLE
Avoid a warning running under Ruby 1.8.7

### DIFF
--- a/lib/bundler/rubygems_ext.rb
+++ b/lib/bundler/rubygems_ext.rb
@@ -142,6 +142,7 @@ module Gem
       @cpu.hash ^ @os.hash ^ @version.hash
     end
 
+    remove_method :eql?
     alias eql? ==
   end
 end


### PR DESCRIPTION
I was seeing the following warning in Mocha's build [1,2,3].

```
/home/vagrant/.rvm/gems/ruby-1.8.7-p358/gems/bundler-1.1.3/lib/bundler/rubygems_ext.rb:145:
```

warning: discarding old eql?

I like to avoid any warnings in the build output to keep the
signal-to-noise ratio high in case any important warnings crop up.

[1] http://floehopper.github.com/mocha
[2] http://travis-ci.org/#!/floehopper/mocha/jobs/1088237/L45
[3] http://travis-ci.org/#!/floehopper/mocha/jobs/1088237/L53
