### PR TITLE
Console options

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -286,6 +286,7 @@ module Bundler
     end
 
     desc "console [GROUP]", "Opens an IRB session with the bundle pre-loaded"
+    method_option :load_paths, :type => :array, :default => [], :aliases => '-I'
     def console(group = nil)
       require 'bundler/cli/console'
       Console.new(options, group).run

--- a/lib/bundler/cli/console.rb
+++ b/lib/bundler/cli/console.rb
@@ -12,6 +12,11 @@ module Bundler
 
       console = get_console(Bundler.settings[:console] || 'irb')
       load '.consolerc' if File.exists?('.consolerc')
+
+      options[:load_paths].each do |dir|
+        $LOAD_PATH.unshift(File.expand_path(dir))
+      end
+
       console.start
     end
 

--- a/spec/commands/console_spec.rb
+++ b/spec/commands/console_spec.rb
@@ -55,6 +55,31 @@ describe "bundle console" do
     expect(out).to include("NameError")
   end
 
+  context "when given -I options" do
+    let(:dir) { '/foo/bar' }
+
+    it "adds the directories to the front of $LOAD_PATH" do
+      bundle "console -I #{dir}" do |input|
+        input.puts("puts $LOAD_PATH[0]")
+        input.puts("exit")
+      end
+      expect(out.split($/)).to include(dir)
+    end
+
+    context "when the directory is relative" do
+      let(:relative_path) { "./foo/bar" }
+      let(:expanded_path) { File.expand_path(relative_path) }
+
+      it "expands the directory path" do
+        bundle "console -I #{relative_path}" do |input|
+          input.puts("puts $LOAD_PATH[0]")
+          input.puts("exit")
+        end
+        expect(out.split($/)).to include(expanded_path)
+      end
+    end
+  end
+
   context "when given a group" do
     it "loads the given group" do
       bundle "console test" do |input|


### PR DESCRIPTION
- Added the `-I,--load-paths` option to the console command.
- Directory paths are expanded and unshifted onto `$LOAD_PATH`.
