### PR TITLE
Require OpenSSL when bundling on JRuby

### DIFF
--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -1,5 +1,6 @@
 require 'uri'
 require 'bundler/vendored_persistent'
+require 'openssl' if defined?(JRUBY_VERSION)
 
 module Bundler
   # Handles all the fetching with the rubygems server


### PR DESCRIPTION
By default, most Gemfiles use https://rubygems.org/ as their source, and
rightly so. SSL is a good default to maintain. However, bundling on the
JRuby platform has had issues for a long time now, usually throwing
`LoadError: OpenSSL::SSL requires the jruby-openssl gem`. This is a
problem I see repeatedly on Rails applications generated under JRuby,
despite having `gem 'jruby-openssl'` in the Gemfile. Bundler dies before
the gem can be installed, however; even having `jruby-openssl`
preinstalled would fail.

This patch adds a `require` statement for `'openssl'` in the place that
seemed most logical to me, `lib/bundler/fetcher.rb`. After adding this
require statement, bundling via HTTPS has worked flawlessly.

Fixes issues #1621, #1819, #1975 (closed), and #1996 (closed).

Signed-off-by: David Celis david@davidcelis.com
