### PR TITLE
Fixing "bundle clean --force" banner.

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -619,7 +619,7 @@ module Bundler
 
     desc "clean", "Cleans up unused gems in your bundler directory"
     method_option "force", :type => :boolean, :default => false, :banner =>
-      "forces clean even if --path is set"
+      "forces clean even if --path is not set"
     def clean
       if Bundler.settings[:path] || options[:force]
         Bundler.load.clean


### PR DESCRIPTION
The --force option was incorrectly stating that it forces a clean if --path IS set. It actually forces a clean if --path is NOT set.
