### PR TITLE
support setting boolean environment variables

### DIFF
--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -7,8 +7,9 @@ module Bundler
     end
 
     def [](key)
-      key = key_for(key)
-      @local_config[key] || ENV[key] || @global_config[key]
+      the_key = key_for(key)
+      value = (@local_config[the_key] || ENV[the_key] || @global_config[the_key])
+      is_bool(key) ? to_bool(value) : value
     end
 
     def []=(key, value)
@@ -102,6 +103,14 @@ module Bundler
     def key_for(key)
       key = key.to_s.sub(".", "__").upcase
       "BUNDLE_#{key}"
+    end
+
+    def is_bool(key)
+      %w(frozen cache_all no_prune disable_local_branch_check).include? key.to_s
+    end
+
+    def to_bool(value)
+      !(value.nil? || value == '' || value =~ /^(false|f|no|n|0)$/i)
     end
 
     def set_key(key, value, hash, file)

--- a/spec/install/deploy_spec.rb
+++ b/spec/install/deploy_spec.rb
@@ -113,6 +113,20 @@ describe "install with --deployment or --frozen" do
       expect(out).not_to include("You have changed in the Gemfile")
     end
 
+    it "can have --frozen set to false via an environment variable" do
+      gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem "rack"
+        gem "rack-obama"
+      G
+
+      ENV['BUNDLE_FROZEN'] = "false"
+      bundle "install"
+      expect(out).not_to include("deployment mode")
+      expect(out).not_to include("You have added to the Gemfile")
+      expect(out).not_to include("* rack-obama")
+    end
+
     it "explodes with the --frozen flag if you make a change and don't check in the lockfile" do
       gemfile <<-G
         source "file://#{gem_repo1}"

--- a/spec/other/config_spec.rb
+++ b/spec/other/config_spec.rb
@@ -135,4 +135,35 @@ describe ".bundle/config" do
       expect(out).to eq("local")
     end
   end
+
+  describe "env" do
+    before(:each) { bundle :install }
+
+    it "can set boolean properties via the environment" do
+      ENV["BUNDLE_FROZEN"] = "true"
+
+      run "if Bundler.settings[:frozen]; puts 'true' else puts 'false' end"
+      expect(out).to eq("true")
+    end
+
+    it "can set negative boolean properties via the environment" do
+      run "if Bundler.settings[:frozen]; puts 'true' else puts 'false' end"
+      expect(out).to eq("false")
+
+      ENV["BUNDLE_FROZEN"] = "false"
+
+      run "if Bundler.settings[:frozen]; puts 'true' else puts 'false' end"
+      expect(out).to eq("false")
+
+      ENV["BUNDLE_FROZEN"] = "0"
+
+      run "if Bundler.settings[:frozen]; puts 'true' else puts 'false' end"
+      expect(out).to eq("false")
+
+      ENV["BUNDLE_FROZEN"] = ""
+
+      run "if Bundler.settings[:frozen]; puts 'true' else puts 'false' end"
+      expect(out).to eq("false")
+    end
+  end
 end


### PR DESCRIPTION
These were previously stored as a string if they are derived from the
environment or configuration files. Rather than altering each of the checks,
we can select a list of settings to convert to boolean values when they are
accessed.

I bumped into this specific problem trying to override `bundle config --global frozen true` with a `BUNDLE_FROZEN=false` environment variable.
