### PR TITLE
Fix gem_helper_spec.rb when run with git 2.0

### DIFF
--- a/spec/bundler/gem_helper_spec.rb
+++ b/spec/bundler/gem_helper_spec.rb
@@ -163,6 +163,7 @@ describe Bundler::GemHelper do
           `git init`
           `git config user.email "you@example.com"`
           `git config user.name "name"`
+          `git config push.default simple`
         end
       end
 
@@ -203,7 +204,7 @@ describe Bundler::GemHelper do
           mock_confirm_message "Pushed git commits and tags."
           expect(subject).to receive(:rubygem_push).with(app_gem_path.to_s)
 
-          Dir.chdir(app_path) { sys_exec("git push origin master", true) }
+          Dir.chdir(app_path) { sys_exec("git push -u origin master", true) }
 
           subject.release_gem
         end


### PR DESCRIPTION
Git now errors out if you haven't set a default push behavior.

This caused a spec failure:

```
Failures:

  1) Bundler::GemHelper gem management #release_gem succeeds on releasing
     Failure/Error: subject.release_gem
     RuntimeError:
       Couldn't git push. `git push  2>&1' failed with the following output:

       warning: push.default is unset; its implicit value has changed in
       Git 2.0 from 'matching' to 'simple'. To squelch this message
       and maintain the traditional behavior, use:

         git config --global push.default matching

       To squelch this message and adopt the new behavior now, use:

         git config --global push.default simple

       When push.default is set to 'matching', git will push local branches
       to the remote branches that already exist with the same name.

       Since Git 2.0, Git defaults to the more conservative 'simple'
       behavior, which only pushes the current branch to the corresponding
       remote branch that 'git pull' uses to update the current branch.

       See 'git help config' and search for 'push.default' for further information.
       (the 'simple' mode was introduced in Git 1.7.11. Use the similar mode
       'current' instead of 'simple' if you sometimes use older versions of Git)

       fatal: The current branch master has no upstream branch.
       To push the current branch and set the remote as upstream, use

           git push --set-upstream origin master
     # ./lib/bundler/gem_helper.rb:103:in `perform_git_push'
     # ./lib/bundler/gem_helper.rb:95:in `git_push'
     # ./lib/bundler/gem_helper.rb:76:in `block in release_gem'
     # ./lib/bundler/gem_helper.rb:128:in `tag_version'
     # ./lib/bundler/gem_helper.rb:76:in `release_gem'
     # ./spec/bundler/gem_helper_spec.rb:208:in `block (5 levels) in <top (required)>'

Finished in 1.14 seconds (files took 0.32351 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/bundler/gem_helper_spec.rb:200 # Bundler::GemHelper gem management #release_gem succeeds on releasing
```

The spec still passes with reasonably-recent but older versions of git, too. I tested with git version 1.8.5.2. As the message says above, the "simple" mode was added in 1.7.11, so versions before that will probably fail, but that version was released two years ago so I think it should be OK. If not, I can change it to use another mode. For this test case, it probably won't matter.
