### PR TITLE
Adding MagLev to man page

### DIFF
--- a/man/gemfile.5.ronn
+++ b/man/gemfile.5.ronn
@@ -153,6 +153,8 @@ There are a number of `Gemfile` platforms:
     Same as _ruby_, but only Rubinius (not MRI)
   * `jruby`:
     JRuby
+  * `maglev`:
+    MagLev
   * `mswin`:
     Windows
   * `mingw`:


### PR DESCRIPTION
Was poking around and saw that MagLev wasn't listed on the man page.

(re #1444)
