### PR TITLE
Create makefile with path `underscored_name`/`underscored_name`

### DIFF
--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -29,6 +29,7 @@ module Bundler
         :name             => name,
         :underscored_name => underscored_name,
         :namespaced_path  => namespaced_path,
+        :makefile_path    => "#{underscored_name}/#{underscored_name}",
         :constant_name    => constant_name,
         :constant_array   => constant_array,
         :author           => git_user_name.empty? ? "TODO: Write your name" : git_user_name,

--- a/lib/bundler/templates/newgem/ext/newgem/extconf.rb.tt
+++ b/lib/bundler/templates/newgem/ext/newgem/extconf.rb.tt
@@ -1,3 +1,3 @@
 require "mkmf"
 
-create_makefile(<%=config[:underscored_name].inspect%>)
+create_makefile(<%= config[:makefile_path].inspect %>)


### PR DESCRIPTION
This fixes compilation issues in Windows. Closes #3028
