### PR TITLE
add minitest skeleton

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -623,6 +623,9 @@ module Bundler
         template(File.join("newgem/rspec.tt"),               File.join(target, ".rspec"),                 opts)
         template(File.join("newgem/spec/spec_helper.rb.tt"), File.join(target, "spec/spec_helper.rb"),    opts)
         template(File.join("newgem/spec/newgem_spec.rb.tt"), File.join(target, "spec/#{name}_spec.rb"),   opts)
+      when 'minitest'
+        template(File.join("newgem/test/minitest_helper.rb.tt"), File.join(target, "test/minitest_helper.rb"), opts)
+        template(File.join("newgem/test/test_newgem.rb.tt"),     File.join(target, "test/test_#{name}.rb"),    opts)
       end
       Bundler.ui.info "Initializating git repo in #{target}"
       Dir.chdir(target) { `git init`; `git add .` }

--- a/lib/bundler/templates/newgem/test/minitest_helper.rb.tt
+++ b/lib/bundler/templates/newgem/test/minitest_helper.rb.tt
@@ -1,0 +1,4 @@
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+require '<%= config[:name] %>'
+
+require 'minitest/autorun'

--- a/lib/bundler/templates/newgem/test/test_newgem.rb.tt
+++ b/lib/bundler/templates/newgem/test/test_newgem.rb.tt
@@ -1,0 +1,11 @@
+require './minitest_helper'
+
+class Test<%= config[:constant_name] %> < MiniTest::Unit::TestCase
+  def test_that_it_has_a_version_number
+    refute_nil ::<%= config[:constant_name] %>::VERSION
+  end
+
+  def test_it_does_something_useful
+    assert false
+  end
+end

--- a/spec/other/newgem_spec.rb
+++ b/spec/other/newgem_spec.rb
@@ -127,4 +127,29 @@ RAKEFILE
       expect(bundled_app("test-gem/spec/test-gem_spec.rb").read).to match(/false.should be_true/)
     end
   end
+  
+  context "--test parameter set to minitest" do
+    before :each do
+      reset!
+      in_app_root
+      bundle "gem test-gem --test=minitest"
+    end
+
+    it "builds spec skeleton" do
+      expect(bundled_app("test-gem/test/test_test-gem.rb")).to exist
+      expect(bundled_app("test-gem/test/minitest_helper.rb")).to exist
+    end
+
+    it "requires 'test-gem'" do
+      expect(bundled_app("test-gem/test/minitest_helper.rb").read).to match(/require 'test-gem'/)
+    end
+
+    it "requires 'minitest_helper'" do
+      expect(bundled_app("test-gem/test/test_test-gem.rb").read).to match(/require '.\/minitest_helper'/)
+    end
+
+    it "creates a default test which fails" do
+      expect(bundled_app("test-gem/test/test_test-gem.rb").read).to match(/assert false/)
+    end
+  end
 end


### PR DESCRIPTION
this is a follow up for ticket #2108.

I know you are working on getting plugins up and working, but in the meantime this adds support for using minitest when using `bundle gem` with the `--test` option
