### PR TITLE
Require --force on update with no other arguments

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -282,6 +282,7 @@ module Bundler
       update when you have changed the Gemfile, or if you want to get the newest
       possible versions of the gems in the bundle.
     D
+    method_option "force", :type => :boolean, :banner => "Update all the dependencies if a gem is not specified."
     method_option "source", :type => :array, :banner => "Update a specific source (and all gems associated with it)"
     method_option "local", :type => :boolean, :banner =>
       "Do not attempt to fetch gems remotely and use the gem cache instead"
@@ -292,6 +293,11 @@ module Bundler
     def update(*gems)
       sources = Array(options[:source])
       Bundler.ui.level = "warn" if options[:quiet]
+
+      if gems.empty? && !options[:force]
+        Bundler.ui.error "Run `bundle update GEM` to update a specific gem. Run `bundle update --force` if you really want to update all gems."
+        exit 1
+      end
 
       if gems.empty? && sources.empty?
         # We're doing a full update

--- a/spec/cache/gems_spec.rb
+++ b/spec/cache/gems_spec.rb
@@ -129,7 +129,7 @@ describe "bundle cache" do
 
     it "adds and removes when gems are updated" do
       update_repo2
-      bundle 'update'
+      bundle 'update --force'
       expect(cached_gem("rack-1.2")).to exist
       expect(cached_gem("rack-1.0.0")).not_to exist
     end

--- a/spec/cache/git_spec.rb
+++ b/spec/cache/git_spec.rb
@@ -81,7 +81,7 @@ end
       ref = git.ref_for("master", 11)
       expect(ref).not_to eq(old_ref)
 
-      bundle "update"
+      bundle "update --force"
       bundle "#{cmd} --all"
 
       expect(bundled_app("vendor/cache/foo-1.0-#{ref}")).to exist

--- a/spec/cache/platform_spec.rb
+++ b/spec/cache/platform_spec.rb
@@ -48,7 +48,7 @@ describe "bundle cache with multiple platforms" do
   end
 
   it "ensures that bundle update does not delete gems for other platforms" do
-    bundle "update"
+    bundle "update --force"
 
     expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
     expect(bundled_app("vendor/cache/activesupport-2.3.5.gem")).to exist

--- a/spec/install/gems/dependency_api_spec.rb
+++ b/spec/install/gems/dependency_api_spec.rb
@@ -176,7 +176,7 @@ describe "gemcutter's dependency API" do
         gem "rack"
       G
 
-      bundle "update --full-index", :artifice => "endpoint"
+      bundle "update --full-index --force", :artifice => "endpoint"
       expect(out).to include("Fetching source index from #{source_uri}")
       should_be_installed "rack 1.0.0"
     end

--- a/spec/install/git_spec.rb
+++ b/spec/install/git_spec.rb
@@ -558,14 +558,14 @@ describe "bundle install with git sources" do
       s.write "lib/forced.rb", "FORCED = '1.1'"
     end
 
-    bundle "update"
+    bundle "update --force"
     should_be_installed "forced 1.1"
 
     Dir.chdir(lib_path('forced-1.0')) do
       `git reset --hard HEAD^`
     end
 
-    bundle "update"
+    bundle "update --force"
     should_be_installed "forced 1.0"
   end
 

--- a/spec/lock/lockfile_spec.rb
+++ b/spec/lock/lockfile_spec.rb
@@ -764,7 +764,7 @@ describe "the lockfile format" do
       it "preserves Gemfile.lock \\n line endings" do
         update_repo2
 
-        expect { bundle "update" }.to change { File.mtime(bundled_app('Gemfile.lock')) }
+        expect { bundle "update --force" }.to change { File.mtime(bundled_app('Gemfile.lock')) }
         expect(File.read(bundled_app("Gemfile.lock"))).not_to match("\r\n")
         should_be_installed "rack 1.2"
       end
@@ -775,7 +775,7 @@ describe "the lockfile format" do
         File.open(bundled_app("Gemfile.lock"), "wb"){|f| f.puts(win_lock) }
         set_lockfile_mtime_to_known_value
 
