### PR TITLE
Fix ruby -w warnings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Features:
   - add `bundle viz --without` to exclude gem groups from resulting graph (@fnichol)
   - add support for private S3 sources (@tryba)
   - prevent whitespace in gem declarations with clear messaging
+  - remove ruby -w warnings
 
 ## 1.7.2 (2014-08-23)
 

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -388,7 +388,9 @@ module Bundler
 
   private
 
-    attr_reader :sources
+    def sources
+      @sources
+    end
 
     def nothing_changed?
       !@source_changes && !@dependency_changes && !@new_platform && !@path_changes && !@local_changes

--- a/lib/bundler/index.rb
+++ b/lib/bundler/index.rb
@@ -102,7 +102,7 @@ module Bundler
     # returns a list of the dependencies
     def unmet_dependency_names
       names = []
-      each{|s| names.push *s.dependencies.map{|d| d.name } }
+      each{|s| names.push(*s.dependencies.map{|d| d.name }) }
       names.uniq!
       names.delete_if{|n| n == "bundler" }
       names.select{|n| search(n).empty? }


### PR DESCRIPTION
This removes ruby warnings that are emitted when running with `RUBYOPT=-w`.
