### PR TITLE
Ruby 2.2: support mri_22, (x64_)mingw_22 as platform options

### DIFF
--- a/lib/bundler/dependency.rb
+++ b/lib/bundler/dependency.rb
@@ -31,9 +31,11 @@ module Bundler
       :mingw_19 => Gem::Platform::MINGW,
       :mingw_20 => Gem::Platform::MINGW,
       :mingw_21 => Gem::Platform::MINGW,
+      :mingw_22 => Gem::Platform::MINGW,
       :x64_mingw    => Gem::Platform::X64_MINGW,
       :x64_mingw_20 => Gem::Platform::X64_MINGW,
-      :x64_mingw_21 => Gem::Platform::X64_MINGW
+      :x64_mingw_21 => Gem::Platform::X64_MINGW,
+      :x64_mingw_22 => Gem::Platform::X64_MINGW
     }.freeze
 
     def initialize(name, version, options = {}, &blk)

--- a/man/gemfile.5.ronn
+++ b/man/gemfile.5.ronn
@@ -211,12 +211,16 @@ There are a number of `Gemfile` platforms:
     _mingw_ `AND` version 2.0
   * `mingw_21`:
     _mingw_ `AND` version 2.1
+  * `mingw_22`:
+    _mingw_ `AND` version 2.2
   * `x64_mingw`:
     Windows 64 bit 'mingw32' platform (aka RubyInstaller x64)
   * `x64_mingw_20`:
     _x64_mingw_ `AND` version 2.0
   * `x64_mingw_21`:
     _x64_mingw_ `AND` version 2.1
+  * `x64_mingw_22`:
+    _x64_mingw_ `AND` version 2.2
 
 As with groups, you can specify one or more platforms:
 


### PR DESCRIPTION
Bundler 1.7.10 only supports `:ruby_22` as platform. `mri_22`,  `mingw_22`, `x64_mingw_22` are unrecognised still. This appears to be an omission in #3309 (and also #3189).
