### PR TITLE
an idea how to solve 95% of cases bundler is complaining about stuff fixes #1994

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -17,7 +17,7 @@ module Bundler
       Bundler.ui.debug! if options["verbose"]
     end
 
-    check_unknown_options!(:except => [:config, :exec])
+    check_unknown_options!(:except => [:config, :exec, :do])
 
     stop_on_unknown_option! :exec
 
@@ -447,6 +447,12 @@ module Bundler
         Bundler.ui.error "bundler: exec needs a command to run"
         exit 128
       end
+    end
+
+    desc "do", "asdadas"
+    def do(*args)
+      ENV["TRY_TO_BUNDLE"] = "YES"
+      exec(*args)
     end
 
     desc "config NAME [VALUE]", "retrieve or set a configuration value"

--- a/lib/bundler/setup.rb
+++ b/lib/bundler/setup.rb
@@ -1,17 +1,36 @@
 require 'bundler/shared_helpers'
 
+fail = lambda do |e|
+  puts "\e[31m#{e.message}\e[0m"
+  puts e.backtrace.join("\n") if ENV["DEBUG"]
+  if Bundler::GemNotFound === e
+    puts "\e[33mRun `bundle install` to install missing gems.\e[0m"
+  end
+  exit e.status_code
+end
+
 if Bundler::SharedHelpers.in_bundle?
   require 'bundler'
   if STDOUT.tty?
     begin
       Bundler.setup
     rescue Bundler::BundlerError => e
-      puts "\e[31m#{e.message}\e[0m"
-      puts e.backtrace.join("\n") if ENV["DEBUG"]
-      if Bundler::GemNotFound === e
-        puts "\e[33mRun `bundle install` to install missing gems.\e[0m"
+      if ENV["TRY_TO_BUNDLE"]
+        ENV["TRY_TO_BUNDLE"] = nil
+        puts "trying to bundle ..."
+        if Bundler.with_clean_env{ system("bundle") }
+          Bundler.clear_gemspec_cache
+          begin
+            Bundler.setup
+          rescue Bundler::BundlerError => e
+            fail(e)
+          end
+        else
+          fail.call(e)
+        end
+      else
+        fail.call(e)
       end
-      exit e.status_code
     end
   else
     Bundler.setup


### PR DESCRIPTION
most of the time bundler is annoying is when someone else on the team updated some dependency or I switched ruby, so how about being nice and just try to bundle before declaring failure.

Either `TRY_TO_BUNDLE=1 bundle exec foo` or `bundle do foo`

this is pretty crappy code, atm it fails after the bundling because the old dependencies are still cached, but should be fixable, I basically want to know if this is something that would get merged at all <-> if it's going in the right direction...

```
bundle do ruby -e 'puts 1'
trying to bundle ...
Fetching gem metadata from http://rubygems.org/..
Installing rake (0.9.5) 
Using bundler (1.3.0.pre) 
Your bundle is complete! Use `bundle show [gemname]` to see where a bundled gem is installed.
/Users/mgrosser/.rvm/gems/ruby-1.9.3-p327/gems/bundler-1.3.0.pre/lib/bundler/spec_set.rb:90:in `block in materialize': Could not find rake-0.9.5 in any of the sources (Bundler::GemNotFound)
```

/cc @rohit
