### PR TITLE
update net-http-persistent to v2.8

### DIFF
--- a/lib/bundler/vendor/net/http/persistent.rb
+++ b/lib/bundler/vendor/net/http/persistent.rb
@@ -1,7 +1,13 @@
 require 'net/http'
+require 'net/https'
 require 'net/http/faster'
 require 'uri'
 require 'cgi' # for escaping
+
+begin
+  require 'net/http/pipeline'
+rescue LoadError
+end
 
 ##
 # Persistent connections for Net::HTTP
@@ -22,22 +28,155 @@ require 'cgi' # for escaping
 #
 # Example:
 #
-#   uri = URI.parse 'http://example.com/awesome/web/service'
-#   http = Net::HTTP::Persistent.new
-#   stuff = http.request uri # performs a GET
+#   require 'net/http/persistent'
 #
-#   # perform a POST
+#   uri = URI 'http://example.com/awesome/web/service'
+#
+#   http = Net::HTTP::Persistent.new 'my_app_name'
+#
+#   # perform a GET
+#   response = http.request uri
+#
+#   # create a POST
 #   post_uri = uri + 'create'
 #   post = Net::HTTP::Post.new post_uri.path
 #   post.set_form_data 'some' => 'cool data'
-#   http.request post_uri, post # URI is always required
+#
+#   # perform the POST, the URI is always required
+#   response http.request post_uri, post
+#
+# == SSL
+#
+# SSL connections are automatically created depending upon the scheme of the
+# URI.  SSL connections are automatically verified against the default
+# certificate store for your computer.  You can override this by changing
+# verify_mode or by specifying an alternate cert_store.
+#
+# Here are the SSL settings, see the individual methods for documentation:
+#
+# #certificate        :: This client's certificate
+# #ca_file            :: The certificate-authority
+# #cert_store         :: An SSL certificate store
+# #private_key        :: The client's SSL private key
+# #reuse_ssl_sessions :: Reuse a previously opened SSL session for a new
+#                        connection
+# #ssl_version        :: Which specific SSL version to use
+# #verify_callback    :: For server certificate verification
+# #verify_mode        :: How connections should be verified
+#
+# == Proxies
+#
+# A proxy can be set through #proxy= or at initialization time by providing a
+# second argument to ::new.  The proxy may be the URI of the proxy server or
+# <code>:ENV</code> which will consult environment variables.
+#
+# See #proxy= and #proxy_from_env for details.
+#
+# == Headers
+#
+# Headers may be specified for use in every request.  #headers are appended to
+# any headers on the request.  #override_headers replace existing headers on
+# the request.
+#
+# The difference between the two can be seen in setting the User-Agent.  Using
+# <code>http.headers['User-Agent'] = 'MyUserAgent'</code> will send "Ruby,
+# MyUserAgent" while <code>http.override_headers['User-Agent'] =
+# 'MyUserAgent'</code> will send "MyUserAgent".
+#
+# == Tuning
+#
+# === Segregation
+#
+# By providing an application name to ::new you can separate your connections
+# from the connections of other applications.
+#
+# === Idle Timeout
+#
+# If a connection hasn't been used for this number of seconds it will automatically be
+# reset upon the next use to avoid attempting to send to a closed connection.
+# The default value is 5 seconds. nil means no timeout. Set through #idle_timeout.
+#
+# Reducing this value may help avoid the "too many connection resets" error
+# when sending non-idempotent requests while increasing this value will cause
+# fewer round-trips.
+#
+# === Read Timeout
+#
+# The amount of time allowed between reading two chunks from the socket.  Set
+# through #read_timeout
+#
+# === Open Timeout
+#
+# The amount of time to wait for a connection to be opened.  Set through
+# #open_timeout.
+#
+# === Socket Options
+#
+# Socket options may be set on newly-created connections.  See #socket_options
+# for details.
+#
+# === Non-Idempotent Requests
+#
+# By default non-idempotent requests will not be retried per RFC 2616.  By
+# setting retry_change_requests to true requests will automatically be retried
+# once.
+#
+# Only do this when you know that retrying a POST or other non-idempotent
+# request is safe for your application and will not create duplicate
+# resources.
+#
+# The recommended way to handle non-idempotent requests is the following:
+#
+#   require 'net/http/persistent'
+#
+#   uri = URI 'http://example.com/awesome/web/service'
+#   post_uri = uri + 'create'
+#
+#   http = Net::HTTP::Persistent.new 'my_app_name'
+#
+#   post = Net::HTTP::Post.new post_uri.path
+#   # ... fill in POST request
+#
+#   begin
+#     response = http.request post_uri, post
+#   rescue Net::HTTP::Persistent::Error
+#
+#     # POST failed, make a new request to verify the server did not process
+#     # the request
+#     exists_uri = uri + '...'
+#     response = http.get exists_uri
+#
+#     # Retry if it failed
+#     retry if response.code == '404'
+#   end
+#
+# The method of determining if the resource was created or not is unique to
+# the particular service you are using.  Of course, you will want to add
+# protection from infinite looping.
+#
+# === Connection Termination
+#
+# If you are done using the Net::HTTP::Persistent instance you may shut down
+# all the connections in the current thread with #shutdown.  This is not
+# recommended for normal use, it should only be used when it will be several
+# minutes before you make another HTTP request.
+#
+# If you are using multiple threads, call #shutdown in each thread when the
+# thread is done making requests.  If you don't call shutdown, that's OK.
+# Ruby will automatically garbage collect and shutdown your HTTP connections
+# when the thread terminates.
 
 class Net::HTTP::Persistent
 
   ##
