### PR TITLE
Custom git sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+Features:
+
+  - add ability to define custom git source to use as an option like :github, :gist by using `git_source` (@strzalek)
+
 ## 1.6.0
 
 Bugfixes:

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -5,29 +5,48 @@ describe Bundler::Dsl do
     Bundler::Source::Rubygems.stub(:new){ double("rubygems") }
   end
 
-  describe "#_normalize_options" do
-    it "converts :github to :git" do
-      subject.gem("sparks", :github => "indirect/sparks")
-      github_uri = "git://github.com/indirect/sparks.git"
-      expect(subject.dependencies.first.source.uri).to eq(github_uri)
+  describe "#register_host" do
+    it "registers custom hosts" do
+      subject.git_source(:example){ |repo_name| "git@git.example.com:#{repo_name}.git" }
+      subject.git_source(:foobar){ |repo_name| "git@foobar.com:#{repo_name}.git" }
+      subject.gem("dobry-pies", :example => "strzalek/dobry-pies")
+      example_uri = "git@git.example.com:strzalek/dobry-pies.git"
+      expect(subject.dependencies.first.source.uri).to eq(example_uri)
     end
 
-    it "converts numeric :gist to :git" do
-      subject.gem("not-really-a-gem", :gist => 2859988)
-      github_uri = "https://gist.github.com/2859988.git"
-      expect(subject.dependencies.first.source.uri).to eq(github_uri)
+    it "raises expection on invalid hostname" do
+      subject.git_source(:group){ |repo_name| "git@git.example.com:#{repo_name}.git" }
+      expect{ subject.gem("dobry-pies", :group => "strzalek/dobry-pies") }.to raise_error(Bundler::InvalidOption)
     end
 
-    it "converts :gist to :git" do
-      subject.gem("not-really-a-gem", :gist => "2859988")
-      github_uri = "https://gist.github.com/2859988.git"
-      expect(subject.dependencies.first.source.uri).to eq(github_uri)
+    it "expects block passed" do
+      expect{ subject.git_source(:example) }.to raise_error(Bundler::InvalidOption)
     end
 
-    it "converts 'rails' to 'rails/rails'" do
-      subject.gem("rails", :github => "rails")
-      github_uri = "git://github.com/rails/rails.git"
-      expect(subject.dependencies.first.source.uri).to eq(github_uri)
+    context "default hosts (git, gist)" do
+      it "converts :github to :git" do
+        subject.gem("sparks", :github => "indirect/sparks")
+        github_uri = "git://github.com/indirect/sparks.git"
+        expect(subject.dependencies.first.source.uri).to eq(github_uri)
+      end
+
+      it "converts numeric :gist to :git" do
+        subject.gem("not-really-a-gem", :gist => 2859988)
+        github_uri = "https://gist.github.com/2859988.git"
+        expect(subject.dependencies.first.source.uri).to eq(github_uri)
+      end
+
+      it "converts :gist to :git" do
+        subject.gem("not-really-a-gem", :gist => "2859988")
+        github_uri = "https://gist.github.com/2859988.git"
+        expect(subject.dependencies.first.source.uri).to eq(github_uri)
+      end
+
+      it "converts 'rails' to 'rails/rails'" do
+        subject.gem("rails", :github => "rails")
+        github_uri = "git://github.com/rails/rails.git"
+        expect(subject.dependencies.first.source.uri).to eq(github_uri)
+      end
     end
   end
 


### PR DESCRIPTION
Adds ability to register custom git sources like :github and :gist.

Example:

``` ruby
git_source(:acme){ |repo_name| "git@git.acme.org:#{repo_name}.git" }

gem "secret", :acme => "strzalek/secret"
```

I work at the moment on the project in which we have custom wrapper methods around `gem` method. One sets ssh urls to github projects becouse `:github` option defined by bundler uses `git://` protocol and the port it uses is blocked on production, another one, which is very similar to github, just sets url for our github enterprise instance through ssh.

It makes our gemfile ugly.

This PR introduces nice solution to this problem. It adds ability to register custom sources as well as overwrite `:github` and `:gist` if you need to. What do you think?

On tech side - I'm not sure if `Dsl`'s `initializer` is a good place to set `:github` and `:gists` defaults. Is there be a better one? Also maybe just `git_source`, without `register_` prefix would be a better name?
