### PR TITLE
Fix source credentials storage in Gemfile.lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Features:
 
 Bugfixes:
 
+  - store source credentials for not configured source in Gemfile.lock (@splattael)
   - require openssl explicitly to fix rare HTTPS request failures (@indirect, #3107)
 
 ## 1.6.4 (2014-07-17)

--- a/lib/bundler/source/rubygems.rb
+++ b/lib/bundler/source/rubygems.rb
@@ -203,7 +203,7 @@ module Bundler
       end
 
       def suppress_configured_credentials(remote)
-        remote_nouser = remote.tap { |uri| uri.user = uri.password = nil }.to_s
+        remote_nouser = remote.dup.tap { |uri| uri.user = uri.password = nil }.to_s
         if remote.userinfo && remote.userinfo == Bundler.settings[remote_nouser]
           remote_nouser
         else

--- a/spec/lock/lockfile_spec.rb
+++ b/spec/lock/lockfile_spec.rb
@@ -70,6 +70,29 @@ describe "the lockfile format" do
     G
   end
 
+  it "generates a lockfile with credentials without for a not configured source" do
+    install_gemfile(<<-G, :artifice => "endpoint_strict_basic_authentication", :quiet => true)
+      source "http://user:pass@localgemserver.test/"
+
+      gem "rack-obama", ">= 1.0"
+    G
+
+    lockfile_should_be <<-G
+      GEM
+        remote: http://user:pass@localgemserver.test/
+        specs:
+          rack (1.0.0)
+          rack-obama (1.0)
+            rack
+
+      PLATFORMS
+        #{generic(Gem::Platform.local)}
+
+      DEPENDENCIES
+        rack-obama (>= 1.0)
+    G
+  end
+
   it "generates a lockfile without credentials for a configured source" do
     bundle "config http://localgemserver.test/ user:pass"
 


### PR DESCRIPTION
This PR enables storage for source credentials in Gemfile.lock again.

This feature has been accidentally broken in #3049.
