### PR TITLE
Fix use of deprecated failure_message_should

### DIFF
--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -46,7 +46,7 @@ describe "The library itself" do
       actual.empty?
     end
 
-    failure_message_for_should do |actual|
+    failure_message do |actual|
       actual.join("\n")
     end
   end


### PR DESCRIPTION
- Replaced failure_message_should with failure_message
- Fixed https://travis-ci.org/bundler/bundler/jobs/25404164#L1837
