### PR TITLE
Correct bundle-config manpage

### DIFF
--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -86,12 +86,6 @@ learn more about their operation in [bundle install(1)][bundle-install].
 * `bin` (`BUNDLE_BIN`):
   Install executables from gems in the bundle to the specified directory.
   Defaults to `false`.
-* `gemfile` (`BUNDLE_GEMFILE`):
-  The name of the file that bundler should use as the `Gemfile`. This location
-  of this file also sets the root of the project, which is used to resolve
-  relative paths in the `Gemfile`, among other things. By default, bundler
-  will search up from the current working directory until it finds a
-  `Gemfile`.
 * `ssl_ca_cert` (`BUNDLE_SSL_CA_CERT`):
   Path to a designated CA certificate file or folder containing multiple
   certificates for trusted CAs in PEM format.
@@ -105,6 +99,18 @@ flag to the [bundle install(1)][bundle-install] command.
 You can set them globally either via environment variables or `bundle config`,
 whichever is preferable for your setup. If you use both, environment variables
 will take preference over global settings.
+
+An additional setting is available only as an environment variable:
+
+* `BUNDLE_GEMFILE`:
+  The name of the file that bundler should use as the `Gemfile`. This location
+  of this file also sets the root of the project, which is used to resolve
+  relative paths in the `Gemfile`, among other things. By default, bundler
+  will search up from the current working directory until it finds a
+  `Gemfile`.
+
+Bundler will ignore any `BUNDLE_GEMFILE` entries in local or global
+configuration files.
 
 ## LOCAL GIT REPOS
 


### PR DESCRIPTION
Per the discussion in #1315, it is not possible to set the gemfile using `bundle-config`, so the docs should not claim otherwise.

Cheers,
Simon

edit: the build failure would seem to be unrelated.
