### PR TITLE
Add option to show semantic output of gems for easy pasting into gemfiles

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -175,6 +175,8 @@ module Bundler
     D
     method_option "paths", :type => :boolean,
       :banner => "List the paths of all gems that are required by your Gemfile."
+    method_option "semantic", :type => :boolean,
+      :banner => "Output the gems using the ~> format, which can be used to paste into gemfiles"
     def show(gem_name = nil)
       require 'bundler/cli/show'
       Show.new(options, gem_name).run

--- a/lib/bundler/cli/show.rb
+++ b/lib/bundler/cli/show.rb
@@ -38,6 +38,8 @@ module Bundler
           desc = "  * #{s.name} (#{s.version}#{s.git_version})"
           if @options[:verbose]
             Bundler.ui.info "#{desc} - #{s.summary || 'No description available.'}"
+          elsif @options[:semantic]
+            Bundler.ui.info "  * gem '#{s.name}', '~> #{s.version}'"
           else
             Bundler.ui.info desc
           end

--- a/spec/commands/show_spec.rb
+++ b/spec/commands/show_spec.rb
@@ -66,6 +66,13 @@ describe "bundle show" do
       expect(out).to include(' - This is just a fake gem for testing')
       expect(out).to include(' - Ruby based make-like utility.')
     end
+
+    it "prints summary of gems that can be copied to a gemfile" do
+      bundle "show --semantic"
+
+      expect(out).to include('rake', '~> 10.0.2')
+      expect(out).to include('rails', '~> 2.3.2')
+    end
   end
 
   context "with a git repo in the Gemfile" do


### PR DESCRIPTION
Outputs a semantic version of gems by running `bundle show --semantic`; output resembles how rubygems.org displays gem versions. Had help with this from @zilkey.
