### PR TITLE
use HTTPS for gists

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -236,7 +236,7 @@ module Bundler
       end
 
       if gist = opts.delete("gist")
-        opts["git"] = "git://gist.github.com/#{gist}.git"
+        opts["git"] = "https://gist.github.com/#{gist}.git"
       end
 
       ["git", "path"].each do |type|

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -15,13 +15,13 @@ describe Bundler::Dsl do
 
     it "converts numeric :gist to :git" do
       subject.gem("not-really-a-gem", :gist => 2859988)
-      github_uri = "git://gist.github.com/2859988.git"
+      github_uri = "https://gist.github.com/2859988.git"
       expect(subject.dependencies.first.source.uri).to eq(github_uri)
     end
 
     it "converts :gist to :git" do
       subject.gem("not-really-a-gem", :gist => "2859988")
-      github_uri = "git://gist.github.com/2859988.git"
+      github_uri = "https://gist.github.com/2859988.git"
       expect(subject.dependencies.first.source.uri).to eq(github_uri)
     end
 


### PR DESCRIPTION
Seems `git://` doesn't work anymore.
