### PR TITLE
Add a notice about preventing publishing the gem.

### DIFF
--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -44,7 +44,8 @@ module Bundler
         install_gem(built_gem_path)
       end
 
-      desc "Create tag #{version_tag} and build and push #{name}-#{version}.gem to Rubygems"
+      desc "Create tag #{version_tag} and build and push #{name}-#{version}.gem to Rubygems\n" \
+           "To prevent publishing in Rubygems use `gem_push=no rake release`"
       task 'release' => ['build', 'release:guard_clean',
                          'release:source_control_push', 'release:rubygem_push'] do
       end


### PR DESCRIPTION
I always forget about the environment variable to use to release a version without publishing it (for private gems).

This add a notice on the long description so the short one keeps the same.

Sample output:

```
$ rake -T release
rake release  # Create tag v1.6.5 and build and push bundler-1.6.5.gem to Rubygems
$ rake -D release
rake release
    Create tag v1.6.5 and build and push bundler-1.6.5.gem to Rubygems
    To prevent publishing in Rubygems use `gem_push=no rake release`
```
