### PR TITLE
api calls now get retried

### DIFF
--- a/spec/realworld/dependency_api_spec.rb
+++ b/spec/realworld/dependency_api_spec.rb
@@ -48,7 +48,7 @@ describe "gemcutter's dependency API", :realworld => true do
         gem "rack"
 
         old_v, $VERBOSE = $VERBOSE, nil
-        Bundler::Fetcher::API_TIMEOUT = 1
+        Bundler::Fetcher.api_timeout = 1
         $VERBOSE = old_v
       G
 


### PR DESCRIPTION
I've also made api_timeout, redirect_limit, and max_retries Fetcher class instance variables.
This is so we can set them with out warning (prior they were constants) at the class level, and all future instances of a Fetcher get the set variables, but can be individually changed as well.

This is in response to this issue:
https://github.com/bundler/bundler/issues/2421

As well as a personal need for the api call to be retried.

If there's anything I can do to improve the quality of this request, or anything, please don't hesitate to teach me something!
