### PR TITLE
Add test for gemspecs containing unicode characters.

### DIFF
--- a/spec/bundler/bundler_spec.rb
+++ b/spec/bundler/bundler_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'spec_helper'
 require 'bundler'
 
@@ -43,6 +44,31 @@ describe Bundler do
           YAML::ENGINE.yamler = orig_yamler
         end
       end
+    end
+
+    it "can load a gemspec with unicode characters with default ruby encoding" do
+      # spec_helper forces the external encoding to UTF-8 but that's not the
+      # ruby default.
+      encoding = nil
+
+      if defined?(Encoding)
+        encoding = Encoding.default_external
+        Encoding.default_external = "ASCII"
+      end
+
+      File.open(tmp("test.gemspec"), "wb") do |file|
+        file.puts <<-G
+# -*- encoding: utf-8 -*-
+Gem::Specification.new do |gem|
+  gem.author = "André the Giant"
+end
+        G
+      end
+
+      gemspec = Bundler.load_gemspec_uncached(tmp("test.gemspec"))
+      expect(gemspec.author).to eq("André the Giant")
+
+      Encoding.default_external = encoding if defined?(Encoding)
     end
 
   end


### PR DESCRIPTION
On Ruby 1.8 and 1.9 if the default locale was not overriden Bundler
1.2.x would raise an exception trying to load the gemspec. Though it was
fixed by changes to 1.3 this test is to ensure it doesn't crop up again.
