### PR TITLE
Exec: add option for ruby 1.9 FD behavior for 2.0

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -513,7 +513,7 @@ module Bundler
     map %w(pack) => :package
 
     desc "exec", "Run the command in context of the bundle"
-    method_options :keep_file_descriptors => :boolean
+    method_option :keep_file_descriptors, :type => :boolean, :default => false
     long_desc <<-D
       Exec runs a command, providing it access to the gems in the bundle. While using
       bundle exec you can require and call the bundled gems as if they were installed
@@ -524,10 +524,10 @@ module Bundler
       Bundler.load.setup_environment
 
       begin
-        # Ruby 2.0 changed the default file descriptor
-        # behavior for #exec, this option forces 1.9 behavior
-        if RUBY_VERSION >= "2.0" && options.keep_file_descriptors?
-          args << { :close_others => false }
+        if RUBY_VERSION >= "2.0"
+          args << { :close_others => !options.keep_file_descriptors? }
+        elsif options.keep_file_descriptors?
+          Bundler.ui.warn "Ruby version #{RUBY_VERSION} defaults to keeping non-standard file descriptors on Kernel#exec."
         end
 
         # Run

--- a/man/bundle-exec.ronn
+++ b/man/bundle-exec.ronn
@@ -3,7 +3,7 @@ bundle-exec(1) -- Execute a command in the context of the bundle
 
 ## SYNOPSIS
 
-`bundle exec` <command>
+`bundle exec` <command> [--keep-file-descriptors]
 
 ## DESCRIPTION
 
@@ -17,6 +17,13 @@ should run `bundle exec rspec spec/my_spec.rb`.
 
 Note that `bundle exec` does not require that an executable is
 available on your shell's `$PATH`.
+
+## OPTIONS
+
+* `--keep-file-descriptors`:
+  Ruby 2.0's default Kernel#exec behavior discards non-standard file descriptors.
+  This option enabled Ruby <= 1.9's default behavior and passes all file descriptors
+  to the new command.
 
 ## BUNDLE INSTALL --BINSTUBS
 

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -78,14 +78,21 @@ describe "bundle exec" do
 
     install_gemfile ''
     sys_exec("#{Gem.ruby} #{command.path}")
-    expect(out).to eq("")
+
+    if RUBY_VERSION >= "2.0"
+      expect(out).to eq("")
+    else
+      expect(out).to eq("Ruby version #{RUBY_VERSION} defaults to keeping non-standard file descriptors on Kernel#exec.")
+    end
+
     expect(err).to eq("")
   end
 
   it "accepts --keep-file-descriptors" do
     install_gemfile ''
     bundle "exec --keep-file-descriptors echo foobar"
-    expect(out).to eq("foobar")
+
+    expect(err).to eq("")
   end
 
   it "can run a command named --verbose" do


### PR DESCRIPTION
Ruby 2.0 changed the behavior of file descriptors when doing a Kernel.exec.
Where in 1.9 it wouldn't automatically close non-standard file descriptors
when doing a Kernel.exec, in 2.0 the default is to close them.

Issue #2628
