### PR TITLE
gemspec template: clarify summary vs description.

### DIFF
--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -8,8 +8,8 @@ Gem::Specification.new do |spec|
   spec.version       = <%=config[:constant_name]%>::VERSION
   spec.authors       = [<%=config[:author].inspect%>]
   spec.email         = [<%=config[:email].inspect%>]
-  spec.description   = %q{TODO: Write a gem description}
-  spec.summary       = %q{TODO: Write a gem summary}
+  spec.summary       = %q{TODO: Write a short summary. Required.}
+  spec.description   = %q{TODO: Write a longer description. Optional.}
   spec.homepage      = ""
   spec.license       = "MIT"
 


### PR DESCRIPTION
I never remember which is which, so I clarified based on http://guides.rubygems.org/specification-reference/.
