### PR TITLE
Document git_source method in gemfile man page

### DIFF
--- a/man/gemfile.5.ronn
+++ b/man/gemfile.5.ronn
@@ -291,6 +291,19 @@ and then installs the resulting gem. The `gem build` command,
 which comes standard with Rubygems, evaluates the `.gemspec` in
 the context of the directory in which it is located.
 
+### GIT SOURCE (:git_source)
+
+A custom git source can be defined via the `git_source` method. Provide the source's name
+as an argument, and a block which receives a single argument and interpolates it into a
+string to return the full repo address:
+
+    git_source(:stash){ |repo_name| "https://stash.corp.acme.pl/#{repo_name}.git" }
+    gem 'rails', :stash => 'forks/rails'
+
+In addition, if you wish to choose a specific branch:
+
+    gem "rails", :stash => "forks/rails", :branch => "branch_name"
+
 ### GITHUB (:github)
 
 `NOTE`: This shorthand should be avoided until Bundler 2.0, since it
@@ -309,9 +322,36 @@ Are both equivalent to
 
     gem "rails", :git => "git://github.com/rails/rails.git"
 
-In addition, if you wish to choose a specific branch:
+Since the `github` method is a specialization of `git_source`, it accepts a `:branch` named argument.
 
-    gem "rails", :github => "rails/rails", :branch => "branch_name"
+### GIST (:gist)
+
+If the git repository you want to use is hosted as a Github Gist and is public, you can use
+the :gist shorthand to specify just the gist identifier (without the trailing ".git").
+
+    gem "the_hatch", :gist => "4815162342"
+
+Is equivalent to:
+
+    gem "the_hatch", :git => "https://gist.github.com/4815162342.git"
+
+Since the `gist` method is a specialization of `git_source`, it accepts a `:branch` named argument.
+
+### BITBUCKET (:bitbucket)
+
+If the git repository you want to use is hosted on Bitbucket and is public, you can use the
+:bitbucket shorthand to specify just the bitbucket username and repository name (without the
+trailing ".git"), separated by a slash. If both the username and repository name are the
+same, you can omit one.
+
+    gem "rails", :bitbucket => "rails/rails"
+    gem "rails", :bitbucket => "rails"
+
+Are both equivalent to
+
+    gem "rails", :git => "https://rails@bitbucket.org/rails/rails.git"
+
+Since the `bitbucket` method is a specialization of `git_source`, it accepts a `:branch` named argument.
 
 ### PATH (:path)
 


### PR DESCRIPTION
Resolves #3125. Also documented `bitbucket` and `gist`, since `github` is explicitly documented. It looks like `git_source` has been documented on the [git page](http://bundler.io/git.html) of the website.
