### PR TITLE
Pass `-z` arg to git ls-files & split on null char

### DIFF
--- a/bundler.gemspec
+++ b/bundler.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'ronn', '~> 0.7.3'
   spec.add_development_dependency 'rspec', '~> 2.11'
 
-  spec.files       = `git ls-files`.split($/)
+  spec.files       = `git ls-files -z`.split("\x0")
   spec.files      += Dir.glob('lib/bundler/man/**/*') # man/ is ignored by git
   spec.test_files  = spec.files.grep(%r{^spec/})
 

--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = ""
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files`.split($/)
+  spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]

--- a/spec/install/git_spec.rb
+++ b/spec/install/git_spec.rb
@@ -34,7 +34,7 @@ describe "bundle install with git sources" do
       git = update_git "foo" do |s|
         s.executables = ["foobar"] # we added this the first time, so keep it now
         s.files = ["bin/foobar"] # updating git nukes the files list
-        foospec = s.to_ruby.gsub(/s\.files.*/, 's.files = `git ls-files`.split("\n")')
+        foospec = s.to_ruby.gsub(/s\.files.*/, 's.files = `git ls-files -z`.split("\x0")')
         s.write "foo.gemspec", foospec
       end
 

--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -54,7 +54,7 @@ describe "The library itself" do
     exempt = /\.gitmodules|\.marshal|fixtures|vendor|ssl_certs|LICENSE/
     error_messages = []
     Dir.chdir(File.expand_path("../..", __FILE__)) do
-      `git ls-files`.split("\n").each do |filename|
+      `git ls-files -z`.split("\x0").each do |filename|
         next if filename =~ exempt
         error_messages << check_for_tab_characters(filename)
         error_messages << check_for_extra_spaces(filename)
@@ -67,7 +67,7 @@ describe "The library itself" do
     included = /spec/
     error_messages = []
     Dir.chdir(File.expand_path("../", __FILE__)) do
-      `git ls-files`.split("\n").each do |filename|
+      `git ls-files -z`.split("\x0").each do |filename|
         next unless filename =~ included
         error_messages << check_for_spec_defs_with_single_quotes(filename)
       end


### PR DESCRIPTION
It seems a little bit paranoid to assume there might be a newline or tab in a file name, but it's perfectly valid on many systems. When such a character exists in a filename, `git ls-files` will return something like `"file\nname"` in its listing, which is problematic because the calling code expects neither the escaped whitespace nor the quotes.

By passing the `-z` argument, git uses the null character as the separator, never escaping whitespace nor quoting file names.
