### PR TITLE
Default remote source for Gemfile

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -247,12 +247,6 @@ module Bundler
       if opts[:local] && Bundler.app_cache.exist?
         Bundler.ui.warn "Some gems seem to be missing from your vendor/cache directory."
       end
-
-      if Bundler.definition.no_sources?
-        Bundler.ui.warn "Your Gemfile has no remote sources. If you need " \
-          "gems that are not already on\nyour machine, add a line like this " \
-          "to your Gemfile:\n    source 'https://rubygems.org'"
-      end
       raise e
     end
 

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -211,10 +211,6 @@ module Bundler
       end
     end
 
-    def no_sources?
-      @sources.length == 1 && @sources.first.remotes.empty?
-    end
-
     def groups
       dependencies.map { |d| d.groups }.flatten.uniq
     end

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -145,6 +145,7 @@ module Bundler
 
     def to_definition(lockfile, unlock)
       @sources << @rubygems_source unless @sources.include?(@rubygems_source)
+      set_default_remote_source if still_empty_sources?
       Definition.new(lockfile, @dependencies, @sources, unlock, @ruby_version)
     end
 
@@ -250,6 +251,15 @@ module Bundler
       opts["env"]     ||= @env
       opts["platforms"] = platforms.dup
       opts["group"]     = groups
+    end
+
+    def set_default_remote_source
+      source :rubygems
+      @sources << @rubygems_source
+    end
+
+    def still_empty_sources?
+      @sources.length == 1 && @sources.first.remotes.empty?
     end
 
   end


### PR DESCRIPTION
I don't know if somebody need this, but I really do. 

Nowadays 99.9% of every Gemfile contains `source 'https://rubygems.org'`.

More than that, if you accidentally delete this line, you'll get a message `add a line like this: ...` in your console. Why can't we add this line automagically? 

Where is `Convention over configuration`? It's the right place for it!
