### PR TITLE
Continue catching ArgumentError on YAML parsing errors in order to eval when using Syck as YAML::ENGINE.yamler

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -295,7 +295,7 @@ module Bundler
             Gem::Specification.from_yaml(contents)
             # Raises ArgumentError if the file is not valid YAML (on syck)
             # Psych raises a Psych::SyntaxError
-          rescue YamlSyntaxError, Gem::EndOfYAMLException, Gem::Exception
+          rescue YamlSyntaxError, ArgumentError, Gem::EndOfYAMLException, Gem::Exception
             eval_gemspec(path, contents)
           end
         else

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -839,4 +839,61 @@ describe "Bundler.setup" do
     end
   end
 
+  context "when using Syck as YAML::Engine" do
+    it "should try to eval gemspec after YAML load throws ArgumentError" do
+      orig_yamler = YAML::ENGINE.yamler
+      YAML::ENGINE.yamler = 'syck'
+
+      spec_file = tmp.join('temp_gemspec_to_be_loaded_with_yaml_syck')
+      File.open(spec_file, 'w') do |file|
+        file << <<-S
+--- # -*- encoding: utf-8 -*-
+spec = Gem::Specification.new do |s|
+  s.name = 'test'
+  s.summary     = %q{TODO: Write a gem summary}
+  s.description = %q{TODO: Write a gem description}
+  s.add_dependency 'rack', '= 1.0.1'
+  s.add_development_dependency 'rspec', '1.2'
+end
+      S
+      end
+
+      # <ArgumentError: syntax error on line 4, col 26: `  s.description = %q{TODO: Write a gem description}'>
+      # should be thrown here, tried to be evaled and then fail with NoMethodError
+      expect {
+        Bundler.load_gemspec_uncached(tmp('temp_gemspec_to_be_loaded_with_yaml_syck'))
+      }.to raise_error(NoMethodError)
+
+      YAML::ENGINE.yamler = orig_yamler
+    end
+  end
+
+  context "when using Psych as YAML::Engine" do
+    it "should try to eval gemspec after YAML load throws Psych::SyntaxError" do
+      orig_yamler = YAML::ENGINE.yamler
+      YAML::ENGINE.yamler = 'psych'
+
+      spec_file = tmp.join('temp_gemspec_to_be_loaded_with_yaml_psych')
+      File.open(spec_file, 'w') do |file|
+        file << <<-S
+--- # -*- encoding: utf-8 -*-
+Gem::Specification.new do |s|
+  s.name = 'test'
+  s.summary     = "TODO: Write a gem summary"
+  s.description = "TODO: Write a gem description"
+  s.add_dependency 'rack', '= 1.0.1'
+  s.add_development_dependency 'rspec', '1.2'
+end
+      S
+      end
+
+      # <Psych::SyntaxError: couldn't parse YAML at line 4 column 23>
+      # should be thrown here, tried to be evaled and then fail with NoMethodError
+      expect {
+        Bundler.load_gemspec_uncached(tmp('temp_gemspec_to_be_loaded_with_yaml_psych'))
+      }.to raise_error(NoMethodError)
+
+      YAML::ENGINE.yamler = orig_yamler
+    end
+  end
 end


### PR DESCRIPTION
There is an issue in latest release from Bundler (1.2.2 as of now) that partially breaks support for loading gemspecs when using the Syck as the YAML engine.

Bundler supports loading gemspecs that could not be parsed by YAML by falling back to evaling the file, but somewhere between 1.2.1 and 1.2.2 this has stopped working and ArgumentError is raised instead, and Bundler setup fails.

This patch is a bit redundant, but the case that `Psych::SyntaxError` is defined and the `YAML::ENGINE.yamler` is set to 'syck' can still happen. I added a couple of tests that attempt to recreate this.

Thanks,
- Waldemar
