### PR TITLE
Prevent whitespace in gem declarations and provide clear error messaging.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Features:
   - adds a `--no-install` flag to `bundle package`
   - add `bundle viz --without` to exclude gem groups from resulting graph (@fnichol)
   - add support for private S3 sources (@tryba)
+  - prevent whitespace in gem declarations with clear messaging
 
 ## 1.7.0 (2014-08-13)
 

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -73,6 +73,9 @@ module Bundler
       if name.is_a?(Symbol)
         raise GemfileError, %{You need to specify gem names as Strings. Use 'gem "#{name.to_s}"' instead.}
       end
+      if name =~ /\s/
+        raise GemfileError, %{'#{name}' is not a valid gem name because it contains whitespace.}
+      end
 
       options = args.last.is_a?(Hash) ? args.pop.dup : {}
       version = args

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -96,6 +96,47 @@ describe Bundler::Dsl do
       expect { subject.gem("foo", :platform => :bogus) }.
         to raise_error(Bundler::GemfileError, /is not a valid platform/)
     end
+
+    it "rejects with a leading space in the name" do
+      expect { subject.gem(" foo") }.
+        to raise_error(Bundler::GemfileError, /' foo' is not a valid gem name because it contains whitespace/)
+    end
+
+    it "rejects with a trailing space in the name" do
+      expect { subject.gem("foo ") }.
+        to raise_error(Bundler::GemfileError, /'foo ' is not a valid gem name because it contains whitespace/)
+    end
+
+    it "rejects with a space in the gem name" do
+      expect { subject.gem("fo o") }.
+        to raise_error(Bundler::GemfileError, /'fo o' is not a valid gem name because it contains whitespace/)
+    end
+
+    it "rejects with a tab in the gem name" do
+      expect { subject.gem("fo\to") }.
+        to raise_error(Bundler::GemfileError, /'fo\to' is not a valid gem name because it contains whitespace/)
+    end
+
+    it "rejects with a newline in the gem name" do
+      expect { subject.gem("fo\no") }.
+        to raise_error(Bundler::GemfileError, /'fo\no' is not a valid gem name because it contains whitespace/)
+    end
+
+    it "rejects with a carriage return in the gem name" do
+      expect { subject.gem("fo\ro") }.
+        to raise_error(Bundler::GemfileError, /'fo\ro' is not a valid gem name because it contains whitespace/)
+    end
+
+    it "rejects with a form feed in the gem name" do
+      expect { subject.gem("fo\fo") }.
+        to raise_error(Bundler::GemfileError, /'fo\fo' is not a valid gem name because it contains whitespace/)
+    end
+
+    it "rejects symbols as gem name" do
+      expect { subject.gem(:foo) }.
+        to raise_error(Bundler::GemfileError, /You need to specify gem names as Strings. Use 'gem "foo"' instead/)
+    end
+
   end
 
   describe "syntax errors" do

--- a/spec/install/gems/dependency_api_spec.rb
+++ b/spec/install/gems/dependency_api_spec.rb
@@ -21,7 +21,7 @@ describe "gemcutter's dependency API" do
     G
 
     bundle :install, :artifice => "endpoint"
-    expect(out).to include("Could not find gem ' sinatra")
+    expect(out).to include("' sinatra' is not a valid gem name because it contains whitespace.")
   end
 
   it "should handle nested dependencies" do


### PR DESCRIPTION
As discussed in https://github.com/bundler/bundler-features/issues/61

This prevents whitespace (leading, trailing, or containing) from being part of a gem declaration since gem names with whitespaces are invalid. This also provides clear error messaging about why.
