### PR TITLE
Hightlight "installing" logs

### DIFF
--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -109,7 +109,11 @@ module Bundler
       debug_message        = nil
       Bundler.rubygems.with_build_args [settings] do
         install_message, post_install_message, debug_message = spec.source.install(spec)
-        Bundler.ui.info install_message
+        if install_message.include? 'Installing'
+          Bundler.ui.confirm install_message
+        else
+          Bundler.ui.info install_message
+        end
         Bundler.ui.debug debug_message if debug_message
         Bundler.ui.debug "#{worker}:  #{spec.name} (#{spec.version}) from #{spec.loaded_from}"
       end


### PR DESCRIPTION
Highlight logs like this if gems are newly being installed.
![image](https://f.cloud.github.com/assets/18807/1582228/298eff04-51ea-11e3-8815-f8c9e7a34e79.png)

I know calling private method must be avoided but I have no idea how to detect each gem is already installed or not.
Do you have any ideas? :octocat: 
