### PR TITLE
introducing `bundle grep` command

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -22,6 +22,7 @@ module Bundler
   autoload :GemHelpers,            'bundler/gem_helpers'
   autoload :GemInstaller,          'bundler/gem_installer'
   autoload :Graph,                 'bundler/graph'
+  autoload :Grep,                  'bundler/grep'
   autoload :Index,                 'bundler/index'
   autoload :Installer,             'bundler/installer'
   autoload :LazySpecification,     'bundler/lazy_specification'

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -318,6 +318,12 @@ module Bundler
     end
     map %w(list) => "show"
 
+    desc "grep inside bundled gems", "greps the source directories of the bundled gems"
+    def grep(*args)
+      gem_paths = Bundler.load.specs.map(&:lib_dirs_glob).flatten
+      Bundler.ui.info `grep -r #{args.join(' ')} #{gem_paths.join(' ')}`
+    end
+
     desc "outdated [GEM]", "list installed gems with newer versions available"
     long_desc <<-D
       Outdated lists the names and versions of gems that have a newer version available


### PR DESCRIPTION
Let me propose a new sub-command, `bundle grep`.

This is a simple but life changing command that greps the given words within the bundled gem:gem: sources.
## use case
- Someone is setting "must-revalidate" to my Rails app's "Cache-Control" response header. But who?

``````
% bundle grep must-revalidate
/Users/a_matsuda/.rvm/gems/ruby-1.9.3-p194/gems/rack-1.4.1/lib/rack/etag.rb:  # defaults to nil, while the second defaults to "max-age=0, private, must-revalidate"
/Users/a_matsuda/.rvm/gems/ruby-1.9.3-p194/gems/rack-1.4.1/lib/rack/etag.rb:    DEFAULT_CACHE_CONTROL = "max-age=0, private, must-revalidate".freeze
/Users/a_matsuda/.rvm/gems/ruby-1.9.3-p194/gems/rack-cache-1.2/lib/rack/cache/cachecontrol.rb:      # of a cache entry on any subsequent use. When the must-revalidate
/Users/a_matsuda/.rvm/gems/ruby-1.9.3-p194/gems/rack-cache-1.2/lib/rack/cache/cachecontrol.rb:      # The must-revalidate directive is necessary to support reliable
/Users/a_matsuda/.rvm/gems/ruby-1.9.3-p194/gems/rack-cache-1.2/lib/rack/cache/cachecontrol.rb:      # HTTP/1.1 cache MUST obey the must-revalidate directive; in
/Users/a_matsuda/.rvm/gems/ruby-1.9.3-p194/gems/rack-cache-1.2/lib/rack/cache/cachecontrol.rb:      # Servers SHOULD send the must-revalidate directive if and only if
/Users/a_matsuda/.rvm/gems/ruby-1.9.3-p194/gems/rack-cache-1.2/lib/rack/cache/cachecontrol.rb:        self['must-revalidate']
/Users/a_matsuda/.rvm/gems/ruby-1.9.3-p194/gems/rack-cache-1.2/lib/rack/cache/context.rb:        # the response; the must-revalidate cache control directive disables
/Users/a_matsuda/.rvm/gems/ruby-1.9.3-p194/gems/rack-cache-1.2/lib/rack/cache/response.rb:    # Valueless parameters (e.g., must-revalidate, no-store) have a Hash value
/Users/a_matsuda/.rvm/gems/ruby-1.9.3-p194/gems/sprockets-2.1.3/lib/sprockets/server.rb:          # Otherwise set `must-revalidate` since the asset could be modified.
/Users/a_matsuda/.rvm/gems/ruby-1.9.3-p194/gems/sprockets-2.1.3/lib/sprockets/server.rb:            headers["Cache-Control"] << ", must-revalidate"
/Users/a_matsuda/.rvm/gems/ruby-1.9.3-p194/gems/actionpack-3.2.6/lib/action_dispatch/http/cache.rb:        DEFAULT_CACHE_CONTROL = "max-age=0, private, must-revalidate".freeze
/Users/a_matsuda/.rvm/gems/ruby-1.9.3-p194/gems/actionpack-3.2.6/lib/action_dispatch/http/cache.rb:        MUST_REVALIDATE       = "must-revalidate".freeze```
``````
- Where exactly is `link_to_if` method defined?

```
% bundle grep \"def link_to_if\"
/Users/a_matsuda/.rvm/gems/ruby-1.9.3-p194/gems/actionpack-3.2.6/lib/action_view/helpers/url_helper.rb:      def link_to_if(condition, name, options = {}, html_options = {}, &block)
```

OMG this is super useful, isn't it:question:
