### PR TITLE
Update references to the repository URL.

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -1,4 +1,4 @@
-Great to have you here! Here are a few ways you can help out with [Bundler](http://github.com/carlhuda/bundler).
+Great to have you here! Here are a few ways you can help out with [Bundler](http://github.com/bundler/bundler).
 
 # Learn & listen
 
@@ -12,10 +12,10 @@ The Bundler core team consists of André Arko ([@indirect](http://github.com/ind
 
 When adding a new feature to Bundler, please follow these steps:
 
-  1. [Create an issue](https://github.com/carlhuda/bundler/issues/new) to discuss your feature.
+  1. [Create an issue](https://github.com/bundler/bundler/issues/new) to discuss your feature.
   2. Base your commits on the master branch, since we follow [SemVer](http://semver.org) and don't add new features to old releases.
   3. Commit the code and at least one test covering your changes to a feature branch in your fork.
-  4. Put a line in the [CHANGELOG](https://github.com/carlhuda/bundler/blob/master/CHANGELOG.md) summarizing your changes under the next release under the "Features" heading.
+  4. Put a line in the [CHANGELOG](https://github.com/bundler/bundler/blob/master/CHANGELOG.md) summarizing your changes under the next release under the "Features" heading.
   5. Send us a [pull request](https://help.github.com/articles/using-pull-requests) from your feature branch.
 
 If you don't hear back immediately, don’t get discouraged! We all have day jobs, but we respond to most tickets within a day or two.
@@ -24,9 +24,9 @@ If you don't hear back immediately, don’t get discouraged! We all have day job
 
 Triage is the work of processing tickets that have been opened into actionable issues, feature requests, or bug reports. That includes verifying bugs, categorizing the ticket, and ensuring there's enough information to reproduce the bug for anyone who wants to try to fix it.
 
-We've created an [issues guide](https://github.com/carlhuda/bundler/blob/master/ISSUES.md) to walk Bundler users through the process of troubleshooting issues and reporting bugs.
+We've created an [issues guide](https://github.com/bundler/bundler/blob/master/ISSUES.md) to walk Bundler users through the process of troubleshooting issues and reporting bugs.
 
-If you'd like to help, awesome! You can [report a new bug](https://github.com/carlhuda/bundler/issues/new) or browse our [existing open tickets](https://github.com/carlhuda/bundler/issues).
+If you'd like to help, awesome! You can [report a new bug](https://github.com/bundler/bundler/issues/new) or browse our [existing open tickets](https://github.com/bundler/bundler/issues).
 
 Not every ticket will point to a bug in Bundler's code, but open tickets usually mean that there is something we could improve to help that user. Sometimes that means writing additional documentation, sometimes that means making error messages clearer, and sometimes that means explaining to a user that they need to install git to use git gems.
 
@@ -45,7 +45,7 @@ If you can reproduce an issue, you're well on your way to fixing it. :) Fixing i
   1. Discuss the fix on the existing issue. Coordinating with everyone else saves duplicate work and serves as a great way to get suggestions and ideas if you need any.
   2. Base your commits on the correct branch. Bugfixes for 1.x versions of Bundler should be based on the matching 1-x-stable branch.
   3. Commit the code and at least one test covering your changes to a named branch in your fork.
-  4. Put a line in the [CHANGELOG](https://github.com/carlhuda/bundler/blob/master/CHANGELOG.md) summarizing your changes under the next release under the “Bugfixes” heading.
+  4. Put a line in the [CHANGELOG](https://github.com/bundler/bundler/blob/master/CHANGELOG.md) summarizing your changes under the next release under the “Bugfixes” heading.
   5. Send us a [pull request](https://help.github.com/articles/using-pull-requests) from your bugfix branch.
 
 Finally, the ticket may be a duplicate of another older ticket. If you notice a ticket is a duplicate, simply comment on the ticket noting the original ticket’s number. For example, you could say “This is a duplicate of issue #42, and can be closed”.
@@ -78,7 +78,7 @@ If you have a suggestion or proposed change for [gembundler.com](http://gembundl
 
 Community is an important part of all we do. If you’d like to be part of the Bundler community, you can jump right in and start helping make Bundler better for everyone who uses it.
 
-It would be tremendously helpful to have more people answering questions about Bundler (and often simply about Rubygems or Ruby itself) in our [issue tracker](https://github.com/carlhuda/bundler/issues) or on [Stack Overflow](http://stackoverflow.com/questions/tagged/bundler).
+It would be tremendously helpful to have more people answering questions about Bundler (and often simply about Rubygems or Ruby itself) in our [issue tracker](https://github.com/bundler/bundler/issues) or on [Stack Overflow](http://stackoverflow.com/questions/tagged/bundler).
 
 Additional documentation and explanation is always helpful, too. If you have any suggestions for the Bundler website [gembundler.com](http://www.gembundler.com), we would absolutely love it if you opened an issue or pull request on the [bundler-site](https://github.com/bundler/bundler-site) repository.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Creating Issues
 
-If you're having a problem, please see [ISSUES](https://github.com/carlhuda/bundler/blob/master/ISSUES.md) for troubleshooting steps and a guide for how to submit a ticket that will help us solve the problem you are having as quickly as possible.
+If you're having a problem, please see [ISSUES](https://github.com/bundler/bundler/blob/master/ISSUES.md) for troubleshooting steps and a guide for how to submit a ticket that will help us solve the problem you are having as quickly as possible.
 
 # Discussing Bundler
 
@@ -8,6 +8,6 @@ If you'd like to discuss features, ask questions, or just engage in general Bund
 
 # Helping Out
 
-If you'd like to help make Bundler better, you totally rock! Please check out the [CONTRIBUTE](https://github.com/carlhuda/bundler/blob/master/CONTRIBUTE.md) file for an introduction to the project, guidelines for contributing, and suggestions for things anyone can do that would be helpful.
+If you'd like to help make Bundler better, you totally rock! Please check out the [CONTRIBUTE](https://github.com/bundler/bundler/blob/master/CONTRIBUTE.md) file for an introduction to the project, guidelines for contributing, and suggestions for things anyone can do that would be helpful.
 
 Thanks for helping us make Bundler better.

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -78,6 +78,6 @@ If you are using Rails 2.3, please also include:
 
 If you have either `rubygems-bundler` or `open_gem` installed, please try removing them and then following the troubleshooting steps above before opening a new ticket.
 
-[Create a gist](https://gist.github.com) containing all of that information, then visit the [Bundler issue tracker](https://github.com/carlhuda/bundler/issues) and [create a ticket](https://github.com/carlhuda/bundler/issues/new) describing your problem and linking to your gist.
+[Create a gist](https://gist.github.com) containing all of that information, then visit the [Bundler issue tracker](https://github.com/bundler/bundler/issues) and [create a ticket](https://github.com/bundler/bundler/issues/new) describing your problem and linking to your gist.
 
 Thanks for reporting issues and helping make Bundler better!

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Bundler: a gem to bundle gems [![Build Status](https://secure.travis-ci.org/carlhuda/bundler.png?branch=1-3-stable)](http://travis-ci.org/carlhuda/bundler)
+# Bundler: a gem to bundle gems [![Build Status](https://secure.travis-ci.org/bundler/bundler.png?branch=1-3-stable)](http://travis-ci.org/bundler/bundler)
 
 Bundler keeps ruby applications running the same code on every machine.
 
@@ -18,15 +18,15 @@ See [gembundler.com](http://gembundler.com) for the full documentation.
 
 ### Troubleshooting
 
-For help with common problems, see [ISSUES](https://github.com/carlhuda/bundler/blob/master/ISSUES.md).
+For help with common problems, see [ISSUES](https://github.com/bundler/bundler/blob/master/ISSUES.md).
 
 ### Contributing
 
-If you'd like to contribute to Bundler, that's awesome, and we <3 you. There's a guide to contributing to Bundler (both code and general help) over in [CONTRIBUTE](https://github.com/carlhuda/bundler/blob/master/CONTRIBUTE.md)
+If you'd like to contribute to Bundler, that's awesome, and we <3 you. There's a guide to contributing to Bundler (both code and general help) over in [CONTRIBUTE](https://github.com/bundler/bundler/blob/master/CONTRIBUTE.md)
 
 ### Development
 
-To see what has changed in recent versions of Bundler, see the [CHANGELOG](https://github.com/carlhuda/bundler/blob/master/CHANGELOG.md).
+To see what has changed in recent versions of Bundler, see the [CHANGELOG](https://github.com/bundler/bundler/blob/master/CHANGELOG.md).
 
 The `master` branch contains our current progress towards version 1.3. Versions 1.0 to 1.2 each have their own stable branches. Please submit bugfixes as pull requests to the stable branch for the version you would like to fix.
 

--- a/lib/bundler/source/git/git_proxy.rb
+++ b/lib/bundler/source/git/git_proxy.rb
@@ -95,7 +95,7 @@ module Bundler
             out
           else
             raise GitError, "Bundler is trying to run a `git #{command}` at runtime. You probably need to run `bundle install`. However, " \
-                            "this error message could probably be more useful. Please submit a ticket at http://github.com/carlhuda/bundler/issues " \
+                            "this error message could probably be more useful. Please submit a ticket at http://github.com/bundler/bundler/issues " \
                             "with steps to reproduce as well as the following\n\nCALLER: #{caller.join("\n")}"
           end
         end

--- a/spec/realworld/edgecases_spec.rb
+++ b/spec/realworld/edgecases_spec.rb
@@ -10,7 +10,7 @@ describe "real world edgecases", :realworld => true do
     expect(err).to eq("")
   end
 
-  # https://github.com/carlhuda/bundler/issues/1202
+  # https://github.com/bundler/bundler/issues/1202
   it "bundle cache works with rubygems 1.3.7 and pre gems", :ruby => "1.8" do
     install_gemfile <<-G
       source :rubygems
@@ -21,7 +21,7 @@ describe "real world edgecases", :realworld => true do
     expect(out).not_to include("Removing outdated .gem files from vendor/cache")
   end
 
-  # https://github.com/carlhuda/bundler/issues/1486
+  # https://github.com/bundler/bundler/issues/1486
   # this is a hash collision that only manifests on 1.8.7
   it "finds the correct child versions", :ruby => "1.8" do
     install_gemfile <<-G
@@ -35,7 +35,7 @@ describe "real world edgecases", :realworld => true do
     expect(out).to include("activemodel (3.0.5)")
   end
 
-  # https://github.com/carlhuda/bundler/issues/1500
+  # https://github.com/bundler/bundler/issues/1500
   it "does not fail install because of gem plugins" do
     realworld_system_gems("open_gem --version 1.4.2", "rake --version 0.9.2")
     gemfile <<-G


### PR DESCRIPTION
The repository has moved from the carlhuda account to the bundler organization.

See also bundler/bundler-site#45.
