### PR TITLE
Error-out on "bundle update unknown-gem"

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -277,6 +277,8 @@ module Bundler
         # We're doing a full update
         Bundler.definition(true)
       else
+        # cycle through the requested gems, just to make sure they exist
+        gems.each{ |n| gem_dependency_with_name(n) }
         Bundler.definition(:gems => gems, :sources => sources)
       end
 
@@ -684,6 +686,12 @@ module Bundler
         return File.expand_path('../../../', __FILE__)
       end
       spec.full_gem_path
+    end
+
+    def gem_dependency_with_name(name)
+      dep = Bundler.load.dependencies.find{|d| d.name == name }
+      raise GemNotFound, "Could not find gem '#{name}'." unless dep
+      dep
     end
 
   end

--- a/spec/update/gems_spec.rb
+++ b/spec/update/gems_spec.rb
@@ -56,6 +56,13 @@ describe "bundle update" do
     end
   end
 
+  describe "with a unknown dependency" do
+    it "should inform the user" do
+      bundle "update halting-problem-solver", :expect_err=>true
+      out.should include "Could not find gem 'halting-problem-solver'"
+    end
+  end
+
   describe "with --local option" do
     it "doesn't hit repo2" do
       FileUtils.rm_rf(gem_repo2)


### PR DESCRIPTION
With this commit, "bundle update unknown-gem" will raise GemNotFound rather than ignoring the error and carrying through with the empty update.

It basically just loops through the known dependencies before running the update, so "bundle update unknown-gem" will result in a GemNotFound exception.
WDYT?

(this then leads into Bundler being able to suggest typos for bundle-update & bundle-open - https://github.com/jdelStrother/bundler/commit/d5cb470405975f364c29a9f88b5a97e87d6a1bc1 - but let's see if this gets accepted first)
