### PR TITLE
Add info about `bundle env` to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ Features:
   - `binstubs` lists child gem bins if a gem has no binstubs
   - `bundle gem --edit` will open the new gemspec (@ndbroadbent)
   - `bundle gem --test rspec` now makes working tests (@tricknotes)
+  - `bundle env` prints info about bundler's environment. `bundle e` is now ambiguous. (@peeja)
   - add `BUNDLE_IGNORE_CONFIG` environment variable support (@richo)
 
 Bugfixes:


### PR DESCRIPTION
New command `bundle env` prints information about bundler's environment.

Notably, `bundle e`, which some people used as shorthand for `bundle exec`, is no longer operable as it matches both "exec" and "env".
