### PR TITLE
If Git is not available, prints better error message when using gems from git

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -352,6 +352,10 @@ module Bundler
       @gemspec_cache = {}
     end
 
+    def git_present?
+      @git_present ||= Bundler.which("git")
+    end
+
   private
 
     def eval_yaml_gemspec(path, contents)

--- a/lib/bundler/source/git/git_proxy.rb
+++ b/lib/bundler/source/git/git_proxy.rb
@@ -85,6 +85,8 @@ module Bundler
 
         def git(command, check_errors=true)
           if allow?
+            raise GitError, "You need to install git to be able to use gems from git repositories. For help installing git, please refer to GitHub's tutorial at https://help.github.com/articles/set-up-git" if !Bundler.git_present?
+
             out = SharedHelpers.with_clean_git_env { %x{git #{command}} }
 
             if check_errors && $?.exitstatus != 0

--- a/spec/install/git_spec.rb
+++ b/spec/install/git_spec.rb
@@ -897,4 +897,18 @@ describe "bundle install with git sources" do
     end
   end
 
+  describe "without git installed" do
+    it "prints a better error message" do
+      build_git "foo"
+
+      install_gemfile <<-G
+        git "#{lib_path('foo-1.0')}" do
+          gem 'foo'
+        end
+      G
+
+      bundle "update", :env => {"PATH" => ""}
+      expect(out).to include("You need to install git to be able to use gems from git repositories. For help installing git, please refer to GitHub's tutorial at https://help.github.com/articles/set-up-git")
+    end
+  end
 end


### PR DESCRIPTION
https://github.com/bundler/bundler-features/issues/11
