### PR TITLE
Fix deploying packaged git gems without git (#2968)

### DIFF
--- a/lib/bundler/source/git/git_proxy.rb
+++ b/lib/bundler/source/git/git_proxy.rb
@@ -40,7 +40,7 @@ module Bundler
           @ref      = ref
           @revision = revision
           @allow    = allow || Proc.new { true }
-          raise GitNotInstalledError.new unless Bundler.git_present?
+          raise GitNotInstalledError.new if allow? && !Bundler.git_present?
         end
 
         def revision

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -947,5 +947,21 @@ describe "bundle install with git sources" do
       bundle "update", :env => {"PATH" => ""}
       expect(out).to include("You need to install git to be able to use gems from git repositories. For help installing git, please refer to GitHub's tutorial at https://help.github.com/articles/set-up-git")
     end
+
+    it "installs a packaged git gem successfully" do
+      build_git "foo"
+
+      install_gemfile <<-G
+        git "#{lib_path('foo-1.0')}" do
+          gem 'foo'
+        end
+      G
+      bundle "package --all"
+      simulate_new_machine
+
+      bundle "install", :env => {"PATH" => ""}, :exitstatus => true
+      expect(out).to_not include("You need to install git to be able to use gems from git repositories.")
+      expect(exitstatus).to be_zero
+    end
   end
 end


### PR DESCRIPTION
If git isn't allowed to run, we don't blow up if we don't have it.

It looks like master's build is failing, so please let me know if I'll need to force a rebuild of this at any point.
