### PR TITLE
Allow `require: true` as an alias for `require: <name>`

### DIFF
--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -68,6 +68,8 @@ module Bundler
           # dependency. If there are none, use the dependency's name
           # as the autorequire.
           Array(dep.autorequire || dep.name).each do |file|
+            # Allow `require: true` as an alias for `require: <name>`
+            file = dep.name if file == true
             required_file = file
             Kernel.require file
           end

--- a/spec/runtime/require_spec.rb
+++ b/spec/runtime/require_spec.rb
@@ -33,6 +33,10 @@ describe "Bundler.require" do
       s.write "lib/seven.rb", "puts 'seven'"
     end
 
+    build_lib "eight", "1.0.0" do |s|
+      s.write "lib/eight.rb", "puts 'eight'"
+    end
+
     gemfile <<-G
       path "#{lib_path}"
       gem "one", :group => :bar, :require => %w(baz qux)
@@ -42,6 +46,7 @@ describe "Bundler.require" do
       gem "five"
       gem "six", :group => "string"
       gem "seven", :group => :not
+      gem "eight", :require => true, :group => :require_true
     G
   end
 
@@ -69,6 +74,10 @@ describe "Bundler.require" do
     # required in resolver order instead of gemfile order
     run("Bundler.require(:not)")
     expect(out.split("\n").sort).to eq(['seven', 'three'])
+
+    # test require: true
+    run "Bundler.require(:require_true)"
+    expect(out).to eq("eight")
   end
 
   it "allows requiring gems with non standard names explicitly" do


### PR DESCRIPTION
Here's my use-case:

``` ruby
# Don't require debugger if using RubyMine
gem 'debugger', require: !ENV['RM_INFO']
```

---

Currently we have to write:

``` ruby
gem 'debugger', require: (ENV['RM_INFO'] ? false : 'debugger')
```

or

``` ruby
gem 'debugger', {}.merge(ENV['RM_INFO'] ? {require: false} : {})
```
