### PR TITLE
Ensure #dump doesn't add a new line in config

### DIFF
--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -137,7 +137,7 @@ module Bundler
         hash.delete(key) if value.nil?
         FileUtils.mkdir_p(file.dirname)
         require 'bundler/psyched_yaml'
-        File.open(file, "w") { |f| f.puts YAML.dump(hash, :line_width => -1) }
+        File.open(file, "w") { |f| f.puts YAML.dump(hash) }
       end
       value
     end
@@ -154,8 +154,8 @@ module Bundler
     def load_config(config_file)
       valid_file = config_file && config_file.exist? && !config_file.size.zero?
       if !ignore_config? && valid_file
-        config_regex = /^(BUNDLE_.+): (?:['"](.*)['"]|(.+))$/
-        config_pairs = config_file.read.scan(config_regex).map{|m| m.compact }
+        config_regex =/^(BUNDLE_.+): (?:['"](.*)['"]|(.+(?:\n(?!BUNDLE).+))|(.+))$/
+        config_pairs = config_file.read.scan(config_regex).map{|m| m.compact.map { |n| n.gsub(/\n\s?/, "") } }
         Hash[config_pairs]
       else
         {}

--- a/spec/commands/config_spec.rb
+++ b/spec/commands/config_spec.rb
@@ -214,13 +214,13 @@ E
   describe "very long lines" do
     before(:each) { bundle :install }
     let(:long_string) do
-      '--with-xml2-include=/usr/pkg/include/libxm l2 --with-xml2-lib=/usr/pkg/lib --with-xslt-dir=/usr/pkg'
+      "--with-xml2-include=/usr/pkg/include/libxml2 --with-xml2-lib=/usr/pkg/lib --with-xslt-dir=/usr/pkg"
     end
 
     it "doesn't wrap values" do
-      bundle "config foo.name '#{long_string}'"
-      run "puts Bundler.settings['foo.name']"
-      expect(out).to eq(long_string)
+      bundle "config foo #{long_string}"
+      run "puts Bundler.settings[:foo]"
+      expect(out).to match(long_string)
     end
   end
 


### PR DESCRIPTION
Fixes #2821
- YAML#dump without any option parameters hard-wraps a string at 80
  characters and this causes errors while reading the config file
  and parsing it.
- There is another way to fix this: Modify the Regex that is used for
  parsing the config file. The current regex supports only a single line
  of "key: value" type statements. Presumably, YAML#load is not used for
  security reasons and so, this is the only other option.
  
    modified:   lib/bundler/settings.rb
    modified:   spec/commands/config_spec.rb
