### PR TITLE
support escaped characters in user and pass in url

### DIFF
--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -260,8 +260,8 @@ module Bundler
       Bundler.ui.debug "Fetching from: #{uri}"
       req = Net::HTTP::Get.new uri.request_uri
       if uri.user
-        user = CGI::unescape(uri.user)
-        password = uri.password ? CGI::unescape(uri.password) : nil
+        user = CGI.unescape(uri.user)
+        password = uri.password ? CGI.unescape(uri.password) : nil
         req.basic_auth(user, password)
       end
       response = connection.request(uri, req)


### PR DESCRIPTION
A recent release of artifactory (an artefact repository) has added support for hosting ruby gems. http://www.jfrog.com/confluence/display/RTF/Artifactory+3.0.3

Artifactory provides basic authentication for it's rubygem repositories. As a way to mitigate the risks of users providing plain text passwords artifactory encrypts the passwords on the server and prepends the password with the String {DESede}. This password can then be used in basic auth.

As the password contains the brace characters it should to be encoded in the url. However, this becomes an issue as the password is not being unescaped (or username for that matter) before the setting up the basic auth when connecting to the gem servers.

This patch fixes this issue.

Please let me know if you have any questions.
