### PR TITLE
Set binstubs permissions using umask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Bugfixes:
 
   - set --no-cache when bundle install --local is called (@TimMoore)
   - make gemspec path option preserve relative paths in lock file (@bwillis)
+  - use umask when creating binstubs (#1618, @v-yarotsky)
 
 ## 1.3.5 (3 April 2013)
 

--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -163,7 +163,7 @@ module Bundler
           next
         end
 
-        File.open(binstub_path, 'w', 0755) do |f|
+        File.open(binstub_path, 'w', 0777 & ~File.umask) do |f|
           f.puts ERB.new(template, nil, '-').result(binding)
         end
       end

--- a/spec/other/binstubs_spec.rb
+++ b/spec/other/binstubs_spec.rb
@@ -66,6 +66,19 @@ describe "bundle binstubs <gem>" do
 
       expect(bundled_app("bin/foo")).to exist
     end
+
+    it "sets correct permissions for binstubs" do
+      with_umask(0002) do
+        install_gemfile <<-G
+          source "file://#{gem_repo1}"
+          gem "rack"
+        G
+
+        bundle "binstubs rack"
+        binary = bundled_app("bin/rackup")
+        expect(File.stat(binary).mode.to_s(8)).to eq("100775")
+      end
+    end
   end
 
   context "--path" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,6 +43,7 @@ RSpec.configure do |config|
   config.include Spec::Rubygems
   config.include Spec::Platforms
   config.include Spec::Sudo
+  config.include Spec::Permissions
 
   if Spec::Sudo.test_sudo?
     config.filter_run :sudo => true

--- a/spec/support/permissions.rb
+++ b/spec/support/permissions.rb
@@ -1,0 +1,11 @@
+module Spec
+  module Permissions
+    def with_umask(new_umask)
+      old_umask = File.umask(new_umask)
+      yield if block_given?
+    ensure
+      File.umask(old_umask)
+    end
+  end
+end
+


### PR DESCRIPTION
As discussed in #1618, currently bundler sets 0755 permissions on binstubs, disregarding umask. It can cause issues, for example, in multi-user environments, when group-write permissions may be necessary.
