### PR TITLE
Don't raise a warning when git cat-file fails, it's expected to.

### DIFF
--- a/lib/bundler/source/git/git_proxy.rb
+++ b/lib/bundler/source/git/git_proxy.rb
@@ -114,7 +114,8 @@ module Bundler
 
         def has_revision_cached?
           return unless @revision
-          in_path { git("cat-file -e #{@revision}") }
+          # Don't raise an error report, will always exit(1) when it's not cached.
+          in_path { git("cat-file -e #{@revision}", false) }
           true
         rescue GitError
           false


### PR DESCRIPTION
Quick fix for issue #2885.
