### PR TITLE
Don't change local behavior with app cache

### DIFF
--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -136,10 +136,6 @@ module Bundler
 
       # TODO: actually cache git specs
       def specs(*)
-        if has_app_cache? && !local?
-          set_local!(app_cache_path)
-        end
-
         if requires_checkout? && !@copied
           git_proxy.checkout
           git_proxy.copy_to(install_path, submodules)


### PR DESCRIPTION
If you cache git remotes (`bundle package --all`), and then change the version you are locked to, bundler will do a fresh checkout of the repo into the `app_cache_path` instead of using the one that is already in the global `cache_path` (because `set_local!` overrides `cache_path`).

I can't figure out what the reason is for calling `set_local!` if it is cached.
