### PR TITLE
lib/bundler/settings.rb: Always respect Bundler.ruby_scope

### DIFF
--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -84,10 +84,10 @@ module Bundler
     # @local_config["BUNDLE_PATH"] should be prioritized over ENV["BUNDLE_PATH"]
     def path
       key  = key_for(:path)
-      path = ENV[key] || @global_config[key]
-      return "#{path}/#{Bundler.ruby_scope}" if path && !@local_config.key?(key)
+      path = ENV[key]
+      return path if path && !@local_config.key?(key)
 
-      if path = self[:path]
+      if path = self[:path] || @global_config[key]
         "#{path}/#{Bundler.ruby_scope}"
       else
         Bundler.rubygems.gem_dir


### PR DESCRIPTION
I have a long standing headache that ~/.bundle/config works
differently than /path/to/project/.bundle/config.
This would make them work the same way, respecting ruby scope.
Not sure if this would have other side-effects,
but really the config should have the same meaning!

Thanks!
