### PR TITLE
Fix typo in method name

### DIFF
--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -85,7 +85,7 @@ module Bundler
       # that said, it's a rare situation (other than rake), and parallel
       # installation is just SO MUCH FASTER. so we let people opt in.
       jobs = [Bundler.settings[:jobs].to_i-1, 1].max
-      if jobs > 1 && can_install_parallely?
+      if jobs > 1 && can_install_in_parallel?
         install_in_parallel jobs, options[:standalone]
       else
         install_sequentially options[:standalone]
@@ -192,7 +192,7 @@ module Bundler
 
   private
 
-    def can_install_parallely?
+    def can_install_in_parallel?
       min_rubygems = "2.0.7"
       if Bundler.current_ruby.mri? || Bundler.rubygems.provides?(">= #{min_rubygems}")
         true


### PR DESCRIPTION
Changed from can_install_parallely? to can_install_in_parallel?

The actual dictionary word would be [parallelly](http://dictionary.reference.com/browse/parallelly) but that just sounds weird.

Sorry about the nitpick, I was digging around the source and this sort of thing just gets on my nerves.

Hope it helps.
