### PR TITLE
Pass in `--local` when running `rake install` from gem helper tasks.

### DIFF
--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -64,7 +64,7 @@ module Bundler
 
     def install_gem
       built_gem_path = build_gem
-      out, _ = sh_with_code("gem install '#{built_gem_path}'")
+      out, _ = sh_with_code("gem install '#{built_gem_path}' --local")
       raise "Couldn't install gem, run `gem install #{built_gem_path}' for more detailed output" unless out[/Successfully installed/]
       Bundler.ui.confirm "#{name} (#{version}) installed."
     end


### PR DESCRIPTION
- I don't see any reason why this could break anything
- This speeds up installing gems significantly when you're on a slow
  connection
