### PR TITLE
Ignore emacs backup files

### DIFF
--- a/lib/bundler/templates/newgem/gitignore.tt
+++ b/lib/bundler/templates/newgem/gitignore.tt
@@ -20,3 +20,4 @@ tmp
 *.o
 *.a
 mkmf.log
+*~


### PR DESCRIPTION
This is one of the first things I have to do every single time I run `bundle gem foo`
