### PR TITLE
Write skipped groups to output for bundle install and update actions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.3.2 (tbd)
+
+Features:
+
+ - mention skipped groups in bundle install and bundle update output (@simi)
+
 ## 1.3.1 (3 March 2013)
 
 Bugfixes:

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -251,11 +251,13 @@ module Bundler
       if Bundler.settings[:path]
         absolute_path = File.expand_path(Bundler.settings[:path])
         relative_path = absolute_path.sub(File.expand_path('.'), '.')
-        Bundler.ui.confirm "Your bundle is complete! " +
+        Bundler.ui.confirm without_groups_message.to_s +
+          "Your bundle is complete!\n" +
           "It was installed into #{relative_path}"
       else
-        Bundler.ui.confirm "Your bundle is complete! " +
-          "Use `bundle show [gemname]` to see where a bundled gem is installed."
+        Bundler.ui.confirm use_budle_show_message +
+          without_groups_message.to_s +
+          "Your bundle is complete!"
       end
       Installer.post_install_messages.to_a.each do |name, msg|
         Bundler.ui.confirm "Post-install message from #{name}:\n#{msg}"
@@ -316,8 +318,9 @@ module Bundler
       Installer.install Bundler.root, Bundler.definition, opts
       Bundler.load.cache if Bundler.root.join("vendor/cache").exist?
       clean if Bundler.settings[:clean] && Bundler.settings[:path]
-      Bundler.ui.confirm "Your bundle is updated! " +
-        "Use `bundle show [gemname]` to see where a bundled gem is installed."
+      Bundler.ui.confirm use_budle_show_message +
+        without_groups_message.to_s +
+        "Your bundle is updated!"
     end
 
     desc "show [GEM]", "Shows all gems that are part of the bundle, or the path to a given gem"
@@ -856,6 +859,16 @@ module Bundler
       pager ||= 'less -R' if Bundler.which("less")
       pager ||= 'more' if Bundler.which("more")
       pager ||= 'cat'
+    end
+
+    def without_groups_message
+      if Bundler.settings.without.any?
+        "Skipped groups for this bundle are: #{Bundler.settings.without.join(' ')}.\n"
+      end
+    end
+
+    def use_budle_show_message
+      "Use `bundle show [gemname]` to see where a bundled gem is installed.\n"
     end
 
   end

--- a/spec/install/gems/groups_spec.rb
+++ b/spec/install/gems/groups_spec.rb
@@ -105,6 +105,17 @@ describe "bundle install with gem sources" do
           expect(out).not_to include("activesupport")
         end
 
+        it "does say the groups are skipped from the previously excluded groups" do
+          bundle :install, :without => "emo"
+          bundle :install
+          expect(out).to include("Skipped groups for this bundle are: emo.")
+        end
+
+        it "does say the group is skipped" do
+          bundle :install, :without => "emo"
+          expect(out).to include("Skipped groups for this bundle are: emo.")
+        end
+
         it "allows Bundler.setup for specific groups" do
           bundle :install, :without => "emo"
           run("require 'rack'; puts RACK", :default)
@@ -216,6 +227,11 @@ describe "bundle install with gem sources" do
           it "does not install the gem w/ option --without 'emo lolercoaster'" do
             bundle "install --without 'emo lolercoaster'"
             should_not_be_installed "activesupport 2.3.5"
+          end
+
+          it "does say the groups are skipped" do
+            bundle "install --without 'emo lolercoaster'"
+            expect(out).to include("Skipped groups for this bundle are: emo lolercoaster.")
           end
         end
       end

