### PR TITLE
TypeError: can't convert Pathname into String

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -262,7 +262,7 @@ module Bundler
         bin_dir = bin_dir.parent until bin_dir.exist?
 
         # if any directory is not writable, we need sudo
-        dirs = [path, bin_dir] | Dir[path.join('*')]
+        dirs = [path, bin_dir] | Dir[path.join('*').to_s]
         sudo_needed = dirs.find{|d| !File.writable?(d) }
       end
 


### PR DESCRIPTION
I've got problem with bundle install. After adding to_s it works OK. 

```
$ ruby -v
ruby 1.9.1p378 (2010-01-10 revision 26273) [i386-darwin12.3.0]
gem -v
$ 1.3.6
```

```
TypeError: can't convert Pathname into String
/Users/.../.rbenv/versions/1.9.1-p378/lib/ruby/gems/1.9.1/gems/bundler-1.3.5/lib/bundler.rb:265:in `[]'
/Users/.../.rbenv/versions/1.9.1-p378/lib/ruby/gems/1.9.1/gems/bundler-1.3.5/lib/bundler.rb:265:in `requires_sudo?'
/Users/.../.rbenv/versions/1.9.1-p378/lib/ruby/gems/1.9.1/gems/bundler-1.3.5/lib/bundler/fetcher.rb:52:in `download_gem_from_uri'
/Users/.../.rbenv/versions/1.9.1-p378/lib/ruby/gems/1.9.1/gems/bundler-1.3.5/lib/bundler/fetcher.rb:43:in `fetch'
/Users/.../.rbenv/versions/1.9.1-p378/lib/ruby/gems/1.9.1/gems/bundler-1.3.5/lib/bundler/installer.rb:101:in `install_gem_from_spec'
/Users/.../.rbenv/versions/1.9.1-p378/lib/ruby/gems/1.9.1/gems/bundler-1.3.5/lib/bundler/installer.rb:91:in `block in run'
/Users/.../.rbenv/versions/1.9.1-p378/lib/ruby/1.9.1/forwardable.rb:182:in `each'
/Users/.../.rbenv/versions/1.9.1-p378/lib/ruby/1.9.1/forwardable.rb:182:in `each'
/Users/.../.rbenv/versions/1.9.1-p378/lib/ruby/gems/1.9.1/gems/bundler-1.3.5/lib/bundler/installer.rb:90:in `run'
/Users/.../.rbenv/versions/1.9.1-p378/lib/ruby/gems/1.9.1/gems/bundler-1.3.5/lib/bundler/installer.rb:14:in `install'
/Users/.../.rbenv/versions/1.9.1-p378/lib/ruby/gems/1.9.1/gems/bundler-1.3.5/lib/bundler/cli.rb:247:in `install'
/Users/.../.rbenv/versions/1.9.1-p378/lib/ruby/gems/1.9.1/gems/bundler-1.3.5/lib/bundler/vendor/thor/task.rb:27:in `run'
/Users/.../.rbenv/versions/1.9.1-p378/lib/ruby/gems/1.9.1/gems/bundler-1.3.5/lib/bundler/vendor/thor/invocation.rb:120:in `invoke_task'
/Users/.../.rbenv/versions/1.9.1-p378/lib/ruby/gems/1.9.1/gems/bundler-1.3.5/lib/bundler/vendor/thor.rb:344:in `dispatch'
/Users/.../.rbenv/versions/1.9.1-p378/lib/ruby/gems/1.9.1/gems/bundler-1.3.5/lib/bundler/vendor/thor/base.rb:434:in `start'
/Users/.../.rbenv/versions/1.9.1-p378/lib/ruby/gems/1.9.1/gems/bundler-1.3.5/bin/bundle:20:in `block in <top (required)>'
/Users/.../.rbenv/versions/1.9.1-p378/lib/ruby/gems/1.9.1/gems/bundler-1.3.5/lib/bundler/friendly_errors.rb:3:in `with_friendly_errors'
/Users/.../.rbenv/versions/1.9.1-p378/lib/ruby/gems/1.9.1/gems/bundler-1.3.5/bin/bundle:20:in `<top (required)>'
/Users/.../.rbenv/versions/1.9.1-p378/bin/bundle:19:in `load'
/Users/.../.rbenv/versions/1.9.1-p378/bin/bundle:19:in `<main>'
An error occurred while installing rake (0.9.2), and Bundler cannot continue.
Make sure that `gem install rake -v '0.9.2'` succeeds before bundling.
Bundler::InstallError: An error occurred while installing rake (0.9.2), and Bundler cannot continue.
Make sure that `gem install rake -v '0.9.2'` succeeds before bundling.
/Users/.../.rbenv/versions/1.9.1-p378/lib/ruby/gems/1.9.1/gems/bundler-1.3.5/lib/bundler/installer.rb:130:in `rescue in install_gem_from_spec'
/Users/.../.rbenv/versions/1.9.1-p378/lib/ruby/gems/1.9.1/gems/bundler-1.3.5/lib/bundler/installer.rb:101:in `install_gem_from_spec'
/Users/.../.rbenv/versions/1.9.1-p378/lib/ruby/gems/1.9.1/gems/bundler-1.3.5/lib/bundler/installer.rb:91:in `block in run'
/Users/.../.rbenv/versions/1.9.1-p378/lib/ruby/gems/1.9.1/gems/bundler-1.3.5/lib/bundler/installer.rb:90:in `run'
/Users/.../.rbenv/versions/1.9.1-p378/lib/ruby/gems/1.9.1/gems/bundler-1.3.5/lib/bundler/installer.rb:14:in `install'
/Users/.../.rbenv/versions/1.9.1-p378/lib/ruby/gems/1.9.1/gems/bundler-1.3.5/lib/bundler/cli.rb:247:in `install'
/Users/.../.rbenv/versions/1.9.1-p378/lib/ruby/gems/1.9.1/gems/bundler-1.3.5/lib/bundler/vendor/thor/task.rb:27:in `run'
/Users/.../.rbenv/versions/1.9.1-p378/lib/ruby/gems/1.9.1/gems/bundler-1.3.5/lib/bundler/vendor/thor/invocation.rb:120:in `invoke_task'
/Users/.../.rbenv/versions/1.9.1-p378/lib/ruby/gems/1.9.1/gems/bundler-1.3.5/lib/bundler/vendor/thor.rb:344:in `dispatch'
/Users/.../.rbenv/versions/1.9.1-p378/lib/ruby/gems/1.9.1/gems/bundler-1.3.5/lib/bundler/vendor/thor/base.rb:434:in `start'
/Users/.../.rbenv/versions/1.9.1-p378/lib/ruby/gems/1.9.1/gems/bundler-1.3.5/bin/bundle:20:in `block in <top (required)>'
/Users/.../.rbenv/versions/1.9.1-p378/lib/ruby/gems/1.9.1/gems/bundler-1.3.5/lib/bundler/friendly_errors.rb:3:in `with_friendly_errors'
/Users/.../.rbenv/versions/1.9.1-p378/lib/ruby/gems/1.9.1/gems/bundler-1.3.5/bin/bundle:20:in `<top (required)>'
/Users/.../.rbenv/versions/1.9.1-p378/bin/bundle:19:in `load'
/Users/.../.rbenv/versions/1.9.1-p378/bin/bundle:19:in `<main>'
```
