### PR TITLE
fix a method redefinition warning

### DIFF
--- a/lib/bundler/source.rb
+++ b/lib/bundler/source.rb
@@ -503,7 +503,8 @@ module Bundler
       # All actions required by the Git source is encapsualted in this
       # object.
       class GitProxy
-        attr_accessor :path, :uri, :ref, :revision
+        attr_accessor :path, :uri, :ref
+        attr_writer :revision
 
         def initialize(path, uri, ref, revision=nil, &allow)
           @path     = path


### PR DESCRIPTION
`attr_accessor` defines a reader and writer method, but a reader method is later defined and emits a warning.
