### PR TITLE
Add `gem 'rake', :group => :test` to Gemfile template

### DIFF
--- a/lib/bundler/templates/newgem/Gemfile.tt
+++ b/lib/bundler/templates/newgem/Gemfile.tt
@@ -1,4 +1,7 @@
 source 'https://rubygems.org'
 
+# Include rake in Gemfile so that `bundle exec rake` doesn't raise an error
+gem 'rake', :group => :test
+
 # Specify your gem's dependencies in <%=config[:name]%>.gemspec
 gemspec


### PR DESCRIPTION
Added `gem 'rake', :group => :test` to the `Gemfile` template, in case someone happens to have `rake` aliased to `bundle exec rake`. Otherwise, they'll get an error saying `rake is not part of the bundle`.

This also supports the advice in the [Travis CI Ruby docs](http://about.travis-ci.org/docs/user/languages/ruby/), under the  **Default Test Script** section:

> Travis will use Bundler to install your project's dependencies and run rake by default to execute your tests. Please note that you need to add rake to your Gemfile (adding it to just :test group should be sufficient).
