### PR TITLE
Add a space characters to fix PullReview website errors

### DIFF
--- a/spec/bundler/s3_fetcher_spec.rb
+++ b/spec/bundler/s3_fetcher_spec.rb
@@ -15,9 +15,9 @@ describe Bundler::S3Fetcher do
       accessId = "a"
       secretKey = "b"
       url = "s3://#{accessId}:#{secretKey}@foo"
-      time = Time.utc(2014,6,1).to_i
+      time = Time.utc(2014, 6, 1).to_i
 
-      actual = Bundler::S3Fetcher.new(url).sign(URI(url),time)
+      actual = Bundler::S3Fetcher.new(url).sign(URI(url), time)
       expect(actual.host).to eq "foo.s3.amazonaws.com"
       expect(actual.scheme).to eq "https"
       query = CGI.parse(actual.query)

--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -8,7 +8,7 @@ describe "The library itself" do
   def check_for_spec_defs_with_single_quotes(filename)
     failing_lines = []
 
-    File.readlines(filename).each_with_index do |line,number|
+    File.readlines(filename).each_with_index do |line, number|
       failing_lines << number + 1 if line =~ /^ *(describe|it|context) {1}'{1}/
     end
 
@@ -19,7 +19,7 @@ describe "The library itself" do
 
   def check_for_tab_characters(filename)
     failing_lines = []
-    File.readlines(filename).each_with_index do |line,number|
+    File.readlines(filename).each_with_index do |line, number|
       failing_lines << number + 1 if line =~ /\t/
     end
 
@@ -30,7 +30,7 @@ describe "The library itself" do
 
   def check_for_extra_spaces(filename)
     failing_lines = []
-    File.readlines(filename).each_with_index do |line,number|
+    File.readlines(filename).each_with_index do |line, number|
       next if line =~ /^\s+#.*\s+\n$/
       next if %w(LICENCE.md).include?(line)
       failing_lines << number + 1 if line =~ /\s+\n$/

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -68,8 +68,8 @@ module Spec
       requires << File.expand_path('../artifice/'+options.delete(:artifice)+'.rb', __FILE__) if options.key?(:artifice)
       requires_str = requires.map{|r| "-r#{r}"}.join(" ")
 
-      env = (options.delete(:env) || {}).map{|k,v| "#{k}='#{v}'"}.join(" ")
-      args = options.map do |k,v|
+      env = (options.delete(:env) || {}).map{|k, v| "#{k}='#{v}'"}.join(" ")
+      args = options.map do |k, v|
         v == true ? " --#{k}" : " --#{k} #{v}" if v
       end.join
 
@@ -93,7 +93,7 @@ module Spec
       requires << File.expand_path('../artifice/'+options.delete(:artifice)+'.rb', __FILE__) if options.key?(:artifice)
       requires_str = requires.map{|r| "-r#{r}"}.join(" ")
 
-      env = (options.delete(:env) || {}).map{|k,v| "#{k}='#{v}' "}.join
+      env = (options.delete(:env) || {}).map{|k, v| "#{k}='#{v}' "}.join
       cmd = "#{env}#{Gem.ruby} -I#{lib} #{requires_str} #{bundle_bin}"
 
       if exitstatus
@@ -105,7 +105,7 @@ module Spec
 
     def ruby(ruby, options = {})
       expect_err = options.delete(:expect_err)
-      env = (options.delete(:env) || {}).map{|k,v| "#{k}='#{v}' "}.join
+      env = (options.delete(:env) || {}).map{|k, v| "#{k}='#{v}' "}.join
       ruby.gsub!(/["`\$]/) {|m| "\\#{m}" }
       lib_option = options[:no_lib] ? "" : " -I#{lib}"
       sys_exec(%{#{env}#{Gem.ruby}#{lib_option} -e "#{ruby}"}, expect_err)


### PR DESCRIPTION
Add a space character after the comma to fix the ten **“Spaces Missing After Commas”** items on this page:  https://www.pullreview.com/github/bundler/bundler/reviews/master
