### PR TITLE
Use loaded_from only when non-nil

### DIFF
--- a/lib/bundler/source/rubygems.rb
+++ b/lib/bundler/source/rubygems.rb
@@ -292,11 +292,10 @@ module Bundler
       end
 
       def builtin_gem?(spec)
-        # Ruby 2.1-style
-        return true if spec.summary =~ /is bundled with Ruby/
-
-        # Ruby 2.0 style
-        spec.loaded_from.include?("specifications/default/")
+        # gems bundled with ruby have summary as - "is bundled with ruby"
+        # or else use "specifications/default" to store the gemspecs.
+        spec.summary =~ /is bundled with Ruby/ ||
+          (spec.loaded_from && spec.loaded_from.include?("specifications/default/"))
       end
     end
   end


### PR DESCRIPTION
For a gem which is not installed in specified path
"loaded_from" will return nil and hence check for builtin_gem?
will throw error. This fixes bug #2915
