### PR TITLE
Move add_basic_auth method into the appropriate block

### DIFF
--- a/lib/bundler/s3_fetcher.rb
+++ b/lib/bundler/s3_fetcher.rb
@@ -34,11 +34,10 @@ module Bundler
     end
 
     BASE64_URI_TRANSLATE = { '+' => '%2B', '/' => '%2F', '=' => '%3D' }.freeze
-  end
-
-  protected
-  # The s3 fetcher does not use the username and password for basic auth,
-  # so this is a no-op
-  def add_basic_auth(req)
+    protected
+      # The s3 fetcher does not use the username and password for basic auth,
+      # so this is a no-op
+      def add_basic_auth(req)
+      end
   end
 end


### PR DESCRIPTION
The add_basic_auth method was sitting in the Bundler module instead of the S3Fetcher class. This PR moves the method into the correct scope.
