### PR TITLE
Remove assigned but unused variable in exception rescuing

### DIFF
--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -141,7 +141,7 @@ module Bundler
         response = @@connection.request(uri)
       rescue Timeout::Error, Errno::EINVAL, Errno::ECONNRESET, Errno::ETIMEDOUT,
              EOFError, SocketError, Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError,
-             Errno::EAGAIN, Net::HTTP::Persistent::Error, Net::ProtocolError => e
+             Errno::EAGAIN, Net::HTTP::Persistent::Error, Net::ProtocolError
         raise HTTPError, "Network error while fetching #{uri}"
       end
 

--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -95,7 +95,7 @@ module Bundler
         # Then fetch the prerelease specs
         begin
           Gem::SpecFetcher.new.list(false, true).each {|k, v| spec_list[k] += v }
-        rescue Gem::RemoteFetcher::FetchError => e
+        rescue Gem::RemoteFetcher::FetchError
           # ignore if we can't fetch the prerelease specs
         end
       end


### PR DESCRIPTION
This avoids warning when running ruby verbose mode.
