### PR TITLE
Switch double to single quotes on newgem.gemspec

### DIFF
--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -4,35 +4,35 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require '<%=config[:namespaced_path]%>/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = <%=config[:name].inspect%>
+  spec.name          = '<%=config[:name]%>'
   spec.version       = <%=config[:constant_name]%>::VERSION
-  spec.authors       = [<%=config[:author].inspect%>]
-  spec.email         = [<%=config[:email].inspect%>]
+  spec.authors       = ['<%=config[:author]%>']
+  spec.email         = ['<%=config[:email]%>']
 
-<%- if ::Gem::Requirement.new(">= 2.0").satisfied_by? ::Gem::Version.new(::Gem::VERSION) -%>
+<%- if ::Gem::Requirement.new('>= 2.0').satisfied_by? ::Gem::Version.new(::Gem::VERSION) -%>
   spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com' to prevent pushes to rubygems.org, or delete to allow pushes to any server."
-  spec.required_rubygems_version = ">= 2.0"
+  spec.required_rubygems_version = '>= 2.0'
 <% end -%>
 
 <%- if config[:ext] -%>
-  spec.extensions    = ["ext/<%=config[:underscored_name]%>/extconf.rb"]
+  spec.extensions    = ['ext/<%=config[:underscored_name]%>/extconf.rb']
 <%- end -%>
   spec.summary       = %q{TODO: Write a short summary, because Rubygems requires one.}
   spec.description   = %q{TODO: Write a longer description or delete this line.}
   spec.homepage      = "TODO: Put your gem's website or public repo URL here."
-  spec.license       = "MIT"
+  spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_development_dependency "bundler", "~> <%= Bundler::VERSION.split(".")[0..1].join(".") %>"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency 'bundler', '~> <%= Bundler::VERSION.split(".")[0..1].join(".") %>'
+  spec.add_development_dependency 'rake', '~> 10.0'
 <%- if config[:ext] -%>
-  spec.add_development_dependency "rake-compiler"
+  spec.add_development_dependency 'rake-compiler'
 <%- end -%>
 <%- if config[:test] -%>
-  spec.add_development_dependency "<%=config[:test]%>"
+  spec.add_development_dependency '<%=config[:test]%>'
 <%- end -%>
 end

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -428,7 +428,7 @@ describe "bundle gem" do
       end
 
       it "includes rake-compiler" do
-        expect(bundled_app("test_gem/test_gem.gemspec").read).to include('spec.add_development_dependency "rake-compiler"')
+        expect(bundled_app("test_gem/test_gem.gemspec").read).to include("spec.add_development_dependency 'rake-compiler'")
       end
 
       it "depends on compile task for build" do


### PR DESCRIPTION
When generating a new gem, prefer single-quoted strings when you don't need
string interpolation on `gemspec` file.
