### PR TITLE
Ruby 2.0+ should have platform definitions

### DIFF
--- a/lib/bundler/dependency.rb
+++ b/lib/bundler/dependency.rb
@@ -107,7 +107,7 @@ module Bundler
     def mri_19?
       mri? && RUBY_VERSION >= "1.9" && RUBY_VERSION < "2.0"
     end
-    
+
     def mri_20?
       mri? && RUBY_VERSION >= "2.0" && RUBY_VERSION < "3.0"
     end


### PR DESCRIPTION
Added `:ruby_20`, `:mri_20` and `:mingw_20`
Also made same fix to `mingw_19?` as #1539 -- 19 is not 20.
