### PR TITLE
Extract standalone path expansion to do it only once

### DIFF
--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -252,7 +252,7 @@ module Bundler
         file.puts "ruby_version = RbConfig::CONFIG[\"ruby_version\"]"
         file.puts "path = File.expand_path('..', __FILE__)"
         paths.each do |path|
-          file.puts %{$:.unshift File.expand_path("\#{path}/#{path}")}
+          file.puts %{$:.unshift "\#{path}/#{path}"}
         end
       end
     end


### PR DESCRIPTION
When using the `--standalone` options to create a setup file, each path is expanded in its own inside the setup file.

But the `path` prefix is already expanded, so that expansion is unnecessary.
