### PR TITLE
Add flat docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Version     ](https://img.shields.io/gem/v/bundler.svg?style=flat)](https://rubygems.org/gems/bundler)
 [![Build Status](https://img.shields.io/travis/bundler/bundler/master.svg?style=flat)](https://travis-ci.org/bundler/bundler)
 [![Code Climate](https://img.shields.io/codeclimate/github/bundler/bundler.svg?style=flat)](https://codeclimate.com/github/bundler/bundler)
+[![Inline docs ](http://inch-ci.org/github/bundler/bundler.svg?style=flat)](http://inch-ci.org/github/bundler/bundler)
 [![Gittip
 ](http://img.shields.io/gittip/bundler.svg?style=flat)](http://gittip.com/bundler)
 


### PR DESCRIPTION
Hi,

this re-adds the docs badge with `flat`-style to match the other badges. Please note that this assumes that the badge was removed because its `flat`-setting is undocumented (it was added [some time ago](https://github.com/inch-ci/inch_ci-web/issues/19)).

If you deleted the docs badge deliberately, please ignore this PR. :+1: 
