### PR TITLE
Rewrite history to send 1.3.4's changelog back to 2013.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ Bugfixes:
   - use basic auth even when SSL is not available (@jayniz)
   - installing git gems without dependencies in deployment now works
 
-## 1.3.4 (15 March 2103)
+## 1.3.4 (15 March 2013)
 
 Bugfixes:
 


### PR DESCRIPTION
I was pretty skeptical when I saw that Bundler 1.3.4 had been released 90 years in the future. I figured Bundler would be at least 2.0.0 by then. I really tried to believe it... But ultimately, I just had to check for myself.

So, I cobbled together a time machine (ostensibly, mostly with Perl) and went forward 90 years to find an aged @indirect. I queried him on this mysterious release of 1.3.4 that he (theoretically) had just produced. "How can it be?", I said. "How is it that you reached back through the vortex of time and bestowed upon us this gift of Bundler 1.3.4?"

But he just cocked his head to the right and raised an eyebrow, "Don't you know? In the year 2071 the Noders came to power... Ruby has been illegal for 42 years."

And so there you have it. 1.3.4 can't be from 2103, because Ruby is outlawed in 2103. Thus, it must be from 2013.
