### PR TITLE
Realign Source#version_message to reveal intent

### DIFF
--- a/lib/bundler/source.rb
+++ b/lib/bundler/source.rb
@@ -22,12 +22,16 @@ module Bundler
     end
 
     def version_message(spec)
-      locked_spec = Bundler.locked_gems.specs.find { |s| s.name == spec.name } if Bundler.locked_gems
-      locked_spec_version = locked_spec.version if locked_spec
       message = "#{spec.name} #{spec.version}"
-      if locked_spec_version && spec.version != locked_spec_version
-        message << " (was #{locked_spec_version})"
+
+      if Bundler.locked_gems
+        locked_spec = Bundler.locked_gems.specs.find { |s| s.name == spec.name }
+        locked_spec_version = locked_spec.version if locked_spec
+        if locked_spec_version && spec.version != locked_spec_version
+          message << " (was #{locked_spec_version})"
+        end
       end
+
       message
     end
 


### PR DESCRIPTION
IMHO the method is easier to understand if all the tasks to be done in case of locked gems is in one section.

I considered pulling out the getting of `locked_spec_version` into a private method like so:

```ruby
def get_locked_spec_version(spec)
  locked_spec = Bundler.locked_gems.specs.find { |s| s.name == spec.name }
  locked_spec.version if locked_spec
end

# To be used as
def version_message(spec)
  message = "#{spec.name} #{spec.version}"

  if Bundler.locked_gems
    locked_spec_version = get_locked_spec_version_of(spec)
    if locked_spec_version && spec.version != locked_spec_version
      message << " (was #{locked_spec_version})"
    end
  end

  message
end
```

But I thought it might be too much. Feel free to close if this is undesirable. :smile: