### PR TITLE
Add :rubygems_secure option for 'source'

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -109,9 +109,12 @@ module Bundler
       case source
       when :gemcutter, :rubygems, :rubyforge then
         Bundler.ui.warn "The source :#{source} is deprecated because HTTP " \
-          "requests are insecure.\nPlease change your source to 'https://" \
-          "rubygems.org' if possible, or 'http://rubygems.org' if not."
+          "requests are insecure.\nPlease change your source to ':rubygems_secure'" \
+          " if possible, or 'http://rubygems.org' if not."
         @rubygems_source.add_remote "http://rubygems.org"
+        return
+      when :rubygems_secure then
+        @rubygems_source.add_remote 'https://rubygems.org'
         return
       when String
         @rubygems_source.add_remote source


### PR DESCRIPTION
This pull request adds a ':rubygems_secure' option to the `source` method, so you don't need to type the 'https...' URL if you want to use the rubygems.org source.
