### PR TITLE
Better outdated --strict.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Features:
   - add support for IRB alternatives such as Pry and Ripl (@joallard, @postmodern)
   - highlight installed or updated gems (#2722, #2741, @yaotti, @simi)
   - display post_install_message's for gems installed via :git (@phallstrom)
+  - `bundle outdated --strict` only reports dependencies that can be updated (@davidblondeau)
 
 ## 1.5.2 (2014-01-10)
 
@@ -56,7 +57,7 @@ Features:
 
   - bundle update also accepts --jobs (#2692, @mrkn)
   - add fork URL to README for new `bundle gem` (#2665, @zzak)
-  - add `bundle outdated --strict` (#2685, @rhysd)
+  - add `bundle outdated --strict` (#2685, @davidblondeau)
   - warn if same gem/version is added twice (#2679, @jendiamond)
   - don't redownload installed specs for `bundle install` (#2680, @cainlevy)
   - override gem sources with mirrors (#2650, @danielsdeleo, @mkristian)

--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -38,15 +38,13 @@ module Bundler
 
         dependency = current_dependencies[current_spec.name]
 
-        active_spec = definition.index[current_spec.name].sort_by { |b| b.version }
-        if !current_spec.version.prerelease? && !options[:pre] && active_spec.size > 1
-          active_spec = active_spec.delete_if { |b| b.respond_to?(:version) && b.version.prerelease? }
-        end
         if options["strict"]
-          active_spec =  active_spec.reverse.detect do |b|
-            dependency && b.respond_to?(:version) && dependency.requirement.satisfied_by?(b.version)
-          end || active_spec.last
+          active_spec =  definition.specs.detect { |spec| spec.name == current_spec.name }
         else
+          active_spec = definition.index[current_spec.name].sort_by { |b| b.version }
+          if !current_spec.version.prerelease? && !options[:pre] && active_spec.size > 1
+            active_spec = active_spec.delete_if { |b| b.respond_to?(:version) && b.version.prerelease? }
+          end
           active_spec = active_spec.last
         end
         next if active_spec.nil?

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -129,6 +129,17 @@ describe "bundle outdated" do
       expect(out).to_not include("activesupport (3.0 > 2.3.5) Gemfile specifies \"= 2.3.5\"")
       expect(out).to include("weakling (0.0.5 > 0.0.3) Gemfile specifies \"~> 0.0.1\"")
     end
+
+    it "only reports gem dependencies when they can actually be updated" do
+      install_gemfile <<-G
+        source "file://#{gem_repo2}"
+        gem "rack_middleware", "1.0"
+      G
+
+      bundle "outdated --strict"
+
+      expect(out).to_not include("rack (1.2 > 0.9.1)")
+    end
   end
 
   describe "with invalid gem name" do


### PR DESCRIPTION
`bundle outdated --strict` now behaves like if performing a dry run of `bundle update` as discussed in #2685 with @indirect
