### PR TITLE
Remove load path tampering from gemspec template.

### DIFF
--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -1,7 +1,5 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require '<%=config[:namespaced_path]%>/version'
+require File.expand_path('../lib/<%=config[:namespaced_path]%>/version', __FILE__)
 
 Gem::Specification.new do |spec|
   spec.name          = <%=config[:name].inspect%>


### PR DESCRIPTION
I don't believe that it is necessary for a gemspec to ever modify the load path.

I notice that this used to be the behaviour but then e12e5071f8238f5c9909ee5109ccc9db7291165c changed this? 
I don't understand why "require breaks (and can load twice) if you use relative paths, so don't do that" is relevant because we're not using relative paths at all as all paths are being expanded.

Thanks!
