### PR TITLE
fix raising error when path contains unexisting users home dir

### DIFF
--- a/lib/bundler/source/path.rb
+++ b/lib/bundler/source/path.rb
@@ -97,16 +97,15 @@ module Bundler
         name
       end
 
-    private
+      private
 
       def expand(somepath)
-        #TODO improve catch errors
-        begin
-          somepath.expand_path(Bundler.root)
-        rescue ArgumentError => e
-          raise PathError, "The path `#{somepath}` is incorrect: #{e.message}."
-        end
+        somepath.expand_path(Bundler.root)
+      rescue ArgumentError => e
+        Bundler.ui.debug(e)
+        raise PathError, "The path `#{somepath}` could not be used due to an error: #{e.message}."
       end
+
       def app_cache_path
         @app_cache_path ||= Bundler.app_cache.join(app_cache_dirname)
       end

--- a/spec/install/gemfile/path_spec.rb
+++ b/spec/install/gemfile/path_spec.rb
@@ -54,8 +54,8 @@ describe "bundle install with explicit source paths" do
     install_gemfile <<-G
       gem 'foo', :path => "~#{username}/#{relative_path}"
     G
-    # TODO improve expect condition
-    expect(out).to match("The path `~#{username}/#{relative_path}` is incorrect: user #{username} doesn't exist")
+    expect(out).to match("The path `~#{username}/#{relative_path}` could not be used due to an error")
+    expect(out).to match("user #{username} doesn't exist")
   end
 
   it "expands paths relative to Bundler.root" do


### PR DESCRIPTION
When I put some gem to `gemfile` like

```
gem 'gemname', path: "~someunexistinguser/path/to/gemname"
```

I get a message

```
Unfortunately, a fatal error has occurred. Please see the Bundler troubleshooting documentation at http://bit.ly/bundler-issues. Thanks!
/home/vagrant/.rvm/gems/ruby-2.0.0-p247@global/gems/bundler-1.3.5/lib/bundler/source/path.rb:62:in `expand_path': user someunexistinguser doesn't exist (ArgumentError)
    from /home/vagrant/.rvm/gems/ruby-2.0.0-p247@global/gems/bundler-1.3.5/lib/bundler/source/path.rb:62:in `expand_path'
    from /home/vagrant/.rvm/gems/ruby-2.0.0-p247@global/gems/bundler-1.3.5/lib/bundler/source/path.rb:62:in `eql?'
    from /home/vagrant/.rvm/gems/ruby-2.0.0-p247@global/gems/bundler-1.3.5/lib/bundler/definition.rb:466:in `block (2 levels) in converge_dependencies'
    ...
```

So, I propose a solution and I think it's not the best. I'm waiting for feedback 
