### PR TITLE
Fix loading of gemspecs that contain unicode characters.

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -291,7 +291,7 @@ module Bundler
       Dir.chdir(path.dirname.to_s) do
         contents = File.read(path.basename.to_s)
 
-        if contents =~ /\A---/ # try YAML
+        if contents[0..2] == "---" # YAML header
           begin
             Gem::Specification.from_yaml(contents)
           rescue ArgumentError, YamlSyntaxError, Gem::EndOfYAMLException, Gem::Exception

--- a/spec/bundler/bundler_spec.rb
+++ b/spec/bundler/bundler_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'spec_helper'
 require 'bundler'
 
@@ -14,6 +15,31 @@ GEMSPEC
       proc {
         Bundler.load_gemspec_uncached(tmp("test.gemspec"))
       }.should raise_error(Bundler::GemspecError)
+    end
+
+    it "can load a gemspec with unicode characters with default ruby encoding" do
+      # spec_helper forces the external encoding to UTF-8 but that's not the
+      # ruby default.
+      encoding = nil
+
+      if defined?(Encoding)
+        encoding = Encoding.default_external
+        Encoding.default_external = "ASCII"
+      end
+
+      File.open(tmp("test.gemspec"), "wb") do |file|
+        file.puts <<-G
+# -*- encoding: utf-8 -*-
+Gem::Specification.new do |gem|
+  gem.author = "André the Giant"
+end
+        G
+      end
+
+      gemspec = Bundler.load_gemspec_uncached(tmp("test.gemspec"))
+      gemspec.author.should == "André the Giant"
+
+      Encoding.default_external = encoding if defined?(Encoding)
     end
   end
 end


### PR DESCRIPTION
If Ruby's default encoding is not changed then the files are read in as
US-ASCII. When compared against the regular expression they were raising
encoding errors on 1.9 because the unicode characters could not be
converted to ASCII.

This changes the YAML header to check to match what is currently in 1.3
which doesn't have the problem (as it doesn't need to process the whole
string).

Should fix #2240. Possible make #2241 unneeded.
