### PR TITLE
Add spec test for dependency in multiple sources

### DIFF
--- a/spec/install/gems/dependency_api_spec.rb
+++ b/spec/install/gems/dependency_api_spec.rb
@@ -196,6 +196,31 @@ describe "gemcutter's dependency API" do
     end
   end
 
+  it "should handle dependencies with versions in multiple sources" do
+    FileUtils.rm_rf upstream_gem_repo
+    build_repo upstream_gem_repo do
+      build_gem "from-upstream", "1.0.0"
+      build_gem "from-upstream", "1.1.0"
+    end
+
+    FileUtils.rm_rf local_gem_repo
+    build_repo local_gem_repo do
+      build_gem "site-local", "1.0.0" do |s|
+        s.add_dependency "from-upstream", "~> 1.1"
+      end
+      build_gem "from-upstream", "1.0.1"
+    end
+
+    gemfile <<-G
+      source "#{source_uri}/upstream"
+      source "#{source_uri}/local"
+      gem "site-local", "~> 1.0"
+    G
+
+    bundle :install, :artifice => "local_endpoint_with_api"
+    should_be_installed "site-local 1.0.0"
+  end
+
   it "fetches again when more dependencies are found in subsequent sources" do
     build_repo2 do
       build_gem "back_deps" do |s|

--- a/spec/support/artifice/local_endpoint_with_api.rb
+++ b/spec/support/artifice/local_endpoint_with_api.rb
@@ -1,0 +1,97 @@
+require File.expand_path("../endpoint", __FILE__)
+
+Artifice.deactivate
+
+module ApiDependencies
+  def self.dependencies_for(gem_names, repo_path)
+    return [] if gem_names.nil? || gem_names.empty?
+    read_dependencies(gem_names, repo_path, "specs.4.8") # + read_dependencies(gem_names, repo_path, "prerelease_specs.4.8")
+  end
+
+  def self.read_dependencies(gem_names, repo_path, index_file)
+    marshal_file = File.join(repo_path, index_file)
+    return [] unless File.exists?(marshal_file)
+
+    require 'rubygems'
+    require 'bundler'
+    Bundler::Deprecate.skip_during do
+      Marshal.load(File.open(marshal_file).read).map do |name, version, platform|
+        spec = load_spec(name, version, platform, repo_path)
+        if gem_names.include?(spec.name)
+          rv = {
+            :name         => spec.name,
+            :number       => spec.version.version,
+            :platform     => spec.platform.to_s,
+            :dependencies => spec.dependencies.select {|dep| dep.type == :runtime }.map do |dep|
+              [dep.name, dep.requirement.requirements.map {|a| a.join(" ") }.join(", ")]
+            end
+          }
+          rv
+        end
+      end.compact
+    end
+  end
+
+  def self.load_spec(name, version, platform, repo_path)
+    full_name = "#{name}-#{version}"
+    full_name += "-#{platform}" if platform != "ruby"
+    Marshal.load(Gem.inflate(File.open(File.join(repo_path, "/quick/Marshal.4.8/#{full_name}.gemspec.rz")).read))
+  end
+end
+
+class LocalEndpointWithApi < Endpoint
+  # Local
+  get "/local/quick/Marshal.4.8/:id" do
+    redirect "/local/fetch/actual/gem/#{params[:id]}"
+  end
+
+  get "/local/fetch/actual/gem/:id" do
+    File.read("#{local_gem_repo}/quick/Marshal.4.8/#{params[:id]}")
+  end
+
+  get "/local/gems/:id" do
+    File.read("#{local_gem_repo}/gems/#{params[:id]}")
+  end
+
+  get "/local/api/v1/dependencies" do
+    gem_list = (params[:gems] || '').split(',')
+    deps = Marshal.dump(ApiDependencies.dependencies_for(gem_list, local_gem_repo))
+    deps
+  end
+
+  get "/local/specs.4.8.gz" do
+    File.read("#{local_gem_repo}/specs.4.8.gz")
+  end
+
+  get "/local/prerelease_specs.4.8.gz" do
+    File.read("#{local_gem_repo}/prerelease_specs.4.8.gz")
+  end
+
+  # Upstream
+  get "/upstream/quick/Marshal.4.8/:id" do
+    redirect "/upstream/fetch/actual/gem/#{params[:id]}"
+  end
+
+  get "/upstream/fetch/actual/gem/:id" do
+    File.read("#{upstream_gem_repo}/quick/Marshal.4.8/#{params[:id]}")
+  end
+
+  get "/upstream/gems/:id" do
+    File.read("#{upstream_gem_repo}/gems/#{params[:id]}")
+  end
+
+  get "/upstream/api/v1/dependencies" do
+    gem_list = (params[:gems] || '').split(',')
+    Marshal.dump(ApiDependencies.dependencies_for(gem_list, upstream_gem_repo))
+  end
+
+  get "/upstream/specs.4.8.gz" do
+    File.read("#{upstream_gem_repo}/specs.4.8.gz")
+  end
+
+  get "/upstream/prerelease_specs.4.8.gz" do
+    File.read("#{upstream_gem_repo}/prerelease_specs.4.8.gz")
+  end
+end
+
+Artifice.activate_with(LocalEndpointWithApi)

--- a/spec/support/path.rb
+++ b/spec/support/path.rb
@@ -56,6 +56,14 @@ module Spec
       tmp("gems/remote3", *args)
     end
 
+    def local_gem_repo(*args)
+      tmp("gems/remote_local", *args)
+    end
+
+    def upstream_gem_repo(*args)
+      tmp("gems/remote_upstream", *args)
+    end
+
     def security_repo(*args)
       tmp("gems/security_repo", *args)
     end


### PR DESCRIPTION
I have a gemserver local to my site which supports the Bundler dependency API. Some time ago, we fixed a bug in an upstream gem and published a pre-release version of that gem to our server. We now observe that Bundler doesn't query rubygems.org for this upstream gem, so we only see versions on our local gemserver.

See attached integration test.
