### PR TITLE
Make rspec a lazy default for `--test` parameter on `bundle new gem`.

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -639,7 +639,7 @@ module Bundler
 
     desc "gem GEM", "Creates a skeleton for creating a rubygem"
     method_option :bin, :type => :boolean, :default => false, :aliases => '-b', :banner => "Generate a binary for your library."
-    method_option :test, :type => :string, :default => 'rspec', :aliases => '-t', :banner => "Generate a test directory for your library: 'rspec' is the default, but 'minitest' is also supported."
+    method_option :test, :type => :string, :lazy_default => 'rspec', :aliases => '-t', :banner => "Generate a test directory for your library: 'rspec' is the default, but 'minitest' is also supported."
     method_option :edit, :type => :string, :aliases => "-e",
                   :lazy_default => [ENV['BUNDLER_EDITOR'], ENV['VISUAL'], ENV['EDITOR']].find{|e| !e.nil? && !e.empty? },
                   :required => false, :banner => "/path/to/your/editor",

--- a/spec/other/newgem_spec.rb
+++ b/spec/other/newgem_spec.rb
@@ -120,6 +120,22 @@ RAKEFILE
       end
     end
 
+    context "no --test parameter" do
+      before do
+        reset!
+        in_app_root
+        bundle "gem #{gem_name}"
+      end
+
+      it "doesn't create any spec/test file" do
+        expect(bundled_app("test_gem/.rspec")).to_not exist
+        expect(bundled_app("test_gem/spec/test_gem_spec.rb")).to_not exist
+        expect(bundled_app("test_gem/spec/spec_helper.rb")).to_not exist
+        expect(bundled_app("test_gem/test/test_test_gem.rb")).to_not exist
+        expect(bundled_app("test_gem/test/minitest_helper.rb")).to_not exist
+      end
+    end
+
     context "--test parameter set to rspec" do
       before do
         reset!
@@ -277,6 +293,22 @@ RAKEFILE
 
       it "requires 'test/gem'" do
         expect(bundled_app("test-gem/bin/test-gem").read).to match(/require 'test\/gem'/)
+      end
+    end
+
+    context "no --test parameter" do
+      before do
+        reset!
+        in_app_root
+        bundle "gem #{gem_name}"
+      end
+
+      it "doesn't create any spec/test file" do
+        expect(bundled_app("test-gem/.rspec")).to_not exist
+        expect(bundled_app("test-gem/spec/test/gem_spec.rb")).to_not exist
+        expect(bundled_app("test-gem/spec/spec_helper.rb")).to_not exist
+        expect(bundled_app("test-gem/test/test_test/gem.rb")).to_not exist
+        expect(bundled_app("test-gem/test/minitest_helper.rb")).to_not exist
       end
     end
 


### PR DESCRIPTION
Fix for #2286

I haven't really written many specs, so let me know if they're not good.
