### PR TITLE
Duplicate options' hash

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -67,7 +67,7 @@ module Bundler
         raise GemfileError, %{You need to specify gem names as Strings. Use 'gem "#{name.to_s}"' instead.}
       end
 
-      options = Hash === args.last ? args.pop : {}
+      options = Hash === args.last ? args.pop.dup : {}
       version = args
 
       _normalize_options(name, version, options)


### PR DESCRIPTION
Duplication of options' hash in gem specification allows to do this in Gemfile:

``` Gemfile
options_hash = {github: 'rails', branch: 'master'}
gem 'activemodel', options_hash
gem 'activerecord', options_hash
```

without damaging `options_hash` after passing it to `gem` method.

Without this fix, you can't pass the `options_hash` twice, because it will include 'env' and 'source' keys in it, and `gem` method [will complain about invalid keys](https://github.com/carlhuda/bundler/blob/master/lib/bundler/dsl.rb#L203).
