### PR TITLE
Make rake release task to re-use a tag

### DIFF
--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -71,12 +71,11 @@ module Bundler
 
     def release_gem
       guard_clean
-      guard_already_tagged
       built_gem_path = build_gem
-      tag_version {
-        git_push
-        rubygem_push(built_gem_path)
-      }
+      unless guard_already_tagged
+        tag_version { git_push }
+      end
+      rubygem_push(built_gem_path)
     end
 
     protected
@@ -107,7 +106,8 @@ module Bundler
 
     def guard_already_tagged
       if sh('git tag').split(/\n/).include?(version_tag)
-        raise("This tag has already been committed to the repo.")
+        Bundler.ui.confirm "This tag has already been committed to the repo."
+        true
       end
     end
 

--- a/spec/bundler/gem_helper_spec.rb
+++ b/spec/bundler/gem_helper_spec.rb
@@ -169,6 +169,23 @@ describe "Bundler::GemHelper tasks" do
         }
         @helper.release_gem
       end
+
+      it "releases even if tag already exists" do
+        mock_build_message
+        mock_confirm_message("This tag has already been committed to the repo.")
+
+        @helper.should_receive(:rubygem_push).with(bundled_app('test/pkg/test-0.0.1.gem').to_s)
+
+        Dir.chdir(gem_repo1) {
+          `git init --bare`
+        }
+        Dir.chdir(@app) {
+         `git commit -a -m "another commit"`
+         `git tag -a -m \"Version 0.0.1\" v0.0.1`
+        }
+        @helper.release_gem
+      end
+
     end
   end
 end


### PR DESCRIPTION
Closes #2155
Should the `rake release` task somehow check for the current git HEAD?
