### PR TITLE
Ensure that Git revision-parsing doesn't result in errors in repos with no commits

### DIFF
--- a/lib/bundler/rubygems_ext.rb
+++ b/lib/bundler/rubygems_ext.rb
@@ -99,8 +99,7 @@ module Gem
     # TODO: Do not rely on /dev/null.
     # see https://github.com/bundler/bundler/blob/98f79a1d/lib/bundler/source/git/git_proxy.rb#L97-101
     def null_command(command)
-      out = Bundler::SharedHelpers.dev_null_available? ? `#{command} 2>/dev/null` : ''
-      out.empty? ? `#{command}` : out
+      `#{command} 2>#{Bundler::NULL}`.tap {|out| return `#{command}` if out.empty? }
     end
 
   end

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -29,10 +29,6 @@ module Bundler
       Pathname.new("#{default_gemfile}.lock")
     end
 
-    def dev_null_available?
-      !Bundler::WINDOWS && File.exist?("/dev/null")
-    end
-
     def in_bundle?
       find_gemfile
     end

--- a/lib/bundler/source/git/git_proxy.rb
+++ b/lib/bundler/source/git/git_proxy.rb
@@ -100,8 +100,7 @@ module Bundler
         # If it doesn't, everything will work fine, but the user
         # will get the $stderr messages as well.
         def git_null(command)
-          command += " 2>/dev/null" if SharedHelpers.dev_null_available?
-          git(command, false)
+          git("#{command} 2>#{Bundler::NULL}", false)
         end
 
         def git(command, check_errors=true)


### PR DESCRIPTION
Fix for https://github.com/bundler/bundler/issues/2637. It turns out that this can occur not just with `bundle outdated`, but also `bundle show` with a new repo, which is what I used for the new spec example.

Sorry about the diff cruft in spec/commands/show_spec.rb - it's mostly indentation changes from arranging the spec into high-level contexts; the new example/context is in https://github.com/tdumitrescu/bundler/commit/738e42c87594eb67c0b25586348a99b51fd31c86

I followed the code in `GitProxy` in redirecting to `/dev/null` rather than using open3, because "open3 is not cross platform until Ruby 1.9.3". This won't hide legit Git errors (like git not being installed...) because the new code in `#null_command` will rerun the command without redirection if it doesn't produce anything on `$stdout`.

How does this approach look?
