### PR TITLE
Bundler 1.3.0.pre.6 bundle install crash due to lack of dependancies in some gems

### DIFF
--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -130,8 +130,8 @@ module Bundler
       if spec.executables.empty?
         options = {}
         spec.dependencies.each do |dep|
-          bins = Bundler.definition.specs[dep].first.executables
-          options[dep.name] = bins unless bins.empty?
+          bins = Bundler.definition.specs[dep].first.executables unless Bundler.definition.specs[dep].empty?
+          options[dep.name] = bins unless bins.nil? || bins.empty?
         end
         if options.any?
           Bundler.ui.warn "#{spec.name} has no executables, but you may want " +


### PR DESCRIPTION
Running bundle install:

```
> bundle install
Using rake (10.0.3) 
Using i18n (0.6.1) 

NoMethodError: undefined method `executables' for nil:NilClass
An error occurred while installing i18n (0.6.1), and Bundler cannot continue.
Make sure that `gem install i18n -v '0.6.1'` succeeds before bundling.
```

After applying attached patch:

```
> bundle install
Using rake (10.0.3) 
Using i18n (0.6.1) 
There are no executables for the gem i18n.
Using minitest (4.4.0) 
minitest has no executables, but you may want one from a gem it depends on.
  rdoc has: rdoc, ri
Using multi_json (1.5.0) 
multi_json has no executables, but you may want one from a gem it depends on.
  rake has: rake
  rdoc has: rdoc, ri
Using atomic (1.0.1) 
There are no executables for the gem atomic.
Using thread_safe (0.1.0) 
There are no executables for the gem thread_safe.
Using tzinfo (0.3.35) 
There are no executables for the gem tzinfo.
Using activesupport (4.0.0.beta) from git://github.com/rails/rails.git (at master) 
There are no executables for the gem activesupport.
Using builder (3.1.4) 
There are no executables for the gem builder.
Using erubis (2.7.0) 
Using rack (1.4.4) 
Using rack-test (0.6.2) 
rack-test has no executables, but you may want one from a gem it depends on.
  rack has: rackup
Using actionpack (4.0.0.beta) from git://github.com/rails/rails.git (at master) 
actionpack has no executables, but you may want one from a gem it depends on.
  rack has: rackup
  erubis has: erubis
Using mime-types (1.19) 
mime-types has no executables, but you may want one from a gem it depends on.
  rdoc has: rdoc, ri
Using polyglot (0.3.3) 
There are no executables for the gem polyglot.
Using treetop (1.4.12) 
Using mail (2.5.3) 
mail has no executables, but you may want one from a gem it depends on.
  treetop has: tt
Using actionmailer (4.0.0.beta) from git://github.com/rails/rails.git (at master) 
There are no executables for the gem actionmailer.
Using activemodel (4.0.0.beta) from git://github.com/rails/rails.git (at master) 
There are no executables for the gem activemodel.
Using activerecord-deprecated_finders (0.0.2) 
There are no executables for the gem activerecord-deprecated_finders.
Using arel (3.0.2.20120819075748) from git://github.com/rails/arel.git (at master) 
arel has no executables, but you may want one from a gem it depends on.
  rdoc has: rdoc, ri
Using activerecord (4.0.0.beta) from git://github.com/rails/rails.git (at master) 
There are no executables for the gem activerecord.
Using bcrypt-ruby (3.0.1) 
There are no executables for the gem bcrypt-ruby.
Using sass (3.2.5) 
Using bootstrap-sass (2.2.2.0) 
bootstrap-sass has no executables, but you may want one from a gem it depends on.
  sass has: sass, sass-convert, scss
Using bundler (1.3.0.pre.6) 
There are no executables for the gem bundler.
Using json (1.7.6) 
There are no executables for the gem json.
Using rdoc (3.12) 
Using thor (0.16.0) 
Using railties (4.0.0.beta) from git://github.com/rails/rails.git (at master) 
Using hike (1.2.1) 
There are no executables for the gem hike.
Using tilt (1.3.3) 
Using sprockets (2.8.2) 
Using sprockets-rails (2.0.0.rc1) from git://github.com/rails/sprockets-rails.git (at master) 
sprockets-rails has no executables, but you may want one from a gem it depends on.
  sprockets has: sprockets
  rake has: rake
