### PR TITLE
Remove unnecessary constants

### DIFF
--- a/spec/support/builders.rb
+++ b/spec/support/builders.rb
@@ -514,11 +514,8 @@ module Spec
     end
 
     class GitUpdater < LibBuilder
-      WINDOWS = RbConfig::CONFIG["host_os"] =~ %r!(msdos|mswin|djgpp|mingw)!
-      NULL    = WINDOWS ? "NUL" : "/dev/null"
-
       def silently(str)
-        `#{str} 2>#{NULL}`
+        `#{str} 2>#{Bundler::NULL}`
       end
 
       def _build(options)


### PR DESCRIPTION
`Bundler::NULL` is already defined in 'lib/bundler.rb'.
