### PR TITLE
Bug from removing USE_PERSISTENT

### DIFF
--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -68,7 +68,7 @@ module Bundler
       @remote_uri = remote_uri
       @public_uri = remote_uri.dup
       @public_uri.user, @public_uri.password = nil, nil # don't print these
-      if defined?(OpenSSL::SSL)
+      if defined?(OpenSSL::SSL) && defined?(Net::HTTP::Persistent)
         @connection = Net::HTTP::Persistent.new 'bundler', :ENV
         @connection.verify_mode = (Bundler.settings[:ssl_verify_mode] ||
           OpenSSL::SSL::VERIFY_PEER)
@@ -198,7 +198,7 @@ module Bundler
 
       begin
         Bundler.ui.debug "Fetching from: #{uri}"
-        if @connection.is_a?(Net::HTTP::Persistent)
+        if defined?(Net::HTTP::Persistent) && @connection.is_a?(Net::HTTP::Persistent)
           response = @connection.request(uri)
         else
           req = Net::HTTP::Get.new uri.request_uri


### PR DESCRIPTION
...101b89a00b0f21d5b28f67

The use of USE_PERSISTENT was needed as it was because of the behavior of require statements within rescue blocks

Alternatively, we could revert https://github.com/carlhuda/bundler/commit/ec49087a5acef97cf4101b89a00b0f21d5b28f67

Here's a gist illustrating the issue: https://gist.github.com/dmueller/5164088

I'm open for advice on where/how to write tests to verify the minor change in my pull request.
