### PR TITLE
Fix typo in bundle-install.ronn

### DIFF
--- a/man/bundle-install.ronn
+++ b/man/bundle-install.ronn
@@ -133,7 +133,7 @@ update process below under [CONSERVATIVE UPDATING][].
 Bundler's defaults are optimized for development. To switch to
 defaults optimized for deployment, use the `--deployment` flag.
 Do not activate deployment mode on development machines, as it
-will cause in an error when the Gemfile(5) is modified.
+will cause an error when the Gemfile(5) is modified.
 
 1. A `Gemfile.lock` is required.
 


### PR DESCRIPTION
Change "as it will cause in an error" to "as it will cause an error".
