### PR TITLE
first try on faster bundle exec ruby

### DIFF
--- a/bin/bundle
+++ b/bin/bundle
@@ -1,4 +1,9 @@
 #!/usr/bin/env ruby
+if ARGV[0..1] == ["exec", "ruby"]
+  # stop execution early, to not load bundler/setup twice, to not parse the gemfile/dependencies twice
+  exec "ruby", "-rbundler/setup", *ARGV[2..-1] # execution ends here
+end
+
 require 'bundler'
 # Check if an older version of bundler is installed
 $:.each do |path|


### PR DESCRIPTION
as per discussion in #2117

```
normal ruby:
time ruby -rbundler/setup -e 'puts "foo"' --> 2.3s

bundle exec with patch:
time bundle exec ruby -e 'puts "foo"' --> 2.9s

bundle exec without patch:
time bundle exec ruby -e 'puts "foo"' --> 4.0s
```

the time diff in case 2 is because rubygems is loaded once for the executable and once for the exec ruby run. Getting rid of it like the hub gem does might be a solution, but still kind of nasty...

I'm trying to preserve the original ARGV, so that e.g. `ruby -e ''` does not blow up, maybe there is a better way of doing this...
