### PR TITLE
Remove a warning

### DIFF
--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -302,12 +302,12 @@ module Bundler
         # on this conflict.  Note that if the tree has multiple conflicts, we don't
         # care which one we throw, as long as we get out safe
         if !current.required_by.empty? && !conflicts.empty?
-          @errors.reverse_each do |name, pair|
-            if conflicts.include?(name)
+          @errors.reverse_each do |req_name, pair|
+            if conflicts.include?(req_name)
               # Choose the closest pivot in the stack that will affect the conflict
-              errorpivot = (@stack & [name, current.required_by.last.name]).last
+              errorpivot = (@stack & [req_name, current.required_by.last.name]).last
               debug { "    -> Jumping to: #{errorpivot}" }
-              throw errorpivot, name
+              throw errorpivot, req_name
             end
           end
         end


### PR DESCRIPTION
This makes Bundler 1.3.0.pre.8 `ruby -w`-clean again, by removing a warning that crept in recently. This is especially useful when one runs `rake spec` with warnings on, to catch potential code issues in development.

Most anything other than `name` will work, of course, so if `req_name` is sub-optimal then I’ll gladly adjust. :)
