### PR TITLE
Adding platform support for Ruby 2.1

### DIFF
--- a/lib/bundler/current_ruby.rb
+++ b/lib/bundler/current_ruby.rb
@@ -19,6 +19,10 @@ module Bundler
       RUBY_VERSION =~ /^2\.0/
     end
 
+    def on_21?
+      RUBY_VERSION =~ /^2\.1/
+    end
+
     def ruby?
       !mswin? && (!defined?(RUBY_ENGINE) || RUBY_ENGINE == "ruby" || RUBY_ENGINE == "rbx" || RUBY_ENGINE == "maglev")
     end
@@ -35,6 +39,10 @@ module Bundler
       ruby? && on_20?
     end
 
+    def ruby_21?
+      ruby? && on_21?
+    end
+
     def mri?
       !mswin? && (!defined?(RUBY_ENGINE) || RUBY_ENGINE == "ruby")
     end
@@ -47,9 +55,12 @@ module Bundler
       mri? && on_19?
     end
 
-
     def mri_20?
       mri? && on_20?
+    end
+
+    def mri_21?
+      mri? && on_21?
     end
 
     def rbx?
@@ -84,12 +95,20 @@ module Bundler
       mingw? && on_20?
     end
 
+    def mingw_21?
+      mingw? && on_21?
+    end
+
     def x64_mingw?
       Bundler::WINDOWS && Gem::Platform.local.os == "mingw32" && Gem::Platform.local.cpu == 'x64'
     end
 
     def x64_mingw_20?
       x64_mingw? && on_20?
+    end
+
+    def x64_mingw_21?
+      x64_mingw? && on_21?
     end
 
   end

--- a/lib/bundler/dependency.rb
+++ b/lib/bundler/dependency.rb
@@ -13,10 +13,12 @@ module Bundler
       :ruby_18  => Gem::Platform::RUBY,
       :ruby_19  => Gem::Platform::RUBY,
       :ruby_20  => Gem::Platform::RUBY,
+      :ruby_21  => Gem::Platform::RUBY,
       :mri      => Gem::Platform::RUBY,
       :mri_18   => Gem::Platform::RUBY,
       :mri_19   => Gem::Platform::RUBY,
       :mri_20   => Gem::Platform::RUBY,
+      :mri_21   => Gem::Platform::RUBY,
       :rbx      => Gem::Platform::RUBY,
       :jruby    => Gem::Platform::JAVA,
       :mswin    => Gem::Platform::MSWIN,
@@ -24,8 +26,10 @@ module Bundler
       :mingw_18 => Gem::Platform::MINGW,
       :mingw_19 => Gem::Platform::MINGW,
       :mingw_20 => Gem::Platform::MINGW,
+      :mingw_21 => Gem::Platform::MINGW,
       :x64_mingw    => Gem::Platform::X64_MINGW,
-      :x64_mingw_20 => Gem::Platform::X64_MINGW
+      :x64_mingw_20 => Gem::Platform::X64_MINGW,
+      :x64_mingw_21 => Gem::Platform::X64_MINGW
     }.freeze
 
     def initialize(name, version, options = {}, &blk)

--- a/man/gemfile.5.ronn
+++ b/man/gemfile.5.ronn
@@ -149,6 +149,8 @@ There are a number of `Gemfile` platforms:
     _ruby_ `AND` version 1.9
   * `ruby_20`:
     _ruby_ `AND` version 2.0
+  * `ruby_21`:
+    _ruby_ `AND` version 2.1
   * `mri`:
     Same as _ruby_, but not Rubinius
   * `mri_18`:
@@ -157,6 +159,8 @@ There are a number of `Gemfile` platforms:
     _mri_ `AND` version 1.9
   * `mri_20`:
     _mri_ `AND` version 2.0
+  * `mri_21`:
+    _mri_ `AND` version 2.1
   * `rbx`:
     Same as _ruby_, but only Rubinius (not MRI)
   * `jruby`:
@@ -171,10 +175,14 @@ There are a number of `Gemfile` platforms:
     _mingw_ `AND` version 1.9
   * `mingw_20`:
     _mingw_ `AND` version 2.0
+  * `mingw_21`:
+    _mingw_ `AND` version 2.1
   * `x64_mingw`:
     Windows 64 bit 'mingw32' platform (aka RubyInstaller x64)
   * `x64_mingw_20`:
     _x64_mingw_ `AND` version 2.0
+  * `x64_mingw_21`:
+    _x64_mingw_ `AND` version 2.1
 
 As with groups, you can specify one or more platforms:
 

--- a/spec/cache/platform_spec.rb
+++ b/spec/cache/platform_spec.rb
@@ -5,7 +5,7 @@ describe "bundle cache with multiple platforms" do
     gemfile <<-G
       source "file://#{gem_repo1}"
 
-      platforms :ruby, :ruby_18, :ruby_19, :ruby_20 do
+      platforms :ruby, :ruby_18, :ruby_19, :ruby_20, :ruby_21 do
         gem "rack", "1.0.0"
       end
 
@@ -13,7 +13,7 @@ describe "bundle cache with multiple platforms" do
         gem "activesupport", "2.3.5"
       end
 
-      platforms :mri, :mri_18, :mri_19, :mri_20 do
+      platforms :mri, :mri_18, :mri_19, :mri_20, :mri_21 do
         gem "activerecord", "2.3.2"
       end
     G


### PR DESCRIPTION
Ruby 2.1.0-preview1 is out and my gemfile already hates it. :-/ This pull request adds support in bundler for the 2.1 platform to resolves issues for anyone using platform checks in their gemfile.
