### PR TITLE
bundle install --deployment fails with new source blocks

### DIFF
--- a/spec/install/deploy_spec.rb
+++ b/spec/install/deploy_spec.rb
@@ -90,6 +90,18 @@ describe "install with --deployment or --frozen" do
 
     expect(exitstatus).to eq(0)
   end
+  
+  it "works with sources given by a block" do
+    install_gemfile(<<-G, :artifice => "endpoint_strict_basic_authentication", :quiet => true)
+      source "http://user:pass@localgemserver.test/" do
+        gem "rack-obama", ">= 1.0"
+      end
+    G
+
+    bundle "install --deployment", :exitstatus => true, :artifice => "endpoint_strict_basic_authentication"
+
+    expect(exitstatus).to eq(0)
+  end
 
   describe "with an existing lockfile" do
     before do


### PR DESCRIPTION
I'm getting bit by this bug when trying to use source blocks for private gems. Install, update, install --local all work fine, but install --deployment throws:

```
$ b install --deployment --local
You are trying to install in deployment mode after changing
your Gemfile. Run `bundle install` elsewhere and add the
updated Gemfile.lock to version control.

You have added to the Gemfile:
* source: rubygems repository https://user:pass@a-private-gem.server/
* source: rubygems repository https://rubygems.org/

You have deleted from the Gemfile:
* source: rubygems repository https://user:pass@a-private-gem.server/,
https://rubygems.org/

You have changed in the Gemfile:
* a-private-gem from `rubygems repository https://user:pass@a-private-gem.server/` to `no
specified source`
```

Pull is just a failing spec as an example