-  # The version of Net::HTTP::Persistent use are using
+  # The beginning of Time
 
-  VERSION = '1.4.1'
+  EPOCH = Time.at 0 # :nodoc:
+
+  ##
+  # The version of Net::HTTP::Persistent you are using
+
+  VERSION = '2.8'
 
   ##
   # Error class for errors raised by Net::HTTP::Persistent.  Various
@@ -47,20 +186,71 @@ class Net::HTTP::Persistent
   class Error < StandardError; end
 
   ##
+  # Use this method to detect the idle timeout of the host at +uri+.  The
+  # value returned can be used to configure #idle_timeout.  +max+ controls the
+  # maximum idle timeout to detect.
+  #
+  # After
+  #
+  # Idle timeout detection is performed by creating a connection then
+  # performing a HEAD request in a loop until the connection terminates
+  # waiting one additional second per loop.
+  #
+  # NOTE:  This may not work on ruby > 1.9.
+
+  def self.detect_idle_timeout uri, max = 10
+    uri = URI uri unless URI::Generic === uri
+    uri += '/'
+
+    req = Net::HTTP::Head.new uri.request_uri
+
+    http = new 'net-http-persistent detect_idle_timeout'
+
+    connection = http.connection_for uri
+
+    sleep_time = 0
+
+    loop do
+      response = connection.request req
+
+      $stderr.puts "HEAD #{uri} => #{response.code}" if $DEBUG
+
+      unless Net::HTTPOK === response then
+        raise Error, "bad response code #{response.code} detecting idle timeout"
+      end
+
+      break if sleep_time >= max
+
+      sleep_time += 1
+
+      $stderr.puts "sleeping #{sleep_time}" if $DEBUG
+      sleep sleep_time
+    end
+  ensure
+    http.shutdown
+
+    return sleep_time unless $!
+  end
+
+  ##
   # This client's OpenSSL::X509::Certificate
 
-  attr_accessor :certificate
+  attr_reader :certificate
+
+  # For Net::HTTP parity
+  alias cert certificate
 
   ##
   # An SSL certificate authority.  Setting this will set verify_mode to
   # VERIFY_PEER.
 
-  attr_accessor :ca_file
+  attr_reader :ca_file
 
   ##
-  # Where this instance's connections live in the thread local variables
+  # An SSL certificate store.  Setting this will override the default
+  # certificate store.  See verify_mode for more information.
 
-  attr_reader :connection_key # :nodoc:
+  attr_reader :cert_store
 
   ##
   # Sends debug_output to this IO via Net::HTTP#set_debug_output.
@@ -71,7 +261,17 @@ class Net::HTTP::Persistent
   attr_accessor :debug_output
 
   ##
-  # Headers that are added to every request
+  # Current connection generation
+
+  attr_reader :generation # :nodoc:
+
+  ##
+  # Where this instance's connections live in the thread local variables
+
+  attr_reader :generation_key # :nodoc:
+
+  ##
+  # Headers that are added to every request using Net::HTTP#add_field
 
   attr_reader :headers
 
@@ -80,6 +280,12 @@ class Net::HTTP::Persistent
   # specific features.
 
   attr_reader :http_versions
+
+  ##
+  # Maximum time an unused connection can remain idle before being
+  # automatically closed.
+
+  attr_accessor :idle_timeout
 
   ##
   # The value sent in the Keep-Alive header.  Defaults to 30.  Not needed for
@@ -104,14 +310,27 @@ class Net::HTTP::Persistent
   attr_accessor :open_timeout
 
   ##
+  # Headers that are added to every request using Net::HTTP#[]=
+
+  attr_reader :override_headers
+
+  ##
   # This client's SSL private key
 
-  attr_accessor :private_key
+  attr_reader :private_key
+
+  # For Net::HTTP parity
+  alias key private_key
 
   ##
   # The URL through which requests will be proxied
 
   attr_reader :proxy_uri
+
+  ##
+  # List of host suffixes which will not be proxied
+
+  attr_reader :no_proxy
 
   ##
   # Seconds to wait until reading one block.  See Net::HTTP#read_timeout
@@ -124,17 +343,74 @@ class Net::HTTP::Persistent
   attr_reader :request_key # :nodoc:
 
   ##
-  # SSL verification callback.  Used when ca_file is set.
+  # By default SSL sessions are reused to avoid extra SSL handshakes.  Set
+  # this to false if you have problems communicating with an HTTPS server
+  # like:
+  #
+  #   SSL_connect [...] read finished A: unexpected message (OpenSSL::SSL::SSLError)
 
-  attr_accessor :verify_callback
+  attr_accessor :reuse_ssl_sessions
 
   ##
-  # HTTPS verify mode.  Defaults to OpenSSL::SSL::VERIFY_NONE which ignores
-  # certificate problems.
+  # An array of options for Socket#setsockopt.
+  #
+  # By default the TCP_NODELAY option is set on sockets.
+  #
+  # To set additional options append them to this array:
+  #
+  #   http.socket_options << [Socket::SOL_SOCKET, Socket::SO_KEEPALIVE, 1]
+
+  attr_reader :socket_options
+
+  ##
+  # Current SSL connection generation
+
+  attr_reader :ssl_generation # :nodoc:
+
+  ##
+  # Where this instance's SSL connections live in the thread local variables
+
+  attr_reader :ssl_generation_key # :nodoc:
+
+  ##
+  # SSL version to use.
+  #
+  # By default, the version will be negotiated automatically between client
+  # and server.  Ruby 1.9 and newer only.
+
+  attr_reader :ssl_version if RUBY_VERSION > '1.9'
+
+  ##
+  # Where this instance's last-use times live in the thread local variables
+
+  attr_reader :timeout_key # :nodoc:
+
+  ##
+  # SSL verification callback.  Used when ca_file is set.
+
+  attr_reader :verify_callback
+
+  ##
+  # HTTPS verify mode.  Defaults to OpenSSL::SSL::VERIFY_PEER which verifies
+  # the server certificate.
+  #
+  # If no ca_file or cert_store is set the default system certificate store is
+  # used.
   #
   # You can use +verify_mode+ to override any default values.
 
-  attr_accessor :verify_mode
+  attr_reader :verify_mode
+
+  ##
+  # Enable retries of non-idempotent requests that change data (e.g. POST
+  # requests) when the server has disconnected.
+  #
+  # This will in the worst case lead to multiple requests with the same data,
+  # but it may be useful for some applications.  Take care when enabling
+  # this option to ensure it is safe to POST or perform other non-idempotent
+  # requests to the server.
+
+  attr_accessor :retry_change_requests
 
   ##
   # Creates a new Net::HTTP::Persistent.
@@ -146,89 +422,166 @@ class Net::HTTP::Persistent
   # +proxy+ may be set to a URI::HTTP or :ENV to pick up proxy options from
   # the environment.  See proxy_from_env for details.
   #
-  # In order to use a URI for the proxy you'll need to do some extra work
-  # beyond URI.parse:
+  # In order to use a URI for the proxy you may need to do some extra work
+  # beyond URI parsing if the proxy requires a password:
   #
-  #   proxy = URI.parse 'http://proxy.example'
+  #   proxy = URI 'http://proxy.example'
   #   proxy.user     = 'AzureDiamond'
   #   proxy.password = 'hunter2'
 
   def initialize name = nil, proxy = nil
     @name = name
 
-    @proxy_uri = case proxy
-                 when :ENV      then proxy_from_env
-                 when URI::HTTP then proxy
-                 when nil       then # ignore
-                 else raise ArgumentError, 'proxy must be :ENV or a URI::HTTP'
-                 end
+    @debug_output     = nil
+    @proxy_uri        = nil
+    @no_proxy         = []
+    @headers          = {}
+    @override_headers = {}
+    @http_versions    = {}
+    @keep_alive       = 30
+    @open_timeout     = nil
+    @read_timeout     = nil
+    @idle_timeout     = 5
+    @socket_options   = []
 
-    if @proxy_uri then
-      @proxy_args = [
-        @proxy_uri.host,
-        @proxy_uri.port,
-        @proxy_uri.user,
-        @proxy_uri.password,
-      ]
+    @socket_options << [Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1] if
+      Socket.const_defined? :TCP_NODELAY
 
