### PR TITLE
`bundle config --local gemfile /foo/bar/MyGemfile` now works

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -191,7 +191,13 @@ module Bundler
     end
 
     def root
-      @root ||= default_gemfile.dirname.expand_path
+      @root ||= begin
+                  default_gemfile.dirname.expand_path
+                rescue GemfileNotFound
+                  bundle_dir = default_bundle_dir
+                  raise GemfileNotFound, "Could not locate Gemfile or .bundle/ directory" unless bundle_dir
+                  Pathname.new(File.expand_path("..", bundle_dir))
+                end
     end
 
     def app_config_path
@@ -214,7 +220,7 @@ module Bundler
       return @settings if defined?(@settings)
       @settings = Settings.new(app_config_path)
     rescue GemfileNotFound
-      @settings = Settings.new
+      @settings = Settings.new(Pathname.new(".bundle").expand_path)
     end
 
     def with_original_env
@@ -251,6 +257,10 @@ module Bundler
 
     def default_lockfile
       SharedHelpers.default_lockfile
+    end
+
+    def default_bundle_dir
+      SharedHelpers.default_bundle_dir
     end
 
     def system_bindir

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -14,7 +14,8 @@ module Bundler
 
     def initialize(*)
       super
-      ENV['BUNDLE_GEMFILE']   = File.expand_path(options[:gemfile]) if options[:gemfile]
+      custom_gemfile = options[:gemfile] || Bundler.settings[:gemfile]
+      ENV['BUNDLE_GEMFILE']   = File.expand_path(custom_gemfile) if custom_gemfile
       Bundler::Retry.attempts = options[:retry] || Bundler.settings[:retry] || Bundler::Retry::DEFAULT_ATTEMPTS
       Bundler.rubygems.ui = UI::RGProxy.new(Bundler.ui)
     rescue UnknownArgumentError => e

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -86,6 +86,12 @@ learn more about their operation in [bundle install(1)][bundle-install].
 * `bin` (`BUNDLE_BIN`):
   Install executables from gems in the bundle to the specified directory.
   Defaults to `false`.
+* `gemfile` (`BUNDLE_GEMFILE`):
+  The name of the file that bundler should use as the `Gemfile`. This location
+  of this file also sets the root of the project, which is used to resolve
+  relative paths in the `Gemfile`, among other things. By default, bundler
+  will search up from the current working directory until it finds a
+  `Gemfile`.
 * `ssl_ca_cert` (`BUNDLE_SSL_CA_CERT`):
   Path to a designated CA certificate file or folder containing multiple
   certificates for trusted CAs in PEM format.
@@ -99,18 +105,6 @@ flag to the [bundle install(1)][bundle-install] command.
 You can set them globally either via environment variables or `bundle config`,
 whichever is preferable for your setup. If you use both, environment variables
 will take preference over global settings.
-
-An additional setting is available only as an environment variable:
-
-* `BUNDLE_GEMFILE`:
-  The name of the file that bundler should use as the `Gemfile`. This location
-  of this file also sets the root of the project, which is used to resolve
-  relative paths in the `Gemfile`, among other things. By default, bundler
-  will search up from the current working directory until it finds a
-  `Gemfile`.
-
-Bundler will ignore any `BUNDLE_GEMFILE` entries in local or global
-configuration files.
 
 ## LOCAL GIT REPOS
 

--- a/spec/commands/config_spec.rb
+++ b/spec/commands/config_spec.rb
@@ -237,5 +237,23 @@ E
       expect(out).to match(long_string)
     end
   end
+end
 
+describe "setting gemfile via config" do
+  context "when only the non-default Gemfile exists" do
+    before do
+      gemfile bundled_app("NotGemfile"), <<-G
+      source "file://#{gem_repo1}"
+      gem 'rack'
+      G
+    end
+    it "persists the gemfile location to .bundle/config" do
+
+      bundle "config --local gemfile #{bundled_app("NotGemfile")}"
+      expect(File.exists?(".bundle/config")).to eq(true)
+
+      bundle "config"
+      expect(out).to include("NotGemfile")
+    end
+  end
 end

--- a/spec/install/gemfile_spec.rb
+++ b/spec/install/gemfile_spec.rb
@@ -26,6 +26,32 @@ describe "bundle install" do
     end
   end
 
+  context "with gemfile set via config" do
+    before do
+      gemfile bundled_app("NotGemfile"), <<-G
+        source "file://#{gem_repo1}"
+        gem 'rack'
+      G
+
+      bundle "config --local gemfile #{bundled_app("NotGemfile")}"
+    end
+    it "uses the gemfile to install" do
+      bundle "install"
+      bundle "show"
+
+      expect(out).to include("rack (1.0.0)")
+    end
+    it "uses the gemfile while in a subdirectory" do
+      bundled_app("subdir").mkpath
+      Dir.chdir(bundled_app("subdir")) do
+        bundle "install"
+        bundle "show"
+
+        expect(out).to include("rack (1.0.0)")
+      end
+    end
+  end
+
   context "with deprecated features" do
     before :each do
       in_app_root


### PR DESCRIPTION
- `bundle config` can be used to set a custom gemfile name for a
  project (specifying an absolute path)
- using other bundle commands will now search up parent directories
  for a .bundle dir and use the gemfile specified in .bundle/config if
  it is set
- does not require a file named 'Gemfile' to exist
- Revert "Correct bundle-config manpage"
  This reverts commit 0a81457.
- An added bonus: you can now both set and _delete_ a global bundler
  setting from _anywhere_: `bundle config --delete foo`
### Manual Test:

In an empty directory `/foo/bar/`:
`echo "source 'https://rubygems.org'" > MyGemfile`
`echo "gem 'rake'" >> MyGemfile`
`bundle config --local gemfile /foo/bar/FooGemfile`
`bundle install`
`bundle show` # Should show the rake gem
`mkdir spec && cd spec && bundle show` # Should also show the rake gem
