### PR TITLE
Make updated net-http-persistent work without openssl

### DIFF
--- a/lib/bundler/vendor/net/http/persistent.rb
+++ b/lib/bundler/vendor/net/http/persistent.rb
@@ -458,12 +458,12 @@ class Net::HTTP::Persistent
     @private_key        = nil
     @ssl_version        = nil
     @verify_callback    = nil
-    @verify_mode        = OpenSSL::SSL::VERIFY_PEER
+    @verify_mode        = defined?(OpenSSL) ? OpenSSL::SSL::VERIFY_PEER : nil
     @cert_store         = nil
 
     @generation         = 0 # incremented when proxy URI changes
     @ssl_generation     = 0 # incremented when SSL session variables change
-    @reuse_ssl_sessions = OpenSSL::SSL.const_defined? :Session
+    @reuse_ssl_sessions = defined?(OpenSSL) ? OpenSSL::SSL.const_defined?(:Session) : false
 
     @retry_change_requests = false
 


### PR DESCRIPTION
One more pull request on my quest for a green build...

The updated net http persitent library doesn't expect the OpenSSL module to not be available.
This patch should fix that for now.

Hopefully this fixes the remainig failing tests on 1.8.7.