-      @proxy_connection_id = [nil, *@proxy_args].join ':'
+    key = ['net_http_persistent', name].compact
+    @generation_key     = [key, 'generations'    ].join('_').intern
+    @ssl_generation_key = [key, 'ssl_generations'].join('_').intern
+    @request_key        = [key, 'requests'       ].join('_').intern
+    @timeout_key        = [key, 'timeouts'       ].join('_').intern
+
+    @certificate        = nil
+    @ca_file            = nil
+    @private_key        = nil
+    @ssl_version        = nil
+    @verify_callback    = nil
+    @verify_mode        = OpenSSL::SSL::VERIFY_PEER
+    @cert_store         = nil
+
+    @generation         = 0 # incremented when proxy URI changes
+    @ssl_generation     = 0 # incremented when SSL session variables change
+    @reuse_ssl_sessions = OpenSSL::SSL.const_defined? :Session
+
+    @retry_change_requests = false
+
+    self.proxy = proxy if proxy
+  end
+
+  ##
+  # Sets this client's OpenSSL::X509::Certificate
+
+  def certificate= certificate
+    @certificate = certificate
+
+    reconnect_ssl
+  end
+
+  # For Net::HTTP parity
+  alias cert= certificate=
+
+  ##
+  # Sets the SSL certificate authority file.
+
+  def ca_file= file
+    @ca_file = file
+
+    reconnect_ssl
+  end
+
+  ##
+  # Overrides the default SSL certificate store used for verifying
+  # connections.
+
+  def cert_store= store
+    @cert_store = store
+
+    reconnect_ssl
+  end
+
+  ##
+  # Finishes all connections on the given +thread+ that were created before
+  # the given +generation+ in the threads +generation_key+ list.
+  #
+  # See #shutdown for a bunch of scary warning about misusing this method.
+
+  def cleanup(generation, thread = Thread.current,
+              generation_key = @generation_key) # :nodoc:
+    timeouts = thread[@timeout_key]
+
+    (0...generation).each do |old_generation|
+      next unless thread[generation_key]
+
+      conns = thread[generation_key].delete old_generation
+
+      conns.each_value do |conn|
+        finish conn, thread
+
+        timeouts.delete conn.object_id if timeouts
+      end if conns
     end
-
-    @debug_output  = nil
-    @headers       = {}
-    @http_versions = {}
-    @keep_alive    = 30
-    @open_timeout  = nil
-    @read_timeout  = nil
-
-    key = ['net_http_persistent', name, 'connections'].compact.join '_'
-    @connection_key = key.intern
-    key = ['net_http_persistent', name, 'requests'].compact.join '_'
-    @request_key    = key.intern
-
-    @certificate     = nil
-    @ca_file         = nil
-    @private_key     = nil
-    @verify_callback = nil
-    @verify_mode     = nil
   end
 
   ##
   # Creates a new connection for +uri+
 
   def connection_for uri
-    Thread.current[@connection_key] ||= {}
-    Thread.current[@request_key]    ||= Hash.new 0
+    Thread.current[@generation_key]     ||= Hash.new { |h,k| h[k] = {} }
+    Thread.current[@ssl_generation_key] ||= Hash.new { |h,k| h[k] = {} }
+    Thread.current[@request_key]        ||= Hash.new 0
+    Thread.current[@timeout_key]        ||= Hash.new EPOCH
 
-    connections = Thread.current[@connection_key]
+    use_ssl = uri.scheme.downcase == 'https'
+
+    if use_ssl then
+      ssl_generation = @ssl_generation
+
+      ssl_cleanup ssl_generation
+
+      connections = Thread.current[@ssl_generation_key][ssl_generation]
+    else
+      generation = @generation
+
+      cleanup generation
+
+      connections = Thread.current[@generation_key][generation]
+    end
 
     net_http_args = [uri.host, uri.port]
     connection_id = net_http_args.join ':'
 
-    if @proxy_uri then
+    if @proxy_uri and not proxy_bypass? uri.host, uri.port then
       connection_id << @proxy_connection_id
       net_http_args.concat @proxy_args
     end
 
+    connection = connections[connection_id]
+
     unless connection = connections[connection_id] then
-      connections[connection_id] = Net::HTTP.new(*net_http_args)
+      connections[connection_id] = http_class.new(*net_http_args)
       connection = connections[connection_id]
-      ssl connection if uri.scheme == 'https'
+      ssl connection if use_ssl
+    else
+      reset connection if expired? connection
     end
 
-    unless connection.started? then
-      connection.set_debug_output @debug_output if @debug_output
-      connection.open_timeout = @open_timeout if @open_timeout
-      connection.read_timeout = @read_timeout if @read_timeout
+    start connection unless connection.started?
 
-      connection.start
-    end
+    connection.read_timeout = @read_timeout if @read_timeout
 
     connection
   rescue Errno::ECONNREFUSED
-    raise Error, "connection refused: #{connection.address}:#{connection.port}"
+    address = connection.proxy_address || connection.address
+    port    = connection.proxy_port    || connection.port
+
+    raise Error, "connection refused: #{address}:#{port}"
   rescue Errno::EHOSTDOWN
-    raise Error, "host down: #{connection.address}:#{connection.port}"
+    address = connection.proxy_address || connection.address
+    port    = connection.proxy_port    || connection.port
+
+    raise Error, "host down: #{address}:#{port}"
   end
 
   ##
@@ -236,10 +589,13 @@ class Net::HTTP::Persistent
   # this connection
 
   def error_message connection
-    requests =
-      Thread.current[@request_key][connection.object_id]
+    requests = Thread.current[@request_key][connection.object_id] - 1 # fixup
+    last_use = Thread.current[@timeout_key][connection.object_id]
 
