### PR TITLE
Require version file for checking capistrano version

### DIFF
--- a/lib/bundler/capistrano.rb
+++ b/lib/bundler/capistrano.rb
@@ -3,12 +3,8 @@
 # Just add "require 'bundler/capistrano'" in your Capistrano deploy.rb, and
 # Bundler will be activated after each new deployment.
 require 'bundler/deployment'
-begin
-  require 'capistrano/version'
-rescue LoadError
-end
 
-if !defined?(Capistrano::Version) || Gem::Version.new(Capistrano::Version).release >= Gem::Version.new("3.0")
+if defined?(Capistrano::Version) && Gem::Version.new(Capistrano::Version).release >= Gem::Version.new("3.0")
   raise "For Capistrano 3.x integration, please use http://github.com/capistrano/bundler"
 end
 


### PR DESCRIPTION
bundler-1.4.0.pre.1 works fine, but bundler-1.4.0.pre.2 shows error below:

```
$ bundle exec cap production deploy
/path/to/bundler-1.4.0.pre.2/lib/bundler/capistrano.rb:7:in `<top (required)>': uninitialized constant Capistrano::Version (NameError)
```

This commit brings this error, so I add require version file.
1d7a7893dfeb85afa25a3a526354b31c85f05dbf

bundler: 1.4.0.pre.2
capistrano: 2.14.2
