### PR TITLE
Added -t option for `bundle gem` to generate a .travis.yml file with the current Ruby version

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -684,6 +684,9 @@ module Bundler
         template(File.join("newgem/test/minitest_helper.rb.tt"), File.join(target, "test/minitest_helper.rb"),         opts)
         template(File.join("newgem/test/test_newgem.rb.tt"),     File.join(target, "test/test_#{namespaced_path}.rb"), opts)
       end
+      if options[:test]
+        template(File.join("newgem/.travis.yml.tt"),         File.join(target, ".travis.yml"),            opts)
+      end
       Bundler.ui.info "Initializating git repo in #{target}"
       Dir.chdir(target) { `git init`; `git add .` }
 

--- a/lib/bundler/templates/newgem/.travis.yml.tt
+++ b/lib/bundler/templates/newgem/.travis.yml.tt
@@ -1,0 +1,3 @@
+language: ruby
+rvm:
+  - <%= RUBY_VERSION %>

--- a/spec/other/newgem_spec.rb
+++ b/spec/other/newgem_spec.rb
@@ -178,6 +178,10 @@ RAKEFILE
         expect(bundled_app("test_gem/spec/spec_helper.rb")).to exist
         expect(bundled_app("test_gem/test/minitest_helper.rb")).to_not exist
       end
+
+      it "creates a .travis.yml file to test the library against the current Ruby version on Travis CI" do
+        expect(bundled_app("test_gem/.travis.yml").read).to match(%r(- #{RUBY_VERSION}))
+      end
     end
 
     context "--edit option" do


### PR DESCRIPTION
A lot of open source gems are running their tests on [Travis CI](http://travis-ci.org/). 

This PR adds the option to generate an minimal (but functional) `.travis.yml` config file, so you can start testing on Travis CI right away.

Let me know if you think we should make this a default file, and remove the option. Gems are _usually_ open source, so it might be cool to encourage testing on Travis CI.
