### PR TITLE
Rubygems source should fetch specs from all caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ spec/reports
 
 # Netbeans
 nbproject
+
+# Rubymine
+.idea

--- a/lib/bundler/source.rb
+++ b/lib/bundler/source.rb
@@ -205,18 +205,19 @@ module Bundler
         @cached_specs ||= begin
           idx = installed_specs.dup
 
-          path = Bundler.app_cache
-          Dir["#{path}/*.gem"].each do |gemfile|
-            next if gemfile =~ /^bundler\-[\d\.]+?\.gem/
+          caches.each do |path|
+            Dir["#{path}/*.gem"].each do |gemfile|
+              next if gemfile =~ /^bundler\-[\d\.]+?\.gem/
 
-            begin
-              s ||= Bundler.rubygems.spec_from_gem(gemfile)
-            rescue Gem::Package::FormatError
-              raise GemspecError, "Could not read gem at #{gemfile}. It may be corrupted."
+              begin
+                s ||= Bundler.rubygems.spec_from_gem(gemfile)
+              rescue Gem::Package::FormatError
+                raise GemspecError, "Could not read gem at #{gemfile}. It may be corrupted."
+              end
+
+              s.source = self
+              idx << s
             end
-
-            s.source = self
-            idx << s
           end
         end
 


### PR DESCRIPTION
This is a bug fix. The Rubygems source fetched cached specs only from
the bundle_cache, instead of all of its @caches.

I have no idea how to test this, but would love a suggestion - the spec/bundler/source_spec.rb was quite empty, and I scratched trying to determine which integration test would cover this. 
