### PR TITLE
Optimize conflict resolution to prevent "infinite loop" effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Bugfixes:
 
   - stubs for gems with dev deps no longer cause exceptions (#2272)
   - don't suggest binstubs to --binstubs users
+  - optimize conflict resolution to avoid "infinite loop" (#2248)
 
 ## 1.3.0.pre.6 (22 January 2013)
 

--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -295,6 +295,15 @@ module Bundler
           conflict = resolve_requirement(spec_group, current, reqs.dup, activated.dup)
           conflicts << conflict if conflict
         end
+
+        # If didn't jump on a conflict, but we are still carrying errors,
+        # we should rewind up the bad dependency chain to pivot on gems that matter
+        if conflicts.empty? && !@errors.empty? && !current.required_by.empty?
+          errorpivot = current.required_by.last.name
+          debug { "    -> Jumping to: #{errorpivot}" }
+          throw errorpivot
+        end
+
         # If the current requirement is a root level gem and we have conflicts, we
         # can figure out the best spot to backtrack to.
         if current.required_by.empty? && !conflicts.empty?

--- a/spec/resolver/basic_spec.rb
+++ b/spec/resolver/basic_spec.rb
@@ -17,4 +17,10 @@ describe "Resolving" do
 
     should_resolve_as %w(actionpack-2.3.5 activesupport-2.3.5 rack-1.0)
   end
+
+  it "resolve a conflicting index" do
+    @index = a_conflict_index
+    dep "my_app"
+    should_resolve_as %w(activemodel-3.2.11 builder-3.0.4 grape-0.2.6 my_app-1.0.0)
+  end
 end

--- a/spec/support/indexes.rb
+++ b/spec/support/indexes.rb
@@ -108,5 +108,27 @@ module Spec
         end
       end
     end
+
+    # Builder 3.1.4 will activate first, but if all
+    # goes well, it should resolve to 3.0.4
+    def a_conflict_index
+      build_index do
+        gem "builder", %w(3.0.4 3.1.4)
+        gem("grape", '0.2.6') do
+          dep "builder", ">= 0"
+        end
+
+        versions '3.2.8 3.2.9 3.2.10 3.2.11' do |version|
+          gem("activemodel", version) do
+            dep "builder", "~> 3.0.0"
+          end
+        end
+
+        gem("my_app", '1.0.0') do
+          dep "activemodel", ">= 0"
+          dep "grape", ">= 0"
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
The current implementation of the Resolver keeps iterating through all the possible permutations of versions until one satisfies all the requirements.  This is ok for most cases, but when you have a dependency (like `builder`) in a deep dependency tree with many versions (like `rails => activerecord => activemodel => builder`) that encounters a conflict, Bundler will start trying all the permutations of the tree, which closely imitates the effect of an infinite loop.

This patch prevents iterating on dependency tree branches that don't matter by only traversing up the dependency chain that has generated the conflict.

Note: My understanding of the Resolver is limited, so I hope someone more experienced gives this some more thought before merging.

Possibly related to #2248, #2090, #2273
