### PR TITLE
[close #2813] Fix circular parallel gem resolution

### DIFF
--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -285,8 +285,8 @@ module Bundler
         { :name => spec.name, :post_install => message }
       }
       specs.each do |spec|
-        deps = spec.dependencies.select { |dep| dep.type != :development }
-        if deps.empty?
+        deps = spec.dependencies.select { |dep| dep.type != :development && dep.name != spec.name }
+        if deps.empty? || deps.all? {|dep| remains[dep.name] }
           worker_pool.enq spec.name
           enqueued[spec.name] = true
         end

--- a/spec/realworld/parallel_install_spec.rb
+++ b/spec/realworld/parallel_install_spec.rb
@@ -20,4 +20,17 @@ describe "installing dependencies parallely", :realworld => true do
     bundle "config jobs"
     expect(out).to match(/: "2"/)
   end
+
+  it 'installs even with circular dependency' do
+    gemfile <<-G
+      source 'https://rubygems.org'
+      gem 'mongoid_auto_increment', "0.1.1"
+    G
+
+    bundle :install, :jobs => 2, :env => {"DEBUG" => "1"}
+    (0..1).each {|i| expect(out).to include("#{i}: ") }
+
+    bundle "show mongoid_auto_increment"
+    expect(out).to match(/mongoid_auto_increment/)
+  end
 end


### PR DESCRIPTION
Right now if you install via parallel a gem that has a circular dependency it will know that it needs to be installed based on the `remains` hash, but does not actually enqueue the circular dependency to be installed. This commit fixes that by checking for duplicate name as well as whether or not dependencies have been previously enqueued.
