### PR TITLE
Properly require Capistrano version

### DIFF
--- a/lib/bundler/capistrano.rb
+++ b/lib/bundler/capistrano.rb
@@ -3,6 +3,7 @@
 # Just add "require 'bundler/capistrano'" in your Capistrano deploy.rb, and
 # Bundler will be activated after each new deployment.
 require 'bundler/deployment'
+require 'capistrano/version'
 
 if defined?(Capistrano::Version) && Gem::Version.new(Capistrano::Version).release >= Gem::Version.new("3.0")
   raise "For Capistrano 3.x integration, please use http://github.com/capistrano/bundler"


### PR DESCRIPTION
If you don't do this, `Capistrano::Version` doesn't exist, so this whole thing blows up.
