### PR TITLE
Add :github_account option

### DIFF
--- a/lib/bundler/version.rb
+++ b/lib/bundler/version.rb
@@ -2,5 +2,5 @@ module Bundler
   # We're doing this because we might write tests that deal
   # with other versions of bundler and we are unsure how to
   # handle this better.
-  VERSION = "1.2.0" unless defined?(::Bundler::VERSION)
+  VERSION = "1.2.1" unless defined?(::Bundler::VERSION)
 end

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -18,6 +18,21 @@ describe Bundler::Dsl do
       github_uri = "git://github.com/rails/rails.git"
       subject.dependencies.first.source.uri.should == github_uri
     end
+
+    it "should concatenate :github_account + gem name" do
+      subject.gem("bundler", :github_account => "carlhuda")
+      github_uri = "git://github.com/carlhuda/bundler.git"
+      subject.dependencies.first.source.uri.should == github_uri
+    end
+
+    it "should complain if :github_account and :git are specified" do
+      lambda {
+        subject.gem("tricycle",
+          :git => "git@foo.com/trike.git",
+          :github_account => "nonsense"
+        )
+      }.should raise_error Bundler::DslError
+    end
   end
 
   describe '#method_missing' do


### PR DESCRIPTION
A specification like:

```
gem 'bundler', github_account: 'carlhuda'
```

Transforms to:

```
gem 'bundler', git: 'git://github.com/carlhuda/bundler.git'
```

Note that I went ahead and bumped the version to 1.2.1, so that users of the
:github_account feature can easily say, "This Gemfile requires bundler ≥1.2.1".

I didn't update any docs.

In actuality, it seems like the existing ":github" interpretation is not very useful. I'm using a new key, :github_account, because I'm a fraidy cat and don't want to break someone's Gemfile if they depend on it. A more aggressive move would be to make the :github semantics be like this patch's :github_account.

Thanks!
