### PR TITLE
Remove deprecation warning caused by use of failure_message_for_should

### DIFF
--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -42,7 +42,7 @@ describe "The library itself" do
   end
 
   RSpec::Matchers.define :be_well_formed do
-    failure_message_for_should do |actual|
+    failure_message do |actual|
       actual.join("\n")
     end
 


### PR DESCRIPTION
- RSpec has replaced failure_message_for_should with failure_message in
  https://github.com/rspec/rspec-expectations/commit/bfe92020d5569350c1382235feb9b113907fa2db
- This change removes deprecation warning caused by https://github.com/rspec/rspec-expectations/commit/cd0d347d3115f8aad801e6dc8fe2a311d75626bd#diff-a51020971ade2c87f1d5b93f20d711c7R207
