### PR TITLE
Using https instead of http

### DIFF
--- a/lib/bundler/templates/newgem/README.md.tt
+++ b/lib/bundler/templates/newgem/README.md.tt
@@ -22,7 +22,7 @@ TODO: Write usage instructions here
 
 ## Contributing
 
-1. Fork it ( http://github.com/[my-github-username]/<%=config[:name]%>/fork )
+1. Fork it ( https://github.com/[my-github-username]/<%=config[:name]%>/fork )
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)


### PR DESCRIPTION
Use https://github.com instead of http://github.com inside the README.md template.
