### PR TITLE
Handle cross-host redirects with plain Net::HTTP

### DIFF
--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -203,7 +203,12 @@ module Bundler
         else
           req = Net::HTTP::Get.new uri.request_uri
           req.basic_auth(uri.user, uri.password) if uri.user && uri.password
-          response = @connection.request(req)
+          if uri.host == @connection.address && uri.port == @connection.port
+            connection = @connection
+          else
+            connection = Net::HTTP.new(uri.host, uri.port)
+          end
+          response = connection.request(req)
         end
       rescue OpenSSL::SSL::SSLError
         raise CertificateFailureError.new(@public_uri)

--- a/spec/support/artifice/endpoint_host_redirect.rb
+++ b/spec/support/artifice/endpoint_host_redirect.rb
@@ -1,0 +1,15 @@
+require File.expand_path("../endpoint", __FILE__)
+
+Artifice.deactivate
+
+class EndpointHostRedirect < Endpoint
+  get "/fetch/actual/gem/:id", :host_name => 'localgemserver.test' do
+    redirect "http://bundler.localgemserver.test#{request.path_info}"
+  end
+
+  get "/api/v1/dependencies" do
+    status 404
+  end
+end
+
+Artifice.activate_with(EndpointHostRedirect)


### PR DESCRIPTION
This adds a failing test corresponding to the infinite redirect issue #2451 and also solves it in a way that does not assume all redirects go to the same host
