### PR TITLE
close persistent connections before forking

### DIFF
--- a/lib/bundler/parallel_workers/unix_worker.rb
+++ b/lib/bundler/parallel_workers/unix_worker.rb
@@ -14,6 +14,12 @@ module Bundler
         end
       end
 
+      def initialize(size, job)
+        # Close the persistent connections for the main thread before forking
+        Net::HTTP::Persistent.new('bundler', :ENV).shutdown
+        super
+      end
+
       private
 
       # Start forked workers for downloading gems. This version of worker


### PR DESCRIPTION
An attempt to fork without causing broken SSL connections. In testing with @hone, using threads instead of forking has a roughly 50% performance penalty. Looks like Gem::Installer spends a lot of time doing CPU-bound ungzipping and the like. So we're trying to make forking work even with SSL connections.

Please to tell me if this is crazy, @drbrain, @hone, @evanphx, @skottler.
