### PR TITLE
Add failing spec for #3004.

### DIFF
--- a/spec/realworld/parallel_spec.rb
+++ b/spec/realworld/parallel_spec.rb
@@ -66,4 +66,23 @@ describe "parallel", :realworld => true do
     bundle "config jobs"
     expect(out).to match(/: "4"/)
   end
+
+  it "works with --standalone" do
+    gemfile <<-G, :standalone => true
+      source "https://rubygems.org"
+      gem "diff-lcs"
+    G
+
+    bundle :install, :standalone => true, :jobs => 4
+
+    ruby <<-RUBY, :no_lib => true
+      $:.unshift File.expand_path("bundle")
+      require "bundler/setup"
+
+      require "diff/lcs"
+      puts Diff::LCS
+    RUBY
+
+    expect(out).to eq("Diff::LCS")
+  end
 end


### PR DESCRIPTION
This is a failing spec based on my investigation in #3004.  This spec passes if you remove the `:jobs => 4` option, so it is demonstrating the same issue and root cause discussed there.

I tried making a non-realworld spec for this but wasn't able to create a failing one for some reason...so you may want to redo this in non-realworld fashion.  Figured this would help get you started, though.

I'm very keen to see this bug get fixed as it affects both my personal projects and work projects (I tend to use `--standalone` everywhere), so let me know if I can do anything else to help.
