### PR TITLE
Create a default rake task for new gems using minitest.

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -681,6 +681,7 @@ module Bundler
       constant_array = constant_name.split('::')
       git_user_name = `git config user.name`.chomp
       git_user_email = `git config user.email`.chomp
+      test_framework = options[:test] || 'no_test'
       opts = {
         :name            => name,
         :namespaced_path => namespaced_path,
@@ -691,28 +692,28 @@ module Bundler
         :test            => options[:test]
       }
       gemspec_dest = File.join(target, "#{name}.gemspec")
-      template(File.join("newgem/Gemfile.tt"),               File.join(target, "Gemfile"),                             opts)
-      template(File.join("newgem/Rakefile.tt"),              File.join(target, "Rakefile"),                            opts)
-      template(File.join("newgem/LICENSE.txt.tt"),           File.join(target, "LICENSE.txt"),                         opts)
-      template(File.join("newgem/README.md.tt"),             File.join(target, "README.md"),                           opts)
-      template(File.join("newgem/gitignore.tt"),             File.join(target, ".gitignore"),                          opts)
-      template(File.join("newgem/newgem.gemspec.tt"),        gemspec_dest,                                             opts)
-      template(File.join("newgem/lib/newgem.rb.tt"),         File.join(target, "lib/#{namespaced_path}.rb"),           opts)
-      template(File.join("newgem/lib/newgem/version.rb.tt"), File.join(target, "lib/#{namespaced_path}/version.rb"),   opts)
+      template(File.join("newgem/Gemfile.tt"),                    File.join(target, "Gemfile"),                           opts)
+      template(File.join("newgem/Rakefile_#{test_framework}.tt"), File.join(target, "Rakefile"),                          opts)
+      template(File.join("newgem/LICENSE.txt.tt"),                File.join(target, "LICENSE.txt"),                       opts)
+      template(File.join("newgem/README.md.tt"),                  File.join(target, "README.md"),                         opts)
+      template(File.join("newgem/gitignore.tt"),                  File.join(target, ".gitignore"),                        opts)
+      template(File.join("newgem/newgem.gemspec.tt"),             gemspec_dest,                                           opts)
+      template(File.join("newgem/lib/newgem.rb.tt"),              File.join(target, "lib/#{namespaced_path}.rb"),         opts)
+      template(File.join("newgem/lib/newgem/version.rb.tt"),      File.join(target, "lib/#{namespaced_path}/version.rb"), opts)
       if options[:bin]
-        template(File.join("newgem/bin/newgem.tt"),          File.join(target, 'bin', name),                           opts)
+        template(File.join("newgem/bin/newgem.tt"),               File.join(target, 'bin', name),                         opts)
       end
       case options[:test]
       when 'rspec'
-        template(File.join("newgem/rspec.tt"),               File.join(target, ".rspec"),                              opts)
-        template(File.join("newgem/spec/spec_helper.rb.tt"), File.join(target, "spec/spec_helper.rb"),                 opts)
-        template(File.join("newgem/spec/newgem_spec.rb.tt"), File.join(target, "spec/#{namespaced_path}_spec.rb"),     opts)
+        template(File.join("newgem/rspec.tt"),                    File.join(target, ".rspec"),                            opts)
+        template(File.join("newgem/spec/spec_helper.rb.tt"),      File.join(target, "spec/spec_helper.rb"),               opts)
+        template(File.join("newgem/spec/newgem_spec.rb.tt"),      File.join(target, "spec/#{namespaced_path}_spec.rb"),   opts)
       when 'minitest'
-        template(File.join("newgem/test/minitest_helper.rb.tt"), File.join(target, "test/minitest_helper.rb"),         opts)
-        template(File.join("newgem/test/test_newgem.rb.tt"),     File.join(target, "test/test_#{namespaced_path}.rb"), opts)
+        template(File.join("newgem/test/minitest_helper.rb.tt"),  File.join(target, "test/minitest_helper.rb"),           opts)
+        template(File.join("newgem/test/test_newgem.rb.tt"),      File.join(target, "test/test_#{namespaced_path}.rb"),   opts)
       end
       if options[:test]
-        template(File.join("newgem/.travis.yml.tt"),         File.join(target, ".travis.yml"),            opts)
+        template(File.join("newgem/.travis.yml.tt"),              File.join(target, ".travis.yml"),                       opts)
       end
       Bundler.ui.info "Initializating git repo in #{target}"
       Dir.chdir(target) { `git init`; `git add .` }

--- a/lib/bundler/templates/newgem/Rakefile_minitest.tt
+++ b/lib/bundler/templates/newgem/Rakefile_minitest.tt
@@ -1,5 +1,4 @@
 require "bundler/gem_tasks"
-<% if config[:test] == 'minitest' -%>
 require "rake/testtask"
 
 Rake::TestTask.new :test do |t|
@@ -7,4 +6,3 @@ Rake::TestTask.new :test do |t|
 end
 
 task :default => :test
-<% end -%>

--- a/lib/bundler/templates/newgem/Rakefile_no_test.tt
+++ b/lib/bundler/templates/newgem/Rakefile_no_test.tt
@@ -1,0 +1,1 @@
+require "bundler/gem_tasks"

--- a/lib/bundler/templates/newgem/Rakefile_rspec.tt
+++ b/lib/bundler/templates/newgem/Rakefile_rspec.tt
@@ -1,0 +1,6 @@
+require "bundler/gem_tasks"
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec)
+
+task :default => :spec

--- a/spec/other/newgem_spec.rb
+++ b/spec/other/newgem_spec.rb
@@ -332,6 +332,19 @@ RAKEFILE
       it "creates a default test which fails" do
         expect(bundled_app("test-gem/spec/test/gem_spec.rb").read).to match(/false.should be_true/)
       end
+
+      it "creates a default rake task to run test suite" do
+        rakefile = <<-RAKEFILE
+require "bundler/gem_tasks"
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec)
+
+task :default => :spec
+RAKEFILE
+
+        expect(bundled_app("test-gem/Rakefile").read).to eq(rakefile)
+      end
     end
 
     context "--test parameter set to minitest" do


### PR DESCRIPTION
Almost always the first thing I do is add a rake task for running my entire test suite. This pull request adds that functionality for anyone creating a gem using the minitest framework. I'm happy to add a default task for rspec but I'm not 100% on what it looks like.
