### PR TITLE
Put Process.waitpid in the same loop

### DIFF
--- a/lib/bundler/parallel_workers/unix_worker.rb
+++ b/lib/bundler/parallel_workers/unix_worker.rb
@@ -83,8 +83,6 @@ module Bundler
           worker.io_r.close
           worker.io_w.close
           Process.kill :INT, worker.pid
-        end
-        @workers.each do |worker|
           Process.waitpid worker.pid
         end
       end


### PR DESCRIPTION
I think there is no need for another loop here.
Process.waitpid can safely be put after Process.kill.
