### PR TITLE
URLs in friendly exceptions

### DIFF
--- a/lib/bundler/friendly_errors.rb
+++ b/lib/bundler/friendly_errors.rb
@@ -22,7 +22,7 @@ module Bundler
     Bundler.ui.warn <<-WARN, :wrap => true
       You must recompile Ruby with OpenSSL support or change the sources in your \
       Gemfile from 'https' to 'http'. Instructions for compiling with OpenSSL \
-      using RVM are available at rvm.io/packages/openssl.
+      using RVM are available at http://rvm.io/packages/openssl.
     WARN
     Bundler.ui.trace e
     exit 1


### PR DESCRIPTION
URLS were unclickable URLs in a terminal
