### PR TITLE
Suggest alternatives when typoing gem names

### DIFF
--- a/lib/bundler/similarity_detector.rb
+++ b/lib/bundler/similarity_detector.rb
@@ -1,0 +1,63 @@
+module Bundler
+  class SimilarityDetector
+    SimilarityScore = Struct.new(:string, :distance)
+
+    # initialize with an array of words to be matched against
+    def initialize(corpus)
+      @corpus = corpus
+    end
+
+    # return an array of words similar to 'word' from the corpus
+    def similar_words(word, limit=3)
+      words_by_similarity = @corpus.map{|w| SimilarityScore.new(w, levenshtein_distance(word, w))}
+      words_by_similarity.select{|s| s.distance<=limit}.sort_by(&:distance).map(&:string)
+    end
+
+    # return the result of 'similar_words', concatenated into a list
+    # (eg "a, b, or c")
+    def similar_word_list(word, limit=3)
+      words = similar_words(word,limit)
+      if words.length==1
+        words[0]
+      elsif words.length>1
+        [words[0..-2].join(', '), words[-1]].join(' or ')
+      end
+    end
+
+
+  protected
+    # http://www.informit.com/articles/article.aspx?p=683059&seqNum=36
+    def levenshtein_distance(this, that, ins=2, del=2, sub=1)
+      # ins, del, sub are weighted costs
+      return nil if this.nil?
+      return nil if that.nil?
+      dm = []        # distance matrix
+
+      # Initialize first row values
+      dm[0] = (0..this.length).collect { |i| i * ins }
+      fill = [0] * (this.length - 1)
+
+      # Initialize first column values
+      for i in 1..that.length
+        dm[i] = [i * del, fill.flatten]
+      end
+
+      # populate matrix
+      for i in 1..that.length
+        for j in 1..this.length
+          # critical comparison
+          dm[i][j] = [
+               dm[i-1][j-1] +
+                 (this[j-1] == that[i-1] ? 0 : sub),
+                   dm[i][j-1] + ins,
+               dm[i-1][j] + del
+         ].min
+        end
+      end
+
+      # The last value in matrix is the Levenshtein distance between the strings
+      dm[that.length][this.length]
+    end
+
+  end
+end

--- a/spec/other/open_spec.rb
+++ b/spec/other/open_spec.rb
@@ -32,4 +32,9 @@ describe "bundle open" do
     bundle "open missing", :env => {"EDITOR" => "echo editor", "VISUAL" => "", "BUNDLER_EDITOR" => ""}
     out.should match(/could not find gem 'missing'/i)
   end
+
+  it "suggests alternatives for similar-sounding gems" do
+    bundle "open Rails", :env => {"EDITOR" => "echo editor", "VISUAL" => "", "BUNDLER_EDITOR" => ""}
+    out.should match(/did you mean rails\?/i)
+  end
 end

--- a/spec/update/gems_spec.rb
+++ b/spec/update/gems_spec.rb
@@ -61,6 +61,10 @@ describe "bundle update" do
       bundle "update halting-problem-solver", :expect_err=>true
       out.should include "Could not find gem 'halting-problem-solver'"
     end
+    it "should suggest alternatives" do
+      bundle "update active-support", :expect_err=>true
+      out.should include "Did you mean activesupport?"
+    end
   end
 
   describe "with --local option" do


### PR DESCRIPTION
eg
$ bundle open thinking_sphinx
Could not find gem 'thinking_sphinx'.
Did you mean thinking-sphinx?

This is basically a repeat of https://github.com/carlhuda/bundler/pull/2050, but now supports both bundle-open and bundle-update typos, and is somewhat refactored.
I'm not loving the implementation, but it works fine... would be open to any suggestions.