-    "after #{requests} requests on #{connection.object_id}"
+    age = Time.now - last_use
+
+    "after #{requests} requests on #{connection.object_id}, " \
+      "last used #{age} seconds ago"
   end
 
   ##
@@ -250,13 +606,58 @@ class Net::HTTP::Persistent
   end
 
   ##
+  # Returns true if the connection should be reset due to an idle timeout,
+  # false otherwise.
+
+  def expired? connection
+    return false unless @idle_timeout
+    return true  if     @idle_timeout.zero?
+
+    last_used = Thread.current[@timeout_key][connection.object_id]
+
+    Time.now - last_used > @idle_timeout
+  end
+
+  ##
+  # Starts the Net::HTTP +connection+
+
+  def start connection
+    connection.set_debug_output @debug_output if @debug_output
+    connection.open_timeout = @open_timeout if @open_timeout
+
+    connection.start
+
+    socket = connection.instance_variable_get :@socket
+
+    if socket then # for fakeweb
+      @socket_options.each do |option|
+        socket.io.setsockopt(*option)
+      end
+    end
+  end
+
+  ##
   # Finishes the Net::HTTP +connection+
 
-  def finish connection
-    Thread.current[@request_key].delete connection.object_id
+  def finish connection, thread = Thread.current
+    if requests = thread[@request_key] then
+      requests.delete connection.object_id
+    end
 
     connection.finish
   rescue IOError
+  end
+
+  def http_class # :nodoc:
+    if RUBY_VERSION > '2.0' then
+      Net::HTTP
+    elsif [:Artifice, :FakeWeb, :WebMock].any? { |klass|
+             Object.const_defined?(klass)
+          } or not @reuse_ssl_sessions then
+        Net::HTTP
+    else
+      Net::HTTP::Persistent::SSLReuse
+    end
   end
 
   ##
@@ -278,10 +679,130 @@ class Net::HTTP::Persistent
   end
 
   ##
+  # Is the request idempotent or is retry_change_requests allowed
+
+  def can_retry? req
+    retry_change_requests or idempotent?(req)
+  end
+
+  if RUBY_VERSION > '1.9' then
+    ##
+    # Workaround for missing Net::HTTPHeader#connection_close? on Ruby 1.8
+
+    def connection_close? header
+      header.connection_close?
+    end
+
+    ##
+    # Workaround for missing Net::HTTPHeader#connection_keep_alive? on Ruby 1.8
+
+    def connection_keep_alive? header
+      header.connection_keep_alive?
+    end
+  else
+    ##
+    # Workaround for missing Net::HTTPRequest#connection_close? on Ruby 1.8
+
+    def connection_close? header
+      header['connection'] =~ /close/ or header['proxy-connection'] =~ /close/
+    end
+
+    ##
+    # Workaround for missing Net::HTTPRequest#connection_keep_alive? on Ruby
+    # 1.8
+
+    def connection_keep_alive? header
+      header['connection'] =~ /keep-alive/ or
+        header['proxy-connection'] =~ /keep-alive/
+    end
+  end
+
+  ##
+  # Deprecated in favor of #expired?
+
+  def max_age # :nodoc:
+    return Time.now + 1 unless @idle_timeout
+
+    Time.now - @idle_timeout
+  end
+
+  ##
   # Adds "http://" to the String +uri+ if it is missing.
 
   def normalize_uri uri
     (uri =~ /^https?:/) ? uri : "http://#{uri}"
+  end
+
+  ##
+  # Pipelines +requests+ to the HTTP server at +uri+ yielding responses if a
+  # block is given.  Returns all responses recieved.
+  #
+  # See
+  # Net::HTTP::Pipeline[http://docs.seattlerb.org/net-http-pipeline/Net/HTTP/Pipeline.html]
+  # for further details.
+  #
+  # Only if <tt>net-http-pipeline</tt> was required before
+  # <tt>net-http-persistent</tt> #pipeline will be present.
+
+  def pipeline uri, requests, &block # :yields: responses
+    connection = connection_for uri
+
+    connection.pipeline requests, &block
+  end
+
+  ##
+  # Sets this client's SSL private key
+
+  def private_key= key
+    @private_key = key
+
+    reconnect_ssl
+  end
+
+  # For Net::HTTP parity
+  alias key= private_key=
+
+  ##
+  # Sets the proxy server.  The +proxy+ may be the URI of the proxy server,
+  # the symbol +:ENV+ which will read the proxy from the environment or nil to
+  # disable use of a proxy.  See #proxy_from_env for details on setting the
+  # proxy from the environment.
+  #
+  # If the proxy URI is set after requests have been made, the next request
+  # will shut-down and re-open all connections.
+  #
+  # The +no_proxy+ query parameter can be used to specify hosts which shouldn't
+  # be reached via proxy; if set it should be a comma separated list of
+  # hostname suffixes, optionally with +:port+ appended, for example
+  # <tt>example.com,some.host:8080</tt>.
+
+  def proxy= proxy
+    @proxy_uri = case proxy
+                 when :ENV      then proxy_from_env
+                 when URI::HTTP then proxy
+                 when nil       then # ignore
+                 else raise ArgumentError, 'proxy must be :ENV or a URI::HTTP'
+                 end
+
+    @no_proxy.clear
+
+    if @proxy_uri then
+      @proxy_args = [
+        @proxy_uri.host,
+        @proxy_uri.port,
+        @proxy_uri.user,
+        @proxy_uri.password,
+      ]
+
+      @proxy_connection_id = [nil, *@proxy_args].join ':'
+
+      if @proxy_uri.query then
+        @no_proxy = CGI.parse(@proxy_uri.query)['no_proxy'].join(',').downcase.split(',').map { |x| x.strip }.reject { |x| x.empty? }
+      end
+    end
+
+    reconnect
+    reconnect_ssl
   end
 
   ##
