### PR TITLE
Fix uninitialized constant Capistrano::Version (NameError)

### DIFF
--- a/lib/bundler/capistrano.rb
+++ b/lib/bundler/capistrano.rb
@@ -3,6 +3,7 @@
 # Just add "require 'bundler/capistrano'" in your Capistrano deploy.rb, and
 # Bundler will be activated after each new deployment.
 require 'bundler/deployment'
+require 'capistrano/version'
 
 if defined?(Capistrano::Version) && Gem::Version.new(Capistrano::Version).release >= Gem::Version.new("3.0")
   raise "For Capistrano 3.x integration, please use http://github.com/capistrano/bundler"


### PR DESCRIPTION
When using bundler 1.4.0.pre.2, a NameError occurs:

/gems/bundler-1.4.0.pre.2/lib/bundler/capistrano.rb:7:in `<top (required)>': uninitialized constant Capistrano::Version (NameError)

This fix explicitly requires the 'capistrano/version' file, and the error no longer exists.
