### PR TITLE
Change :github DSL option to use HTTPS rather than the bare git://

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -127,7 +127,7 @@ begin
 
         task "clone_rubygems_#{rg}" do
           unless File.directory?("tmp/rubygems")
-            system("git clone git://github.com/rubygems/rubygems.git tmp/rubygems")
+            system("git clone https://github.com/rubygems/rubygems.git tmp/rubygems")
           end
           hash = nil
 

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -211,7 +211,7 @@ module Bundler
     def add_github_sources
       git_source(:github) do |repo_name|
         repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
-        "git://github.com/#{repo_name}.git"
+        "https://github.com/#{repo_name}.git"
       end
 
       git_source(:gist){ |repo_name| "https://gist.github.com/#{repo_name}.git" }

--- a/man/gemfile.5.ronn
+++ b/man/gemfile.5.ronn
@@ -276,7 +276,7 @@ same, you can omit one.
 
 Are both equivalent to
 
-    gem "rails", :git => "git://github.com/rails/rails.git"
+    gem "rails", :git => "https://github.com/rails/rails.git"
 
 In addition, if you wish to choose a specific branch:
 

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -28,7 +28,7 @@ describe Bundler::Dsl do
     context "default hosts (git, gist)" do
       it "converts :github to :git" do
         subject.gem("sparks", :github => "indirect/sparks")
-        github_uri = "git://github.com/indirect/sparks.git"
+        github_uri = "https://github.com/indirect/sparks.git"
         expect(subject.dependencies.first.source.uri).to eq(github_uri)
       end
 
@@ -46,7 +46,7 @@ describe Bundler::Dsl do
 
       it "converts 'rails' to 'rails/rails'" do
         subject.gem("rails", :github => "rails")
-        github_uri = "git://github.com/rails/rails.git"
+        github_uri = "https://github.com/rails/rails.git"
         expect(subject.dependencies.first.source.uri).to eq(github_uri)
       end
     end

--- a/spec/lock/lockfile_spec.rb
+++ b/spec/lock/lockfile_spec.rb
@@ -134,7 +134,7 @@ describe "the lockfile format" do
 
     lockfile <<-L
       GIT
-        remote: git://github.com/nex3/haml.git
+        remote: https://github.com/nex3/haml.git
         revision: 8a2271f
         specs:
 


### PR DESCRIPTION
This changes the use of `git://` URLs generated from the DSL via the `:github` option to use HTTPS instead (e.g., `http://github.com/bundler/bundler` rather than `git://github.com/bundler/bundler`).  GitHub discourages the use of the `git://` style URLs these days, and using HTTPS is more secure anyhow (prevents an unlikely but possible MITM attack and so on).

This doesn't break any specs (other than the ones I've updated), but I also didn't change a few that were sending `git://` URLs to the `:git` DSL option since I didn't think they were relevant.  Feel free to tell me otherwise, and I'll make the change. :smile: 
