### PR TITLE
Local Git override requires :branch, :tag or :ref instead of just :branch

### DIFF
--- a/lib/bundler/source.rb
+++ b/lib/bundler/source.rb
@@ -716,9 +716,9 @@ module Bundler
         path = Pathname.new(path)
         path = path.expand_path(Bundler.root) unless path.relative?
 
-        unless options["branch"]
+        unless options["branch"] || options["tag"] || options["ref"]
           raise GitError, "Cannot use local override for #{name} at #{path} because " \
-            ":branch is not specified in Gemfile. Specify a branch or check " \
+            ":branch, :tag, or :ref is not specified in Gemfile. Specify a commit reference or check " \
             "`bundle config --delete` to remove the local override"
         end
 
@@ -732,11 +732,6 @@ module Bundler
         # Create a new git proxy without the cached revision
         # so the Gemfile.lock always picks up the new revision.
         @git_proxy = GitProxy.new(path, uri, ref)
-
-        if git_proxy.branch != options["branch"]
-          raise GitError, "Local override for #{name} at #{path} is using branch " \
-            "#{git_proxy.branch} but Gemfile specifies #{options["branch"]}"
-        end
 
         changed = cached_revision && cached_revision != git_proxy.revision
 

--- a/spec/install/git_spec.rb
+++ b/spec/install/git_spec.rb
@@ -254,7 +254,7 @@ describe "bundle install with git sources" do
       out.should =~ /Cannot use local override for rack-0.8 because #{Regexp.escape(lib_path('local-rack').to_s)} does not exist/
     end
 
-    it "explodes if branch is not given" do
+    it "explodes if branch, tag, or ref is not given" do
       build_git "rack", "0.8"
       FileUtils.cp_r("#{lib_path('rack-0.8')}/.", lib_path('local-rack'))
 
@@ -265,26 +265,7 @@ describe "bundle install with git sources" do
 
       bundle %|config local.rack #{lib_path('local-rack')}|
       bundle :install
-      out.should =~ /because :branch is not specified in Gemfile/
-    end
-
-    it "explodes on different branches" do
-      build_git "rack", "0.8"
-
-      FileUtils.cp_r("#{lib_path('rack-0.8')}/.", lib_path('local-rack'))
-
-      update_git "rack", "0.8", :path => lib_path('local-rack'), :branch => "another" do |s|
-        s.write "lib/rack.rb", "puts :LOCAL"
-      end
-
-      install_gemfile <<-G
-        source "file://#{gem_repo1}"
-        gem "rack", :git => "#{lib_path('rack-0.8')}", :branch => "master"
-      G
-
-      bundle %|config local.rack #{lib_path('local-rack')}|
-      bundle :install
-      out.should =~ /is using branch another but Gemfile specifies master/
+      out.should =~ /because :branch, :tag, or :ref is not specified in Gemfile/
     end
 
     it "explodes on invalid revision" do


### PR DESCRIPTION
This pull request is very similar to #1810. It requires that a developer must supply a :branch, :tag, or :ref option to a git based gem in a Gemfile. It also removes the requirement that the local version of the included gem must be on the same branch as the fallback. 

The reasoning behind this change is to allow developers to use more than just a branch to safeguard deployed code while also letting developers to make changes on feature branches of included gems. I could see an additional config flag, much like #1810, to enable waiving the same branch requirement and I can put that in if needed.

**Note:** There is one failing test that is unrelated. The cause is mentioned in Issue #1605
