### PR TITLE
Add indicator progress in resolver 

### DIFF
--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -109,7 +109,7 @@ module Bundler
       end
     end
 
-    attr_reader :errors
+    attr_reader :errors, :started_at, :iteration_rate, :iteration_counter
 
     # Figures out the best possible configuration of gems that satisfies
     # the list of passed dependencies and any child dependencies without
@@ -134,7 +134,6 @@ module Bundler
     end
 
     def initialize(index, source_requirements, base)
-      @iteration_counter    = 0
       @errors               = {}
       @stack                = []
       @base                 = base
@@ -142,6 +141,8 @@ module Bundler
       @deps_for             = {}
       @missing_gems         = Hash.new(0)
       @source_requirements  = source_requirements
+      @iteration_counter    = 0
+      @started_at           = Time.now
     end
 
     def debug
@@ -168,10 +169,7 @@ module Bundler
       # gem dependencies have been resolved.
       throw :success, successify(activated) if reqs.empty?
 
-      @iteration_counter += 1
-      if((@iteration_counter % 10000) == 0)
-        Bundler.ui.info ".", false
-      end
+      indicate_progress
 
       debug { print "\e[2J\e[f" ; "==== Iterating ====\n\n" }
 
@@ -503,6 +501,25 @@ module Bundler
 
         end
         o
+      end
+    end
+
+    private
+
+    # Indicates progress by writing a '.' every iteration_rate time which is
+    # aproximately every second. iteration_rate is calculated in the first
+    # second of resolve running.
+    def indicate_progress
+      @iteration_counter += 1
+
+      if iteration_rate.nil?
+        if ((Time.now - started_at) % 3600).round >= 1
+          @iteration_rate = iteration_counter
+        end
+      else
+        if ((iteration_counter % iteration_rate) == 0)
+          Bundler.ui.info ".", false
+        end
       end
     end
   end


### PR DESCRIPTION
This is from [#2265](https://github.com/carlhuda/bundler/issues/2265) by @indirect

Calculates iteration rate for the first second and
uses this knowledge to print a '.' so the user 
doesn't have the impression that bundler crashed.

I can't figure out how to properly spec this minor feature.
