### PR TITLE
Fix unknown constant error

### DIFF
--- a/lib/bundler/cli/binstubs.rb
+++ b/lib/bundler/cli/binstubs.rb
@@ -1,3 +1,5 @@
+require "bundler/cli/common"
+
 module Bundler
   class CLI::Binstubs
     attr_reader :options, :gems

--- a/spec/commands/binstubs_spec.rb
+++ b/spec/commands/binstubs_spec.rb
@@ -105,6 +105,19 @@ describe "bundle binstubs <gem>" do
     end
   end
 
+  context "when the gem doesn't exist" do
+    it "displays an error with correct status" do
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+      G
+
+      bundle "binstubs doesnt_exist", :exitstatus => true
+
+      expect(exitstatus).to eq(7)
+      expect(out).to eq("Could not find gem 'doesnt_exist'.")
+    end
+  end
+
   context "--path" do
     it "sets the binstubs dir" do
       install_gemfile <<-G


### PR DESCRIPTION
When the binstubs command loads, cli/common is not loaded which causes it to error out when a gem is not present
