### PR TITLE
Show something better than "Bundle::GemfileNotFound" when bundle is run in the wrong directory.

### DIFF
--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -13,7 +13,7 @@ module Bundler
     end
 
     def []=(key, value)
-      local_config_file || raise(GemfileNotFound)
+      local_config_file or raise GemfileNotFound, "Could not locate Gemfile"
       set_key(key, value, @local_config, local_config_file)
     end
 

--- a/spec/bundler/settings_spec.rb
+++ b/spec/bundler/settings_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+require 'bundler/settings'
+
+describe Bundler::Settings do
+
+  describe "#set_local" do
+    context "when the local config file is not found" do
+      it "raises a GemfileNotFound error with explanation" do
+        expect{ subject.set_local("foo", "bar") }.
+          to raise_error(Bundler::GemfileNotFound, "Could not locate Gemfile")
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Currently, users who just run 'bundle' in the wrong directory will just see "Bundle::GemfileNotFound" instead of a friendly error.  This pull request fixes that by adding a message to the GemfileNotFound exception raised from Bundler::Settings.  It also adds a spec for Bundler::Settings that tests that the exception with the message is raised.
