### PR TITLE
disable rubygems plugins when shared gems disabled

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -220,7 +220,7 @@ module Bundler
 
       Bundler::Fetcher.disable_endpoint = opts["full-index"]
       # rubygems plugins sometimes hook into the gem install process
-      Gem.load_env_plugins if Gem.respond_to?(:load_env_plugins)
+      Gem.load_env_plugins if Gem.respond_to?(:load_env_plugins) && !Bundler.settings[:disable_shared_gems]
 
       definition = Bundler.definition
       definition.validate_ruby!
@@ -282,7 +282,7 @@ module Bundler
 
       opts = {"update" => true, "local" => options[:local]}
       # rubygems plugins sometimes hook into the gem install process
-      Gem.load_env_plugins if Gem.respond_to?(:load_env_plugins)
+      Gem.load_env_plugins if Gem.respond_to?(:load_env_plugins) && !Bundler.settings[:disable_shared_gems]
 
       Bundler.definition.validate_ruby!
       Installer.install Bundler.root, Bundler.definition, opts


### PR DESCRIPTION
related: https://github.com/mpapis/rubygems-bundler/issues/24

I'm not sure if this should be merged, I come out from assumption that when you disable shared gems you would like also to disable rubygems-plugins from shared gems.

There is other point for users that explicitly rubygem-plugin in Gemfile ...

The best explanation here fits is for `--deployment` you want to avoid any unwanted interactions - which is for disabling rubygems-plugins.

Cheers,
Michal
