### PR TITLE
Don't blow on bundle update gem when lock is not present.

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -67,6 +67,7 @@ module Bundler
   class SecurityError         < BundlerError; status_code(19) ; end
   class LockfileError         < BundlerError; status_code(20) ; end
   class CyclicDependencyError < BundlerError; status_code(21) ; end
+  class GemfileLockNotFound   < BundlerError; status_code(22) ; end
 
   # Internal errors, should be rescued
   class VersionConflict  < BundlerError

--- a/spec/update/gems_spec.rb
+++ b/spec/update/gems_spec.rb
@@ -187,4 +187,15 @@ describe "bundle update" do
     bundle "update"
     expect(out).to include("Installing activesupport 3.0 (was 2.3.5)")
   end
+
+  it "shows error message when Gemfile.lock is not preset and gem is specified" do
+    install_gemfile <<-G
+      source "file://#{gem_repo2}"
+      gem "activesupport"
+    G
+
+    bundle "update nonexisting", :exitstatus => true
+    expect(out).to include("This Bundle hasn't been installed yet. Run `bundle install` to update and install the bundled gems.")
+    expect(@exitstatus).to eq(22)
+  end
 end


### PR DESCRIPTION
- rename `not_found_message` to `gem_not_found_message`
- add `lock_not_found_message`
- add `GemfileLockNotFound` error with 22 status code
# Before

```
[retro@localhost  testgem (master #)]❤ bundle update ryba
Unfortunately, a fatal error has occurred. Please see the Bundler troubleshooting documentation at http://bit.ly/bundler-issues. Thanks!
/home/retro/.rvm/gems/ruby-2.0.0-p353/gems/bundler-1.6.0.pre.1/lib/bundler/cli.rb:316:in `update': undefined method `specs' for nil:NilClass (NoMethodError)
        from /home/retro/.rvm/gems/ruby-2.0.0-p353/gems/bundler-1.6.0.pre.1/lib/bundler/vendor/thor/command.rb:27:in `run'
        from /home/retro/.rvm/gems/ruby-2.0.0-p353/gems/bundler-1.6.0.pre.1/lib/bundler/vendor/thor/invocation.rb:121:in `invoke_command'
        from /home/retro/.rvm/gems/ruby-2.0.0-p353/gems/bundler-1.6.0.pre.1/lib/bundler/vendor/thor.rb:363:in `dispatch'
        from /home/retro/.rvm/gems/ruby-2.0.0-p353/gems/bundler-1.6.0.pre.1/lib/bundler/vendor/thor/base.rb:440:in `start'
        from /home/retro/.rvm/gems/ruby-2.0.0-p353/gems/bundler-1.6.0.pre.1/lib/bundler/cli.rb:9:in `start'
        from /home/retro/.rvm/gems/ruby-2.0.0-p353/gems/bundler-1.6.0.pre.1/bin/bundle:20:in `block in <top (required)>'
        from /home/retro/.rvm/gems/ruby-2.0.0-p353/gems/bundler-1.6.0.pre.1/lib/bundler/friendly_errors.rb:5:in `with_friendly_errors'
        from /home/retro/.rvm/gems/ruby-2.0.0-p353/gems/bundler-1.6.0.pre.1/bin/bundle:20:in `<top (required)>'
        from /home/retro/bin/bundle:23:in `load'
        from /home/retro/bin/bundle:23:in `<main>'
[retro@localhost  testgem (master #)]❤ echo $?
1
```
# After

```
[retro@localhost  testgem (master #)]❤ dbundle update ryba
This Bundle hasn't been installed yet. Run `bundle install` to update and install the bundled gems.
[retro@localhost  testgem (master #)]❤ echo $?
22
```
