### PR TITLE
Added pager system selection

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -46,8 +46,8 @@ module Bundler
         root = File.expand_path("../man", __FILE__)
 
         if have_groff? && root !~ %r{^file:/.+!/META-INF/jruby.home/.+}
-          groff   = "groff -Wall -mtty-char -mandoc -Tascii"
-          pager   = ENV['MANPAGER'] || ENV['PAGER'] || 'less -R'
+          groff = "groff -Wall -mtty-char -mandoc -Tascii"
+          pager = pager_system
 
           Kernel.exec "#{groff} #{root}/#{command} | #{pager}"
         else
@@ -793,6 +793,30 @@ module Bundler
       suggestions = SimilarityDetector.new(alternate_names).similar_word_list(missing_gem_name)
       message += "\nDid you mean #{suggestions}?" if suggestions
       message
+    end
+
+    def pager_system
+      pager_environment_variable or available_pager_system
+    end
+
+    def pager_environment_variable
+      ENV['PAGER'] or ENV['MANPAGER']
+    end
+
+    def available_pager_system
+      less or more or fallback_pager
+    end
+
+    def less
+      'less -R' if !(`which less` rescue '').empty?
+    end
+
+    def more
+      'more' if !(`which more` rescue '').empty?
+    end
+
+    def fallback_pager
+      'cat'
     end
 
   end


### PR DESCRIPTION
Pager system should rely on $PAGER or $MANPAGER environment variables.
If these variables does not exists, pager system should rely on `less` then `more` then `cat` commands.