@@ -293,7 +814,13 @@ class Net::HTTP::Persistent
   # indicated user and password unless HTTP_PROXY contains either of these in
   # the URI.
   #
-  # For Windows users lowercase ENV variables are preferred over uppercase ENV
+  # The +NO_PROXY+ ENV variable can be used to specify hosts which shouldn't
+  # be reached via proxy; if set it should be a comma separated list of
+  # hostname suffixes, optionally with +:port+ appended, for example
+  # <tt>example.com,some.host:8080</tt>. When set to <tt>*</tt> no proxy will
+  # be returned.
+  #
+  # For Windows users, lowercase ENV variables are preferred over uppercase ENV
   # variables.
 
   def proxy_from_env
@@ -301,7 +828,16 @@ class Net::HTTP::Persistent
 
     return nil if env_proxy.nil? or env_proxy.empty?
 
-    uri = URI.parse normalize_uri env_proxy
+    uri = URI normalize_uri env_proxy
+
+    env_no_proxy = ENV['no_proxy'] || ENV['NO_PROXY']
+
+    # '*' is special case for always bypass
+    return nil if env_no_proxy == '*' 
+
+    if env_no_proxy then
+      uri.query = "no_proxy=#{escape(env_no_proxy)}"
+    end 
 
     unless uri.user or uri.password then
       uri.user     = escape ENV['http_proxy_user'] || ENV['HTTP_PROXY_USER']
@@ -312,14 +848,44 @@ class Net::HTTP::Persistent
   end
 
   ##
+  # Returns true when proxy should by bypassed for host.
+
+  def proxy_bypass? host, port
+    host = host.downcase
+    host_port = [host, port].join ':'
+
+    @no_proxy.each do |name|
+      return true if host[-name.length, name.length] == name or
+         host_port[-name.length, name.length] == name
+    end
+
+    false
+  end
+
+  ##
+  # Forces reconnection of HTTP connections.
+
+  def reconnect
+    @generation += 1
+  end
+
+  ##
+  # Forces reconnection of SSL connections.
+
+  def reconnect_ssl
+    @ssl_generation += 1
+  end
+
+  ##
   # Finishes then restarts the Net::HTTP +connection+
 
   def reset connection
     Thread.current[@request_key].delete connection.object_id
+    Thread.current[@timeout_key].delete connection.object_id
 
     finish connection
 
-    connection.start
+    start connection
   rescue Errno::ECONNREFUSED
     raise Error, "connection refused: #{connection.address}:#{connection.port}"
   rescue Errno::EHOSTDOWN
@@ -344,7 +910,7 @@ class Net::HTTP::Persistent
 
     req = Net::HTTP::Get.new uri.request_uri unless req
 
-    headers.each do |pair|
+    @headers.each do |pair|
       req.add_field(*pair)
     end
 
@@ -352,8 +918,14 @@ class Net::HTTP::Persistent
       req.basic_auth uri.user, uri.password
     end
 
-    req.add_field 'Connection', 'keep-alive'
-    req.add_field 'Keep-Alive', @keep_alive
+    @override_headers.each do |name, value|
+      req[name] = value
+    end
+
+    unless req['Connection'] then
+      req.add_field 'Connection', 'keep-alive'
+      req.add_field 'Keep-Alive', @keep_alive
+    end
 
     connection = connection_for uri
     connection_id = connection.object_id
@@ -362,20 +934,27 @@ class Net::HTTP::Persistent
       Thread.current[@request_key][connection_id] += 1
       response = connection.request req, &block
 
+      if connection_close?(req) or
+         (response.http_version <= '1.0' and
+          not connection_keep_alive?(response)) or
+         connection_close?(response) then
+        connection.finish
+      end
     rescue Net::HTTPBadResponse => e
       message = error_message connection
 
       finish connection
 
       raise Error, "too many bad responses #{message}" if
-        bad_response or not idempotent? req
+        bad_response or not can_retry? req
 
       bad_response = true
       retry
     rescue IOError, EOFError, Timeout::Error,