Using rails (4.0.0.beta) from git://github.com/rails/rails.git (at master) 
rails has no executables, but you may want one from a gem it depends on.
  railties has: rails
Using clearance (1.0.0.rc4) from git://github.com/amaabca/clearance.git (at master) 
There are no executables for the gem clearance.
Using coderay (1.0.8) 
Using coffee-script-source (1.4.0) 
There are no executables for the gem coffee-script-source.
Using execjs (1.4.0) 
execjs has no executables, but you may want one from a gem it depends on.
  rake has: rake
Using coffee-script (2.2.0) 
There are no executables for the gem coffee-script.
Using coffee-rails (4.0.0.beta) from git://github.com/rails/coffee-rails.git (at master) 
coffee-rails has no executables, but you may want one from a gem it depends on.
  railties has: rails
Using foreman (0.61.0) 
Using jquery-rails (2.2.0) 
jquery-rails has no executables, but you may want one from a gem it depends on.
  railties has: rails
  thor has: rake2thor, thor
Using kramdown (0.14.2) 
Using method_source (0.8.1) 
method_source has no executables, but you may want one from a gem it depends on.
  rake has: rake
Using opro (0.4.3) from git://github.com/amaabca/opro.git (at master) 
opro has no executables, but you may want one from a gem it depends on.
  kramdown has: kramdown
Using slop (3.4.3) 
slop has no executables, but you may want one from a gem it depends on.
  rake has: rake
Using pry (0.9.11.4) 
Using sass-rails (4.0.0.beta) from git://github.com/rails/sass-rails.git (at master) 
sass-rails has no executables, but you may want one from a gem it depends on.
  sass has: sass, sass-convert, scss
  railties has: rails
  tilt has: tilt
Using simple_form (1.4.1) 
There are no executables for the gem simple_form.
Using sqlite3 (1.3.7) 
sqlite3 has no executables, but you may want one from a gem it depends on.
  rdoc has: rdoc, ri
Using turbolinks (1.0.0) 
There are no executables for the gem turbolinks.
Using uglifier (1.3.0) 
uglifier has no executables, but you may want one from a gem it depends on.
  rdoc has: rdoc, ri
Your bundle is complete! It was installed into ./vendor
```

This seems to be really spammy, but I'm not sure if that's the vision or not, so I made as few changes as possible to get it to work.

Other Info:
rbenv/2.0.0-rc1

```
> gem list

*** LOCAL GEMS ***

