### PR TITLE
Because required files can sometimes themselves contain unrelated LoadErrors (e.g. during inter-gem development), run the regexps against the LoadError before the namespaced fallback check.

### DIFF
--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -68,6 +68,9 @@ module Bundler
             Kernel.require file
           end
         rescue LoadError => e
+          REGEXPS.find { |r| r =~ e.message }
+          raise if dep.autorequire || $1 != required_file
+
           if dep.autorequire.nil? && dep.name.include?('-')
             begin
               namespaced_file = dep.name.gsub('-', '/')
@@ -78,9 +81,6 @@ module Bundler
               raise if dep.autorequire || (regex_name && regex_name.gsub('-', '/') != namespaced_file)
               raise e if regex_name.nil?
             end
-          else
-            REGEXPS.find { |r| r =~ e.message }
-            raise if dep.autorequire || $1 != required_file
           end
         end
       end


### PR DESCRIPTION
In the case where we legitimately need to be looking up the namespaced fallback, the error should pass the required_file check.
