### PR TITLE
remove quotes on RUBYOPT on Windows

### DIFF
--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -224,11 +224,7 @@ module Bundler
       rubyopt = [ENV["RUBYOPT"]].compact
       if rubyopt.empty? || rubyopt.first !~ /-rbundler\/setup/
         rubyopt.unshift %|-rbundler/setup|
-        if Bundler::WINDOWS
-          rubyopt.unshift %|"-I#{File.expand_path('../..', __FILE__)}"|
-        else
-          rubyopt.unshift %|-I#{File.expand_path('../..', __FILE__)}|
-        end
+        rubyopt.unshift %|-I#{File.expand_path('../..', __FILE__)}|
         ENV["RUBYOPT"] = rubyopt.join(' ')
       end
     end


### PR DESCRIPTION
Quotes breaks things on Windows, too.
My RbConfig::CONFIG["host_os"] is mingw32.
My ruby is ruby-1.9.3-p392-i386-mingw32 (RubyInstaller for Windows).

When the quotes are included as in master, bundler/setup cannot be loaded.
After the quotes are removed, Rails (3.2.12) starts up normally.
The following is the log when executing 

```
bundle exec rails s
```

with quotes included.

```
C:/ruby-1.9.3-p392-i386-mingw32/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require': cannot load such file -- bundler/setup (LoadError)
        from C:/ruby-1.9.3-p392-i386-mingw32/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
        from E:/myrailsproject/config/boot.rb:6:in `<top (required)>'
        from C:/ruby-1.9.3-p392-i386-mingw32/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
        from C:/ruby-1.9.3-p392-i386-mingw32/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
        from script/rails:5:in `<main>'
```
