### PR TITLE
Subgroups

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -23,6 +23,7 @@ module Bundler
       @sources         = []
       @dependencies    = []
       @groups          = []
+      @subgroups       = {}
       @platforms       = []
       @env             = nil
       @ruby_version    = nil
@@ -30,6 +31,7 @@ module Bundler
 
     def eval_gemfile(gemfile)
       instance_eval(Bundler.read_file(gemfile.to_s), gemfile.to_s, 1)
+      resolve_subgroups
     rescue SyntaxError => e
       bt = e.message.split("\n")[1..-1]
       raise GemfileError, ["Gemfile syntax error:", *bt].join("\n")
@@ -156,12 +158,9 @@ module Bundler
     end
 
     def include_group(group)
-      @dependencies.each do |dependency|
-        if dependency.groups.include?(group)
-          new_groups = dependency.groups + @groups.dup
-          new_groups.uniq!
-          dependency.groups = new_groups
-        end
+      @groups.each do |parent_group|
+        @subgroups[parent_group] ||= []
+        @subgroups[parent_group] << group unless @subgroups[parent_group].include?(group)
       end
     end
 
@@ -260,6 +259,18 @@ module Bundler
       opts["env"]     ||= @env
       opts["platforms"] = platforms.dup
       opts["group"]     = groups
+    end
+
+    def resolve_subgroups
+      @subgroups.each do |parent_group, subgroups|
+        @dependencies.each do |dependency|
+          in_subgroup = subgroups.length != (subgroups - dependency.groups).length
+
+          if in_subgroup && !dependency.groups.include?(parent_group)
+            dependency.groups += [parent_group]
+          end
+        end
+      end
     end
 
   end

--- a/spec/install/gems/groups_spec.rb
+++ b/spec/install/gems/groups_spec.rb
@@ -274,11 +274,11 @@ describe "bundle install with gem sources" do
         group :sub1 do
           gem "activesupport"
         end
-        gem "thin", :groups => :sub2
         group :parent do
           include_group :sub1
           include_group :sub2
         end
+        gem "thin", :groups => :sub2
       G
     end
 


### PR DESCRIPTION
This patch adds a new method `include_group` to the Bundler DSL which allows one group to be included in another. The goal is to be able to group dependencies by their function, and later declare which functional groups should be loaded in which environments (e.g. production, development). It would look something like this simplified example:

``` ruby
# Default group

gem "rails"

# Functional groups

group :pry do
  gem "pry"
  gem "pry-rails"
  gem "pry-nav"
end

group :unit_tests do
  gem "rspec-rails"
  gem "factory_girl"
end

group :integration_tests do
  gem "capybara"
  gem "poltergeist"
end

# Environment groups

group :development do
  include_group :pry
end

group :test do
  include_group :unit_tests
  include_group :integration_tests
end
```

These composable groups allow for better organization of large Gemfiles.

This is my first foray into the Bundler code, so I'm opening this pull request very early to get feedback on whether or not the Bundler team would be receptive to this feature. If so, I'd like to get some feedback on my approach and what potential complications and edge cases I should consider and test for. The most obvious limitation so far is that subgroups must be defined before they are included in order to have any effect.

Thanks for your time!
