### PR TITLE
Optimized bundle-exec

### DIFF
--- a/lib/bundler/cli/exec.rb
+++ b/lib/bundler/cli/exec.rb
@@ -1,36 +1,79 @@
 module Bundler
   class CLI::Exec
-    attr_reader :options, :args
+    attr_reader :options, :args, :cmd
 
     def initialize(options, args)
       @options = options
+      @cmd = args.shift
       @args = args
+
+      if RUBY_VERSION >= "2.0"
+        @args << { :close_others => !options.keep_file_descriptors? }
+      elsif options.keep_file_descriptors?
+        Bundler.ui.warn "Ruby version #{RUBY_VERSION} defaults to keeping non-standard file descriptors on Kernel#exec."
+      end
     end
 
     def run
-      Bundler.definition.validate_ruby!
-      Bundler.load.setup_environment
-
       begin
-        if RUBY_VERSION >= "2.0"
-          @args << { :close_others => !options.keep_file_descriptors? }
-        elsif options.keep_file_descriptors?
-          Bundler.ui.warn "Ruby version #{RUBY_VERSION} defaults to keeping non-standard file descriptors on Kernel#exec."
+        if cmd.nil?
+          raise ArgumentError.new
         end
 
-        # Run
-        Kernel.exec(*args)
+        execute_within_path
       rescue Errno::EACCES
-        Bundler.ui.error "bundler: not executable: #{args.first}"
+        Bundler.ui.error "bundler: not executable: #{cmd}"
         exit 126
       rescue Errno::ENOENT
-        Bundler.ui.error "bundler: command not found: #{args.first}"
+        Bundler.ui.error "bundler: command not found: #{cmd}"
         Bundler.ui.warn  "Install missing gem executables with `bundle install`"
         exit 127
       rescue ArgumentError
         Bundler.ui.error "bundler: exec needs a command to run"
         exit 128
       end
+    end
+
+    private
+
+    def execute_within_path
+      if RUBY_VERSION >= "1.9"
+        path.each do |path|
+          bin_path = File.join(path, @cmd)
+          if bin_path == Bundler.which(@cmd)
+            Kernel.exec(build_env, bin_path, *args)
+          end
+        end
+      end
+
+      # fallback
+      Bundler.definition.validate_ruby!
+      Bundler.load.setup_environment
+      Kernel.exec(@cmd, *args)
+    end
+
+    def path
+      ENV['PATH'].split(":").map { |p| File.expand_path(p) }
+    end
+
+    def build_env
+      rubyopt = [ENV["RUBYOPT"]].compact
+      if rubyopt.empty? || rubyopt.first !~ /-rbundler\/setup/
+        rubyopt << %|-rbundler/setup|
+      end
+
+      rubylib = (ENV["RUBYLIB"] || "").split(File::PATH_SEPARATOR)
+      rubylib.unshift File.expand_path('../../..', __FILE__)
+
+      {
+        'RUBYOPT' => rubyopt.join(' '),
+        'RUBYLIB' => rubylib.uniq.join(File::PATH_SEPARATOR),
+        'FORCE_TTY' => 'true'
+      }
+    end
+
+    def env_string
+      build_env.to_a.map { |k| "#{k[0]}=#{k[1]}"}.join(" ")
     end
 
   end

--- a/lib/bundler/cli/exec.rb
+++ b/lib/bundler/cli/exec.rb
@@ -37,15 +37,11 @@ module Bundler
     private
 
     def execute_within_path
-      path.each do |path|
-        bin_path = File.join(path, @cmd)
-        if bin_path == Bundler.which(@cmd)
-          if RUBY_VERSION >= "1.9"
+      if RUBY_VERSION >= "1.9"
+        path.each do |path|
+          bin_path = File.join(path, @cmd)
+          if bin_path == Bundler.which(@cmd)
             Kernel.exec(build_env, bin_path, *args)
-          else
-            cmd = [env_string, bin_path, args.map { |ar| %("#{ar}") } ].join(" ")
-            cmd << ";"
-            Kernel.exec(cmd)
           end
         end
       end
@@ -70,7 +66,7 @@ module Bundler
       rubylib.unshift File.expand_path('../../..', __FILE__)
 
       {
-        'RUBYOPT' => %("#{rubyopt.join(' ')}"),
+        'RUBYOPT' => rubyopt.join(' '),
         'RUBYLIB' => rubylib.uniq.join(File::PATH_SEPARATOR),
         'FORCE_TTY' => 'true'
       }

--- a/lib/bundler/cli/exec.rb
+++ b/lib/bundler/cli/exec.rb
@@ -37,11 +37,15 @@ module Bundler
     private
 
     def execute_within_path
-      if RUBY_VERSION >= "1.9"
-        path.each do |path|
-          bin_path = File.join(path, @cmd)
-          if bin_path == Bundler.which(@cmd)
+      path.each do |path|
+        bin_path = File.join(path, @cmd)
+        if bin_path == Bundler.which(@cmd)
+          if RUBY_VERSION >= "1.9"
             Kernel.exec(build_env, bin_path, *args)
+          else
+            cmd = [env_string, bin_path, args.map { |ar| %("#{ar}") } ].join(" ")
+            cmd << ";"
+            Kernel.exec(cmd)
           end
         end
       end
@@ -66,7 +70,7 @@ module Bundler
       rubylib.unshift File.expand_path('../../..', __FILE__)
 
       {
-        'RUBYOPT' => rubyopt.join(' '),
+        'RUBYOPT' => %("#{rubyopt.join(' ')}"),
         'RUBYLIB' => rubylib.uniq.join(File::PATH_SEPARATOR),
         'FORCE_TTY' => 'true'
       }

--- a/lib/bundler/setup.rb
+++ b/lib/bundler/setup.rb
@@ -2,7 +2,7 @@ require 'bundler/shared_helpers'
 
 if Bundler::SharedHelpers.in_bundle?
   require 'bundler'
-  if STDOUT.tty?
+  if STDOUT.tty? || ENV['FORCE_TTY']
     begin
       Bundler.setup
     rescue Bundler::BundlerError => e


### PR DESCRIPTION
(from https://trello.com/c/bf90QcsN/66-exec-as-soon-as-possible, originally it's @indirect's idea)

Right now the exec command loads the entire Gemfile, the entire lockfile, resolves the gemfile against the lockfile, and then execs. Instead, let's check $PATH for the exec command and exec instantly if it's there.