### PR TITLE
Load current_ruby from shared_helpers.rb

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -328,14 +328,6 @@ module Bundler
       end
     end
 
-
-    # Returns current version of Ruby
-    #
-    # @return [CurrentRuby] Current version of Ruby
-    def current_ruby
-      @current_ruby ||= CurrentRuby.new()
-    end
-
     def clear_gemspec_cache
       @gemspec_cache = {}
     end

--- a/lib/bundler/current_ruby.rb
+++ b/lib/bundler/current_ruby.rb
@@ -1,4 +1,11 @@
 module Bundler
+  # Returns current version of Ruby
+  #
+  # @return [CurrentRuby] Current version of Ruby
+  def self.current_ruby
+    @current_ruby ||= CurrentRuby.new
+  end
+
   class CurrentRuby
     def on_18?
       RUBY_VERSION =~ /^1\.8/

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -3,6 +3,7 @@ require 'rubygems'
 
 require 'bundler/constants'
 require 'bundler/rubygems_integration'
+require 'bundler/current_ruby'
 
 module Gem
   class Dependency


### PR DESCRIPTION
In case of commands run via bundle exec, we do not require all of
bundler in that environment and we only require bundler/setup there.
Which creates problems because Bundler is unable to find current_ruby there
