### PR TITLE
Backport to 186

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 
 # output from ci_reporter
 /spec/reports/
+Gemfile.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Features:
   - add metadata allowed_push_host to new gem template (#3002, @juanitofatas)
   - adds a `--no-install` flag to `bundle package`
   - add `bundle viz --without` to exclude gem groups from resulting graph (@fnichol)
+  - add compatibility with ruby 1.8.6 (@Nerian)
 
 ## 1.6.2 (2014-04-13)
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/bundler.gemspec
+++ b/bundler.gemspec
@@ -13,8 +13,10 @@ Gem::Specification.new do |spec|
   spec.summary     = %q{The best way to manage your application's dependencies}
   spec.description = %q{Bundler manages an application's dependencies through its entire life, across many machines, systematically and repeatably}
 
-  spec.required_ruby_version     = '>= 1.8.7'
-  spec.required_rubygems_version = '>= 1.3.6'
+  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('1.8.7')
+    spec.add_dependency 'rubysl-securerandom'
+    spec.add_dependency 'backports'
+  end
 
   spec.add_development_dependency 'rdiscount', '~> 1.6'
   spec.add_development_dependency 'ronn', '~> 0.7.3'

--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -1,3 +1,8 @@
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('1.8.7')
+  require 'backports'
+  require 'bundler/backports/time'
+end
+
 require 'fileutils'
 require 'pathname'
 require 'rbconfig'

--- a/lib/bundler/backports/time.rb
+++ b/lib/bundler/backports/time.rb
@@ -1,0 +1,7 @@
+class Time
+
+  def nsec
+    sec * (10**9)
+  end
+
+end


### PR DESCRIPTION
This pull request add compatibility with ruby 1.8.6 by requiring backports and adding Time#nsec.

I wasn't sure about how to configure Travis, so I left that file untouched. 

I tested this on a real project running 1.8.6-p383 and it successfully bundle install gems from both rubygems and github. 

I had some issue running the test suite:

```
➜  bundler git:(backport_to_186) ✗ rake spec
/Users/Nerian/projects/bundler/lib/bundler/lockfile_parser.rb:56:in `<class:LockfileParser>': uninitialized constant Bundler::Source::SVN (NameError)
    from /Users/Nerian/projects/bundler/lib/bundler/lockfile_parser.rb:14:in `<module:Bundler>'
    from /Users/Nerian/projects/bundler/lib/bundler/lockfile_parser.rb:13:in `<top (required)>'
    from /Users/Nerian/.rvm/gems/ruby-2.1.1/gems/bundler-1.6.2/lib/bundler/definition.rb:58:in `initialize'
    from /Users/Nerian/.rvm/gems/ruby-2.1.1/gems/bundler-1.6.2/lib/bundler/dsl.rb:178:in `new'
    from /Users/Nerian/.rvm/gems/ruby-2.1.1/gems/bundler-1.6.2/lib/bundler/dsl.rb:178:in `to_definition'
    from /Users/Nerian/.rvm/gems/ruby-2.1.1/gems/bundler-1.6.2/lib/bundler/dsl.rb:11:in `evaluate'
    from /Users/Nerian/.rvm/gems/ruby-2.1.1/gems/bundler-1.6.2/lib/bundler/definition.rb:26:in `build'
    from /Users/Nerian/.rvm/gems/ruby-2.1.1/gems/bundler-1.6.2/lib/bundler.rb:153:in `definition'
    from /Users/Nerian/.rvm/gems/ruby-2.1.1/gems/bundler-1.6.2/lib/bundler.rb:136:in `load'
    from /Users/Nerian/.rvm/gems/ruby-2.1.1@global/gems/rubygems-bundler-1.4.3/lib/rubygems-bundler/noexec.rb:46:in `candidate?'
    from /Users/Nerian/.rvm/gems/ruby-2.1.1@global/gems/rubygems-bundler-1.4.3/lib/rubygems-bundler/noexec.rb:92:in `setup'
    from /Users/Nerian/.rvm/gems/ruby-2.1.1@global/gems/rubygems-bundler-1.4.3/lib/rubygems-bundler/noexec.rb:124:in `check'
    from /Users/Nerian/.rvm/gems/ruby-2.1.1@global/gems/rubygems-bundler-1.4.3/lib/rubygems-bundler/noexec.rb:131:in `<top (required)>'
    from /Users/Nerian/.rvm/rubies/ruby-2.1.1/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:135:in `require'
    from /Users/Nerian/.rvm/rubies/ruby-2.1.1/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:135:in `rescue in require'
    from /Users/Nerian/.rvm/rubies/ruby-2.1.1/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:144:in `require'
    from /Users/Nerian/.rvm/gems/ruby-2.1.1@global/gems/rubygems-bundler-1.4.3/lib/rubygems_executable_plugin.rb:4:in `block in <top (required)>'
    from /Users/Nerian/.rvm/gems/ruby-2.1.1@global/gems/executable-hooks-1.3.1/lib/executable-hooks/hooks.rb:50:in `call'
    from /Users/Nerian/.rvm/gems/ruby-2.1.1@global/gems/executable-hooks-1.3.1/lib/executable-hooks/hooks.rb:50:in `block in run'
    from /Users/Nerian/.rvm/gems/ruby-2.1.1@global/gems/executable-hooks-1.3.1/lib/executable-hooks/hooks.rb:49:in `each'
    from /Users/Nerian/.rvm/gems/ruby-2.1.1@global/gems/executable-hooks-1.3.1/lib/executable-hooks/hooks.rb:49:in `run'
    from /Users/Nerian/.rvm/gems/ruby-2.1.1/bin/ruby_executable_hooks:10:in `<main>'
```
