### PR TITLE
Properly handle missing binary libraries.

### DIFF
--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -46,6 +46,7 @@ module Bundler
       /^Missing \w+ (?:file\s*)?([^\s]+.rb)$/i,
       /^Missing API definition file in (.+)$/i,
       /^cannot load such file -- (.+)$/i,
+      /^dlopen\([^)]*\): Library not loaded: (.+)$/i,
     ]
 
     def require(*groups)


### PR DESCRIPTION
After removing a binary library dependency from my project (in this case: libffi), bundler started to crash on simple commands as:

```
rake -T
```

Error message:

```
rake aborted!
undefined method `gsub' for nil:NilClass
...
```

Running `rake -T --trace` yields:

```
rake aborted!
undefined method `gsub' for nil:NilClass
/Users/sample/.rvm/gems/ruby-1.9.3-p194@global/gems/bundler-1.1.4/lib/bundler/runtime.rb:77:in `rescue in rescue in block in require'
/Users/sample/.rvm/gems/ruby-1.9.3-p194@global/gems/bundler-1.1.4/lib/bundler/runtime.rb:72:in `rescue in block in require'
/Users/sample/.rvm/gems/ruby-1.9.3-p194@global/gems/bundler-1.1.4/lib/bundler/runtime.rb:62:in `block in require'
/Users/sample/.rvm/gems/ruby-1.9.3-p194@global/gems/bundler-1.1.4/lib/bundler/runtime.rb:55:in `each'
/Users/sample/.rvm/gems/ruby-1.9.3-p194@global/gems/bundler-1.1.4/lib/bundler/runtime.rb:55:in `require'
...
```

After applying this patch, running `rake -T` yields:

```
rake aborted!
dlopen(/Users/sample/.rvm/gems/ruby-1.9.3-p194@gemset/gems/ffi-1.0.11/lib/ffi_c.bundle, 9): Library not loaded: /opt/local/lib/libffi.5.dylib
  Referenced from: /Users/sample/.rvm/gems/ruby-1.9.3-p194@gemset/gems/ffi-1.0.11/lib/ffi_c.bundle
  Reason: image not found - /Users/sample/.rvm/gems/ruby-1.9.3-p194@gemset/gems/ffi-1.0.11/lib/ffi_c.bundle
```

I couldn't find tests for these kinds of errors, but if they exist and someone can give some directions, I'll add tests to the patch.
