### PR TITLE
add jruby_18 and jruby_19 to platforms

### DIFF
--- a/lib/bundler/current_ruby.rb
+++ b/lib/bundler/current_ruby.rb
@@ -60,6 +60,14 @@ module Bundler
       defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby"
     end
 
+    def jruby_18?
+      jruby? && on_18?
+    end
+
+    def jruby_19?
+      jruby? && on_19?
+    end
+
     def maglev?
       defined?(RUBY_ENGINE) && RUBY_ENGINE == "maglev"
     end

--- a/lib/bundler/dependency.rb
+++ b/lib/bundler/dependency.rb
@@ -19,6 +19,8 @@ module Bundler
       :mri_20   => Gem::Platform::RUBY,
       :rbx      => Gem::Platform::RUBY,
       :jruby    => Gem::Platform::JAVA,
+      :jruby_18 => Gem::Platform::JAVA,
+      :jruby_19 => Gem::Platform::JAVA,
       :mswin    => Gem::Platform::MSWIN,
       :mingw    => Gem::Platform::MINGW,
       :mingw_18 => Gem::Platform::MINGW,


### PR DESCRIPTION
Hi!

I'm currently running into a problem where I need a gem in my bundle for _only_ _1.8_ versions of jruby. So I added support for specifying `:jruby_18` and `:jruby_19` as platforms.

I'm working on a test.
