### PR TITLE
Add support for multiple gems in `bundle binstubs`

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -379,18 +379,26 @@ module Bundler
       "binstub destination directory (default bin)"
     method_option "force", :type => :boolean, :default => false, :banner =>
       "overwrite existing binstubs if they exist"
-    def binstubs(gem_name)
+    def binstubs(*gems)
       Bundler.definition.validate_ruby!
       Bundler.settings[:bin] = options["path"] if options["path"]
       Bundler.settings[:bin] = nil if options["path"] && options["path"].empty?
       installer = Installer.new(Bundler.root, Bundler.definition)
-      spec      = installer.specs.find{|s| s.name == gem_name }
-      raise GemNotFound, not_found_message(gem_name, Bundler.definition.specs) unless spec
 
-      if spec.name == "bundler"
-        Bundler.ui.warn "Sorry, Bundler can only be run via Rubygems."
-      else
-        installer.generate_bundler_executable_stubs(spec, :force => options[:force], :binstubs_cmd => true)
+      if gems.empty?
+        Bundler.ui.error "`bundle binstubs` needs at least one gem to run."
+        exit 1
+      end
+
+      gems.each do |gem_name|
+        spec = installer.specs.find{|s| s.name == gem_name }
+        raise GemNotFound, not_found_message(gem_name, Bundler.definition.specs) unless spec
+
+        if spec.name == "bundler"
+          Bundler.ui.warn "Sorry, Bundler can only be run via Rubygems."
+        else
+          installer.generate_bundler_executable_stubs(spec, :force => options[:force], :binstubs_cmd => true)
+        end
       end
     end
 

--- a/spec/other/binstubs_spec.rb
+++ b/spec/other/binstubs_spec.rb
@@ -26,6 +26,30 @@ describe "bundle binstubs <gem>" do
       expect(bundled_app("bin/rails")).to exist
     end
 
+    it "does install multiple binstubs" do
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem "rack"
+        gem "rails"
+      G
+
+      bundle "binstubs rails rack"
+
+      expect(bundled_app("bin/rackup")).to exist
+      expect(bundled_app("bin/rails")).to exist
+    end
+
+    it "displays an error when used without any gem" do
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem "rack"
+      G
+
+      bundle "binstubs", :exitstatus => true
+      expect(exitstatus).to eq(1)
+      expect(out).to eq("`bundle binstubs` needs at least one gem to run.")
+    end
+
     it "does not bundle the bundler binary" do
       install_gemfile <<-G
         source "file://#{gem_repo1}"


### PR DESCRIPTION
I'm migrating some projects to use generated binstubs and thought that this might be a nice addition to help out who needs to generate several binstubs for an app at once.
