### PR TITLE
Added :bitbucket as a new :git source

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -220,8 +220,9 @@ module Bundler
 
     def add_bitbucket_source
       git_source(:bitbucket) do |repo_name|
-        repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
-        "git@bitbucket.org:#{repo_name}.git"
+        repo_name, user_name = repo_name.split '/'
+        user_name ||= repo_name
+        "https://#{user_name}@bitbucket.org/#{user_name}/#{repo_name}.git"
       end
     end
 

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -52,13 +52,13 @@ describe Bundler::Dsl do
 
       it "converts :bitbucket to :git" do
         subject.gem("not-really-a-gem", :bitbucket => "mcorp/flatlab-rails")
-        bitbucket_uri = "git://bitbucket.org/mcorp/flatlab-rails.git"
+        bitbucket_uri = "https://mcorp@bitbucket.org/mcorp/flatlab-rails.git"
         expect(subject.dependencies.first.source.uri).to eq(bitbucket_uri)
       end
 
       it "converts 'mcorp' to 'mcorp/mcorp'" do
         subject.gem("not-really-a-gem", :bitbucket => "mcorp")
-        bitbucket_uri = "git://bitbucket.org/mcorp/mcorp.git"
+        bitbucket_uri = "https://mcorp@bitbucket.org/mcorp/mcorp.git"
         expect(subject.dependencies.first.source.uri).to eq(bitbucket_uri)
       end
     end


### PR DESCRIPTION
When you contributed to a gem and have to wait until your pull request gets approved, it is very handy to be able do do:

```
gem 'jekyll-assets', github: 'mcorp/jekyll-assets'
```

I love the `:github` and `:gist` aliases.

I work on several projects where my contractors keeps its source code on [Bitbucket](http://bitbucket.org/) and I'd love to have the same handy aliases we have for `github` also for `bitbucket`.

This patch will make this possible in bundler

```
gem 'flatlab-rails', bitbucket: 'mcorp/flatlab-rails'
```
