### PR TITLE
Override all editor ENV variables in bundle open spec

### DIFF
--- a/spec/commands/open_spec.rb
+++ b/spec/commands/open_spec.rb
@@ -74,7 +74,7 @@ describe "bundle open" do
     G
 
     bundle "config auto_install 1"
-    bundle "open rails", :env => { "EDITOR" => "echo editor" }
+    bundle "open rails", :env => {"EDITOR" => "echo editor", "VISUAL" => "", "BUNDLER_EDITOR" => ""}
     expect(out).to include("Installing foo 1.0")
   end
 end


### PR DESCRIPTION
This makes sure none of these variables take their value from the developer's environment and cause unwanted editors to be launched.
