### PR TITLE
raise AuthenticationRequiredError on Net::HTTPForbidden

### DIFF
--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -298,7 +298,7 @@ module Bundler
         response.body
       when Net::HTTPRequestEntityTooLarge
         raise FallbackError, response.body
-      when Net::HTTPUnauthorized
+      when Net::HTTPUnauthorized, Net::HTTPForbidden
         raise AuthenticationRequiredError, "#{response.class}: #{response.body}"
       else
         raise HTTPError, "#{response.class}: #{response.body}"


### PR DESCRIPTION
This partly addresses the issue found in the larger discussion with @TimMoore 
https://github.com/bundler/bundler/issues/3180#issuecomment-59780298

This simply adds `Net::HTTPForbidden` as a `AuthenticationRequiredError`, which seems to have been inadvertently removed in this pull_request https://github.com/bundler/bundler/pull/3191
#### Before this fix

```
HTTP GET https://gem.fury.io/me/api/v1/dependencies
HTTP 403 Forbidden  # <-- broken

HTTP GET http://bundler.rubygems.org/api/v1/dependencies
HTTP 200 OK
```
#### After this fix

```
HTTP GET https://gem.fury.io/me/api/v1/dependencies
HTTP 403 Forbidden
HTTP GET https://CREDENTIALS@gem.fury.io/me/api/v1/dependencies
HTTP 200 OK  # <-- fixed

HTTP GET http://bundler.rubygems.org/api/v1/dependencies
HTTP 200 OK
```
