### PR TITLE
Preserve original path for gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.3.6
+
+Bugfixes:
+
+ - make gemspec path option preserve relative paths in lock file (@bwillis)
+
 ## 1.3.5 (3 April 2013)
 
 Features:

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -42,8 +42,9 @@ module Bundler
       path              = opts && opts[:path] || '.'
       name              = opts && opts[:name] || '{,*}'
       development_group = opts && opts[:development_group] || :development
-      path              = File.expand_path(path, Bundler.default_gemfile.dirname)
-      gemspecs = Dir[File.join(path, "#{name}.gemspec")]
+      expanded_path     = File.expand_path(path, Bundler.default_gemfile.dirname)
+
+      gemspecs = Dir[File.join(expanded_path, "#{name}.gemspec")]
 
       case gemspecs.size
       when 1
@@ -56,9 +57,9 @@ module Bundler
           end
         end
       when 0
-        raise InvalidOption, "There are no gemspecs at #{path}."
+        raise InvalidOption, "There are no gemspecs at #{expanded_path}."
       else
-        raise InvalidOption, "There are multiple gemspecs at #{path}. Please use the :name option to specify which one."
+        raise InvalidOption, "There are multiple gemspecs at #{expanded_path}. Please use the :name option to specify which one."
       end
     end
 

--- a/spec/lock/lockfile_spec.rb
+++ b/spec/lock/lockfile_spec.rb
@@ -472,6 +472,30 @@ describe "the lockfile format" do
     G
   end
 
+  it "stores relative paths when the path is provided for gemspec" do
+    build_lib("foo", :path => tmp.join("foo"))
+
+    install_gemfile <<-G
+      gemspec :path => "../foo"
+    G
+
+    lockfile_should_be <<-G
+      PATH
+        remote: ../foo
+        specs:
+          foo (1.0)
+
+      GEM
+        specs:
+
+      PLATFORMS
+        #{generic(Gem::Platform.local)}
+
+      DEPENDENCIES
+        foo!
+    G
+  end
+
   it "keeps existing platforms in the lockfile" do
     lockfile <<-G
       GEM


### PR DESCRIPTION
This change addresses #2458.

When adding a gemspec, the path was always expanded and then passed into the gem command. I'm unsure if this was an unintended side effect of 5a0489f78bd5321c3e414725ab686b29fbeaf4f5 
