### PR TITLE
Automatically switches branch when local override for git repository is given

### DIFF
--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -122,6 +122,13 @@ module Bundler
         # so the Gemfile.lock always picks up the new revision.
         @git_proxy = GitProxy.new(path, uri, ref)
 
+        if git_proxy.branch != options["branch"] && Bundler.settings[:auto_switch_local_branch]
+          if !git_proxy.exists?(options["branch"])
+            raise GitError, "Failed to switch branch, branch #{options["branch"]} doesn't exist"
+          end
+          git_proxy.switch(options["branch"])
+        end
+
         if git_proxy.branch != options["branch"] && !Bundler.settings[:disable_local_branch_check]
           raise GitError, "Local override for #{name} at #{path} is using branch " \
             "#{git_proxy.branch} but Gemfile specifies #{options["branch"]}"

--- a/lib/bundler/source/git/git_proxy.rb
+++ b/lib/bundler/source/git/git_proxy.rb
@@ -48,7 +48,7 @@ module Bundler
         end
 
         def branch
-          @branch ||= allowed_in_path do
+          allowed_in_path do
             git("branch") =~ /^\* (.*)$/ && $1.strip
           end
         end
@@ -56,6 +56,20 @@ module Bundler
         def contains?(commit)
           allowed_in_path do
             result = git_null("branch --contains #{commit}")
+            $? == 0 && result =~ /^\* (.*)$/
+          end
+        end
+
+        def exists?(branch)
+          allowed_in_path do
+            git_null("show-ref --verify --quiet refs/heads/#{branch}")
+            $? == 0
+          end
+        end
+
+        def switch(branch)
+          allowed_in_path do
+            result = git_null("checkout #{branch}")
             $? == 0 && result =~ /^\* (.*)$/
           end
         end

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -300,6 +300,26 @@ describe "bundle install with git sources" do
       expect(out).to match(/Your bundle is complete!/)
     end
 
+    it "switches branch if auto_switch_local_branch is given" do
+      build_git "rack", "0.8"
+
+      FileUtils.cp_r("#{lib_path('rack-0.8')}/.", lib_path('local-rack'))
+
+      update_git "rack", "0.8", :path => lib_path('local-rack'), :branch => "another" do |s|
+        s.write "lib/rack.rb", "puts :ANOTHER"
+      end
+
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem "rack", :git => "#{lib_path('rack-0.8')}", :branch => "master"
+      G
+
+      bundle %|config local.rack #{lib_path('local-rack')}|
+      bundle %|config auto_switch_local_branch true|
+      bundle :install
+      expect(out).to match(/Your bundle is complete!/)
+    end
+
     it "explodes on different branches on install" do
       build_git "rack", "0.8"
 


### PR DESCRIPTION
With a big project that has quite a few git dependencies, sometimes it becomes very annoying to switch the branch manually.

Bundler will try to switch to the branch specified in Gemfile if it exists.

Enable this feature by
bundle config auto_switch_local_branch true
