### PR TITLE
Allow defaulting the number of Bundler jobs via the environment

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -232,6 +232,10 @@ module Bundler
         opts[:system] = true
       end
 
+      if opts[:jobs].nil? && ENV["BUNDLE_JOBS"]
+        opts[:jobs] = ENV["BUNDLE_JOBS"].to_i
+      end
+
       opts["no-cache"] ||= opts[:local]
 
       # Can't use Bundler.settings for this because settings needs gemfile.dirname

--- a/man/bundle-install.ronn
+++ b/man/bundle-install.ronn
@@ -91,6 +91,7 @@ update process below under [CONSERVATIVE UPDATING][].
 
 * `--jobs=[<size>]`:
   Install gems parallely by starting <size> number of parallel workers.
+  This value may also be configured via $BUNDLE_JOBS.
 
 * `--no-cache`:
   Do not update the cache in `vendor/cache` with the newly bundled gems. This


### PR DESCRIPTION
This adds a `BUNDLE_JOBS` environment variable. If set, and
the user has not already specified via the CLI a number of jobs
to run, this will configure the number of jobs Bundler should
use when installing gems.

Using an environment variable for this sort of functionality
is a pretty nice win, mostly because it means that things like
version checking to alter command line arguments to Bundler are
no longer necessary. If the version of Bundler running supports
the environment variable the user gets the desired behavior,
otherwise Bundler will silently ignore it rather than failing
due to invalid command line arguments.
