### PR TITLE
Print friendly error for ambiguous task: bundler/bundler#2550

### DIFF
--- a/lib/bundler/vendor/thor.rb
+++ b/lib/bundler/vendor/thor.rb
@@ -421,7 +421,7 @@ class Thor
 
       possibilities = find_command_possibilities(meth)
       if possibilities.size > 1
-        raise ArgumentError, "Ambiguous command #{meth} matches [#{possibilities.join(', ')}]"
+        raise UndefinedTaskError, "Ambiguous task #{meth} matches [#{possibilities.join(', ')}]"
       elsif possibilities.size < 1
         meth = meth || default_command
       elsif map[meth]


### PR DESCRIPTION
Using `UndefinedTaskError` as in `Thor#handle_no_task_error`.
