### PR TITLE
we should be rescuing from Psych::SyntaxError, not SyntaxError

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -294,7 +294,7 @@ module Bundler
         begin
           Gem::Specification.from_yaml(contents)
           # Raises ArgumentError if the file is not valid YAML
-        rescue ArgumentError, SyntaxError, Gem::EndOfYAMLException, Gem::Exception
+        rescue ArgumentError, Psych::SyntaxError, Gem::EndOfYAMLException, Gem::Exception
           begin
             eval(contents, TOPLEVEL_BINDING, path.expand_path.to_s)
           rescue LoadError, SyntaxError => e


### PR DESCRIPTION
A ruby SyntaxError shouldn't be raised in this block, so we shouldn't catch it.  This _should_ catch Psych::SyntaxErrors (because that can happen when parsing YAML).
