### PR TITLE
Use git sha as part of extension directory for git referenced gems.

### DIFF
--- a/lib/bundler/rubygems_ext.rb
+++ b/lib/bundler/rubygems_ext.rb
@@ -45,6 +45,15 @@ module Gem
       end
     end
 
+    if method_defined?(:extension_dir)
+      alias_method :rg_extension_dir, :extension_dir
+      def extension_dir
+        @extension_dir ||= source.respond_to?(:extension_dir_name) ?
+          File.expand_path(File.join(extensions_dir, source.extension_dir_name)) :
+          rg_extension_dir
+      end
+    end
+
     # RubyGems 1.8+ used only.
     remove_method :gem_dir if instance_methods(false).include?(:gem_dir)
     def gem_dir

--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -90,6 +90,10 @@ module Bundler
 
       alias :path :install_path
 
+      def extension_dir_name
+        "#{base_name}-#{shortref_for_path(revision)}"
+      end
+
       def unlock!
         git_proxy.revision = nil
         @unlocked = true


### PR DESCRIPTION
## Problem

See issue #2947 which this pull request fixes.
## Solution

Monkey patch Gem::Specification#extension_dir so that the source can override the extension directory name if it responds to extension_dir_name, similar to the monkey patch of full_gem_path.
