### PR TITLE
Accepts strings for group names

### DIFF
--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -5,6 +5,8 @@ module Bundler
     include SharedHelpers
 
     def setup(*groups)
+      groups.map! { |g| g.to_sym }
+
       # Has to happen first
       clean_load_path
 

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -46,6 +46,19 @@ describe "Bundler.setup" do
       expect(out).to eq("WIN")
     end
 
+    it "accepts string for group name" do
+      ruby <<-RUBY
+        require 'rubygems'
+        require 'bundler'
+        Bundler.setup(:default, 'test')
+
+        require 'rack'
+        puts RACK
+      RUBY
+      expect(err).to eq("")
+      expect(out).to eq("1.0.0")
+    end
+
     it "leaves all groups available if they were already" do
       ruby <<-RUBY
         require 'rubygems'


### PR DESCRIPTION
This allow Environment#setup behaves in same way as
Environment#require, allowing usage of ENV variables directly:

``` ruby
require "bundler"
Bundler.setup(:default, ENV.fetch("RACK_ENV", "development"))
```

This is a patch for #2305

Thank you!

:heart: :heart: :heart: 
