### PR TITLE
Support for --platform flag to install command and added new platform ruboto(dalvik)

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -169,6 +169,8 @@ module Bundler
       "Use the rubygems modern index instead of the API endpoint"
     method_option "clean", :type => :boolean, :banner =>
       "Run bundle clean automatically after install"
+    method_option "platform", :type => :string, :banner =>
+      "Force the use of the specified platform instead of runtime detected platform"       
     unless Bundler.rubygems.security_policies.empty?
       method_option "trust-policy", :alias => "P", :type => :string, :banner =>
         "Gem trust policy (like gem install -P). Must be one of " + Bundler.rubygems.security_policies.keys.join('|')
@@ -218,7 +220,15 @@ module Bundler
 
         Bundler.settings[:frozen] = '1'
       end
-
+       
+      if opts[:platform]
+        Bundler.settings[:platform] = opts[:platform]  
+      else
+        #Reset settings[:platform] to nil because if the option was given
+        #in a previous call it was stored
+        Bundler.settings[:platform] = nil  
+      end   
+        
       # When install is called with --no-deployment, disable deployment mode
       if opts[:deployment] == false
         Bundler.settings.delete(:frozen)

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -67,6 +67,7 @@ module Bundler
       @unlock[:sources] ||= []
 
       current_platform = Bundler.rubygems.platforms.map { |p| generic(p) }.compact.last
+      current_platform = Dependency.gem_platform(Bundler.settings[:platform].to_sym) if Bundler.settings[:platform] 
       @new_platform = !@platforms.include?(current_platform)
       @platforms |= [current_platform]
 

--- a/lib/bundler/dependency.rb
+++ b/lib/bundler/dependency.rb
@@ -23,7 +23,46 @@ module Bundler
       :mingw    => Gem::Platform::MINGW,
       :mingw_18 => Gem::Platform::MINGW,
       :mingw_19 => Gem::Platform::MINGW,
-      :mingw_20 => Gem::Platform::MINGW
+      :mingw_20 => Gem::Platform::MINGW,
+      :ruboto   => Gem::Platform::DALVIK,
+      :ruboto_1 => Gem::Platform::DALVIK,
+      :ruboto_2 => Gem::Platform::DALVIK,      
+      :ruboto_3 => Gem::Platform::DALVIK,
+      :ruboto_4 => Gem::Platform::DALVIK,
+      :ruboto_5 => Gem::Platform::DALVIK,
+      :ruboto_6 => Gem::Platform::DALVIK,      
+      :ruboto_7 => Gem::Platform::DALVIK,
+      :ruboto_8 => Gem::Platform::DALVIK,
+      :ruboto_9 => Gem::Platform::DALVIK,
+      :ruboto_10 => Gem::Platform::DALVIK,      
+      :ruboto_11 => Gem::Platform::DALVIK,
+      :ruboto_12 => Gem::Platform::DALVIK,
+      :ruboto_13 => Gem::Platform::DALVIK,
+      :ruboto_14 => Gem::Platform::DALVIK,      
+      :ruboto_15 => Gem::Platform::DALVIK,
+      :ruboto_16 => Gem::Platform::DALVIK,
+      :ruboto_17 => Gem::Platform::DALVIK      
+    }.freeze
+    
+    DALVIK_PLATFORM_MAP = {
+      :ruboto   => Gem::Platform::DALVIK,
+      :ruboto_1 => Gem::Platform.new('dalvik1'),
+      :ruboto_2 => Gem::Platform.new('dalvik2'),    
+      :ruboto_3 => Gem::Platform.new('dalvik3'),
+      :ruboto_4 => Gem::Platform.new('dalvik4'),
+      :ruboto_5 => Gem::Platform.new('dalvik5'),
+      :ruboto_6 => Gem::Platform.new('dalvik6'),    
+      :ruboto_7 => Gem::Platform.new('dalvik7'),
+      :ruboto_8 => Gem::Platform.new('dalvik8'),
+      :ruboto_9 => Gem::Platform.new('dalvik9'),
+      :ruboto_10 => Gem::Platform.new('dalvik10'),     
+      :ruboto_11 => Gem::Platform.new('dalvik11'),
+      :ruboto_12 => Gem::Platform.new('dalvik12'),
+      :ruboto_13 => Gem::Platform.new('dalvik13'),
+      :ruboto_14 => Gem::Platform.new('dalvik14'),
+      :ruboto_15 => Gem::Platform.new('dalvik15'),
+      :ruboto_16 => Gem::Platform.new('dalvik16'),
+      :ruboto_17 => Gem::Platform.new('dalvik17')      
     }.freeze
 
     def initialize(name, version, options = {}, &blk)
