### PR TITLE
Implemented a very basic plugin system.

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -67,6 +67,12 @@ module Bundler
       end
     end
 
+    def self.handle_no_command_error(command, has_namespace = $thor_runner)
+      return super unless command_path = Bundler.which("bundler-#{command}")
+
+      Kernel.exec(command_path, *ARGV[1..-1])
+    end
+
     desc "init [OPTIONS]", "Generates a Gemfile into the current working directory"
     long_desc <<-D
       Init generates a default Gemfile in the current working directory. When adding a

--- a/spec/bundler/cli_spec.rb
+++ b/spec/bundler/cli_spec.rb
@@ -13,4 +13,17 @@ describe "bundle executable" do
     bundle 'unrecognized-tast', :exitstatus => true
     expect(exitstatus).to_not be_zero
   end
+
+  it "looks for a binary and executes it if it's named bundler-<task>" do
+    File.open(tmp('bundler-testtasks'), 'w', 0755) do |f|
+      f.puts "#!/usr/bin/env ruby\nputs 'Hello, world'\n"
+    end
+
+    with_path_as(tmp) do
+      bundle 'testtasks', :exitstatus => true
+    end
+
+    expect(exitstatus).to be_zero
+    expect(out).to eq('Hello, world')
+  end
 end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -74,7 +74,6 @@ module Spec
       end.join
 
       cmd = "#{env} #{sudo} #{Gem.ruby} -I#{lib} #{requires_str} #{bundle_bin} #{cmd}#{args}"
-
       if exitstatus
         sys_status(cmd)
       else
@@ -83,7 +82,7 @@ module Spec
     end
 
     def bundle_ruby(options = {})
-      expect_err  = options.delete(:expect_err)
+      expect_err = options.delete(:expect_err)
       exitstatus = options.delete(:exitstatus)
       options["no-color"] = true unless options.key?("no-color")
 
@@ -216,6 +215,14 @@ module Spec
       yield
     ensure
       ENV['GEM_HOME'], ENV['GEM_PATH'] = gem_home, gem_path
+    end
+
+    def with_path_as(path)
+      old_path = ENV['PATH']
+      ENV['PATH'] = "#{path}:#{ENV['PATH']}"
+      yield
+    ensure
+      ENV['PATH'] = old_path
     end
 
     def break_git!


### PR DESCRIPTION
The way this works is pretty much the same way as `git` commands work.

When invoking `bundler <task>`, if the task isn't defined on Bundler::CLI,
Bundler will try and figure out if there is a `bundler-<task>` binary present
on the path. If so, it's invoked.

Same error message (and error codes) apply when a binary isn't found.

Also, this is just a first, simple pass at the problem. @indirect and I had a
chat about how it should work, and we should probably think about offering the
possibility of loading up Ruby plugins in the already loaded Bundler
environment.

(Ref bundler/bundler-features#8)
