### PR TITLE
Don't package test files with gem

### DIFF
--- a/bundler.gemspec
+++ b/bundler.gemspec
@@ -20,12 +20,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'ronn', '~> 0.7.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
 
-  spec.files       = `git ls-files -z`.split("\x0")
+  spec.files       = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   # we don't check in man pages, but we need to ship them because
   # we use them to generate the long-form help for each command.
   spec.files      += Dir.glob('lib/bundler/man/**/*')
 
-  spec.test_files  = spec.files.grep(%r{^spec/})
   spec.executables   = %w(bundle bundler)
   spec.require_paths = ["lib"]
 end

--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -22,9 +22,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = "TODO: Put your gem's website or public repo URL here."
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0")
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> <%= Bundler::VERSION.split(".")[0..1].join(".") %>"


### PR DESCRIPTION
I just :ship: a new version of the [`rails_admin` gem](http://rubygems.org/gems/rails_admin) and it took longer to push than I expected. Upon investigating, I realized that was because the gem had grown to 8.1 MB:exclamation: Digging deeper, I was astonished to [realize](https://twitter.com/sferik/status/519836262631739393) that all but 229 KB were tests! This means that hundreds of thousands of people were downloading a file 36X bigger than necessary to get tests they would almost certainly never run.

This may be an extreme example, as RailsAdmin embeds a full Rails app in the spec directory in order to mount itself as a Rails engine. That said, this problem affects almost every gem, albeit to a lesser extent, and I can’t think of a good reason why any gem should package its tests.

Back in the day, there was a service called [Gem Testers](https://blog.engineyard.com/2011/introducing-gem-testers) (originally at gem-testers.org and eventually at test.rubygems.org) and a corresponding [`rubygems-test` gem](http://rubygems.org/gems/rubygems-test) that automatically ran the test suite of a every gem on install, however, this service never gained traction and is now offline.

If someone wants to run the tests for a particular gem, they can easily find the source code at the project’s homepage. Ninety-nine percent of the time, when someone installs a gem it’s because they want to execute the code, not the tests. I believe changing this default will improve the health of the RubyGems ecosystem and the Ruby community. If everyone adopts this change, `bundle install` will be significantly faster, especially in places where bandwidth is constrained (e.g. in hotels, at conferences, on airplanes, when tethered to a 3G connection, and in much of the developing world).

This patch excludes test files from the `bundle gem` template as well as from Bundler’s own gemspec.
