### PR TITLE
Added ENV['DEBUG_RESOLVER_TREE'] which outputs the resolver tree.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Next Release
+
+Features:
+
+  - add `ENV['DEBUG_RESOLVER_TREE']` outputs resolver tree (@dblock)
+
 ## 1.3.0.pre.5 (Jan 9, 2013)
 
 Features:

--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -161,7 +161,7 @@ module Bundler
       resolve(reqs, activated)
     end
 
-    def resolve(reqs, activated)
+    def resolve(reqs, activated, depth = 0)
       # If the requirements are empty, then we are in a success state. Aka, all
       # gem dependencies have been resolved.
       throw :success, successify(activated) if reqs.empty?
@@ -187,6 +187,8 @@ module Bundler
 
       # Pull off the first requirement so that we can resolve it
       current = reqs.shift
+
+      $stderr.puts "#{' ' * depth}#{current}" if ENV['DEBUG_RESOLVER_TREE']
 
       debug { "Attempting:\n  #{current}"}
 
@@ -219,7 +221,7 @@ module Bundler
             @gems_size[dep] ||= gems_size(dep)
           end
 
-          resolve(reqs, activated)
+          resolve(reqs, activated, depth + 1)
         else
           debug { "    * [FAIL] Already activated" }
           @errors[existing.name] = [existing, current]
@@ -292,7 +294,7 @@ module Bundler
         end
 
         matching_versions.reverse_each do |spec_group|
-          conflict = resolve_requirement(spec_group, current, reqs.dup, activated.dup)
+          conflict = resolve_requirement(spec_group, current, reqs.dup, activated.dup, depth)
           conflicts << conflict if conflict
         end
         # If the current requirement is a root level gem and we have conflicts, we
@@ -312,7 +314,7 @@ module Bundler
       end
     end
 
-    def resolve_requirement(spec_group, requirement, reqs, activated)
+    def resolve_requirement(spec_group, requirement, reqs, activated, depth)
       # We are going to try activating the spec. We need to keep track of stack of
       # requirements that got us to the point of activating this gem.
       spec_group.required_by.replace requirement.required_by
@@ -343,7 +345,7 @@ module Bundler
       @stack << requirement.name
       retval = catch(requirement.name) do
         # try to resolve the next option
-        resolve(reqs, activated)
+        resolve(reqs, activated, depth)
       end
 
       # clear the search cache since the catch means we couldn't meet the

--- a/spec/install/gems/resolving_spec.rb
+++ b/spec/install/gems/resolving_spec.rb
@@ -67,6 +67,43 @@ describe "bundle install with gem sources" do
 
         should_be_installed "net_a 1.0", "net_b 1.0", "net_c 1.0", "net_d 1.0", "net_e 1.0"
       end
+
+      context "with ENV['DEBUG_RESOLVER'] set" do
+        before do
+          ENV['DEBUG_RESOLVER'] = '1'
+        end
+        it "produces debug output" do
+          expect(capture(:stdout) do
+            install_gemfile <<-G
+              source "file://#{gem_repo1}"
+              gem "net_c"
+              gem "net_e"
+            G
+          end).to include "==== Iterating ===="
+        end
+        after do
+          ENV['DEBUG_RESOLVER'] = nil
+        end
+      end
+
+      context "with ENV['DEBUG_RESOLVER_TREE'] set" do
+        before do
+          ENV['DEBUG_RESOLVER_TREE'] = '1'
+        end
+        it "produces debug output" do
+          expect(capture(:stdout) do
+            install_gemfile <<-G
+              source "file://#{gem_repo1}"
+              gem "net_c"
+              gem "net_e"
+            G
+          end).to include " net_b (>= 0) ruby"
+        end
+        after do
+          ENV['DEBUG_RESOLVER_TREE'] = nil
+        end
+      end
+
     end
   end
 end

--- a/spec/support/streams.rb
+++ b/spec/support/streams.rb
@@ -1,0 +1,13 @@
+require 'stringio'
+
+def capture(*streams)
+  streams.map! { |stream| stream.to_s }
+  begin
+    result = StringIO.new
+    streams.each { |stream| eval "$#{stream} = result" }
+    yield
+  ensure
+    streams.each { |stream| eval("$#{stream} = #{stream.upcase}") }
+  end
+  result.string
+end


### PR DESCRIPTION
I was trying to figure out what bundler was doing for https://github.com/carlhuda/bundler/issues/2248 and couldn't make any sense of the output with `DEBUG_RESOLVER=1`. That is really, really big. 

This adds a similar debug feature with setting `DEBUG_RESOLVER_TREE` to output the current state of the resolver. The output looks like this:

```
net_c (>= 0) ruby
net_e (>= 0) ruby
net_a (>= 0) ruby
net_d (>= 0) ruby
net_d (>= 0) ruby
  net_b (>= 0) ruby
  net_build_extensions (>= 0) ruby
  rake (>= 0) ruby
```

I also added tests for both `DEBUG_RESOLVER` and `DEBUG_RESOLVER_TREE`.

If you hate this feature I will gladly separately PR the tests for `DEBUG_RESOLVER`, which I think should be there :)
