### PR TITLE
Update verification of dependency API fallback

### DIFF
--- a/spec/install/gems/dependency_api_spec.rb
+++ b/spec/install/gems/dependency_api_spec.rb
@@ -157,8 +157,8 @@ describe "gemcutter's dependency API" do
       gem "rack"
     G
 
-    bundle :install, :artifice => "endpoint_marshal_fail"
-    expect(out).to include("Fetching source index from #{source_uri}")
+    bundle :install, :verbose => true, :artifice => "endpoint_marshal_fail"
+    expect(out).to include("could not fetch from the dependency API, trying the full index")
     should_be_installed "rack 1.0.0"
   end
 


### PR DESCRIPTION
This fixes the tests and still verifies fallback. Should be enough to get 1.7.1 out the door, but we should do a clean up of the fallback code to remove the duplication.
