### PR TITLE
Gracefully shutdown workers/threads in case of SIGINT

### DIFF
--- a/lib/bundler/parallel_workers/worker.rb
+++ b/lib/bundler/parallel_workers/worker.rb
@@ -19,6 +19,7 @@ module Bundler
         @response_queue = Queue.new
         prepare_workers size, func
         prepare_threads size
+        trap("INT") { @threads.each {|i| i.exit }; stop_workers; exit 1 }
       end
 
       # Enque a request to be executed in the worker pool


### PR DESCRIPTION
I am sending this PR to fix the #2786 issue. I didn't make use stop threads method because Ruby 2.0+ doesn't allow mutex to be used inside signal handlers. So my best bet was to Thread::Exit to make safely exit the thread.

Also, I have added few rescues and conditions to ensure workers are gracefully stopped without any errors. 

Finally now it gives this output if a particular worker was building a native extension

```
SystemExit: exit

Gem::Installer::ExtensionBuildError: ERROR: Failed to build gem native extension.

    /Users/Who/.rbenv/versions/2.0.0-p0/bin/ruby extconf.rb --with-xml2-include=/opt/local/include/libxml2 --with-xml2-lib=/opt/local/lib

Gem files will remain installed in /Users/Who/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/nokogiri-1.5.11 for inspection.
Results logged to /Users/Who/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/nokogiri-1.5.11/ext/nokogiri/gem_make.out
```
