### PR TITLE
fix retry of fetch for protected gem servers

### DIFF
--- a/lib/bundler/version.rb
+++ b/lib/bundler/version.rb
@@ -2,5 +2,5 @@ module Bundler
   # We're doing this because we might write tests that deal
   # with other versions of bundler and we are unsure how to
   # handle this better.
-  VERSION = "1.6.4.authfix.v2" unless defined?(::Bundler::VERSION)
+  VERSION = "1.6.2" unless defined?(::Bundler::VERSION)
 end

--- a/spec/support/artifice/endpoint_strict_basic_authentication.rb
+++ b/spec/support/artifice/endpoint_strict_basic_authentication.rb
@@ -8,7 +8,7 @@ class EndpointStrictBasicAuthentication < Endpoint
       halt 401, "Authentication info not supplied"
     end
 
-    # Only accepts credentials == user:pass
+    # Only accepts password == "password"
     unless env["HTTP_AUTHORIZATION"] == "Basic dXNlcjpwYXNz"
       halt 403, "Authentication failed"
     end


### PR DESCRIPTION
for me the feature with automatic retry for unauthorized response doesn't work. Reasons are missing credentials in the generated uri object and a rescue for Net::HTTPUnauthorized or Net::HTTPForbidden which both are subclasses of Net::HTTPResponse and not exceptions.
