### PR TITLE
Change the initial version of new gems to 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Features:
   - tries to find a `bundler-<command>` executable on your path for non-bundler commands (@andremedeiros)
   - generates a `.consolerc` file with new gems and tries to load it on `bundle console` (@andremedeiros)
   - tries to find `gems.rb` and it's new counterpart, `gems.locked` (@andremedeiros)
+  - Change the initial version of new gems from `0.0.1` to `0.1.0` (@petedmarsh)
 
 Documentation:
   - add missing Gemfile global `path` explanation (@agenteo)

--- a/lib/bundler/templates/newgem/lib/newgem/version.rb.tt
+++ b/lib/bundler/templates/newgem/lib/newgem/version.rb.tt
@@ -1,7 +1,7 @@
 <%- config[:constant_array].each_with_index do |c,i| -%>
 <%= '  '*i %>module <%= c %>
 <%- end -%>
-<%= '  '*config[:constant_array].size %>VERSION = "0.0.1"
+<%= '  '*config[:constant_array].size %>VERSION = "0.1.0"
 <%- (config[:constant_array].size-1).downto(0) do |i| -%>
 <%= '  '*i %>end
 <%- end -%>

--- a/spec/bundler/gem_helper_spec.rb
+++ b/spec/bundler/gem_helper_spec.rb
@@ -58,7 +58,7 @@ describe Bundler::GemHelper do
     end
 
     subject! { Bundler::GemHelper.new(app_path) }
-    let(:app_version) { "0.0.1" }
+    let(:app_version) { "0.1.0" }
     let(:app_gem_dir) { app_path.join("pkg") }
     let(:app_gem_path) { app_gem_dir.join("#{app_name}-#{app_version}.gem") }
     let(:app_gemspec_content) { File.read(app_gemspec_path) }

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -93,8 +93,8 @@ describe "bundle gem" do
       expect(bundled_app("test_gem/.consolerc")).to exist
     end
 
-    it "starts with version 0.0.1" do
-      expect(bundled_app("test_gem/lib/test_gem/version.rb").read).to match(/VERSION = "0.0.1"/)
+    it "starts with version 0.1.0" do
+      expect(bundled_app("test_gem/lib/test_gem/version.rb").read).to match(/VERSION = "0.1.0"/)
     end
 
     it "does not nest constants" do
@@ -274,8 +274,8 @@ describe "bundle gem" do
       expect(bundled_app("test-gem/lib/test/gem/version.rb")).to exist
     end
 
-    it "starts with version 0.0.1" do
-      expect(bundled_app("test-gem/lib/test/gem/version.rb").read).to match(/VERSION = "0.0.1"/)
+    it "starts with version 0.1.0" do
+      expect(bundled_app("test-gem/lib/test/gem/version.rb").read).to match(/VERSION = "0.1.0"/)
     end
 
     it "nests constants so they work" do


### PR DESCRIPTION
I noticed that the FAQ section of the Semantic Versioning 2.0.0 spec suggests that you should start versioning from `0.1.0` but bundler currently sets the version of new gems to `0.0.1` - this is a very small change that makes new gems start with `0.1.0` as their version.