### PR TITLE
Added --editor option to open generated gemspec in editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Features:
   - pushing gems during `rake release` can be disabled (@trans)
   - installing gems with `rake install` is much faster (@utkarshkukreti)
   - added platforms :ruby_20 and :mri_20, since the ABI has changed
+  - added '--edit' option to open generated gemspec in editor
 
 Bugfixes:
 

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -601,6 +601,11 @@ module Bundler
     desc "gem GEM", "Creates a skeleton for creating a rubygem"
     method_option :bin, :type => :boolean, :default => false, :aliases => '-b', :banner => "Generate a binary for your library."
     method_option :test, :type => :string, :default => 'rspec', :aliases => '-t', :banner => "Generate a test directory for your library: 'rspec' is the default, but 'minitest' is also supported."
+    method_option :edit, :type => :string, :aliases => "-e",
+                  :lazy_default => [ENV['BUNDLER_EDITOR'], ENV['VISUAL'], ENV['EDITOR']].find{|e| !e.nil? && !e.empty? },
+                  :required => false, :banner => "/path/to/your/editor",
+                  :desc => "Open generated gemspec in the specified editor (defaults to $EDITOR or $BUNDLER_EDITOR)"
+
     def gem(name)
       name = name.chomp("/") # remove trailing slash if present
       namespaced_path = name.tr('-', '/')
@@ -618,12 +623,13 @@ module Bundler
         :author          => git_user_name.empty? ? "TODO: Write your name" : git_user_name,
         :email           => git_user_email.empty? ? "TODO: Write your email address" : git_user_email
       }
+      gemspec_dest = File.join(target, "#{name}.gemspec")
       template(File.join("newgem/Gemfile.tt"),               File.join(target, "Gemfile"),                             opts)
       template(File.join("newgem/Rakefile.tt"),              File.join(target, "Rakefile"),                            opts)
       template(File.join("newgem/LICENSE.txt.tt"),           File.join(target, "LICENSE.txt"),                         opts)
       template(File.join("newgem/README.md.tt"),             File.join(target, "README.md"),                           opts)
       template(File.join("newgem/gitignore.tt"),             File.join(target, ".gitignore"),                          opts)
-      template(File.join("newgem/newgem.gemspec.tt"),        File.join(target, "#{name}.gemspec"),                     opts)
+      template(File.join("newgem/newgem.gemspec.tt"),        gemspec_dest,                                             opts)
       template(File.join("newgem/lib/newgem.rb.tt"),         File.join(target, "lib/#{namespaced_path}.rb"),           opts)
       template(File.join("newgem/lib/newgem/version.rb.tt"), File.join(target, "lib/#{namespaced_path}/version.rb"),   opts)
       if options[:bin]
@@ -640,6 +646,10 @@ module Bundler
       end
       Bundler.ui.info "Initializating git repo in #{target}"
       Dir.chdir(target) { `git init`; `git add .` }
+
+      if options[:edit]
+        run("#{options["edit"]} \"#{gemspec_dest}\"")  # Open gemspec in editor
+      end
     end
 
     def self.source_root

--- a/spec/other/newgem_spec.rb
+++ b/spec/other/newgem_spec.rb
@@ -179,6 +179,16 @@ RAKEFILE
         expect(bundled_app("test_gem/test/minitest_helper.rb")).to_not exist
       end
     end
+
+    context "--edit option" do
+      it "opens the generated gemspec in the user's text editor" do
+        reset!
+        in_app_root
+        output = bundle "gem #{gem_name} --edit=echo"
+        gemspec_path = File.join(Dir.pwd, gem_name, "#{gem_name}.gemspec")
+        expect(output).to include("echo \"#{gemspec_path}\"")
+      end
+    end
   end
 
   context "gem naming with dashed" do


### PR DESCRIPTION
Adds an `--editor` option for the `bundle gem` command, to open the generated gemspec in the user's editor. Comes with CHANGELOG entry and test.

Similar to https://github.com/rails/rails/pull/8553
