### PR TITLE
Set called console to the one in `bundle config console`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+
+Features:
+
+  - add support for IRB alternatives such as Pry and Ripl (@joallard, @postmodern)
+
 ## 1.4.0.pre.2
 
 Features:

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -634,35 +634,40 @@ module Bundler
       end
     end
 
-    CONSOLES = [
-      ['pry',  :Pry],
-      ['ripl', :Ripl],
-      ['irb',  :IRB]
-    ]
+    CONSOLES = {
+      'pry'  => :Pry,
+      'ripl' => :Ripl,
+      'irb'  => :IRB,
+    }
 
     desc "console [GROUP]", "Opens an IRB session with the bundle pre-loaded"
     def console(group = nil)
       group ? Bundler.require(:default, *(group.split.map! {|g| g.to_sym })) : Bundler.require
       ARGV.clear
 
-      file, constant = CONSOLES.find do |file,constant|
-        begin
-          require(file) || true
-        rescue LoadError
-          false
-        end
+      preferred = Bundler.settings[:console] || 'irb'
+
+      # See if console is available
+      begin
+        require preferred || true
+      rescue LoadError
+        false
+
+        # Is it in Gemfile?
+        Bundler.ui.error "Could not load the #{preferred} console"
+        Bundler.ui.info "Falling back on IRB..."
+
+        require 'irb'
+        preferred = 'irb'
       end
 
-      unless constant
-        Bundler.ui.error "Could not load the Ruby console"
-        return
-      end
+      constant = CONSOLES[preferred]
 
       console = begin
                   Object.const_get(constant)
                 rescue NameError => e
                   Bundler.ui.error e.inspect
-                  Bundler.ui.error "Could not load the #{file} console"
+                  Bundler.ui.error "Could not load the #{constant} console"
                   return
                 end
 

--- a/spec/commands/console_spec.rb
+++ b/spec/commands/console_spec.rb
@@ -18,6 +18,28 @@ describe "bundle console" do
     expect(out).to include("0.9.1")
   end
 
+  it "starts another REPL if configured as such" do
+    bundle "config console pry"
+
+    bundle "console" do |input|
+      input.puts("__callee__")
+      input.puts("exit")
+    end
+    expect(out).to include("pry")
+  end
+
+  it "falls back to IRB if the other REPL isn't available" do
+    bundle "config console pry"
+    # make sure pry isn't there
+
+    bundle "console" do |input|
+      input.puts("__callee__")
+      input.puts("exit")
+    end
+    expect(out).to include("irb")
+  end
+
+
   it "doesn't load any other groups" do
     bundle "console" do |input|
       input.puts("puts ACTIVESUPPORT")


### PR DESCRIPTION
Following @postmodern's #1616 and @indirect's [recommendations](https://github.com/bundler/bundler/pull/1616#issuecomment-22077307) (not to mention a thousand issues later!), 

> IRB alternatives can be selected by setting the config key `console`, for example with `bundle config console pry`.

I am submitting this for code review, as the PR isn't complete.

Comments:
- The alternate console must be in the Gemfile for it to be required. Any way around this? If not, we should add a warning in there.
- In my test (L31), I'm trying to find a way to ensure the console is not installed. Weirdly, the same test twice passes and fails.
- I'm not familiar with the way to convert a file name to a class constant. Maybe there's a standard way (in the project?) already. Thus, Pry and Ripl are hard-coded in and are the only alternates that can be used.
- When invoked, Pry doesn't show line numbers, and an interrupt shuts it down. That's weird.
- Thinking back, I didn't dare add 'pry' as a dev dependency. Should I have?

Improvements welcome.
