### PR TITLE
Fix bundle open when gem does not contain a Gemfile (fixes #2678)

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -652,8 +652,9 @@ module Bundler
       return Bundler.ui.info("To open a bundled gem, set $EDITOR or $BUNDLER_EDITOR") unless editor
       spec = select_spec(name, :regex_match)
       return unless spec
-      Dir.chdir(spec.full_gem_path) do
-        command = "#{editor} #{spec.full_gem_path}"
+      full_gem_path = spec.full_gem_path
+      Dir.chdir(full_gem_path) do
+        command = "#{editor} #{full_gem_path}"
         success = system(command)
         Bundler.ui.info "Could not run '#{command}'" unless success
       end

--- a/spec/commands/open_spec.rb
+++ b/spec/commands/open_spec.rb
@@ -33,6 +33,19 @@ describe "bundle open" do
     expect(out).to match(/could not find gem 'missing'/i)
   end
 
+  it "does not blow up if the gem to open does not have a Gemfile" do
+    git = build_git "foo"
+    ref = git.ref_for("master", 11)
+
+    install_gemfile <<-G
+      source "file://#{gem_repo1}"
+      gem 'foo', :git => "#{lib_path("foo-1.0")}"
+    G
+
+    bundle "open foo", :env => {"EDITOR" => "echo editor", "VISUAL" => "", "BUNDLER_EDITOR" => ""}
+    expect(out).to match("editor #{default_bundle_path.join("bundler/gems/foo-1.0-#{ref}")}")
+  end
+
   it "suggests alternatives for similar-sounding gems" do
     bundle "open Rails", :env => {"EDITOR" => "echo editor", "VISUAL" => "", "BUNDLER_EDITOR" => ""}
     expect(out).to match(/did you mean rails\?/i)


### PR DESCRIPTION
This PR fixes a "Could not locate Gemfile" error which occurs when `bundle open <gemname>` is run with a repository that does not contain a Gemfile (see #2678 for an example).
