### PR TITLE
rake:release should notify of both unstaged and uncommitted changes

### DIFF
--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -112,11 +112,15 @@ module Bundler
     end
 
     def guard_clean
-      clean? or raise("There are files that need to be committed first.")
+      clean? && committed? or raise("There are files that need to be committed first.")
     end
 
     def clean?
       sh_with_code("git diff --exit-code")[1] == 0
+    end
+
+    def committed?
+      sh_with_code("git diff-index --quiet --cached HEAD")[1] == 0
     end
 
     def tag_version

--- a/spec/bundler/gem_helper_spec.rb
+++ b/spec/bundler/gem_helper_spec.rb
@@ -128,7 +128,12 @@ describe "Bundler::GemHelper tasks" do
     end
 
     describe 'release' do
+      it "shouldn't push if there are unstaged files" do
+        proc { @helper.release_gem }.should raise_error(/files that need to be committed/)
+      end
+
       it "shouldn't push if there are uncommitted files" do
+        %x{cd test; git add .}
         proc { @helper.release_gem }.should raise_error(/files that need to be committed/)
       end
 


### PR DESCRIPTION
I recently had a situation where this bit me. I figured if Bundler is going to check for unstaged changes, it should also check for staged but uncommitted changes. I left out the possibility of halting if there are untracked files in the repository, since that seems potentially over-reaching, but if anyone thinks that's a good idea it would be simple enough to implement.
