### PR TITLE
Minor fix on wrong argument message in Thor

### DIFF
--- a/lib/bundler/vendor/thor/base.rb
+++ b/lib/bundler/vendor/thor/base.rb
@@ -469,7 +469,7 @@ class Thor
 
       def handle_argument_error(task, error, arity=nil) #:nodoc:
         msg = "#{basename} #{task.name}"
-        if arity
+        if arity && arity != 0
           required = arity < 0 ? (-1 - arity) : arity
           msg << " requires at least #{required} argument"
           msg << "s" if required > 1


### PR DESCRIPTION
Currently, Thor prints `bundle init requires at least 0 argument: "bundle init".`
I believe to avoid confusion, it should print the same message as in case of nil "arity" value: `call bundle init as: "bundle init".`

Minor fix, so feel free to close it if you think it is not a big deal ;).
