### PR TITLE
fix to not generate unnecessary dir

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -608,7 +608,6 @@ module Bundler
       constant_name = name.split('_').map{|p| p[0..0].upcase + p[1..-1] }.join
       constant_name = constant_name.split('-').map{|q| q[0..0].upcase + q[1..-1] }.join('::') if constant_name =~ /-/
       constant_array = constant_name.split('::')
-      FileUtils.mkdir_p(File.join(target, 'lib', name))
       git_user_name = `git config user.name`.chomp
       git_user_email = `git config user.email`.chomp
       opts = {


### PR DESCRIPTION
I have found the bug my own PR (https://github.com/carlhuda/bundler/pull/2201).
It creates `foo-rails/lib/foo-rails` empty directory which is doesn't needed anymore.

This PR fixes from:

```
foo-rails
├── Gemfile
├── LICENSE.txt
├── README.md
├── Rakefile
├── foo-rails.gemspec
├── lib
│   ├── foo
│   │   ├── rails
│   │   │   └── version.rb
│   │   └── rails.rb
│   └── foo-rails
└── spec
    ├── foo
    │   └── rails_spec.rb
    └── spec_helper.rb
```

to:

```
foo-rails
├── Gemfile
├── LICENSE.txt
├── README.md
├── Rakefile
├── foo-rails.gemspec
├── lib
│   └── foo
│       ├── rails
│       │   └── version.rb
│       └── rails.rb
└── spec
    ├── foo
    │   └── rails_spec.rb
    └── spec_helper.rb
```

it works with not namespaced library as well:

```
foo_rails
├── Gemfile
├── LICENSE.txt
├── README.md
├── Rakefile
├── foo_rails.gemspec
├── lib
│   ├── foo_rails
│   │   └── version.rb
│   └── foo_rails.rb
└── spec
    ├── foo_rails_spec.rb
    └── spec_helper.rb
```
