### PR TITLE
implement all_platforms options for cache/package

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -228,6 +228,7 @@ module Bundler
 
     desc "cache [OPTIONS]", "Cache all the gems to vendor/cache", :hide => true
     method_option "all",  :type => :boolean, :banner => "Include all sources (including path, git and svn)."
+    method_option "all-platforms", :type => :boolean, :banner => "Include gems for all platforms, not just the current one"
     method_option "no-prune",  :type => :boolean, :banner => "Don't remove stale gems from the cache."
     def cache
       require 'bundler/cli/cache'
@@ -236,6 +237,7 @@ module Bundler
 
     desc "package [OPTIONS]", "Locks and then caches all of the gems into vendor/cache"
     method_option "all",  :type => :boolean, :banner => "Include all sources (including path, git and svn)."
+    method_option "all-platforms", :type => :boolean, :banner => "Include gems for all platforms, not just the current one"
     method_option "gemfile", :type => :string, :banner => "Use the specified gemfile instead of Gemfile"
     method_option "no-install",  :type => :boolean, :banner => "Don't actually install the gems, just package."
     method_option "no-prune",  :type => :boolean, :banner => "Don't remove stale gems from the cache."

--- a/lib/bundler/cli/cache.rb
+++ b/lib/bundler/cli/cache.rb
@@ -9,6 +9,7 @@ module Bundler
       Bundler.definition.validate_ruby!
       Bundler.definition.resolve_with_cache!
       setup_cache_all
+      Bundler.settings[:cache_all_platforms] = options["all-platforms"] if options.key?("all-platforms")
       Bundler.load.cache
       Bundler.settings[:no_prune] = true if options["no-prune"]
       Bundler.load.lock

--- a/lib/bundler/cli/package.rb
+++ b/lib/bundler/cli/package.rb
@@ -9,6 +9,7 @@ module Bundler
     def run
       Bundler.ui.level = "error" if options[:quiet]
       Bundler.settings[:path] = File.expand_path(options[:path]) if options[:path]
+      Bundler.settings[:cache_all_platforms] = options["all-platforms"] if options.key?("all-platforms")
 
       setup_cache_all
       install
@@ -22,7 +23,12 @@ module Bundler
 
     def install
       require 'bundler/cli/install'
-      Bundler::CLI::Install.new(options.dup).run
+      options = self.options.dup
+      if Bundler.settings[:cache_all_platforms]
+        options["local"] = false
+        options["update"] = true
+      end
+      Bundler::CLI::Install.new(options).run
     end
 
     def setup_cache_all

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -129,7 +129,7 @@ module Bundler
     # @return [Bundler::SpecSet]
     def specs
       @specs ||= begin
-        specs = resolve.materialize(requested_dependencies)
+        specs = resolve.materialize(Bundler.settings[:cache_all_platforms] ? dependencies : requested_dependencies)
 
         unless specs["bundler"].any?
           local = Bundler.settings[:frozen] ? rubygems_index : index

--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -112,6 +112,7 @@ module Bundler
       Bundler.ui.info "Updating files in vendor/cache"
       specs.each do |spec|
         next if spec.name == 'bundler'
+        spec.source.send(:fetch_gem, spec) if Bundler.settings[:cache_all_platforms] && spec.source.respond_to?(:fetch_gem, true)
         spec.source.cache(spec, custom_path) if spec.source.respond_to?(:cache)
       end
 

--- a/spec/commands/package_spec.rb
+++ b/spec/commands/package_spec.rb
@@ -42,6 +42,18 @@ describe "bundle package" do
       expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
     end
   end
+
+  context "with --all-platforms" do
+    it "puts the gems in vendor/cache even for other rubies", :ruby => "2.1" do
+      gemfile <<-D
+        source "file://#{gem_repo1}"
+        gem 'rack', :platforms => :ruby_19
+      D
+
+      bundle "package --all-platforms"
+      expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
+    end
+  end
 end
 
 describe "bundle install with gem sources" do


### PR DESCRIPTION
so that a single cache directory can be used with multiple ruby versions

we use bundle package to build a package that we then push out to all servers, but when slow-rolling a new version of ruby (i.e. upgrading from 1.9 to 2.1), the cache directory will only have the gems pertinent to the version of ruby used to package. by adding --all-platforms, the cache directory will have them all, and a subsequent bundle install --deployment --local will work correctly, regardless of if the server is running 1.9 or 2.1.