### PR TITLE
Fix for 1847

### DIFF
--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -74,7 +74,7 @@ module Bundler
               Kernel.require namespaced_file
             rescue LoadError
               REGEXPS.find { |r| r =~ e.message }
-              raise if dep.autorequire || $1.gsub('-', '/') != namespaced_file
+              raise e if dep.autorequire || $1.nil? || $1.gsub('-', '/') != namespaced_file
             end
           else
             REGEXPS.find { |r| r =~ e.message }


### PR DESCRIPTION
I added a $1.nil? check in runtime.rb to fix https://github.com/carlhuda/bundler/issues/1847.  Also, I'm not sure this part is correct but I added e to the re-raise because it was more informative in my case:

Before:
LoadError: no such file to load -- ffi/rzmq

After:
LoadError: Could not open library 'libzmq' : libzmq: cannot open shared object file: No such file or directory.
