### PR TITLE
Make generated bin skeleton executable

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -701,6 +701,7 @@ module Bundler
       template(File.join("newgem/lib/newgem/version.rb.tt"), File.join(target, "lib/#{namespaced_path}/version.rb"),   opts)
       if options[:bin]
         template(File.join("newgem/bin/newgem.tt"),          File.join(target, 'bin', name),                           opts)
+        chmod(File.join(target, 'bin', name), 0755)
       end
       case options[:test]
       when 'rspec'

--- a/spec/other/newgem_spec.rb
+++ b/spec/other/newgem_spec.rb
@@ -113,6 +113,7 @@ RAKEFILE
 
       it "builds bin skeleton" do
         expect(bundled_app("test_gem/bin/test_gem")).to exist
+        expect { FileTest.executable?(bundled_app("test_gem/bin/test_gem")) }.to be_true
       end
 
       it "requires 'test-gem'" do


### PR DESCRIPTION
Practically it is not necessary for bin skeletons to be executable because gem install generates bin wrappers for each of them.  But it looks consistent if executables are actually executable.
