### PR TITLE
Add `bundle viz --without` to exclude gem groups from resulting graph.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Features:
   - add support for SVN sources (@msnexploder)
   - add metadata allowed_push_host to new gem template (#3002, @juanitofatas)
   - adds a `--no-install` flag to `bundle package`
+  - add `bundle viz --without` to exclude gem groups from resulting graph (@fnichol)
 
 ## 1.6.2 (2014-04-13)
 

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -315,6 +315,8 @@ module Bundler
     method_option :format, :type => :string, :default => "png", :aliases => '-F', :banner => "This is output format option. Supported format is png, jpg, svg, dot ..."
     method_option :requirements, :type => :boolean, :default => false, :aliases => '-r', :banner => "Set to show the version of each required dependency."
     method_option :version, :type => :boolean, :default => false, :aliases => '-v', :banner => "Set to show each gem version."
+    method_option :without, :type => :array, :default => [], :banner => "Exclude gems that are part of the specified named group."
+
     def viz
       require 'bundler/cli/viz'
       Viz.new(options).run

--- a/lib/bundler/cli/viz.rb
+++ b/lib/bundler/cli/viz.rb
@@ -8,7 +8,7 @@ module Bundler
     def run
       require 'graphviz'
       output_file = File.expand_path(options[:file])
-      graph = Graph.new(Bundler.load, output_file, options[:version], options[:requirements], options[:format])
+      graph = Graph.new(Bundler.load, output_file, options[:version], options[:requirements], options[:format], options[:without])
       graph.viz
     rescue LoadError => e
       Bundler.ui.error e.inspect

--- a/lib/bundler/graph.rb
+++ b/lib/bundler/graph.rb
@@ -3,12 +3,13 @@ module Bundler
   class Graph
     GRAPH_NAME = :Gemfile
 
-    def initialize(env, output_file, show_version = false, show_requirements = false, output_format = "png")
+    def initialize(env, output_file, show_version = false, show_requirements = false, output_format = "png", without = [])
       @env               = env
       @output_file       = output_file
       @show_version      = show_version
       @show_requirements = show_requirements
       @output_format     = output_format
+      @without_groups    = without.map(&:to_sym)
 
       @groups            = []
       @relations         = Hash.new {|h, k| h[k] = Set.new}
@@ -53,6 +54,8 @@ module Bundler
       relations = Hash.new {|h, k| h[k] = Set.new}
       @env.current_dependencies.each do |dependency|
         dependency.groups.each do |group|
+          next if @without_groups.include?(group)
+
           relations[group.to_s].add(dependency)
           @relations[group.to_s].add(dependency.name)
 


### PR DESCRIPTION
Hello Bundler team!

This PR introduces a `--without` flag (similar to the flag on the `install` subcommand) which will drop the inclusion of these gems from the graph.

The ability to exclude gem groups from the graph is very useful when trying to visualize or understand the runtime dependencies of a particular RubyGem or project, minus any development or test related
libraries.

Previously the process of reproducing this behavior was a manual process:
- Inspect the project's Gemfile and comment/remove any gems that are not
  runtime dependencies. Typically these gems would be in `:test` or
  `:development` groups.
- Inspect the project's gemspec (if it exists) and comment/remove any
  gems that are not runtime dependencies.

Now it is as simple as:

```
bundle viz --without=test development
```

---

I have 2 concerns with this PR and I suspect I may require some remediation on one or both:
1. While I would normally include regression/feature specs for a related commit, the `bundle viz` related code currently doesn't have any test coverage. I've attempted to be as minimal and surgical as possible so as to not break any current behavior but it's going to take a code review and test drive to verify this work at present. In short, am I good here, or is there more work to do?
2. I would have preferred to not augment a Class' constructor arguments (for `Bundler::Graph`), but it's my assumption that this class in for internal use only and doesn't constitute the public SemVer API for Bundler. To be on the safe side, I appended this argument at the end and provided a default to preserve backwards compatibility. Does this look reasonable?

Thank you core team for your tireless work to make the Ruby community a better place!
