### PR TITLE
Display gem summary when verbose is passed into show command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Features:
   - highlight installed or updated gems (#2722, #2741, @yaotti, @simi)
   - display the `post_install_message` for gems installed via :git (@phallstrom)
   - `bundle outdated --strict` now only reports allowed updates (@davidblondeau)
+  - `bundle show --verbose` Add gem ummary to the output (@lardcanoe)
 
 ## 1.5.3 (2014-02-06)
 

--- a/lib/bundler/cli/show.rb
+++ b/lib/bundler/cli/show.rb
@@ -35,10 +35,14 @@ module Bundler
       else
         Bundler.ui.info "Gems included by the bundle:"
         Bundler.load.specs.sort_by { |s| s.name }.each do |s|
-          Bundler.ui.info "  * #{s.name} (#{s.version}#{s.git_version})"
+          desc = "  * #{s.name} (#{s.version}#{s.git_version})"
+          if @options[:verbose]
+            Bundler.ui.info "#{desc} - #{s.summary || 'No description available.'}"
+          else
+            Bundler.ui.info desc
+          end
         end
       end
     end
-
   end
 end

--- a/spec/commands/show_spec.rb
+++ b/spec/commands/show_spec.rb
@@ -59,6 +59,13 @@ describe "bundle show" do
       gem_list = out.split.map { |p| p.split('/').last }
       expect(gem_list).to eq(gem_list.sort)
     end
+
+    it "prints summary of gems" do
+      bundle "show --verbose"
+
+      expect(out).to include(' - This is just a fake gem for testing')
+      expect(out).to include(' - Ruby based make-like utility.')
+    end
   end
 
   context "with a git repo in the Gemfile" do


### PR DESCRIPTION
Add summary option to 'show' cli command. Displays the gem's summary if present, or reverts to description.

`bundle show --summary`

```
Gems included by the bundle:
  * actionmailer (2.3.2) - This is just a fake gem for testing
  * actionpack (2.3.2) - This is just a fake gem for testing
  * activerecord (2.3.2) - This is just a fake gem for testing
  * activeresource (2.3.2) - This is just a fake gem for testing
  * activesupport (2.3.2) - This is just a fake gem for testing
  * bundler (1.6.0.pre.2)
  * rails (2.3.2) - This is just a fake gem for testing
  * rake (10.0.2) - Ruby based make-like utility.
```
