### PR TITLE
Allow relative directories as gem names in bundle gem command

### DIFF
--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -6,11 +6,11 @@ module Bundler
 
     def initialize(options, gem_name, thor)
       @options = options
-      @gem_name = gem_name
+      @gem_name = resolve_name(gem_name)
       @thor = thor
 
-      @name = gem_name.chomp("/") # remove trailing slash if present
-      @target = Pathname.pwd.join(name)
+      @name = @gem_name
+      @target = Pathname.pwd.join(gem_name)
 
       validate_ext_name if options[:ext]
     end
@@ -85,6 +85,12 @@ module Bundler
         # Open gemspec in editor
         thor.run("#{options["edit"]} \"#{target.join("#{name}.gemspec")}\"")
       end
+    end
+
+    private
+
+    def resolve_name(name)
+      Pathname.pwd.join(name).basename.to_s
     end
 
     def validate_ext_name

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -35,6 +35,42 @@ describe "bundle gem" do
     end
   end
 
+  context "gem naming with relative paths" do
+    before do
+      reset!
+      in_app_root
+    end
+
+    it "resolves ." do
+      create_temporary_dir('tmp')
+
+      bundle 'gem .'
+
+      expect(bundled_app("tmp/lib/tmp.rb")).to exist
+    end
+
+    it "resolves .." do
+      create_temporary_dir('temp/empty_dir')
+
+      bundle 'gem ..'
+
+      expect(bundled_app("temp/lib/temp.rb")).to exist
+    end
+
+    it "resolves relative directory" do
+      create_temporary_dir('tmp/empty/tmp')
+
+      bundle 'gem ../../empty'
+
+      expect(bundled_app("tmp/empty/lib/empty.rb")).to exist
+    end
+
+    def create_temporary_dir(dir)
+      FileUtils.mkdir_p(dir)
+      Dir.chdir(dir)
+    end
+  end
+
   context "gem naming with underscore" do
     let(:gem_name) { 'test_gem' }
 


### PR DESCRIPTION
I often try to do `bundle gem .` once inside the directory I set up for
the gem. This do creates boilerplate in the current directory, however
it assumes the gem is named `.`.

With this patch you can do `bundle gem .` and it will scaffold the gem
with the current folder name. It even goes a bit beyond that and allows
any relative path to be a valid gem target.
