### PR TITLE
Make bundler display post_install_message's for gems installed via :git or :path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Features:
   - add support for IRB alternatives such as Pry and Ripl (@joallard, @postmodern)
   - highlight installing logs (#2722, @yaotti)
   - highlight updating logs (#2741, @simi)
-  - display post_install_message's for gems installed via :git and :path (@phallstrom)
+  - display post_install_message's for gems installed via :git (@phallstrom)
 
 ## 1.5.0.rc.1 (2013-11-09)
 

--- a/lib/bundler/source/path.rb
+++ b/lib/bundler/source/path.rb
@@ -71,9 +71,6 @@ module Bundler
 
       def install(spec)
         generate_bin(spec, :disable_extensions)
-        if spec.post_install_message
-          Bundler::Installer.post_install_messages[spec.name] = spec.post_install_message
-        end
         ["Using #{version_message(spec)} from #{to_s}", nil]
       end
 

--- a/spec/install/gems/post_install_spec.rb
+++ b/spec/install/gems/post_install_spec.rb
@@ -46,39 +46,6 @@ describe "bundle install with gem sources" do
   end
 end
 
-describe "bundle install with path sources" do
-  describe "when gems include post install messages" do
-    it "should display the post-install messages after installing" do
-      build_lib "foo", :path => lib_path('foo') do |s|
-        s.post_install_message = "Foo's post install message"
-      end
-      gemfile <<-G
-        source "file://#{gem_repo1}"
-        gem 'foo', :path => '#{lib_path("foo")}'
-      G
-
-      bundle :install
-      expect(out).to include("Post-install message from foo:")
-      expect(out).to include("Foo's post install message")
-    end
-  end
-
-  describe "when gems do not include post install messages" do
-    it "should not display any post-install messages" do
-      build_lib "foo", :path => lib_path('foo') do |s|
-        s.post_install_message = nil
-      end
-      gemfile <<-G
-        source "file://#{gem_repo1}"
-        gem 'foo', :path => '#{lib_path("foo")}'
-      G
-
-      bundle :install
-      expect(out).not_to include("Post-install message")
-    end
-  end
-end
-
 describe "bundle install with git sources" do
   describe "when gems include post install messages" do
     it "should display the post-install messages after installing" do


### PR DESCRIPTION
This patch makes bundler display post install messages for gems installed via :git or :path.  

Awhile back I forked a gem and added some functionality.  A number of people starting using my :git repo.  My changes are now in the main gem and I'd like people to stop using my repo.  I'd like to notify them about it without affecting the code.  I could update the README, but that assumes they'd go to github and read it.

This change would allow me to add a post_install_message to my version of the gemspec and the next time they update, they'd get notified.

For :git, it will only display if the repo is updated.  For :path it will always show.  I didn't see an obvious way of indicating that :path gems haven't changed.  But I imagine that's a small edge case.
