### PR TITLE
Add spec around adding a binstub for an unknown gem

### DIFF
--- a/spec/commands/binstubs_spec.rb
+++ b/spec/commands/binstubs_spec.rb
@@ -120,6 +120,19 @@ describe "bundle binstubs <gem>" do
     end
   end
 
+  context "when the gem doesn't exist" do
+    it "displays an error with correct status" do
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+      G
+
+      bundle "binstubs doesnt_exist", :exitstatus => true
+
+      expect(exitstatus).to eq(7)
+      expect(out).to eq("Could not find gem 'doesnt_exist'.")
+    end
+  end
+
   context "--path" do
     it "sets the binstubs dir" do
       install_gemfile <<-G


### PR DESCRIPTION
There's a bug in 1.6.x around trying to add binstubs for a gem that it can't find. 3642d4327228e525974a0ef9e1bdfbf8c7d987dd fixes it, but the issue's still present in 1.6.x