-        expect { bundle "update" }.to change { File.mtime(bundled_app('Gemfile.lock')) }
+        expect { bundle "update --force" }.to change { File.mtime(bundled_app('Gemfile.lock')) }
         expect(File.read(bundled_app("Gemfile.lock"))).to match("\r\n")
         should_be_installed "rack 1.2"
       end

--- a/spec/other/clean_spec.rb
+++ b/spec/other/clean_spec.rb
@@ -200,7 +200,7 @@ describe "bundle clean" do
     update_git "foo", :path => lib_path("foo-bar")
     revision2 = revision_for(lib_path("foo-bar"))
 
-    bundle "update"
+    bundle "update --force"
     bundle :clean
 
     expect(out).to eq("Removing foo-bar (#{revision[0..11]})")
@@ -372,7 +372,7 @@ describe "bundle clean" do
       build_gem 'foo', '1.0.1'
     end
 
-    bundle "update"
+    bundle "update --force"
 
     should_have_gems 'foo-1.0.1'
     should_not_have_gems 'foo-1.0'
@@ -411,7 +411,7 @@ describe "bundle clean" do
       build_gem 'foo', '1.0.1'
     end
 
-    bundle :update
+    bundle 'update --force'
     should_have_gems 'foo-1.0', 'foo-1.0.1'
   end
 
@@ -428,7 +428,7 @@ describe "bundle clean" do
     update_repo2 do
       build_gem 'foo', '1.0.1'
     end
-    bundle :update
+    bundle 'update --force'
 
     sys_exec "gem list"
     expect(out).to include("foo (1.0.1, 1.0)")

--- a/spec/other/platform_spec.rb
+++ b/spec/other/platform_spec.rb
@@ -374,7 +374,7 @@ G
         build_gem "activesupport", "3.0"
       end
 
-      bundle "update"
+      bundle "update --force"
       should_be_installed "rack 1.2", "rack-obama 1.0", "activesupport 3.0"
     end
 
@@ -391,7 +391,7 @@ G
           build_gem "activesupport", "3.0"
         end
 
-        bundle "update"
+        bundle "update --force"
         should_be_installed "rack 1.2", "rack-obama 1.0", "activesupport 3.0"
       end
     end
@@ -408,7 +408,7 @@ G
         build_gem "activesupport", "3.0"
       end
 
-      bundle :update, :exitstatus => true
+      bundle 'update --force', :exitstatus => true
       should_be_ruby_version_incorrect
     end
 
@@ -424,7 +424,7 @@ G
         build_gem "activesupport", "3.0"
       end
 
-      bundle :update, :exitstatus => true
+      bundle 'update --force', :exitstatus => true
       should_be_engine_incorrect
     end
 
@@ -441,7 +441,7 @@ G
           build_gem "activesupport", "3.0"
         end
 
-        bundle :update, :exitstatus => true
+        bundle 'update --force', :exitstatus => true
         should_be_engine_version_incorrect
       end
     end

--- a/spec/update/gems_spec.rb
+++ b/spec/update/gems_spec.rb
@@ -12,12 +12,26 @@ describe "bundle update" do
   end
 
   describe "with no arguments" do
-    it "updates the entire bundle" do
+    it "prints --force message and exits" do
       update_repo2 do
         build_gem "activesupport", "3.0"
       end
 
       bundle "update"
+      expect(out).to include("--force")
+
+      should_be_installed "rack 1.0.0", "rack-obama 1.0", "activesupport 2.3.5"
+    end
+
+  end
+
+  describe "with --force and no arguments" do
+    it "updates the entire bundle" do
+      update_repo2 do
+        build_gem "activesupport", "3.0"
+      end
+
+      bundle "update --force"
       should_be_installed "rack 1.2", "rack-obama 1.0", "activesupport 3.0"
     end
 
@@ -28,19 +42,19 @@ describe "bundle update" do
         gem "rack-obama"
         exit!
       G
