### PR TITLE
Update usage instructions to be correct.

### DIFF
--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -331,7 +331,7 @@ module Bundler
                 message = "You have requested:\n" \
                   "  #{current.name} #{current.requirement}\n\n" \
                   "The bundle currently has #{current.name} locked at #{version}.\n" \
-                  "Try running `bundle update #{current.name}`"
+                  "Try running `bundle update --source #{current.name}`"
               elsif current.source
                 name = current.name
                 versions = @source_requirements[name][name].map { |s| s.version }


### PR DESCRIPTION
As it stands if you try what it suggests you'll get something like:

```
xenia ± bundle update einhorn                                                                                                                                          ~/stripe/pay-server richo-use-new-einhorn
Please don't run `bundle update` on its own - use `bundle update --source <gem>`
```
