### PR TITLE
push to a private gem server.

### DIFF
--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -78,9 +78,9 @@ module Bundler
     end
 
     protected
-    def rubygem_push(path)
+    def rubygem_push(path, gem_server = ENV['GEM_SERVER'] || 'rubygems.org')
       if Pathname.new("~/.gem/credentials").expand_path.exist?
-        sh("gem push '#{path}'")
+        sh("gem push '#{path}' --host #{gem_server}")
         Bundler.ui.confirm "Pushed #{name} #{version} to rubygems.org."
       else
         raise "Your rubygems.org credentials aren't set. Run `gem push` to set them."


### PR DESCRIPTION
This is more a request for comments then anything else.

I made the unfortunate mistake of pushing a gem to rubygems.org instead or our companies internal gemserver. I yanked the gem but sadly the download was still available.

I'm hoping to at least spark a discussion to help prevent this from happening to anyone else.

Please feel free to let me know what you think.
