### PR TITLE
Add rspec test when run bundle outdated with invalid gem name

### DIFF
--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -119,5 +119,10 @@ describe "bundle outdated" do
       bundle "outdated invalid_gem_name"
       expect(out).to include("Could not find gem 'invalid_gem_name'.")
     end
+
+    it "returns non-zero exit code" do
+      bundle "outdated invalid_gem_name", :exitstatus => true
+      expect(exitstatus).to_not be_zero
+    end
   end
 end


### PR DESCRIPTION
bundler/bundler-features#6

It should return a non-zero exit code.
