### PR TITLE
Don't swallow LoadErrors when requiring a dashed gem

### DIFF
--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -83,11 +83,10 @@ module Bundler
             begin
               namespaced_file = dep.name.gsub('-', '/')
               Kernel.require namespaced_file
-            rescue LoadError
+            rescue LoadError => e
               REGEXPS.find { |r| r =~ e.message }
               regex_name = $1
-              raise e if dep.autorequire || (regex_name && regex_name.gsub('-', '/') != namespaced_file)
-              raise e if regex_name.nil?
+              raise if regex_name != namespaced_file
             end
           end
         end


### PR DESCRIPTION
This looks like #1807 

when raising a LoadError in a required gem, bundler will rescue it to try and see if it came from his own namespaced require or from the required file.

If it comes from the dashed require it will re-raise the original exception in case the gem was dashed but the first require was ok but raised a LoadError after.

However, the exception is swallowed if we require a dashed gem without the proper file name, for example gem name : 'foo-bar' and file architecture : 'foo/bar.rb'

This PR cleans a bit the code (remove useless condition) and fixes the issues with the loading :
- If we can't load the filename with the dash, we try with a slash
- if the exception is about the file with a slash, it passes silently because we can't find any of the files
- Otherwise, we rise the exception we just got 
