### PR TITLE
When making new gem, use the --global option so we are not affected by local git configuration settings

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -763,8 +763,8 @@ module Bundler
       constant_name = name.split('_').map{|p| p[0..0].upcase + p[1..-1] }.join
       constant_name = constant_name.split('-').map{|q| q[0..0].upcase + q[1..-1] }.join('::') if constant_name =~ /-/
       constant_array = constant_name.split('::')
-      git_user_name = `git config user.name`.chomp
-      git_user_email = `git config user.email`.chomp
+      git_user_name = `git config --global user.name`.chomp
+      git_user_email = `git config --global user.email`.chomp
       opts = {
         :name            => name,
         :namespaced_path => namespaced_path,


### PR DESCRIPTION
Hello.  When I was making my previous pull request (#2752) I noticed that some of the specs in spec/commands/newgem_spec.rb were failing.  Here is the output I got when I just ran that spec file:

https://gist.github.com/DavidEGrayson/7863232

The theme of these four failures is that they were expecting the newly generated gem to have email and name data in it based on the current state of the global git configuration, but that was not happening because there was a local git configuration of user.name and user.email inside the git repository I was using to develop bundler, (a clone of your repository from github).  Commands like `git config user.name` first check the local configuration before looking at the global configuration.

I didn't change the specs, but I guessed that you didn't want the local git configuration to have an effect on new gems being generated, so I added the --global option in two places in Bundler::CLI.

By making that change, I was able to get all the newgem_spec.rb specs to pass.

Aside:  The specs don't explicitly say what the Bundler code should do in case a local git configuration is present.  It would be nice if the specs were expanded to cover that case.  Another thing that worries me about the specs is that there is no provision to call "git config --global --unset user.email" in an after hook for users that don't want to have a global user.email set, but somehow this didn't actually seem to be a problem on my system.
