### PR TITLE
spec.name fails if spec is still nil

### DIFF
--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -306,12 +306,12 @@ module Bundler
 
         if exec_name
           spec = specs.find { |s| s.executables.include?(exec_name) }
+          spec or raise Gem::Exception, "can't find executable #{exec_name}"
           unless spec.name == name
             warn "Bundler is using a binstub that was created for a different gem.\n" \
               "This is deprecated, in future versions you may need to `bundle binstub #{name}` " \
               "to work around a system/bundle conflict."
           end
-          spec or raise Gem::Exception, "can't find executable #{exec_name}"
         else
           spec = specs.find  { |s| s.name == name }
           exec_name = spec.default_executable or raise Gem::Exception, "no default executable for #{spec.full_name}"


### PR DESCRIPTION
spec.name fails if spec is still nil
