### PR TITLE
Add MagLev to platform map

### DIFF
--- a/lib/bundler/dependency.rb
+++ b/lib/bundler/dependency.rb
@@ -17,6 +17,7 @@ module Bundler
       :mri_19   => Gem::Platform::RUBY,
       :rbx      => Gem::Platform::RUBY,
       :jruby    => Gem::Platform::JAVA,
+      :maglev   => Gem::Platform::RUBY,
       :mswin    => Gem::Platform::MSWIN,
       :mingw    => Gem::Platform::MINGW,
       :mingw_18 => Gem::Platform::MINGW,


### PR DESCRIPTION
Unsure if this is needed, but surprised it wasn't included. Please close if it's unnecessary. Thanks!
