### PR TITLE
bundle install: don't re-download specs for installed gems

### DIFF
--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -102,10 +102,6 @@ module Bundler
     end
 
     def install_gem_from_spec(spec, standalone = false, worker = 0)
-      # Download the gem to get the spec, because some specs that are returned
-      # by rubygems.org are broken and wrong.
-      Bundler::Fetcher.fetch(spec) if spec.source.is_a?(Bundler::Source::Rubygems)
-
       # Fetch the build settings, if there are any
       settings             = Bundler.settings["build.#{spec.name}"]
       install_message      = nil

--- a/lib/bundler/source/rubygems.rb
+++ b/lib/bundler/source/rubygems.rb
@@ -72,6 +72,10 @@ module Bundler
           return ["Using #{spec.name} (#{spec.version})", nil]
         end
 
+        # Download the gem to get the spec, because some specs that are returned
+        # by rubygems.org are broken and wrong.
+        Bundler::Fetcher.fetch(spec)
+
         install_message = "Installing #{spec.name} (#{spec.version})"
         path = cached_gem(spec)
         if Bundler.requires_sudo?


### PR DESCRIPTION
This proposal significantly improves `bundle install` performance when most (but not all) gems have already been installed. It eliminates a couple network roundtrips for the gems that are already installed. These roundtrips are to fetch a fresh copy of the spec for each gem.

With this patch, running `bundle install` on my gem set (~200 gems) on my home cable+wifi reduced the run time by **60%**, from ~80s to ~30s.

The logic in question appears to originate from https://github.com/bundler/bundler/commit/500d94d2198ed07c68a53e647f91d21bb088d4de, four years ago. The [current comments](https://github.com/bundler/bundler/blob/49aa5c5b13fd0e454a74e79de759a3c818fd68e2/lib/bundler/installer.rb#L105-L107) don't mention any details about what might be "broken and wrong", and I don't know much about the historical context. One clue may be in a comment for the underlying [`__swap__`](https://github.com/bundler/bundler/blob/master/lib/bundler/remote_specification.rb#L36-L41) method, which mentions Rubyforge.

When I tried removing the line entirely, many specs broke. Could this be a test harness / teardown issue? Or is it related to why the logic exists?

In any case, moving the line into `Bundler::Source::Rubygems` (the only source it affects) allows the specs to pass while also reducing its frequency so it only runs for gems that need to be installed. This seems like the simplest change with the biggest benefit.
