### PR TITLE
Fix rare issue with rubinius, thor and gem_helper

### DIFF
--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -1,5 +1,8 @@
-$:.unshift File.expand_path('../vendor', __FILE__)
-require 'thor'
+begin
+  Thor
+rescue NameError
+  require 'bundler/vendored_thor'
+end
 require 'bundler'
 
 module Bundler


### PR DESCRIPTION
Steps to reproduce:
1. Create thor task
2. Require 'bundler/gem_helper' inside it
3. any thor command will fail in rubinius with error: `Superclass mismatch: #<Class:0x699c> != #<Class:0x69a0>`
