### PR TITLE
Pass nil to net_http as proxy parameter not to use environment variables

### DIFF
--- a/lib/bundler/vendor/net/http/persistent.rb
+++ b/lib/bundler/vendor/net/http/persistent.rb
@@ -616,7 +616,7 @@ class Net::HTTP::Persistent
     if @proxy_uri and not proxy_bypass? uri.host, uri.port then
       connection_id << @proxy_connection_id
       net_http_args.concat @proxy_args
-    else
+    elsif proxy_bypass? uri.host, uri.port then
       net_http_args.concat [nil, nil]
     end
 


### PR DESCRIPTION
ENV['http_proxy'] is used even if ENV['no_proxy'] is set because Net/HTTP uses environment variables if arguments of proxy is not passed.
