### PR TITLE
Avoid needless spec double load

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -367,7 +367,6 @@ module Bundler
         configure_gem_home
       end
 
-      Bundler.rubygems.refresh
       bundle_path
     end
 

--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -87,10 +87,6 @@ module Bundler
       Gem.bin_path(gem, bin, ver)
     end
 
-    def refresh
-      Gem.refresh
-    end
-
     def preserve_paths
       # this is a no-op outside of Rubygems 1.8
       yield


### PR DESCRIPTION
Per #2454, the (rather expensive) refresh may no longer be necessary.

Without a concrete idea of the problem it was originally introduced to solve, I don't have a better idea than "let's remove it, and see what happens".

The refresh is present back to 1.1.0; I propose merging to 1-3-stable as a perf fix, but not further back. Or is this master-only material?

/cc @tenderlove @indirect
