### PR TITLE
 add Gem::Specification#bindir to the template of gemspec so that user can change their executables dir easily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.3.4
+
+  - add Gem::Specification#bindir to gemspec.tt so that users can change their executables dir easily
+
 ## 1.3.3
 
 Bugfixes:

--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -14,7 +14,8 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.files         = `git ls-files`.split($/)
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.bindir        = "bin"
+  spec.executables   = spec.files.grep(%r{^#{spec.bindir}/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION
I sometimes change executables dir from bin to exe.
I opened gemspec and edited "spec.executables", but after releasing my gem I found executables installed did not work.

That is because installed executables loads file under bindir, but bindir is still bin.

I should also edit not only spec.executables but also "spec.bindir".

When default gemspec have the Gem::Specification#bindir and Gem::Specification#executables uses it, No mistake like me will happen.

Regards,
okitan
