### PR TITLE
bundle open does not quote gem path which may contain spaces

### DIFF
--- a/lib/bundler/cli/open.rb
+++ b/lib/bundler/cli/open.rb
@@ -15,7 +15,7 @@ module Bundler
       return unless spec
       full_gem_path = spec.full_gem_path
       Dir.chdir(full_gem_path) do
-        command = "#{editor} #{full_gem_path}"
+        command = "#{editor} \"#{full_gem_path.to_s.gsub('"', '\\"')}\""
         success = system(command)
         Bundler.ui.info "Could not run '#{command}'" unless success
       end


### PR DESCRIPTION
If path to project directory happens to contain spaces, and a gem was installed into that project directory using the --path option, bundle open does not work as expected because it does not quote the path when calling the system method. Here is a little test script I wrote to understand the issue:

``` ruby
require 'minitest/autorun'

describe 'using `system` on a file path with spaces' do
  before do
    @filepath = "a file with spaces in its name.rb"
    File.write @filepath, ""
  end
  after do
    File.delete @filepath
  end
  it 'does not work if path is not quoted' do
    system("ruby #{ @filepath }").must_equal false
  end
  it 'works if path is quoted' do
    system("ruby \"#{ @filepath }\"").must_equal true
  end
end

begin
  # Only run the following test if this OS supports double quotes in file names.
  # E.g. OS X does, MS Windows does not. Not sure about others - the easiest way
  # to find out is just try it:
  filepath = "\"double quotes\".txt"
  File.write filepath, ""
  File.delete filepath
rescue
else
  describe 'using `system` on a file path with double quotes' do
    before do
      @filepath = "a file with \"double quotes\" in its name.rb"
      File.binwrite @filepath, ""
    end
    after do
      File.delete @filepath
    end
    it 'does not work if double quotes are not escaped' do
      system("ruby \"#{ @filepath }\"").must_equal false
    end
    it 'works if double quotes are escaped' do
      system("ruby \"#{ @filepath.gsub('"', '\\"') }\"").must_equal true
    end
  end
end
```