-      bundle "update"
+      bundle "update --force"
       expect(bundled_app("Gemfile.lock")).to exist
     end
   end
 
   describe "--quiet argument" do
     it 'shows UI messages without --quiet argument' do
-      bundle "update"
+      bundle "update --force"
       expect(out).to include("Fetching source")
     end
 
     it 'does not show UI messages with --quiet argument' do
-      bundle "update --quiet"
+      bundle "update --quiet --force"
       expect(out).not_to include("Fetching source")
     end
   end
@@ -51,7 +65,7 @@ describe "bundle update" do
         build_gem "activesupport", "3.0"
       end
 
-      bundle "update rack-obama"
+      bundle "update rack-obama "
       should_be_installed "rack 1.2", "rack-obama 1.0", "activesupport 2.3.5"
     end
   end
@@ -119,7 +133,7 @@ describe "bundle update without a Gemfile.lock" do
       gem "rack", "1.0"
     G
 
-    bundle "update"
+    bundle "update --force"
 
     should_be_installed "rack 1.0.0"
   end
@@ -140,12 +154,12 @@ describe "bundle update when a gem depends on a newer version of bundler" do
   end
 
   it "should not explode" do
-    bundle "update"
+    bundle "update --force"
     expect(err).to be_empty
   end
 
   it "should explain that bundler conflicted" do
-    bundle "update"
+    bundle "update --force"
     expect(out).not_to match(/in snapshot/i)
     expect(out).to match(/current Bundler version/i)
     expect(out).to match(/perhaps you need to update bundler/i)

--- a/spec/update/git_spec.rb
+++ b/spec/update/git_spec.rb
@@ -16,7 +16,7 @@ describe "bundle update" do
         s.write "lib/foo.rb", "FOO = '1.1'"
       end
 
-      bundle "update"
+      bundle "update --force"
 
       should_be_installed "foo 1.1"
     end
@@ -50,7 +50,7 @@ describe "bundle update" do
         s.write "lib/foo.rb", "FOO = '1.1'"
       end
 
-      bundle "update --source foo"
+      bundle "update --source foo --force"
 
       should_be_installed "foo 1.1"
     end
@@ -113,7 +113,7 @@ describe "bundle update" do
         gem 'foo', :git => "#{@remote.path}", :tag => "fubar"
       G
 
-      bundle "update", :exitstatus => true
+      bundle "update --force", :exitstatus => true
       expect(exitstatus).to eq(0)
     end
 
@@ -188,7 +188,7 @@ describe "bundle update" do
 
       lib_path("foo-1.0").join(".git").rmtree
 
-      bundle :update, :expect_err => true
+      bundle 'update --force', :expect_err => true
       expect(out).to include(lib_path("foo-1.0").to_s)
     end
 

--- a/spec/update/source_spec.rb
+++ b/spec/update/source_spec.rb
@@ -20,7 +20,7 @@ describe "bundle update" do
     it "updates the source" do
       update_git "foo", :path => @git.path
 
-      bundle "update --source foo"
+      bundle "update --source foo --force"
 
       in_app_root do
         run <<-RUBY
@@ -35,7 +35,7 @@ describe "bundle update" do
     it "unlocks gems that were originally pulled in by the source" do
       update_git "foo", "2.0", :path => @git.path
 
-      bundle "update --source foo"
+      bundle "update --source foo --force"
       should_be_installed "foo 2.0"
     end
 
@@ -43,7 +43,7 @@ describe "bundle update" do
       update_repo2
       update_git "foo", :path => @git.path
 
-      bundle "update --source foo"
+      bundle "update --source foo --force"
       should_be_installed "rack 1.0"
     end
   end


### PR DESCRIPTION
One of the biggest arguments I hear for explicitly specifying versions in `Gemfile` is that `bundle update` will blindly update everything, and that novice users do not understand that doing that is a bad idea. This attempts to remedy this situation by encouraging people to be explicit about what gems they want to update, or use `---force` if they understand what they are doing.

```
$ bundle update
Run `bundle update GEM` to update a specific gem. Run `bundle update --force` if you really want to update all gems.
```
