### PR TITLE
Improve advice on updating a single gem

### DIFF
--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -336,7 +336,7 @@ module Bundler
                 message = "You have requested:\n" \
                   "  #{current.name} #{current.requirement}\n\n" \
                   "The bundle currently has #{current.name} locked at #{version}.\n" \
-                  "Try running `bundle update #{current.name}`"
+                  "Try running `bundle update --source #{current.name}`"
               elsif current.source
                 name = current.name
                 versions = @source_requirements[name][name].map { |s| s.version }


### PR DESCRIPTION
The current advice is misleading. To resolve a lock issue, it's usually only necessary to update a single gem, rather than that gem and all of its dependencies.

http://ilikestuffblog.com/2012/07/01/you-should-update-one-gem-at-a-time-with-bundler-heres-how/
