### PR TITLE
Default new gem's gemspec to have MIT license.

### DIFF
--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -11,6 +11,7 @@ Gem::Specification.new do |gem|
   gem.description   = %q{TODO: Write a gem description}
   gem.summary       = %q{TODO: Write a gem summary}
   gem.homepage      = ""
+  gem.license       = "MIT"
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }

--- a/spec/other/newgem_spec.rb
+++ b/spec/other/newgem_spec.rb
@@ -64,6 +64,10 @@ describe "bundle gem" do
     end
   end
 
+  it "sets gemspec license to MIT by default" do
+    generated_gem.gemspec.license.should == "MIT"
+  end
+
   it "requires the version file" do
     bundled_app("test-gem/lib/test-gem.rb").read.should =~ /require "test-gem\/version"/
   end


### PR DESCRIPTION
When creating a new gem, there is already an MIT license file added
(https://github.com/carlhuda/bundler/pull/1571), this makes it explicit
in the .gemspec so that tools like https://github.com/pivotal/licensefinder
can easily detect it.
