### PR TITLE
Short circuit config loading if config file is the null device

### DIFF
--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -126,7 +126,9 @@ module Bundler
     end
 
     def load_config(config_file)
-      if config_file.exist? && !config_file.size.zero?
+      if config_file == "/dev/null"
+        {}
+      elsif config_file.exist? && !config_file.size.zero?
         yaml = YAML.load_file(config_file)
       end
       yaml || {}


### PR DESCRIPTION
## What this is

Recently, I was working with some subprojects on heroku and the need to not inherit the config from the parent arose.

The only way I could find to do this was to set `BUNDLER_CONFIG` to `/nonexistent` which is bad for two reasons:
- It might exist
- It's definitely not writable

Using `/dev/null` would make much more sense, but as the EOF it returns is not valid YAML, psych flips out immediately when trying to read it.

This fairly kludgy patch causes it to emit the "non exist" behaviour if you pass it /dev/null, which should fix most of these issues without breaking backwards compatability.

One thing I couldn't find was whether or not ruby has a variant of python's `os.nulldev` which platform agnostically returns the null device.