--- a/spec/install/post_bundle_message_spec.rb
+++ b/spec/install/post_bundle_message_spec.rb
@@ -1,0 +1,118 @@
+require 'spec_helper'
+
+describe "post bundle message" do
+  before :each do
+    gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem "rack"
+        gem "activesupport", "2.3.5", :group => [:emo, :test]
+        group :test do
+          gem "rspec"
+        end
+    G
+  end
+
+  let(:bundle_show_message)       {"Use `bundle show [gemname]` to see where a bundled gem is installed.\n"}
+  let(:bundle_deployment_message) {"It was installed into ./vendor/bundle"}
+  let(:bundle_complete_message)   {"Your bundle is complete!"}
+  let(:bundle_updated_message)    {"Your bundle is updated!"}
+
+  describe "for fresh bundle install" do
+    it "without any options" do
+      bundle :install
+      expect(out).to include(bundle_show_message)
+      expect(out).not_to include("Skipped groups")
+      expect(out).to include(bundle_complete_message)
+    end
+
+    it "with --without one group" do
+      bundle :install, :without => :emo
+      expect(out).to include(bundle_show_message)
+      expect(out).to include("Skipped groups for this bundle are: emo.\n")
+      expect(out).to include(bundle_complete_message)
+    end
+
+    it "with --without more group" do
+      bundle "install --without emo test"
+      expect(out).to include(bundle_show_message)
+      expect(out).to include("Skipped groups for this bundle are: emo test.\n")
+      expect(out).to include(bundle_complete_message)
+    end
+
+    describe "with --deployment and" do
+      it "without any options" do
+        bundle :install
+        bundle "install --deployment", :exitstatus => true
+        expect(out).to include(bundle_deployment_message)
+        expect(out).not_to include("Skipped groups")
+        expect(out).to include(bundle_complete_message)
+      end
+
+      it "with --without one group" do
+        bundle :install
+        bundle "install  --without emo --deployment"
+        expect(out).to include(bundle_deployment_message)
+        expect(out).to include("Skipped groups for this bundle are: emo.\n")
+        expect(out).to include(bundle_complete_message)
+      end
+
+      it "with --without more group" do
+        bundle :install
+        bundle "install  --without emo test --deployment"
+        expect(out).to include(bundle_deployment_message)
+        expect(out).to include("Skipped groups for this bundle are: emo test.\n")
+        expect(out).to include(bundle_complete_message)
+      end
+    end
+  end
+
+  describe "for second bundle install run" do
+    it "without any options" do
+      2.times { bundle :install }
+      bundle :install
+      expect(out).to include(bundle_show_message)
+      expect(out).not_to include("Skipped groups")
+      expect(out).to include(bundle_complete_message)
+    end
+
+    it "with --without one group" do
+      2.times { bundle :install, :without => :emo }
+      expect(out).to include(bundle_show_message)
+      expect(out).to include("Skipped groups for this bundle are: emo.\n")
+      expect(out).to include(bundle_complete_message)
+    end
+
+    it "with --without more group" do
+      2.times { bundle "install --without emo test" }
+      expect(out).to include(bundle_show_message)
+      expect(out).to include("Skipped groups for this bundle are: emo test.\n")
+      expect(out).to include(bundle_complete_message)
+    end
+  end
+
+  describe "for bundle update" do
+    it "without any options" do
+      bundle :install
+      bundle :update
+      expect(out).to include(bundle_show_message)
+      expect(out).not_to include("Skipped groups")
+      expect(out).to include(bundle_updated_message)
+    end
+
+    it "with --without one group" do
+      bundle :install, :without => :emo
+      bundle :update
+      expect(out).to include(bundle_show_message)
+      expect(out).to include("Skipped groups for this bundle are: emo.\n")
+      expect(out).to include(bundle_updated_message)
+    end
+
+    it "with --without more group" do
+      bundle "install --without emo test"
+      bundle :update
+      expect(out).to include(bundle_show_message)
+      expect(out).to include("Skipped groups for this bundle are: emo test.\n")
+      expect(out).to include(bundle_updated_message)
+    end
+  end
+end


### PR DESCRIPTION
## Better output for bundle install update

I'll try to make better test suite to catch all cases.
Idea by @plentz and @indirect in #2347.
### Output for fresh `bundle install`:

```
Use `bundle show [gemname]` to see where a bundled gem is installed.
Your bundle is complete!
```
### Output for `bundle update` without skipped groups:

```
Use `bundle show [gemname]` to see where a bundled gem is installed.
Your bundle is updated!
```
### Output for `bundle install --without development test`:

```
Use `bundle show [gemname]` to see where a bundled gem is installed.
Skipped groups for this bundle are: development test.
Your bundle is complete!
```
### Output for `bundle install --deployment --without development test`:

```
Skipped groups for this bundle are: development test.
Your bundle is complete!
It was installed into ./vendor/bundle
```
### Output for `bundle update` with skipped groups in memory:

```
Use `bundle show [gemname]` to see where a bundled gem is installed.
Skipped groups for this bundle are: development test.
Your bundle is updated!
```
