### PR TITLE
Add warning message when Gemfiles use source with a block.

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -125,6 +125,13 @@ module Bundler
         return
       when String
         rubygems_source.add_remote source
+
+        if block_given?
+          Bundler.ui.warn "A block was passed to `source`, but Bundler versions " \
+            "prior to 1.7 ignore the block.  Please upgrade Bundler to 1.7 or " \
+            "specify your dependencies outside of the block passed to `source`."
+        end
+
         return
       else
         @source = source

--- a/spec/install/gemfile_spec.rb
+++ b/spec/install/gemfile_spec.rb
@@ -41,4 +41,29 @@ describe "bundle install" do
     end
   end
 
+  context "with future features" do
+    context "when source is used with a block" do
+      it "reports that sources with a block is not supported" do
+        gemfile <<-G
+          source 'http://rubygems.example.org' do
+            gem 'rack'
+          end
+        G
+
+        bundle :install
+        expect(out).to match(/A block was passed to `source`/)
+      end
+    end
+
+    context "when source is used without a block" do
+      it "prints no warnings" do
+        gemfile <<-G
+          source 'http://rubygems.example.org'
+        G
+
+        bundle :install
+        expect(out).not_to match(/A block was passed to `source`/)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This fixes issue #3198.

When a user has a Gemfile such as:

``` ruby
source 'http://example.com' do
  gem 'nokogiri'
end
```

This prints a warning, as this form of `source` is not supported in Bundlers <1.7.
