### PR TITLE
Use HTTP auth if configured when checking for presence of API

### DIFF
--- a/spec/install/gems/dependency_api_spec.rb
+++ b/spec/install/gems/dependency_api_spec.rb
@@ -467,6 +467,8 @@ describe "gemcutter's dependency API" do
         bundle "config #{source_uri}/ #{user}:#{password}"
 
         bundle :install, :artifice => "endpoint_strict_basic_authentication"
+
+        expect(out).to include("Fetching gem metadata from #{source_uri}")
         should_be_installed "rack 1.0.0"
       end
 


### PR DESCRIPTION
If gem server uses HTTP auth set up in config file, API is not used. Instead the whole index of gem server is fetched.
