### PR TITLE
`bundler` bin for those who confuse it with `bundle`

### DIFF
--- a/bin/bundle
+++ b/bin/bundle
@@ -5,7 +5,7 @@ Signal.trap("INT") { exit 1 }
 
 require 'bundler'
 # Check if an older version of bundler is installed
-$:.each do |path|
+$LOAD_PATH.each do |path|
   if path =~ %r'/bundler-0.(\d+)' && $1.to_i < 9
     err = "Looks like you have a version of bundler that's older than 0.9.\n"
     err << "Please remove your old versions.\n"

--- a/bin/bundler
+++ b/bin/bundler
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+
+require 'bundler'
+require 'bundler/cli'
+
+ui = Bundler::UI::Shell.new
+ui.error "It's recommended to use Bundler through 'bundle' binary instead of 'bundler'"
+
+bin = "#{File.dirname(__FILE__)}/bundle #{ARGV.join(" ")}"
+exec bin


### PR DESCRIPTION
As mentioned in https://github.com/bundler/bundler-features/issues/12, we could provide an executable named "bundler" that prints a warning and silently execs to bundle.
