### PR TITLE
Fix Bundler::which

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -290,7 +290,7 @@ module Bundler
     end
 
     def which(executable)
-      if File.executable?(executable)
+      if File.file?(executable) && File.executable?(executable)
         executable
       elsif ENV['PATH']
         path = ENV['PATH'].split(File::PATH_SEPARATOR).find do |p|


### PR DESCRIPTION
`Bundler::which` didn't return `nil` if the argument was a name of
directory.  This was because `File::executable?` returns true when its
argument is a name of directory.  I fixed it with `File::file?`.
