### PR TITLE
Add `bundle profile` CLI command.

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -664,6 +664,16 @@ module Bundler
       Bundler.ui.info output.join("\n\n")
     end
 
+    desc "profile [GROUPS]", "Output performance information"
+    long_desc <<-D
+      Profile loads all dependencies and dumps their load time to STDOUT.
+      If one or more groups are specified, they are loaded in addition to the default group.
+    D
+    def profile(groups = nil)
+      Bundler.load.profiling = true
+      groups ? Bundler.require(:default, *(groups.split.map! {|g| g.to_sym })) : Bundler.require
+    end
+
   private
 
     def setup_cache_all

--- a/man/bundle.ronn
+++ b/man/bundle.ronn
@@ -73,6 +73,10 @@ We divide `bundle` subcommands into primary commands and utilities.
 * `bundle gem(1)`:
   Create a simple gem, suitable for development with bundler
 
+* `bundle profile(1)`:
+  Show how long each gem takes to load. Optionally pass one or more
+  bundle groups, e.g., development
+
 ## OBSOLETE
 
 These commands are obsolete and should no longer be used


### PR DESCRIPTION
This command loads all dependencies and dumps their
load time to STDOUT. It takes an optional list of
groups to be loaded in addition to the default group.

Example output:

```
$ bundle profile
       151ms rails
        16ms pg
       197ms haml
         1ms haml-rails
         3ms jquery-rails
         3ms bcrypt-ruby (LoadError)
        21ms sorcery
         1ms andand
        60ms resque
       108ms heroku
        41ms unicorn
       193ms newrelic_rpm
        90ms rest-client
        82ms jbuilder
        32ms dalli
        21ms thin
       254ms roadie
        31ms rack-mini-profiler
       465ms resque_mail_queue
      1778ms Total time to require all gems
```
