### PR TITLE
Adds a --no-install flag to bundle package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Bugfixes:
 Features:
 
   - warn informatively when `bundle install` is run as root (#2936, @1337807)
+  - adds a `--no-install` flag to `bundle package`
 
 ## 1.6.1 (2014-04-02)
 

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -223,6 +223,7 @@ module Bundler
 
     desc "package [OPTIONS]", "Locks and then caches all of the gems into vendor/cache"
     method_option "no-prune",  :type => :boolean, :banner => "Don't remove stale gems from the cache."
+    method_option "no-install",  :type => :boolean, :banner => "Don't actually install the gems, just package."
     method_option "all",  :type => :boolean, :banner => "Include all sources (including path and git)."
     method_option "quiet", :type => :boolean, :banner => "Only output warnings and errors."
     method_option "path", :type => :string, :banner =>

--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -64,6 +64,7 @@ module Bundler
       Bundler.settings[:shebang]  = options["shebang"] if options["shebang"]
       Bundler.settings[:jobs]     = options["jobs"] if options["jobs"]
       Bundler.settings[:no_prune] = true if options["no-prune"]
+      Bundler.settings[:no_install] = true if options["no-install"]
       Bundler.settings[:clean]    = options["clean"] if options["clean"]
       Bundler.settings.without    = options[:without]
       Bundler.ui.level            = "warn" if options[:quiet]

--- a/spec/commands/package_spec.rb
+++ b/spec/commands/package_spec.rb
@@ -28,6 +28,20 @@ describe "bundle package" do
       expect(bundled_app("test/vendor/cache/")).to exist
     end
   end
+
+  context "with --no-install" do
+    it "puts the gems in vendor/cache but does not install them" do
+      gemfile <<-D
+        source "file://#{gem_repo1}"
+        gem 'rack'
+      D
+
+      bundle "package --no-install"
+
+      should_not_be_installed "rack 1.0.0"
+      expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
+    end
+  end
 end
 
 describe "bundle install with gem sources" do


### PR DESCRIPTION
This PR is a rough draft of the bundle package --no-install flag suggested in this issue: https://github.com/bundler/bundler-features/issues/43

We'd like some feedback on how to better integrate this feature. This patch works and vendors the gems without installing them, but we don't have the familiarity with bundler to know if there are workflows we haven't considered.
