### PR TITLE
Use stdlib's curses for detection of color capability.

### DIFF
--- a/lib/bundler/ui/shell.rb
+++ b/lib/bundler/ui/shell.rb
@@ -76,7 +76,9 @@ module Bundler
     private
 
       def no_color_support?
-        ! Curses.has_colors?.tap { Curses.close_screen }
+        ! Curses.has_colors?
+      ensure
+        Curses.close_screen
       end
 
       # valimism


### PR DESCRIPTION
STDOUT.tty? is sadly not enough: there are terminals that are not capable
of color, and yet return true for STDOUT.tty? (as they should). Examples:
emacs, 9term (basically anything that sets $TERM to "dumb").
