### PR TITLE
Don't allow to use bundler/capistrano with cap 3.x

### DIFF
--- a/lib/bundler/capistrano.rb
+++ b/lib/bundler/capistrano.rb
@@ -4,6 +4,10 @@
 # Bundler will be activated after each new deployment.
 require 'bundler/deployment'
 
+if Gem::Version.new(Capistrano::Version).release >= Gem::Version.new("3.0")
+  raise "For Capistrano 3.x integration, please use http://github.com/capistrano/bundler"
+end
+
 Capistrano::Configuration.instance(:must_exist).load do
   before "deploy:finalize_update", "bundle:install"
   Bundler::Deployment.define_task(self, :task, :except => { :no_release => true })


### PR DESCRIPTION
Capistrano 3.x has separate gem for bundler integration [(capistrano/bundler)](https://github.com/capistrano/bundler) and I think it would be useful to stop Capistrano 3.x users from requiring this task.
