### PR TITLE
Add :gist option for gems embedded in gists

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -200,7 +200,7 @@ module Bundler
     def _normalize_options(name, version, opts)
       _normalize_hash(opts)
 
-      valid_keys = %w(group groups git github path name branch ref tag require submodules platform platforms type)
+      valid_keys = %w(group groups git gist github path name branch ref tag require submodules platform platforms type)
       invalid_keys = opts.keys - valid_keys
       if invalid_keys.any?
         plural = invalid_keys.size > 1
@@ -232,6 +232,10 @@ module Bundler
       if github = opts.delete("github")
         github = "#{github}/#{github}" unless github.include?("/")
         opts["git"] = "git://github.com/#{github}.git"
+      end
+
+      if gist = opts.delete("gist")
+        opts["git"] = "git://gist.github.com/#{gist}.git"
       end
 
       ["git", "path"].each do |type|

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -13,6 +13,18 @@ describe Bundler::Dsl do
       subject.dependencies.first.source.uri.should == github_uri
     end
 
+    it "should convert numeric :gist to :git" do
+      subject.gem("not-really-a-gem", :gist => 2859988)
+      github_uri = "git://gist.github.com/2859988.git"
+      subject.dependencies.first.source.uri.should == github_uri
+    end
+
+    it "should convert :gist to :git" do
+      subject.gem("not-really-a-gem", :gist => "2859988")
+      github_uri = "git://gist.github.com/2859988.git"
+      subject.dependencies.first.source.uri.should == github_uri
+    end
+
     it "should convert 'rails' to 'rails/rails'" do
       subject.gem("rails", :github => "rails")
       github_uri = "git://github.com/rails/rails.git"


### PR DESCRIPTION
This PR allows the use of a `:gist` option to use gems embedded in Github gists: `gem 'my-gem', gist: 1234567890` (either numeric or stringified).

I doubt that the use case for this would be too common, but this is a small convenience for sharing small gem prototypes.
