### PR TITLE
Redirect to bundler.rubygems.org if the host is rubygems.org

### DIFF
--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -292,7 +292,7 @@ module Bundler
     end
 
     def dependency_api_uri(gem_names = [])
-      url = "#{@remote_uri}api/v1/dependencies"
+      url = "#{redirected_uri}api/v1/dependencies"
       url << "?gems=#{URI.encode(gem_names.join(","))}" if gem_names.any?
       URI.parse(url)
     end
@@ -376,6 +376,20 @@ module Bundler
 
       @remote_uri.user, @remote_uri.password = *auth.split(":", 2)
       yield
+    end
+
+    private
+    def redirected_uri
+      return bundler_uri if rubygems?
+      return @remote_uri
+    end
+
+    def rubygems?
+      @remote_uri.host == "rubygems.org"
+    end
+
+    def bundler_uri
+      URI.parse("#{@remote_uri.scheme}://bundler.#{@remote_uri.host}/")
     end
 
   end


### PR DESCRIPTION
This fixes #2866 and the difference is tremendous for the small change (for people outside USA at least).
For me, metadata fetching (on rubygems dependency API) went from 30-35 seconds to 11-16 seconds. 

I'd say we should merge it to push this into the next release if everything looks okay!
