### PR TITLE
Ignore new line breaks when parsing lockfile

### DIFF
--- a/lib/bundler/lockfile_parser.rb
+++ b/lib/bundler/lockfile_parser.rb
@@ -21,7 +21,7 @@ module Bundler
       @specs        = []
       @state        = :source
 
-      lockfile.split(/(\r?\n)+/).each do |line|
+      lockfile.split(/(?:\r?\n)+/).each do |line|
         if line == "DEPENDENCIES"
           @state = :dependency
         elsif line == "PLATFORMS"


### PR DESCRIPTION
I've noticed, that currently a lockfile is split into array including newlines, eg:

``` ruby
  [
    "GEM",
    "\n",
    "  specs:",
    "\n",
    "    actionmailer (3.2.8)",
    "\n",
    "      actionpack (= 3.2.8)",
    "\n", 
    ... 
  ]
```

Each newline symbol goes through several checks and methods until it's discarded. 

To prevent that I've changed split to return only valuable results without capturing breaks, eg:

``` ruby
  [
    "GEM",
    "  specs:",
    "    actionmailer (3.2.8)",
    "      actionpack (= 3.2.8)",
    ... 
  ]
```

This change lead to following timings of running `LockfileParser.new` on a medium gemfile:

```
before:   0.095396
after:    0.049113
```
