### PR TITLE
Added reference to source rubygems in the Sinatra help

### DIFF
--- a/sinatra.html
+++ b/sinatra.html
@@ -29,7 +29,7 @@
             <div class="description">
               To use bundler with a Sinatra application, you only need to do two things. First, create a Gemfile.
             </div>
-            <pre class="sunburst">gem <span class="String"><span class="String">&quot;</span>sinatra<span class="String">&quot;</span></span>, <span class="Constant"><span class="Constant">:</span>require</span> =&gt; <span class="String"><span class="String">&quot;</span>sinatra/base<span class="String">&quot;</span></span>&#x000A;</pre>
+            <pre class="sunburst">source <span class="String">'https://rubygems.org'</span>&#x000A;gem <span class="String"><span class="String">&quot;</span>sinatra<span class="String">&quot;</span></span>, <span class="Constant"><span class="Constant">:</span>require</span> =&gt; <span class="String"><span class="String">&quot;</span>sinatra/base<span class="String">&quot;</span></span>&#x000A;</pre>
           </div>
           <div class="bullet">
             <div class="description">


### PR DESCRIPTION
With the previous version of this Sinatra help, bundler returned

```
Your Gemfile has no remote sources. If you need gems that are not already on
your machine, add a line like this to your Gemfile:
    source 'https://rubygems.org'
Could not find gem 'sinatra (>= 0) ruby' in the gems available on this machine.
```

So I want add the `source 'https://rubygems.org'` to the Bundler website
