### PR TITLE
Rescue RegexpError when an invalid regexp is given to bundle show

### DIFF
--- a/lib/bundler/cli/common.rb
+++ b/lib/bundler/cli/common.rb
@@ -25,6 +25,8 @@ module Bundler
       else
         ask_for_spec_from(specs)
       end
+    rescue RegexpError
+      raise GemNotFound, gem_not_found_message(name, Bundler.definition.dependencies)
     end
 
     def self.ask_for_spec_from(specs)

--- a/spec/commands/show_spec.rb
+++ b/spec/commands/show_spec.rb
@@ -149,4 +149,18 @@ describe "bundle show" do
     bundle :show
     expect(out).to include("Installing foo 1.0")
   end
+
+  context "with an invalid regexp for gem name" do
+    it "does not find the gem" do
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem "rails"
+      G
+
+      invalid_regexp = '[]'
+
+      bundle "show #{invalid_regexp}"
+      expect(out).to include("Could not find gem '#{invalid_regexp}'.")
+    end
+  end
 end


### PR DESCRIPTION
This a fix for [issue #3065](https://github.com/bundler/bundler/issues/3065)
