### PR TITLE
Test against ruby 2.1.0-rc1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ notifications:
     rooms:
       secure: MNTSGIySYwHia5gIgRiZxXtPMPDIP9KmzQk7Kq2ZoVvP3mIk8W1TMkvcyFkEf6uCasyVZZixzUBfY+E0BlHAz1ycQpTh1jvSpuIpEVYW48ShJldJ+8W8xfzafyOHii3z7VrDaomEffmMDdmHRsbQAfekMjdR4bTpXtT9V+wOXlg=
 rvm:
+  - 2.1.0-rc1
   - 2.0.0
   - 1.9.3
 # Rubygems versions MUST be available as rake tasks


### PR DESCRIPTION
This is workaround,
travis-ci rolls out 2.1.0 in the next couple of days
https://github.com/travis-ci/travis-rubies/commit/e8887817f323252548d5890734947a59bc827d47