-           Errno::ECONNABORTED, Errno::ECONNRESET, Errno::EPIPE => e
+           Errno::ECONNABORTED, Errno::ECONNRESET, Errno::EPIPE,
+           Errno::EINVAL, OpenSSL::SSL::SSLError => e
 
-      if retried or not idempotent? req
+      if retried or not can_retry? req
         due_to = "(due to #{e.message} - #{e.class})"
         message = error_message connection
 
@@ -388,6 +967,8 @@ class Net::HTTP::Persistent
 
       retried = true
       retry
+    ensure
+      Thread.current[@timeout_key][connection_id] = Time.now
     end
 
     @http_versions["#{uri.host}:#{uri.port}"] ||= response.http_version
@@ -409,17 +990,14 @@ class Net::HTTP::Persistent
   # best to call #shutdown in the thread at the appropriate time instead!
 
   def shutdown thread = Thread.current
-    connections = thread[@connection_key]
+    generation = reconnect
+    cleanup generation, thread, @generation_key
 
-    connections.each do |_, connection|
-      begin
-        connection.finish
-      rescue IOError
-      end
-    end if connections
+    ssl_generation = reconnect_ssl
+    cleanup ssl_generation, thread, @ssl_generation_key
 
-    thread[@connection_key] = nil
-    thread[@request_key]    = nil
+    thread[@request_key] = nil
+    thread[@timeout_key] = nil
   end
 
   ##
@@ -444,11 +1022,38 @@ class Net::HTTP::Persistent
   # Enables SSL on +connection+
 
   def ssl connection
-    require 'net/https'
     connection.use_ssl = true
 
-    # suppress warning but allow override
-    connection.verify_mode = OpenSSL::SSL::VERIFY_NONE unless @verify_mode
+    connection.ssl_version = @ssl_version if @ssl_version
+
+    connection.verify_mode = @verify_mode
+
+    if OpenSSL::SSL::VERIFY_PEER == OpenSSL::SSL::VERIFY_NONE and
+       not Object.const_defined?(:I_KNOW_THAT_OPENSSL_VERIFY_PEER_EQUALS_VERIFY_NONE_IS_WRONG) then
+      warn <<-WARNING
+                             !!!SECURITY WARNING!!!
+
+The SSL HTTP connection to:
+
+  #{connection.address}:#{connection.port}
+
+                           !!!MAY NOT BE VERIFIED!!!
+
+On your platform your OpenSSL implementation is broken.
+
+There is no difference between the values of VERIFY_NONE and VERIFY_PEER.
+
+This means that attempting to verify the security of SSL connections may not
+work.  This exposes you to man-in-the-middle exploits, snooping on the
+contents of your connection and other dangers to the security of your data.
+
+To disable this warning define the following constant at top-level in your
+application:
+
+  I_KNOW_THAT_OPENSSL_VERIFY_PEER_EQUALS_VERIFY_NONE_IS_WRONG = nil
+
+      WARNING
+    end
 
     if @ca_file then
       connection.ca_file = @ca_file
@@ -461,8 +1066,55 @@ class Net::HTTP::Persistent
       connection.key  = @private_key
     end
 
-    connection.verify_mode = @verify_mode if @verify_mode
+    connection.cert_store = if @cert_store then
+                              @cert_store
+                            else
+                              store = OpenSSL::X509::Store.new
+                              store.set_default_paths
+                              store
+                            end
+  end
+
+  ##
+  # Finishes all connections that existed before the given SSL parameter
+  # +generation+.
+
+  def ssl_cleanup generation # :nodoc:
+    cleanup generation, Thread.current, @ssl_generation_key
+  end
+
+  ##
+  # SSL version to use
+
+  def ssl_version= ssl_version
+    @ssl_version = ssl_version
+
+    reconnect_ssl
+  end if RUBY_VERSION > '1.9'
+
+  ##
+  # Sets the HTTPS verify mode.  Defaults to OpenSSL::SSL::VERIFY_PEER.
+  #
+  # Setting this to VERIFY_NONE is a VERY BAD IDEA and should NEVER be used.
+  # Securely transfer the correct certificate and update the default
+  # certificate store or set the ca file instead.
+
+  def verify_mode= verify_mode
+    @verify_mode = verify_mode
+
+    reconnect_ssl
+  end
+
+  ##
+  # SSL verification callback.
+
+  def verify_callback= callback
+    @verify_callback = callback
+
+    reconnect_ssl
   end
 
 end
+
+require 'net/http/persistent/ssl_reuse'
 

