### PR TITLE
Extended gem generation and generation settings

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -342,6 +342,9 @@ module Bundler
     method_option :test, :type => :string, :lazy_default => 'rspec', :aliases => '-t', :banner =>
       "Generate a test directory for your library: 'rspec' is the default, but 'minitest' is also supported."
 
+    method_option :mit, :type => :boolean, :banner => "Use MIT license"
+    method_option :coc, :type => :boolean, :banner => "Use Code Of Conduct"
+
     def gem(name)
       require 'bundler/cli/gem'
       Gem.new(options, name, self).run

--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -42,29 +42,39 @@ module Bundler
         "gitignore.tt" => ".gitignore",
         "lib/newgem.rb.tt" => "lib/#{namespaced_path}.rb",
         "lib/newgem/version.rb.tt" => "lib/#{namespaced_path}/version.rb",
-        "LICENSE.txt.tt" => "LICENSE.txt",
         "newgem.gemspec.tt" => "#{name}.gemspec",
         "consolerc.tt" => ".consolerc",
         "Rakefile.tt" => "Rakefile",
         "README.md.tt" => "README.md"
       }
 
-      templates.merge!("bin/newgem.tt" => "bin/#{name}") if options[:bin]
-      templates.merge!(".travis.yml.tt" => ".travis.yml") if options[:test]
-
-      case options[:test]
-      when 'rspec'
-        templates.merge!(
-          "rspec.tt" => ".rspec",
-          "spec/spec_helper.rb.tt" => "spec/spec_helper.rb",
-          "spec/newgem_spec.rb.tt" => "spec/#{namespaced_path}_spec.rb"
-        )
-      when 'minitest'
-        templates.merge!(
-          "test/minitest_helper.rb.tt" => "test/minitest_helper.rb",
-          "test/test_newgem.rb.tt" => "test/test_#{namespaced_path}.rb"
-        )
+      if ask_and_set(:coc, "Do you want to include Code Of Conduct?")
+        templates.merge!("CODE_OF_CONDUCT.md.tt" => "CODE_OF_CONDUCT.md")
       end
