### PR TITLE
Allow `bundle viz` to function with gems specified by git and path

### DIFF
--- a/lib/bundler/dependency.rb
+++ b/lib/bundler/dependency.rb
@@ -79,6 +79,10 @@ module Bundler
       out << "\n"
     end
 
+    def to_spec
+      Bundler.definition.specs[name].sort_by(&:version).last
+    end
+
   private
 
     def on_18?


### PR DESCRIPTION
`Gem::Dependency#to_spec` depends on the specifications being loaded and activated in @rubygems. 

This allows gem dependencies which point to non-installed gems to be used with `bundle viz`. 

I am not sure whether my understanding of `Bundler.definitions.specs` (aka `Bundler::SpecSet`) is sound. 
