### PR TITLE
Identify the packaged software license in the gemspec

### DIFF
--- a/bundler.gemspec
+++ b/bundler.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |s|
   s.name        = "bundler"
   s.version     = Bundler::VERSION
   s.platform    = Gem::Platform::RUBY
+  s.license     = "MIT"
   s.authors     = ["André Arko", "Terence Lee", "Carl Lerche", "Yehuda Katz"]
   s.email       = ["andre@arko.net"]
   s.homepage    = "http://gembundler.com"


### PR DESCRIPTION
The library's newgem template already identifies the MIT License in the generated gemspec file.  The Bundler gem itself should do the same.  I assume it was just an oversight that this hadn't been done, sooner.  So, 1 line pull request!

Doing this significantly improves the ease of identifying software licenses and dependencies.