@@ -39,6 +78,14 @@ module Bundler
       if options.key?('require')
         @autorequire = Array(options['require'] || [])
       end
+    end
+
+    def self.gem_platform(platform)
+      PLATFORM_MAP[platform]
+    end 
+    
+    def self.dalvik_platform(platform)
+      DALVIK_PLATFORM_MAP[platform]
     end
 
     def gem_platforms(valid_platforms)
@@ -70,6 +117,10 @@ module Bundler
 
     def current_platform?
       return true if @platforms.empty?
+      if Bundler.settings[:platform]
+        current = Dependency.gem_platform(Bundler.settings[:platform].to_sym)
+        return @platforms.any? { |p| p == current }  
+      end
       @platforms.any? { |p| send("#{p}?") }
     end
 

--- a/lib/bundler/gem_helpers.rb
+++ b/lib/bundler/gem_helpers.rb
@@ -6,6 +6,7 @@ module Bundler
       Gem::Platform.new('java'),
       Gem::Platform.new('mswin32'),
       Gem::Platform.new('x86-mingw32'),
+      Gem::Platform.new('dalvik'),
       Gem::Platform::RUBY
     ]
 

--- a/lib/bundler/index.rb
+++ b/lib/bundler/index.rb
@@ -146,7 +146,11 @@ module Bundler
           if base # allow all platforms when searching from a lockfile
             dependency.matches_spec?(spec)
           else
-            dependency.matches_spec?(spec) && Gem::Platform.match(spec.platform)
+            if Bundler.settings[:platform]          
+              dependency.matches_spec?(spec) && MatchPlatform.match_argument_platform(spec.platform)
+            else
+              dependency.matches_spec?(spec) && Gem::Platform.match(spec.platform)
+            end                         
           end
         end
 

--- a/lib/bundler/match_platform.rb
+++ b/lib/bundler/match_platform.rb
@@ -7,7 +7,38 @@ module Bundler
     def match_platform(p)
       Gem::Platform::RUBY == platform or
       platform.nil? or p == platform or
-      generic(Gem::Platform.new(platform)) == p
+      generic(Gem::Platform.new(platform)) == p or
+      Gem::Platform.new(platform) === p
+    end
+    
+    #If platform is dalvik we allow to specify a lower version than
+    #the one the gem has
+    def self.match_dalvik(current, p)
+      return false if p.class != current.class 
+      # cpu
+      (current.cpu == 'universal' or p.cpu == 'universal' or current.cpu == p.cpu) and
+  
+      # os
+      current.os == p.os and
+  
+      # version
+      (current.version.nil? or p.version.nil? or current.version.to_i <= p.version.to_i)
+    end
+    
+    #Match platform used when --platform is used
+    def self.match_argument_platform(p)
+      return false unless Bundler.settings[:platform]
+      platform = Dependency.gem_platform(Bundler.settings[:platform].to_sym)
+      if platform.os == 'dalvik'
+        platform = Dependency.dalvik_platform(Bundler.settings[:platform].to_sym)
+        Gem::Platform::RUBY == p or
+        p.nil? or match_dalvik(platform, p) or
+        match_dalvik(platform, Gem::Platform.new(p))                
+      else  
+        Gem::Platform::RUBY == p or
+        p.nil? or p == platform or
+        Gem::Platform.new(p) === platform        
+      end     
     end
   end
 end

--- a/lib/bundler/rubygems_ext.rb
+++ b/lib/bundler/rubygems_ext.rb
@@ -136,6 +136,7 @@ module Gem
     JAVA  = Gem::Platform.new('java') unless defined?(JAVA)
     MSWIN = Gem::Platform.new('mswin32') unless defined?(MSWIN)
     MINGW = Gem::Platform.new('x86-mingw32') unless defined?(MINGW)
