### PR TITLE
Fix gem_helper_spec.

### DIFF
--- a/spec/bundler/gem_helper_spec.rb
+++ b/spec/bundler/gem_helper_spec.rb
@@ -185,8 +185,11 @@ describe "Bundler::GemHelper tasks" do
           `git init --bare`
         }
         Dir.chdir(@app) {
-         `git commit -a -m "another commit"`
-         `git tag -a -m \"Version 0.0.1\" v0.0.1`
+          `git init`
+          `git config user.email "you@example.com"`
+          `git config user.name "name"`
+          `git commit -a -m "another commit"`
+          `git tag -a -m \"Version 0.0.1\" v0.0.1`
         }
         @helper.release_gem
       end


### PR DESCRIPTION
Fixes "Bundler::GemHelper tasks gem management release releases even
if tag already exists" error:

```
$ rspec ./spec/bundler/gem_helper_spec.rb:178
Run options:
  include {:locations=>{"./spec/bundler/gem_helper_spec.rb"=>[178]}}
  exclude {:ruby=>"1.8", :realworld=>true, :sudo=>true}

Bundler::GemHelper tasks
  gem management
    release

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: empty ident name (for <mockbuild@unused-4-228.brq.redhat.com>) not allowed
fatal: Failed to resolve 'HEAD' as a valid ref.
      create  test/Gemfile
      create  test/Rakefile
      create  test/LICENSE.txt
      create  test/README.md
      create  test/.gitignore
      create  test/test.gemspec
      create  test/lib/test.rb
      create  test/lib/test/version.rb
Initializating git repo in /builddir/build/BUILD/rubygem-bundler-1.3.1/usr/share/gems/gems/bundler-1.3.1/tmp/bundled_app/test
      releases even if tag already exists (FAILED - 1)

Failures:

  1) Bundler::GemHelper tasks gem management release releases even if tag already exists
     Failure/Error: @helper.release_gem
     RuntimeError:
       There are files that need to be committed first.
     # /builddir/build/BUILD/rubygem-bundler-1.3.1/usr/share/gems/gems/bundler-1.3.1/lib/bundler/gem_helper.rb:115:in `guard_clean'
     # /builddir/build/BUILD/rubygem-bundler-1.3.1/usr/share/gems/gems/bundler-1.3.1/lib/bundler/gem_helper.rb:75:in `release_gem'
     # /builddir/build/BUILD/rubygem-bundler-1.3.1/usr/share/gems/gems/bundler-1.3.1/spec/bundler/gem_helper_spec.rb:191:in `block (4 levels) in <top (required)>'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/example.rb:114:in `instance_eval'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/example.rb:114:in `block in run'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/example.rb:254:in `with_around_each_hooks'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/example.rb:111:in `run'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/example_group.rb:388:in `block in run_examples'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/example_group.rb:384:in `map'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/example_group.rb:384:in `run_examples'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/example_group.rb:369:in `run'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/example_group.rb:370:in `block in run'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/example_group.rb:370:in `map'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/example_group.rb:370:in `run'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/example_group.rb:370:in `block in run'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/example_group.rb:370:in `map'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/example_group.rb:370:in `run'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/command_line.rb:28:in `block (2 levels) in run'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/command_line.rb:28:in `map'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/command_line.rb:28:in `block in run'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/reporter.rb:34:in `report'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/command_line.rb:25:in `run'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/runner.rb:80:in `run'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 1.07 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/bundler/gem_helper_spec.rb:178 # Bundler::GemHelper tasks gem management release releases even if tag already exists
```

 No matter if I called `git config --global` prior as suggested, it was failing. This just follows other spec around, which are doing the same settings internally, so I hope this is right fix.
