### PR TITLE
Fix RubyGems 2.2+ compatibility.

### DIFF
--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -115,7 +115,7 @@ module Bundler
 
         Gem.loaded_specs.clear
 
-        bundler_spec.activate
+        bundler_spec.activate if bundler_spec
       end
     end
 


### PR DESCRIPTION
RubyGems allows since version 2.2 to reconfigure place, where binary
extensions are stored. This might allow easier sharing of gems between
various Ruby interpreters. It can be enabled by redefining
Gem.default_ext_dir_for method.

This patch is adding support for this feature into Bundler.

Please note that this patch very likely breaks compatibility with older version of RubyGems. Not sure what is the desired compatibility matrix, since this [1] one does not answer the question :/

[1] http://bundler.io/compatibility.html