+    DALVIK = Gem::Platform.new('dalvik') unless defined?(DALVIK)
 
     undef_method :hash if method_defined? :hash
     def hash

--- a/lib/bundler/spec_set.rb
+++ b/lib/bundler/spec_set.rb
@@ -23,7 +23,11 @@ module Bundler
 
         spec = lookup[dep.name].find do |s|
           if match_current_platform
-            Gem::Platform.match(s.platform)
+            if Bundler.settings[:platform]             
+              MatchPlatform.match_argument_platform(s.platform)
+            else
+              Gem::Platform.match(s.platform)
+            end                          
           else
             s.match_platform(dep.__platform)
           end

--- a/man/bundle-install.ronn
+++ b/man/bundle-install.ronn
@@ -83,6 +83,11 @@ update process below under [CONSERVATIVE UPDATING][].
   `bundle` directory and installs the bundle there. It also generates
   a `bundle/bundler/setup.rb` file to replace Bundler's own setup.
 
+* `--platform=<platform>`:
+  Force the platform used by bundler to determine the gems to be 
+  installed. By default bundler will use runtime detection to
+  determine the target platform.
+
 * `--trust-policy=[<policy>]`:
   Apply the Rubygems security policy named <policy>, where policy is one of
   HighSecurity, MediumSecurity, LowSecurity, or NoSecurity. For more detail,

--- a/spec/install/gems/platform_spec.rb
+++ b/spec/install/gems/platform_spec.rb
@@ -206,3 +206,92 @@ describe "when a gem has an architecture in its platform" do
   end
 end
 
+describe "bundle install --platform" do
+  it "pulls in the correct platform specific gem" do
+    lockfile <<-G
+      GEM
+        remote: file:#{gem_repo1}
+        specs:
+          platform_specific (1.0)
+          platform_specific (1.0-java)
+          platform_specific (1.0-x86-mswin32)
+
+      PLATFORMS
+        ruby
+
+      DEPENDENCIES
+        platform_specific
+    G
+
+    gemfile <<-G
+      source "file://#{gem_repo1}"
+
+      gem "platform_specific"
+    G
+
+    bundle "install --platorm=jruby"
+    should_be_installed "platform_specific 1.0 JAVA"
+  end
+
+  it "works with gems that have different dependencies" do
+
+    gemfile <<-G
+      source "file://#{gem_repo1}"
+
+      gem "nokogiri"
+    G
+
+    bundle "install --platorm=jruby"
+    should_be_installed "nokogiri 1.4.2 JAVA", "weakling 0.0.3"
+
+    simulate_new_machine
+
+    gemfile <<-G
+      source "file://#{gem_repo1}"
+
+      gem "nokogiri"
+    G
+
+    bundle "install --platorm=ruby"
+    should_be_installed "nokogiri 1.4.2"
+    should_not_be_installed "weakling"
+  end
+
+  it "installs a dalvik gem" do
+
+    gemfile <<-G
+      source "file://#{gem_repo1}"
+
+      gem "example_gem"
+    G
+
+    bundle "install --platorm=ruboto"
+    should_be_installed "example_gem 0.0.1"
+  end
+
+  it "installs a dalvik gem with a higher version" do
+
+    gemfile <<-G
+      source "file://#{gem_repo1}"
+
+      gem "example_gem"
+    G
+
+    bundle "install --platorm=ruboto_9"
+    should_be_installed "example_gem 0.0.1"
+  end
+
+  it "does not installs a dalvik gem with a lower version" do
+
+    gemfile <<-G
+      source "file://#{gem_repo1}"
+
+      gem "example_gem"
+    G
+
+    bundle "install --platorm=ruboto_11"
+    should_not_be_installed "example_gem"
+  end
+
+end
+


### PR DESCRIPTION
I've continued this pull request https://github.com/bundler/bundler/pull/1164 and I believe I have solved the 
problems it had. Also I added support for dalvik platform https://github.com/rubygems/rubygems/pull/539 .
I have used ruboto as the name conversion for the dalvik platform.
Since dalvik version number must be forward compatible, I also created a new comparison method between 
platforms that is only used with dalvik. So for example a `dalvik_10` gem is allowed to be installed when you use
`bundle install --platform=ruboto_5`.
