### PR TITLE
Add more explanation to spec.description for bundle gem template.

### DIFF
--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.extensions    = ["ext/<%=config[:underscored_name]%>/extconf.rb"]
 <% end -%>
   spec.summary       = %q{TODO: Write a short summary. Required.}
-  spec.description   = %q{TODO: Write a longer description. Optional.}
+  spec.description   = %q{TODO: Write a longer description. Optional, please update before building.}
   spec.homepage      = ""
   spec.license       = "MIT"
 


### PR DESCRIPTION
"Optional" sounds like you can leave this value unchanged, but will
raise an exception in this case, aborting before the gem is built:

```
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
ERROR:  While executing gem ... (Gem::InvalidSpecificationException)
  "FIXME" or "TODO" is not a description
```
