### PR TITLE
Fixes: Ancient version check matches unrelated gems

### DIFF
--- a/bin/bundle
+++ b/bin/bundle
@@ -6,7 +6,7 @@ Signal.trap("INT") { exit 1 }
 require 'bundler'
 # Check if an older version of bundler is installed
 $LOAD_PATH.each do |path|
-  if path =~ %r'/bundler-0.(\d+)' && $1.to_i < 9
+  if path =~ %r'/bundler-0\.(\d+)' && $1.to_i < 9
     err = "Looks like you have a version of bundler that's older than 0.9.\n"
     err << "Please remove your old versions.\n"
     err << "An easy way to do this is by running `gem cleanup bundler`."


### PR DESCRIPTION
This commit will fix the following issue: #3188

It's done by fixing a regex, where a `.` was used, but the escaped version `\.` should be used.
## Content of $LOAD_PATH

```
$LOAD_PATH.select { |e| e =~ %r'/bundler-' }

# => 
# [
#   "/home/patrick/.rvm/gems/ruby-2.1.3@rails3/bundler/gems/bundler-010c47fd919a/lib",
#   "/home/patrick/.rvm/gems/ruby-2.1.3@rails3/gems/bundler-1.7.6/lib"
# ]
```

The line `bundler-010c47fd919a/lib` was matched with the old regex, but shout not be matched.
