### PR TITLE
Always try to keep original GEM_PATH

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -1,12 +1,14 @@
 require 'rbconfig'
 require 'fileutils'
 require 'pathname'
+require 'bundler/gem_path_manipulation'
 require 'bundler/psyched_yaml'
 require 'bundler/rubygems_ext'
 require 'bundler/rubygems_integration'
 require 'bundler/version'
 
 module Bundler
+  preserve_gem_path
   ORIGINAL_ENV = ENV.to_hash
 
   autoload :Definition,            'bundler/definition'

--- a/lib/bundler/gem_path_manipulation.rb
+++ b/lib/bundler/gem_path_manipulation.rb
@@ -1,0 +1,8 @@
+module Bundler
+  def self.preserve_gem_path
+    original_gem_path = ENV["_ORIGINAL_GEM_PATH"]
+    gem_path          = ENV["GEM_PATH"]
+    ENV["_ORIGINAL_GEM_PATH"] = gem_path          if original_gem_path.nil? || original_gem_path == ""
+    ENV["GEM_PATH"]           = original_gem_path if gem_path.nil? || gem_path == ""
+  end
+end

--- a/spec/runtime/with_clean_env_spec.rb
+++ b/spec/runtime/with_clean_env_spec.rb
@@ -25,6 +25,20 @@ describe "Bundler.with_env helpers" do
 
     it_should_behave_like "Bundler.with_*_env"
 
+    it "should keep the original GEM_PATH even in sub processes" do
+      gemfile ""
+      bundle "install --path vendor/bundle"
+
+      gem_path = ENV['GEM_PATH']
+
+      code = "Bundler.with_clean_env do;" +
+             "  print ENV['GEM_PATH'] != '';" +
+             "end"
+
+      result = bundle "exec ruby -e #{code.inspect}"
+      result.should == "true"
+    end
+
     it "should not pass any bundler environment variables" do
       Bundler.with_clean_env do
         `echo $BUNDLE_PATH`.strip.should_not == './Gemfile'


### PR DESCRIPTION
This fixes a problem which occures when you want to run `bundle` command
inside code that already loads `Gemfile`. When you start a command with
`bundle exec` it sets `RUBYOPT` to
`-I$PATH_TO_BUNDLER -r"bundler/setup"`. Because of that, when you run
the actual command it already requires bundler, which is fine, but since
`GEM_PATH` was cleared on the first run `ORIGINAL_ENV` will include
empty `GEM_PATH`. Now when you run `Bundler.with_clean_env`, you will
not have any bundler specific env variables, but you will also not have
original gem path, which will make it impossible to run any gem.

Alternative fix would be to assign `ENV["GEM_PATH"] = ORIGINAL_ENV["GEM_PATH"]`
before doing `Kernel.exec` in `bundle exec`.
