### PR TITLE
Remove sources of two outstanding warnings

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -230,7 +230,7 @@ module Bundler
       end
 
       File.open(file, 'wb'){|f| f.puts(contents) }
-    rescue Errno::EACCES => e
+    rescue Errno::EACCES
       raise Bundler::InstallError,
         "There was an error while trying to write to Gemfile.lock. It is likely that \n" \
         "you need to allow write permissions for the file at path: \n" \

--- a/lib/bundler/source.rb
+++ b/lib/bundler/source.rb
@@ -513,6 +513,7 @@ module Bundler
           @allow    = allow || Proc.new { true }
         end
 
+        remove_method :revision if method_defined? :revision
         def revision
           @revision ||= allowed_in_path { git("rev-parse #{ref}").strip }
         end


### PR DESCRIPTION
Bundler was `ruby -w`-clean for a long time, until recently (1.2.0?) two warnings crept in. This is especially irritating when one runs `rake spec` with warnings on, to catch potential code issues in development.

This pull request removes the sources of the two outstanding warnings and is against the `1-2-stable` branch. Let me know if it should be against `master` (but it would be great if it made it into 1.2.x).
