### PR TITLE
Show that current_release can be overridden.

### DIFF
--- a/lib/bundler/deployment.rb
+++ b/lib/bundler/deployment.rb
@@ -34,6 +34,7 @@ module Bundler
             set :bundle_without,  [:development, :test]
             set :bundle_cmd,      "bundle" # e.g. "/opt/ruby/bin/bundle"
             set :bundle_roles,    #{role_default} # e.g. [:app, :batch]
+            set :current_release,    #{current_release} # e.g. "/releases/123456"
         DESC
         send task_method, :install, opts do
           bundle_cmd     = context.fetch(:bundle_cmd, "bundle")


### PR DESCRIPTION
Using "git" style deploy you don't have any releases since everything is updated inside of your main directory. This change just displays an option to override "current_release".
