### PR TITLE
use https://rubygems.org everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Features:
 
   - optimize resolver when too new of a gem is already activated (@rykov, #2248)
+  - `source :rubygems` now uses https://rubygems.org (#2314)
 
 ## 1.3.0.pre.7 (22 January 2013)
 

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -107,7 +107,7 @@ module Bundler
     def source(source, options = {})
       case source
       when :gemcutter, :rubygems, :rubyforge then
-        @rubygems_source.add_remote "http://rubygems.org"
+        @rubygems_source.add_remote "https://rubygems.org"
         return
       when String
         @rubygems_source.add_remote source

--- a/man/bundle-install.ronn
+++ b/man/bundle-install.ronn
@@ -192,7 +192,7 @@ third-party code being used in different environments.`
 
 For a simple illustration, consider the following Gemfile(5):
 
-    source "http://rubygems.org"
+    source "https://rubygems.org"
 
     gem "sinatra"
 
@@ -288,7 +288,7 @@ same versions of all dependencies as it used before the update.
 
 Let's take a look at an example. Here's your original Gemfile(5):
 
-    source "http://rubygems.org"
+    source "https://rubygems.org"
 
     gem "actionpack", "2.3.8"
     gem "activemerchant"
@@ -304,7 +304,7 @@ gems in your Gemfile(5).
 
 Next, you modify your Gemfile(5) to:
 
-    source "http://rubygems.org"
+    source "https://rubygems.org"
 
     gem "actionpack", "3.0.0.rc"
     gem "activemerchant"

--- a/man/bundle-package.ronn
+++ b/man/bundle-package.ronn
@@ -26,7 +26,7 @@ in `vendor/cache`.
 
 For instance, consider this Gemfile(5):
 
-    source "http://rubygems.org"
+    source "https://rubygems.org"
 
     gem "nokogiri"
 

--- a/man/bundle-platform.ronn
+++ b/man/bundle-platform.ronn
@@ -12,7 +12,7 @@ VM about your platform.
 
 For instance, using this Gemfile(5):
 
-    source "http://rubygems.org"
+    source "https://rubygems.org"
 
     ruby "1.9.3"
 

--- a/man/bundle-update.ronn
+++ b/man/bundle-update.ronn
@@ -30,7 +30,7 @@ based on the latest versions of all gems available in the sources.
 
 Consider the following Gemfile(5):
 
-    source "http://rubygems.org"
+    source "https://rubygems.org"
 
     gem "rails", "3.0.0.rc"
     gem "nokogiri"
@@ -38,7 +38,7 @@ Consider the following Gemfile(5):
 When you run [bundle install(1)][bundle-install] the first time, bundler will resolve
 all of the dependencies, all the way down, and install what you need:
 
-    Fetching source index for http://rubygems.org/
+    Fetching source index for https://rubygems.org/
     Installing rake (10.0.2)
     Installing abstract (1.0.0)
     Installing activesupport (3.0.0.rc)
@@ -103,7 +103,7 @@ Sometimes, multiple gems declared in your Gemfile(5) are satisfied by the same
 second-level dependency. For instance, consider the case of `thin` and
 `rack-perftools-profiler`.
 
-    source "http://rubygems.org"
+    source "https://rubygems.org"
 
     gem "thin"
     gem "rack-perftools-profiler"
@@ -111,7 +111,7 @@ second-level dependency. For instance, consider the case of `thin` and
 The `thin` gem depends on `rack >= 1.0`, while `rack-perftools-profiler` depends
 on `rack ~> 1.0`. If you run bundle install, you get:
 
-    Fetching source index for http://rubygems.org/
+    Fetching source index for https://rubygems.org/
     Installing daemons (1.1.0)
     Installing eventmachine (0.12.10) with native extensions
     Installing open4 (1.0.1)

--- a/man/gemfile.5.ronn
+++ b/man/gemfile.5.ronn
@@ -20,7 +20,7 @@ a number of methods used to describe the gem requirements.
 At the top of the `Gemfile`, add one line for each `Rubygems` source that
 might contain the gems listed in the `Gemfile`.
 
-    source "http://rubygems.org"
+    source "https://rubygems.org"
     source "http://gems.github.com"
 
 Each of these _source_s `MUST` be a valid Rubygems repository. Sources are

--- a/spec/install/gems/dependency_api_spec.rb
+++ b/spec/install/gems/dependency_api_spec.rb
@@ -425,7 +425,7 @@ describe "gemcutter's dependency API" do
   context ".gemrc with sources is present" do
     before do
       File.open(home('.gemrc'), 'w') do |file|
-        file.puts({:sources => ["http://rubygems.org"]}.to_yaml)
+        file.puts({:sources => ["https://rubygems.org"]}.to_yaml)
       end
     end
 

--- a/spec/realworld/edgecases_spec.rb
+++ b/spec/realworld/edgecases_spec.rb
@@ -141,7 +141,7 @@ describe "real world edgecases", :realworld => true do
             multi_json (~> 1.0)
 
       GEM
-        remote: http://rubygems.org/
+        remote: https://rubygems.org/
         specs:
           arel (3.0.2)
           builder (3.0.0)


### PR DESCRIPTION
if https is the best way to access rubygems.org
then it should be default everywhere
including in examples on the man page
