### PR TITLE
Stop threads before killing the worker

### DIFF
--- a/lib/bundler/parallel_workers/worker.rb
+++ b/lib/bundler/parallel_workers/worker.rb
@@ -39,8 +39,8 @@ module Bundler
 
       # Stop the forked workers and started threads
       def stop
-        stop_workers
         stop_threads
+        stop_workers
       end
 
       private


### PR DESCRIPTION
It is pretty good idea to kill the threads before killing the worker
because threads are still trying to read from pipe that could be prematurely
closed when workers get killed.
