### PR TITLE
read the ruby version from a .ruby-version file

### DIFF
--- a/lib/bundler/ruby_dsl.rb
+++ b/lib/bundler/ruby_dsl.rb
@@ -7,5 +7,9 @@ module Bundler
       raise GemfileError, "ruby_version must match the :engine_version for MRI" if options[:engine] == "ruby" && options[:engine_version] && ruby_version != options[:engine_version]
       @ruby_version = RubyVersion.new(ruby_version, options[:patchlevel], options[:engine], options[:engine_version])
     end
+
+    def enforce_ruby_version_file!
+      @ruby_version = RubyVersion.from_string(File.read('./.ruby_version'))
+    end
   end
 end

--- a/lib/bundler/ruby_version.rb
+++ b/lib/bundler/ruby_version.rb
@@ -23,6 +23,11 @@ module Bundler
       @patchlevel     = patchlevel
     end
 
+    def self.from_string(ruby_version)
+      version, patchlevel = ruby_version.split('-p')
+      new(version, patchlevel, nil, nil)
+    end
+
     def to_s
       output = "ruby #{version}"
       output << "p#{patchlevel}" if patchlevel


### PR DESCRIPTION
It would be nice to track and enforce the ruby version from a single source - is this an idea people would be interested in?

Note the attached code is just an explanation of the idea, meant more as a point for discussion rather than something I'd actually recommend using. If the idea gets the go ahead, I can rewrite it adding error handling, documentation, tests, etc.