+
+      if ask_and_set(:mit, "Do you want to license your code permissively under the MIT license (http://choosealicense.com/licenses/mit/)?")
+        templates.merge!("LICENSE.txt.tt" => "LICENSE.txt")
+      end
+
+      if test_framework = ask_and_set_test_framework
+        templates.merge!(".travis.yml.tt" => ".travis.yml")
+
+        case test_framework
+        when 'rspec'
+          templates.merge!(
+            "rspec.tt" => ".rspec",
+            "spec/spec_helper.rb.tt" => "spec/spec_helper.rb",
+            "spec/newgem_spec.rb.tt" => "spec/#{namespaced_path}_spec.rb"
+          )
+        when 'minitest'
+          templates.merge!(
+            "test/minitest_helper.rb.tt" => "test/minitest_helper.rb",
+            "test/test_newgem.rb.tt" => "test/test_#{namespaced_path}.rb"
+          )
+        end
+      end
+
+      templates.merge!("bin/newgem.tt" => "bin/#{name}") if options[:bin]
 
       if options[:ext]
         templates.merge!(
@@ -93,6 +103,19 @@ module Bundler
       Pathname.pwd.join(name).basename.to_s
     end
 
+    def ask_and_set(key, message)
+      result = options[key]
+      if !Bundler.settings.all.include?("gem.#{key}")
+        if result.nil?
+          result = Bundler.ui.ask("#{message} (y/n):") == "y"
+        end
+
+        Bundler.settings.set_global("gem.#{key}", result)
+      end
+
+      result || Bundler.settings["gem.#{key}"]
+    end
+
     def validate_ext_name
       return unless gem_name.index('-')
 
@@ -101,6 +124,21 @@ module Bundler
                        "see the 'Extension Naming' section at the following URL:\n" \
                        "http://guides.rubygems.org/gems-with-extensions/\n"
       exit 1
+    end
+
+    def ask_and_set_test_framework
+      test_framework = options[:test] || Bundler.settings["gem.test"]
+      if test_framework.nil?
+        result = Bundler.ui.ask("Would like to generate tests along with their gems? (rspec/minitest/false):")
+        test_framework = result == "false" ? false : result
+      end
+
+      if Bundler.settings["gem.test"].nil?
+        Bundler.settings.set_global("gem.test", test_framework)
+      end
+
+      return if test_framework == "false"
+      test_framework
     end
 
   end

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -1,5 +1,7 @@
 module Bundler
   class Settings
+    BOOL_KEYS = %w(frozen cache_all no_prune disable_local_branch_check gem.mit gem.coc).freeze
+
     def initialize(root = nil)
       @root          = root
       @local_config  = load_config(local_config_file)
@@ -122,7 +124,7 @@ module Bundler
     end
 
     def is_bool(key)
-      %w(frozen cache_all no_prune disable_local_branch_check).include? key.to_s
+      BOOL_KEYS.include?(key.to_s)
     end
 
     def to_bool(value)

--- a/lib/bundler/templates/newgem/CODE_OF_CONDUCT.md.tt
+++ b/lib/bundler/templates/newgem/CODE_OF_CONDUCT.md.tt
@@ -1,0 +1,13 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, age, or religion.
+
+Examples of unacceptable behavior by participants include the use of sexual language or imagery, derogatory comments or personal attacks, trolling, public or private harassment, insults, or other unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed from the project team.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
+
+This Code of Conduct is adapted from the [Contributor Covenant](http:contributor-covenant.org), version 1.0.0, available at [http://contributor-covenant.org/version/1/0/0/](http://contributor-covenant.org/version/1/0/0/)

--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 <%- if config[:ext] -%>
   spec.add_development_dependency "rake-compiler"
 <%- end -%>
-<%- if config[:test] -%>
+<%- if config[:test] && config[:test] != "false" -%>
   spec.add_development_dependency "<%=config[:test]%>"
 <%- end -%>
 end

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -35,6 +35,12 @@ describe "bundle gem" do
     end
   end
 
+  before do
+    bundle 'config gem.mit false'
+    bundle 'config gem.coc false'
+    bundle 'config gem.test false'
+  end
+
   context "gem naming with relative paths" do
     before do
       reset!
@@ -84,7 +90,6 @@ describe "bundle gem" do
 
     it "generates a gem skeleton" do
       expect(bundled_app("test_gem/test_gem.gemspec")).to exist
-      expect(bundled_app("test_gem/LICENSE.txt")).to exist
       expect(bundled_app("test_gem/Gemfile")).to exist
       expect(bundled_app("test_gem/Rakefile")).to exist
       expect(bundled_app("test_gem/lib/test_gem.rb")).to exist
@@ -201,6 +206,35 @@ describe "bundle gem" do
       end
     end
 
+    context "gem.test setting set to rspec" do
+      before do
+        reset!
+        in_app_root
+        bundle "config gem.test rspec"
+        bundle "gem #{gem_name}"
+      end
+
+      it "builds spec skeleton" do
+        expect(bundled_app("test_gem/.rspec")).to exist
+        expect(bundled_app("test_gem/spec/test_gem_spec.rb")).to exist
+        expect(bundled_app("test_gem/spec/spec_helper.rb")).to exist
+      end
+    end
+
+    context "gem.test setting set to rspec and --test is set to minitest" do
+      before do
+        reset!
+        in_app_root
+        bundle "config gem.test rspec"
+        bundle "gem #{gem_name} --test=minitest"
+      end
+
+      it "builds spec skeleton" do
+        expect(bundled_app("test_gem/test/test_test_gem.rb")).to exist
+        expect(bundled_app("test_gem/test/minitest_helper.rb")).to exist
+      end
+    end
+
     context "--test parameter set to minitest" do
       before do
         reset!
@@ -254,6 +288,44 @@ describe "bundle gem" do
     end
   end
 
+  context "with --mit option" do
+    let(:gem_name) { 'test-gem' }
+
+    before do
+      bundle "gem #{gem_name} --mit"
+      # reset gemspec cache for each test because of commit 3d4163a
+      Bundler.clear_gemspec_cache
+    end
+
+    it "generates a gem skeleton with MIT license" do
+      expect(bundled_app("test-gem/test-gem.gemspec")).to exist
+      expect(bundled_app("test-gem/LICENSE.txt")).to exist
+      expect(bundled_app("test-gem/Gemfile")).to exist
+      expect(bundled_app("test-gem/Rakefile")).to exist
+      expect(bundled_app("test-gem/lib/test/gem.rb")).to exist
+      expect(bundled_app("test-gem/lib/test/gem/version.rb")).to exist
+    end
+  end
+
+  context "with --coc option" do
+    let(:gem_name) { 'test-gem' }
+
+    before do
+      bundle "gem #{gem_name} --coc"
+      # reset gemspec cache for each test because of commit 3d4163a
+      Bundler.clear_gemspec_cache
+    end
+
+    it "generates a gem skeleton with Code of Conduct" do
+      expect(bundled_app("test-gem/test-gem.gemspec")).to exist
+      expect(bundled_app("test-gem/CODE_OF_CONDUCT.md")).to exist
+      expect(bundled_app("test-gem/Gemfile")).to exist
+      expect(bundled_app("test-gem/Rakefile")).to exist
+      expect(bundled_app("test-gem/lib/test/gem.rb")).to exist
+      expect(bundled_app("test-gem/lib/test/gem/version.rb")).to exist
+    end
+  end
+
   context "gem naming with dashed" do
     let(:gem_name) { 'test-gem' }
 
@@ -267,7 +339,7 @@ describe "bundle gem" do
 
     it "generates a gem skeleton" do
       expect(bundled_app("test-gem/test-gem.gemspec")).to exist
-      expect(bundled_app("test-gem/LICENSE.txt")).to exist
+      # expect(bundled_app("test-gem/LICENSE.txt")).to exist
       expect(bundled_app("test-gem/Gemfile")).to exist
       expect(bundled_app("test-gem/Rakefile")).to exist
       expect(bundled_app("test-gem/lib/test/gem.rb")).to exist


### PR DESCRIPTION
As discussed in https://github.com/bundler/bundler/pull/3305#issuecomment-67024669, the gem generator should not generate default files that change the rights or responsibilities of gem authors without their explicit consent. Let's change the gem generator to ask gem authors what they want, and allow them to change it via config or --flags.

* Remove LICENSE from default gem
* Remove CODE_OF_CONDUCT from default gem
* Add --coc flag to generate CODE_OF_CONDUCT
* Add --mit flag to generate LICENSE
* On gem generation, if not set to true/false, ask user if they are willing to license their code permissively under the MIT license
* On gem generation, if not set to true/false, ask user if they are willing to add a Code of Conduct to their gem
* On gem generation, if not set to false/rspec/minitest, ask if the user would like to generate tests along with their gems. Save the answer as bundle config gem.tests.
* Ensure that --coc, --mit, --test flags overrule any config settings that may be set.

(from https://trello.com/c/1349U0gF/67-require-consent-when-generating-files-in-gems)