### PR TITLE
Improve child dependency conflict message

### DIFF
--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -444,7 +444,7 @@ module Bundler
       # A requirement that is required by itself is actually in the Gemfile, and does
       # not "depend on" itself
       if requirement.required_by.first && requirement.required_by.first.name != requirement.name
-        print_dependency_tree(m, required_by)
+        dependency_tree(m, required_by)
         m << "#{clean_req(requirement)}\n"
       else
         m << "    #{clean_req(requirement)}\n"
@@ -452,7 +452,7 @@ module Bundler
       m << "\n"
     end
 
-    def print_dependency_tree(m, requirements)
+    def dependency_tree(m, requirements)
       reqs = requirements
       reqs.each_with_index do |i, j|
         m << ("  " * j)


### PR DESCRIPTION
Hey folks,

This pull request fixes the issue #1128, I originally wrote it with my resolver pull request but now I found out it doesn't depend on any of that code at all.

``` ruby
source 'https://rubygems.org'

gem 'aruba', '0.3.6'
gem 'rspec-mocks', '2.6.0.rc2'
```

now properly gives,

```
Bundler could not find compatible versions for gem "rspec-mocks":
  In Gemfile:
aruba (= 0.3.6) ruby depends on
  rspec (>= 2.5.0) ruby depends on
    rspec-mocks (~> 2.5.0) ruby

    rspec-mocks (2.6.0.rc2)
```
