### PR TITLE
Move the task definitions into separate methods

### DIFF
--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -82,7 +82,7 @@ module Bundler
         install_gem
       end
     end
-        
+
     def define_release_task
       desc "Create tag #{version_tag} and build and push #{name}-#{version}.gem to Rubygems"
       task 'release' do


### PR DESCRIPTION
I moved the task definitions into their own separate methods so gems like [bundler_geminabox](https://rubygems.org/gems/bundler_geminabox) that change where gems are released (e.g. not Rubygems) can override them more cleanly.

For example, the description for the release task indicates that the gem will be built and released to Rubygems, which isn't the case for gems hosted on private gem servers like geminabox. Redefining the task and description requires overriding the whole install method, when all really want to do is redefine the task description.

This isn't essential, but is (IMO) a nice thing to have.
