### PR TITLE
[Regression] Allow Basic Auth by a username with no password

### DIFF
--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -217,7 +217,7 @@ module Bundler
       begin
         Bundler.ui.debug "Fetching from: #{uri}"
         req = Net::HTTP::Get.new uri.request_uri
-        req.basic_auth(uri.user, uri.password) if uri.user && uri.password
+        req.basic_auth(uri.user, uri.password) if uri.user
         if defined?(Net::HTTP::Persistent)
           response = @connection.request(uri, req)
         else

--- a/spec/install/gems/dependency_api_spec.rb
+++ b/spec/install/gems/dependency_api_spec.rb
@@ -419,6 +419,20 @@ describe "gemcutter's dependency API" do
       bundle :install, :artifice => "endpoint_creds_diff_host"
       should_be_installed "rack 1.0.0"
     end
+
+    describe "with no password" do
+      let(:password) { nil }
+
+      it "passes basic authentication details" do
+        gemfile <<-G
+          source "#{basic_auth_source_uri}"
+          gem "rack"
+        G
+
+        bundle :install, :artifice => "endpoint_basic_authentication"
+        should_be_installed "rack 1.0.0"
+      end
+    end
   end
 
   context "when ruby is compiled without openssl" do


### PR DESCRIPTION
Gemfury currently relies on Bundler's support for username-only authentication with a source such as:

```
https://secret-token@gem.fury.io/username/
```

Bundler 1.3 supported this authentication method, however the latest `1.4.0.pre1` release is causing `HTTPForbidden` errors for our customers because the authentication token is not passed to our server.

This PR is to continue supporting username-only basic authentication.
