### PR TITLE
Fix basic_auth for gem servers in environments without OpenSSL

### DIFF
--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -202,6 +202,7 @@ module Bundler
           response = @connection.request(uri)
         else
           req = Net::HTTP::Get.new uri.request_uri
+          req.basic_auth(uri.user, uri.password) if uri.user
           response = @connection.request(req)
         end
       rescue OpenSSL::SSL::SSLError


### PR DESCRIPTION
When there's no OpenSSL, `USE_PERSISTENT` becomes false (see [vendored_persistent.rb](https://github.com/carlhuda/bundler/blob/master/lib/bundler/vendored_persistent.rb)). This causes password protected gem servers to not work, because we're only using host, port and path for the request (but not the full url with user and password, as with `USE_PERSISTENT`):

``` ruby
if USE_PERSISTENT
  response = @connection.request(uri)      # Contains user/password
else
  req = Net::HTTP::Get.new uri.request_uri # Contains only path
  response = @connection.request(req)
end
```
