### PR TITLE
Removed the excessive '(c)' from the LICENSE template

### DIFF
--- a/lib/bundler/templates/newgem/LICENSE.txt.tt
+++ b/lib/bundler/templates/newgem/LICENSE.txt.tt
@@ -1,4 +1,4 @@
-Copyright (c) <%=Time.now.year%> <%=config[:author]%>
+Copyright <%=Time.now.year%> <%=config[:author]%>
 
 MIT License
 


### PR DESCRIPTION
_Copyright_ and _(c)_ are [mutually exclusive](https://en.wikipedia.org/wiki/Copyright_symbol#US_copyright_notice).
