### PR TITLE
Added a `bundle licenses` cli task

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -546,6 +546,20 @@ module Bundler
     end
     map %w(-v --version) => :version
 
+    desc "licenses", "Prints the license of all gems in the bundle"
+    def licenses
+      Bundler.load.specs.sort_by { |s| s.license.to_s }.reverse.each do |s|
+        gem_name = s.name
+        license  = s.license || s.licenses
+
+        if license.empty?
+          Bundler.ui.warn "#{gem_name}: Unknown"
+        else
+          Bundler.ui.info "#{gem_name}: #{license}"
+        end
+      end
+    end
+
     desc 'viz', "Generates a visual dependency graph"
     long_desc <<-D
       Viz generates a PNG file of the current Gemfile as a dependency graph.

--- a/spec/other/licenses_spec.rb
+++ b/spec/other/licenses_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+describe "bundle licenses" do
+  before :each do
+    install_gemfile <<-G
+      source "file://#{gem_repo1}"
+      gem "rails"
+      gem "with_license"
+    G
+  end
+
+  it "prints license information for all gems in the bundle" do
+    bundle "licenses"
+
+    out.should include("actionpack: Unknown")
+    out.should include("with_license: MIT")
+  end
+end

--- a/spec/support/builders.rb
+++ b/spec/support/builders.rb
@@ -126,6 +126,10 @@ module Spec
           s.add_development_dependency "activesupport", "= 2.3.5"
         end
 
+        build_gem "with_license" do |s|
+          s.license = "MIT"
+        end
+
         build_gem "with_implicit_rake_dep" do |s|
           s.extensions << "Rakefile"
           s.write "Rakefile", <<-RUBY


### PR DESCRIPTION
This commit adds a `bundle licenses` task, which lists the license for each gem in the bundle or "Unknown" if one isn't found.

After having felt the pain of walking through a Ruby application's dependencies to determine license information on several occasions, it would be a dream to me if more gem authors used the `license` directive in their gemspecs, which would allow a simple task like this to be a more authoritative guide to determine dependency licenses.

I've added a new test for this change, and would love any and all feedback to this approach.

Thanks!
