### PR TITLE
[wip] fix build for the following exception:

### DIFF
--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -170,7 +170,7 @@ module Bundler
       @security_policies ||= begin
         require 'rubygems/security'
         Gem::Security::Policies
-      rescue LoadError
+      rescue LoadError, NameError
         {}
       end
     end


### PR DESCRIPTION
lib/bundler/rubygems_integration.rb:172:in `security_policies':
uninitialized constant Gem::Security::Policies (NameError)

from spec: spec/install/gems/dependency_api_spec.rb:479

/cc @hone @indirect