--- a/lib/bundler/vendor/net/http/persistent/ssl_reuse.rb
+++ b/lib/bundler/vendor/net/http/persistent/ssl_reuse.rb
@@ -1,0 +1,129 @@
+##
+# This Net::HTTP subclass adds SSL session reuse and Server Name Indication
+# (SNI) RFC 3546.
+#
+# DO NOT DEPEND UPON THIS CLASS
+#
+# This class is an implementation detail and is subject to change or removal
+# at any time.
+
+class Net::HTTP::Persistent::SSLReuse < Net::HTTP
+
+  @is_proxy_class = false
+  @proxy_addr = nil
+  @proxy_port = nil
+  @proxy_user = nil
+  @proxy_pass = nil
+
+  def initialize address, port = nil # :nodoc:
+    super
+
+    @ssl_session = nil
+  end
+
+  ##
+  # From ruby trunk r33086 including http://redmine.ruby-lang.org/issues/5341
+
+  def connect # :nodoc:
+    D "opening connection to #{conn_address()}..."
+    s = timeout(@open_timeout) { TCPSocket.open(conn_address(), conn_port()) }
+    D "opened"
+    if use_ssl?
+      ssl_parameters = Hash.new
+      iv_list = instance_variables
+      SSL_ATTRIBUTES.each do |name|
+        ivname = "@#{name}".intern
+        if iv_list.include?(ivname) and
+           value = instance_variable_get(ivname)
+          ssl_parameters[name] = value
+        end
+      end
+      unless @ssl_context then
+        @ssl_context = OpenSSL::SSL::SSLContext.new
+        @ssl_context.set_params(ssl_parameters)
+      end
+      s = OpenSSL::SSL::SSLSocket.new(s, @ssl_context)
+      s.sync_close = true
+    end
+    @socket = Net::BufferedIO.new(s)
+    @socket.read_timeout = @read_timeout
+    @socket.continue_timeout = @continue_timeout if
+      @socket.respond_to? :continue_timeout
+    @socket.debug_output = @debug_output
+    if use_ssl?
+      begin
+        if proxy?
+          @socket.writeline sprintf('CONNECT %s:%s HTTP/%s',
+                                    @address, @port, HTTPVersion)
+          @socket.writeline "Host: #{@address}:#{@port}"
+          if proxy_user
+            credential = ["#{proxy_user}:#{proxy_pass}"].pack('m')
+            credential.delete!("\r\n")
+            @socket.writeline "Proxy-Authorization: Basic #{credential}"
+          end
+          @socket.writeline ''
+          Net::HTTPResponse.read_new(@socket).value
+        end
+        s.session = @ssl_session if @ssl_session
+        # Server Name Indication (SNI) RFC 3546
+        s.hostname = @address if s.respond_to? :hostname=
+        timeout(@open_timeout) { s.connect }
+        if @ssl_context.verify_mode != OpenSSL::SSL::VERIFY_NONE
+          s.post_connection_check(@address)
+        end
+        @ssl_session = s.session
+      rescue => exception
+        D "Conn close because of connect error #{exception}"
+        @socket.close if @socket and not @socket.closed?
+        raise exception
+      end
+    end
+    on_connect
+  end if RUBY_VERSION > '1.9'
+
+  ##
+  # From ruby_1_8_7 branch r29865 including a modified
+  # http://redmine.ruby-lang.org/issues/5341
+
+  def connect # :nodoc:
+    D "opening connection to #{conn_address()}..."
+    s = timeout(@open_timeout) { TCPSocket.open(conn_address(), conn_port()) }
+    D "opened"
+    if use_ssl?
+      unless @ssl_context.verify_mode
+        warn "warning: peer certificate won't be verified in this SSL session"
+        @ssl_context.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      end
+      s = OpenSSL::SSL::SSLSocket.new(s, @ssl_context)
+      s.sync_close = true
+    end
+    @socket = Net::BufferedIO.new(s)
+    @socket.read_timeout = @read_timeout
+    @socket.debug_output = @debug_output
+    if use_ssl?
+      if proxy?
+        @socket.writeline sprintf('CONNECT %s:%s HTTP/%s',
+                                  @address, @port, HTTPVersion)
+        @socket.writeline "Host: #{@address}:#{@port}"
+        if proxy_user
+          credential = ["#{proxy_user}:#{proxy_pass}"].pack('m')
+          credential.delete!("\r\n")
+          @socket.writeline "Proxy-Authorization: Basic #{credential}"
+        end
+        @socket.writeline ''
+        Net::HTTPResponse.read_new(@socket).value
+      end
+      s.session = @ssl_session if @ssl_session
+      s.connect
+      if @ssl_context.verify_mode != OpenSSL::SSL::VERIFY_NONE
+        s.post_connection_check(@address)
+      end
+      @ssl_session = s.session
+    end
+    on_connect
+  end if RUBY_VERSION < '1.9'
+
+  private :connect
+
+end
+


### PR DESCRIPTION
This pull request updates the vendored net-http-persitent library to latest as discussed #2274.

With this newer version of net-http-persistent bundler uses the no_proxy environment variable and skips the proxy for excluded host.

I tried to come up with a test for the no_proxy feature but couldn't figure out how to modify the singelton `Net::HTTP::Persistent` class that is created in `Bundler::Fetcher` to inject the no_proxy and proxy settings.