abstract (1.0.0)
actionmailer (3.2.11, 3.2.6, 3.2.2, 3.2.0)
actionpack (3.2.11, 3.2.6, 3.2.2, 3.2.0)
activemodel (3.2.11, 3.2.6, 3.2.2, 3.2.0)
activerecord (3.2.11, 3.2.6, 3.2.2, 3.2.0)
activerecord-deprecated_finders (0.0.2, 0.0.1)
activeresource (3.2.11, 3.2.6, 3.2.2, 3.2.0)
activesupport (3.2.11, 3.2.6, 3.2.2, 3.2.0)
addressable (2.3.2, 2.2.7)
archive-tar-minitar (0.5.2)
arel (3.0.2)
atomic (1.0.1)
bcrypt-ruby (3.0.1)
better_errors (0.3.2)
bigdecimal (1.1.0)
bootstrap-sass (2.2.2.0)
bson (1.6.1)
builder (3.1.4, 3.0.4, 3.0.0)
bundler (1.3.0.pre.6, 1.2.3)
capybara (1.1.2)
childprocess (0.3.1)
coderay (1.0.8)
coffee-rails (3.2.2)
coffee-script (2.2.0)
coffee-script-source (1.4.0)
columnize (0.3.6)
daemons (1.1.9)
database_cleaner (0.8.0)
delayed_job (3.0.4)
delayed_job_active_record (0.3.3)
devise (2.2.2, 2.0.4)
diff-lcs (1.1.3)
ejs (1.1.1)
em-websocket (0.3.8)
erubis (2.7.0)
eventmachine (1.0.0)
excon (0.16.10)
execjs (1.4.0)
factory_girl (2.5.2)
factory_girl_rails (1.6.0)
faker (1.0.1)
faraday (0.8.4)
ffi (1.0.11)
foreman (0.61.0)
git (1.2.5)
github_api (0.8.7)
guard (1.6.1)
guard-livereload (1.1.3)
guard-rspec (1.2.1)
haml (3.1.7)
hashie (1.2.0)
heroku (2.34.0)
heroku-api (0.3.7)
hike (1.2.1)
hpricot (0.8.6)
httpauth (0.2.0)
i18n (0.6.1, 0.6.0)
io-console (0.3)
jasminerice (0.0.10)
jeweler (1.8.3, 1.6.4)
journey (1.0.4, 1.0.3)
jquery-rails (2.2.0, 2.1.4)
json (1.7.6, 1.7.5, 1.7.3, 1.6.6)
jwt (0.1.5)
kramdown (0.14.1, 0.14.0)
launchy (2.1.2, 2.1.0)
listen (0.7.2)
lumberjack (1.0.2)
mail (2.5.3, 2.4.4)
metaclass (0.0.1)
method_source (0.8.1)
mime-types (1.19, 1.18)
minitest (4.4.0, 4.3.2)
mocha (0.11.4)
multi_json (1.5.0, 1.3.6, 1.3.2)
multipart-post (1.1.5)
netrc (0.7.7)
nokogiri (1.5.6, 1.5.2)
oauth (0.4.7)
oauth2 (0.8.0)
orm_adapter (0.4.0, 0.0.7)
pg (0.14.1)
polyglot (0.3.3)
pry (0.9.11.4, 0.9.11.3, 0.9.11.2)
psych (2.0.0)
rack (1.4.4, 1.4.3, 1.4.1)
rack-cache (1.2)
rack-ssl (1.3.2)
rack-test (0.6.2, 0.6.1)
rails (3.2.11, 3.2.6, 3.2.0)
railties (3.2.11, 3.2.6, 3.2.0)
rake (10.0.3, 0.9.6, 0.9.2.2)
rdoc (4.0.0.preview3.1, 3.12)
rest-client (1.6.7)
ruby_core_source (0.1.5)
rubyzip (0.9.9, 0.9.7, 0.9.6.1)
sass (3.2.5)
sass-rails (3.2.6)
selenium-webdriver (2.20.0)
simple_form (1.4.1)
slop (3.4.3)
sorcery (0.8.0)
sprockets (2.8.2, 2.2.2, 2.1.3, 2.1.2)
sqlite3 (1.3.7, 1.3.5)
test-unit (2.0.0.0)
thor (0.16.0, 0.15.2, 0.14.6)
thread_safe (0.1.0)
tilt (1.3.3)
timecop (0.3.5)
treetop (1.4.12, 1.4.10)
turbolinks (1.0.0)
tzinfo (0.3.35, 0.3.33, 0.3.32)
uglifier (1.3.0)
warden (1.2.1, 1.1.1)
xpath (0.1.4)
```

Gemfile in project:

```
source 'http://rubygems.org'

gem 'rails',     github: 'rails/rails'
gem 'jquery-rails'
gem 'arel',      github: 'rails/arel'
gem 'sqlite3'
gem 'turbolinks'
gem 'foreman'
gem 'opro',      github: 'amaabca/opro'
gem 'simple_form'

group :assets do
  gem 'sprockets-rails', github: 'rails/sprockets-rails'
  gem 'sass-rails',   github: 'rails/sass-rails'
  gem 'bootstrap-sass', '~> 2.2.2.0'
  gem 'coffee-rails', github: 'rails/coffee-rails'

  gem 'uglifier', '>= 1.0.3'
end

group :development, :test do
  gem 'pry'
end

gem 'clearance',      github: 'amaabca/clearance'
```
