### PR TITLE
Fix redundant and slightly silly descriptions in gem spec template

### DIFF
--- a/lib/bundler/templates/newgem/spec/newgem_spec.rb.tt
+++ b/lib/bundler/templates/newgem/spec/newgem_spec.rb.tt
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
 describe <%= config[:constant_name] %> do
-  it 'should have a version number' do
+  it 'has a version number' do
     expect(<%= config[:constant_name] %>::VERSION).not_to be nil
   end
 
-  it 'should do something useful' do
+  it 'does something useful' do
     expect(false).to eq(true)
   end
 end


### PR DESCRIPTION
BDD language is "it [does something]" or "should [do something]", not "it should [do something]".
