### PR TITLE
Fixes 'membor' typo in conduct.html.

### DIFF
--- a/conduct.html
+++ b/conduct.html
@@ -32,7 +32,7 @@
             If anyone engages in harassing behavior, including maintainers, we may take appropriate action, up to and including warning the offender, deletion of comments, removal from the project’s codebase and communication systems, and escalation to Github support.
             <br>
             <br>
-            If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a membor of the core team immediately. The core team is listed on the Bundler website contributors page.
+            If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of the core team immediately. The core team is listed on the Bundler website contributors page.
             <br>
             <br>
             We expect everyone to follow these rules anywhere in the Bundler project’s codebases, issue trackers, IRC channel, Campfire, and mailing lists.


### PR DESCRIPTION
Changes `membor of the core team` to `member of the core team`.
