### PR TITLE
Stop socket from doing a reverse dns lookup

### DIFF
--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -57,6 +57,8 @@ module Bundler
       @public_uri.user, @public_uri.password = nil, nil # don't print these
       @connection ||= Net::HTTP::Persistent.new 'bundler', :ENV
       @connection.read_timeout = API_TIMEOUT
+
+      Socket.do_not_reverse_lookup = true
     end
 
     # fetch a gem specification


### PR DESCRIPTION
This should speed up repeated connects that occur as a result of redirects, etc.
