### PR TITLE
Add load path to ./bin/newgem

### DIFF
--- a/lib/bundler/templates/newgem/bin/newgem.tt
+++ b/lib/bundler/templates/newgem/bin/newgem.tt
@@ -1,3 +1,6 @@
 #!/usr/bin/env ruby
 
+lib = File.expand_path(File.dirname(__FILE__) + '/../lib')
+$LOAD_PATH.unshift(lib) if File.directory?(lib) && !$LOAD_PATH.include?(lib)
+
 require '<%= config[:namespaced_path] %>'


### PR DESCRIPTION
To `require 'newgem'`, load path is necessary to be added.
