### PR TITLE
Use latest minor series of RG

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ env:
   # We need to know if changes to rubygems will break bundler on release
   - RGV=master
   # Test the latest rubygems release with all of our supported rubies
-  - RGV=v2.3.0
+  - RGV=v2.4.0
 
 matrix:
   fast_finish: true

--- a/Rakefile
+++ b/Rakefile
@@ -112,7 +112,7 @@ begin
       rubyopt = ENV["RUBYOPT"]
       # When editing this list, also edit .travis.yml!
       branches = %w(master 2.2)
-      releases = %w(v1.3.6 v1.3.7 v1.4.2 v1.5.3 v1.6.2 v1.7.2 v1.8.29 v2.0.14 v2.1.11 v2.2.2 v2.3.0)
+      releases = %w(v1.3.6 v1.3.7 v1.4.2 v1.5.3 v1.6.2 v1.7.2 v1.8.29 v2.0.14 v2.1.11 v2.2.2 v2.4.0)
       (branches + releases).each do |rg|
         desc "Run specs with Rubygems #{rg}"
         RSpec::Core::RakeTask.new(rg) do |t|


### PR DESCRIPTION
RG 2.3 was never included in a release of Ruby, however the latest minor series(v2.4) will be included with the release of Ruby 2.2.

The latest version of RG in this series is currently 2.4.4.
