### PR TITLE
Switch `source :rubygems` to HTTPS

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -107,10 +107,7 @@ module Bundler
     def source(source, options = {})
       case source
       when :gemcutter, :rubygems, :rubyforge then
-        Bundler.ui.warn "The source :#{source} is deprecated because HTTP " \
-          "requests are insecure.\nPlease change your source to 'https://" \
-          "rubygems.org' if possible, or 'http://rubygems.org' if not."
-        @rubygems_source.add_remote "http://rubygems.org"
+        @rubygems_source.add_remote "https://rubygems.org"
         return
       when String
         @rubygems_source.add_remote source


### PR DESCRIPTION
Promote the right protocol instead of notifying the user. The user can
still switch back to HTTP using the full URL.
