### PR TITLE
Extract Current Ruby version/platform detection from dependency.rb

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -6,6 +6,7 @@ require 'bundler/rubygems_ext'
 require 'bundler/rubygems_integration'
 require 'bundler/version'
 require 'bundler/constants'
+require 'bundler/current_ruby'
 
 module Bundler
   preserve_gem_path
@@ -320,6 +321,14 @@ module Bundler
           eval_gemspec(path, contents)
         end
       end
+    end
+
+
+    # Returns current version of Ruby
+    #
+    # @return [CurrentRuby] Current version of Ruby
+    def current_ruby
+      @current_ruby ||= CurrentRuby.new()
     end
 
     def clear_gemspec_cache

--- a/lib/bundler/current_ruby.rb
+++ b/lib/bundler/current_ruby.rb
@@ -1,0 +1,81 @@
+module Bundler
+  class CurrentRuby
+    def on_18?
+      RUBY_VERSION =~ /^1\.8/
+    end
+
+    def on_19?
+      RUBY_VERSION =~ /^1\.9/
+    end
+
+    def on_20?
+      RUBY_VERSION =~ /^2\.0/
+    end
+
+    def ruby?
+      !mswin? && (!defined?(RUBY_ENGINE) || RUBY_ENGINE == "ruby" || RUBY_ENGINE == "rbx" || RUBY_ENGINE == "maglev")
+    end
+
+    def ruby_18?
+      ruby? && on_18?
+    end
+
+    def ruby_19?
+      ruby? && on_19?
+    end
+
+    def ruby_20?
+      ruby? && on_20?
+    end
+
+    def mri?
+      !mswin? && (!defined?(RUBY_ENGINE) || RUBY_ENGINE == "ruby")
+    end
+
+    def mri_18?
+      mri? && on_18?
+    end
+
+    def mri_19?
+      mri? && on_19?
+    end
+
+
+    def mri_20?
+      mri? && on_20?
+    end
+
+    def rbx?
+      ruby? && defined?(RUBY_ENGINE) && RUBY_ENGINE == "rbx"
+    end
+
+    def jruby?
+      defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby"
+    end
+
+    def maglev?
+      defined?(RUBY_ENGINE) && RUBY_ENGINE == "maglev"
+    end
+
+    def mswin?
+      Bundler::WINDOWS
+    end
+
+    def mingw?
+      Bundler::WINDOWS && Gem::Platform.local.os == "mingw32"
+    end
+
+    def mingw_18?
+      mingw? && on_18?
+    end
+
+    def mingw_19?
+      mingw? && on_19?
+    end
+
+    def mingw_20?
+      mingw? && on_20?
+    end
+
+  end
+end

--- a/lib/bundler/dependency.rb
+++ b/lib/bundler/dependency.rb
@@ -70,7 +70,9 @@ module Bundler
 
     def current_platform?
       return true if @platforms.empty?
-      @platforms.any? { |p| send("#{p}?") }
+      @platforms.any? { |p|
+        Bundler.current_ruby.send("#{p}?")
+      }
     end
 
     def to_lock
@@ -85,85 +87,5 @@ module Bundler
     rescue NoMethodError
       requirement != ">= 0"
     end
-
-  private
-
-    def on_18?
-      RUBY_VERSION =~ /^1\.8/
-    end
-
-    def on_19?
-      RUBY_VERSION =~ /^1\.9/
-    end
-
-    def on_20?
-      RUBY_VERSION =~ /^2\.0/
-    end
-
-    def ruby?
-      !mswin? && (!defined?(RUBY_ENGINE) || RUBY_ENGINE == "ruby" || RUBY_ENGINE == "rbx" || RUBY_ENGINE == "maglev")
-    end
-
-    def ruby_18?
-      ruby? && on_18?
-    end
-
-    def ruby_19?
-      ruby? && on_19?
-    end
-
-    def ruby_20?
-      ruby? && on_20?
-    end
-
-    def mri?
-      !mswin? && (!defined?(RUBY_ENGINE) || RUBY_ENGINE == "ruby")
-    end
-
-    def mri_18?
-      mri? && on_18?
-    end
-
-    def mri_19?
-      mri? && on_19?
-    end
-
-
-    def mri_20?
-      mri? && on_20?
-    end
-
-    def rbx?
-      ruby? && defined?(RUBY_ENGINE) && RUBY_ENGINE == "rbx"
-    end
-
-    def jruby?
-      defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby"
-    end
-
-    def maglev?
-      defined?(RUBY_ENGINE) && RUBY_ENGINE == "maglev"
-    end
-
-    def mswin?
-      Bundler::WINDOWS
-    end
-
-    def mingw?
-      Bundler::WINDOWS && Gem::Platform.local.os == "mingw32"
-    end
-
-    def mingw_18?
-      mingw? && on_18?
-    end
-
-    def mingw_19?
-      mingw? && on_19?
-    end
-
-    def mingw_20?
-      mingw? && on_20?
-    end
-
   end
 end


### PR DESCRIPTION
That can be reused across several places in bundler and hence
extracted that code which is responsible for properly
detecting current ruby version.
