### PR TITLE
Correct error message grammar for commands that take no arguments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Bugfixes:
 
   -  use YAML.dump over {}.to_yaml for better forwards compat
+  -  correct error message grammar for commands that take no arguments (@dougal)
 
 ## 1.3.2 (7 March 2013)
 

--- a/lib/bundler/vendor/thor/base.rb
+++ b/lib/bundler/vendor/thor/base.rb
@@ -471,8 +471,12 @@ class Thor
         msg = "#{basename} #{task.name}"
         if arity
           required = arity < 0 ? (-1 - arity) : arity
-          msg << " requires at least #{required} argument"
-          msg << "s" if required > 1
+          if required == 0
+            msg << " requires no arguments"
+          else
+            msg << " requires at least #{required} argument"
+            msg << "s" if required > 1
+          end
         else
           msg = "call #{msg} as"
         end


### PR DESCRIPTION
Mistyping a command led to me noticing the following odd error message:

Before:

```
$ bundle install foobar
bundle install requires at least 0 argument: "bundle install".
```

After:

```
$ bundle install foobar
bundle install requires no arguments: "bundle install".
```
