### PR TITLE
Fixed Issue #1935: Gemfile :submodules => true only pulls first level submodules

### DIFF
--- a/lib/bundler/source.rb
+++ b/lib/bundler/source.rb
@@ -552,8 +552,7 @@ module Bundler
             git "reset --hard #{@revision}"
 
             if submodules
-              git "submodule init"
-              git "submodule update"
+              git "submodule update --init --recursive"
             end
           end
         end


### PR DESCRIPTION
Bundler was not checking out submodules that belong to submodules. This was fixed by updating the copy_to method in the GitProxy class to run the following command:

```
git submodule update --init --recursive
```
