### PR TITLE
Avoid installing C exts on JRuby to allow running specs.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -30,7 +30,11 @@ end
 namespace :spec do
   desc "Ensure spec dependencies are installed"
   task :deps do
-    {"rdiscount" => "~> 1.6", "ronn" => "~> 0.7.3", "rspec" => "~> 3.0.beta"}.each do |name, version|
+    deps = RUBY_ENGINE == 'jruby' ?
+        {"rspec" => "~> 3.0.beta"} :
+        {"rdiscount" => "~> 1.6", "ronn" => "~> 0.7.3", "rspec" => "~> 3.0.beta"}
+
+    deps.each do |name, version|
       sh "#{Gem.ruby} -S gem list -i '^#{name}$' -v '#{version}' || " \
          "#{Gem.ruby} -S gem install #{name} -v '#{version}' --no-ri --no-rdoc"
     end
@@ -62,11 +66,10 @@ end
 begin
   # running the specs needs both rspec and ronn
   require 'rspec/core/rake_task'
-  require 'ronn'
 
   desc "Run specs"
   RSpec::Core::RakeTask.new do |t|
-    t.rspec_opts = %w(-fs --color)
+    t.rspec_opts = %w(-f documentation --color)
     t.ruby_opts  = %w(-w)
   end
   task :spec => "man:build"
@@ -224,8 +227,8 @@ begin
 
 rescue LoadError
   namespace :man do
-    task(:build) { abort "Install the ronn gem to be able to release!" }
-    task(:clean) { abort "Install the ronn gem to be able to release!" }
+    task(:build) { warn "Install the ronn gem to be able to release!" }
+    task(:clean) { warn "Install the ronn gem to be able to release!" }
   end
 end
 


### PR DESCRIPTION
This patch does the following:
- Omits rdiscount and ronn from deps to be installed when running
  on JRuby, since they're only needed for release tasks.
- Removes an unnecessary require of ronn.
- Rewrites release tasks to warn that ronn is required if it
  cannot be loaded.

The result is that JRuby can run both spec:deps and spec targets,
bringing us closer to getting specs green on JRuby.

I have done a preliminary run of specs on JRuby. The majority of specs pass (88 failures out of 933 examples), but the specs also take a _very_ long time to run due to all the process-launching involved. The output from that run is here: https://gist.github.com/headius/ce373d3488ad39561274
