### PR TITLE
Enhancement - Gemfile syntax for pulling multiple gems from a single github user.

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -68,6 +68,10 @@ module Bundler
       options = Hash === args.last ? args.pop : {}
       version = args || [">= 0"]
 
+      if @github_username
+        options.merge!(:github => "#{@github_username}/#{name}")
+      end
+
       _normalize_options(name, version, options)
 
       dep = Dependency.new(name, version, options)
@@ -142,6 +146,11 @@ module Bundler
       end
 
       source Source::Git.new(_normalize_hash(options).merge("uri" => uri)), source_options, &blk
+    end
+
+    def github(username, &blk)
+      @github_username = username
+      blk.call
     end
 
     def to_definition(lockfile, unlock)

--- a/lib/bundler/version.rb
+++ b/lib/bundler/version.rb
@@ -2,5 +2,5 @@ module Bundler
   # We're doing this because we might write tests that deal
   # with other versions of bundler and we are unsure how to
   # handle this better.
-  VERSION = "1.3.0.pre.3" unless defined?(::Bundler::VERSION)
+  VERSION = "1.3.0.pre.4" unless defined?(::Bundler::VERSION)
 end

--- a/spec/install/github_spec.rb
+++ b/spec/install/github_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe 'bundle install with a github block' do
+  it 'installs multiple gems from a single github user' do
+    gemfile <<-G
+      github 'datamapper' do
+        gem 'dm-core', '~> 1.3.0.beta'
+        gem 'dm-types', '~> 1.3.0.beta'
+      end
+    G
+    bundle "install"
+    should_be_installed 'dm-core'
+    should_be_installed 'dm-types'
+  end
+
+  it 'allows us to pass through a branch' do
+    gemfile <<-G
+      github 'datamapper' do
+        gem 'dm-core', :branch => 'foo'
+      end
+    G
+    should_be_installed 'dm-core'
+  end
+end


### PR DESCRIPTION
Hi

This patch adds some Gemfile syntax to be able to easily pull multiple gems that are hosted on github in a single users account. Rather than having to define gems individually with the :github option I have wrapped that up into a block. So you can now do this:

```
github 'datamapper' do
  gem 'dm-core', '~> 1.3.0.pre'
  gem 'dm-types'
end
```

All the standard options for git based gem's are suported (like setting branches to install) so this is really just some syntactic sugar.

Feedback welcome.

thanks
