### PR TITLE
Expand path when setting local override

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -520,6 +520,11 @@ module Bundler
           Bundler.ui.info "You are replacing the current local value of #{name}, which is currently #{local.inspect}"
         end
 
+        if name.match(/\Alocal\./)
+          pathname = Pathname.new(args.join(" "))
+          args = [pathname.expand_path.to_s] if pathname.directory?
+        end
+
         Bundler.settings.send("set_#{scope}", name, args.join(" "))
       else
         Bundler.ui.error "Invalid scope --#{scope} given. Please use --local or --global."

--- a/spec/other/config_spec.rb
+++ b/spec/other/config_spec.rb
@@ -95,6 +95,12 @@ describe ".bundle/config" do
       run "puts Bundler.settings[:foo]"
       expect(out).to eq("global")
     end
+
+    it "expands the path at time of setting" do
+      bundle "config --global local.foo .."
+      run "puts Bundler.settings['local.foo']"
+      expect(out).to eq(File.expand_path(Dir.pwd + "/.."))
+    end
   end
 
   describe "local" do
@@ -133,6 +139,12 @@ describe ".bundle/config" do
 
       run "puts Bundler.settings[:foo]"
       expect(out).to eq("local")
+    end
+
+    it "expands the path at time of setting" do
+      bundle "config --local local.foo .."
+      run "puts Bundler.settings['local.foo']"
+      expect(out).to eq(File.expand_path(Dir.pwd + "/.."))
     end
   end
 end


### PR DESCRIPTION
Note

The word local is overloaded in bundler land.  In the title of this pull-request, and at http://gembundler.com/v1.2/whats_new.html, local refers to the local machine, and local git overrides are set in config with keys named `local.foo` where foo is the name of the gem.

In bundler config, local apparently refers to the config scope that applies to a bundler-enabled app, to be contrast with global which refers to the config scope that applies to a system user.

(perhaps we should rename the local scope to app scope and the global scope to user scope?)

My code applies to both the local and global config scopes, but only to config settings whose keys match the local.foo format.
