### PR TITLE
source 'https://rubygems.org'

### DIFF
--- a/lib/bundler/rubygems_ext.rb
+++ b/lib/bundler/rubygems_ext.rb
@@ -73,7 +73,7 @@ module Gem
     end
 
     def to_gemfile(path = nil)
-      gemfile = "source :gemcutter\n"
+      gemfile = "source 'https://rubygems.org'\n"
       gemfile << dependencies_to_gemfile(nondevelopment_dependencies)
       unless development_dependencies.empty?
         gemfile << "\n"


### PR DESCRIPTION
in Gem::Specification's `#to_gemfile`
