### PR TITLE
Strip credentials from ambiguous source warnings.

### DIFF
--- a/spec/install/gems/dependency_api_spec.rb
+++ b/spec/install/gems/dependency_api_spec.rb
@@ -444,6 +444,19 @@ describe "gemcutter's dependency API" do
       expect(out).not_to include("#{user}:#{password}")
     end
 
+    it "strips http basic auth creds when warning about ambiguous sources" do
+      gemfile <<-G
+        source "#{basic_auth_source_uri}"
+        source "file://#{gem_repo1}"
+        gem "rack"
+      G
+
+      bundle :install, :artifice => "endpoint_basic_authentication"
+      expect(out).to include("Warning: the gem 'rack' was found in multiple sources.")
+      expect(out).not_to include("#{user}:#{password}")
+      should_be_installed "rack 1.0.0"
+    end
+
     it "does not pass the user / password to different hosts on redirect" do
       gemfile <<-G
         source "#{basic_auth_source_uri}"


### PR DESCRIPTION
Fixes #3249.
