### PR TITLE
Avoid a NameError when OpenSSL is unavailable.

### DIFF
--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -160,7 +160,7 @@ module Bundler
 
     def spec_from_gem(path, policy = nil)
       require 'rubygems/security'
-      gem_from_path(path, Gem::Security::Policies[policy]).spec
+      gem_from_path(path, security_policies[policy]).spec
     rescue Gem::Package::FormatError
       raise GemspecError, "Could not read gem at #{path}. It may be corrupted."
     rescue Exception, Gem::Exception, Gem::Security::Exception => e


### PR DESCRIPTION
Fixes #2893.
