### PR TITLE
Added an option to create a pry console in the gem with a custom prompt

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -341,7 +341,7 @@ module Bundler
     method_option :ext, :type => :boolean, :default => false, :banner => "Generate the boilerplate for C extension code"
     method_option :test, :type => :string, :lazy_default => 'rspec', :aliases => '-t', :banner =>
       "Generate a test directory for your library: 'rspec' is the default, but 'minitest' is also supported."
-    method_option :console, type: :boolean, default: false, aliases: '-c', banner: "Generate a binary pry console that can be run by executing ./bin/console"
+    method_option :console, :type => :boolean, :default => false, :aliases => '-c', :banner => "Generate a binary pry console that can be run by executing ./bin/console"
 
     def gem(name)
       require 'bundler/cli/gem'

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -341,6 +341,7 @@ module Bundler
     method_option :ext, :type => :boolean, :default => false, :banner => "Generate the boilerplate for C extension code"
     method_option :test, :type => :string, :lazy_default => 'rspec', :aliases => '-t', :banner =>
       "Generate a test directory for your library: 'rspec' is the default, but 'minitest' is also supported."
+    method_option :console, type: :boolean, default: false, aliases: '-c', banner: "Generate a binary pry console that can be run by executing ./bin/console"
 
     def gem(name)
       require 'bundler/cli/gem'

--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -34,6 +34,7 @@ module Bundler
         :author           => git_user_name.empty? ? "TODO: Write your name" : git_user_name,
         :email            => git_user_email.empty? ? "TODO: Write your email address" : git_user_email,
         :test             => options[:test],
+        :console          => options[:console],
         :ext              => options[:ext]
       }
 
@@ -74,12 +75,19 @@ module Bundler
         )
       end
 
+      if options[:console]
+        templates.merge!(
+          "bin/console.tt" => "bin/console",
+          "lib/newgem/console.rb" => "lib/#{name}/console.rb"
+        )
+      end
       templates.each do |src, dst|
         thor.template("newgem/#{src}", target.join(dst), opts)
       end
 
       Bundler.ui.info "Initializing git repo in #{target}"
       Dir.chdir(target) { `git init`; `git add .` }
+      Dir.chdir(target) { `chmod +x bin/console` } if options[:console]
 
       if options[:edit]
         # Open gemspec in editor

--- a/lib/bundler/templates/newgem/bin/console.tt
+++ b/lib/bundler/templates/newgem/bin/console.tt
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Run a Ruby REPL.
+
+set -e
+
+cd $(dirname "$0")/..
+PRY_PATH=$(which pry)
+
+if [ -x $PRY_PATH ]
+then
+  exec bundle exec ruby $PRY_PATH -Ilib -r <%=config[:namespaced_path]%> -r <%=config[:namespaced_path]%>/console
+else
+
+  red='\033[0;31m'
+  NC='\033[0m'
+  echo "${red}Pry executable was not found. Try running 'bundle install'.${NC}"
+fi

--- a/lib/bundler/templates/newgem/lib/newgem/console.rb.tt
+++ b/lib/bundler/templates/newgem/lib/newgem/console.rb.tt
@@ -1,0 +1,3 @@
+Pry.config.prompt = lambda do |context, nesting, pry|
+  "[<%=config[:name]%>] #{context}> "
+end

--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -33,4 +33,7 @@ Gem::Specification.new do |spec|
 <%- if config[:test] -%>
   spec.add_development_dependency "<%=config[:test]%>"
 <%- end -%>
+<%- if config[:console] -%>
+  spec.add_development_dependency "pry"
+<%- end -%>
 end

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -483,5 +483,26 @@ describe "bundle gem" do
         expect(bundled_app("test_gem/Rakefile").read).to eq(rakefile)
       end
     end
+
+    context "--console parameter set" do
+      before do
+        reset!
+        in_app_root
+        bundle "gem test_gem --console"
+      end
+
+      it "adds console executable and Pry initializer" do
+        expect(bundled_app("test_gem/bin/console")).to exist
+        expect(bundled_app("test_gem/lib/test_gem/console.rb")).to exist
+      end
+
+      it "should chmod bin/console" do
+        expect(bundled_app("test_gem/bin/console").executable?).to eq(true)
+      end
+
+      it "includes pry" do
+        expect(bundled_app("test_gem/test_gem.gemspec").read).to include('spec.add_development_dependency "pry"')
+      end
+    end
   end
 end


### PR DESCRIPTION
Though it is similar to bundle console with the pry option set, this feature allows for a customizable script and pry prompt. Having a custom prompt and shell in a gem is handy way to show collaborators that they are in the proper context. There could be many other uses for it as well. I found this method in the rugged gem and I thought it was more intuitive to have a shell script ship with the gem. Also you could speed up development by renaming `console` to `c` so you can just call `./bin/c` to hit the pry console.

This feature allows users to call:

    bundle gem coolgem --console
    ./bin/console

Now they are in a pry console with the following prompt:
    
    [coolgem] main > 

I explain the process in my blog: http://lowbrowcoder.me/2015/01/01/how-to-add-a-pry-console-in-your-ruby-gem-for-testing/

Please let me know if there are things you'd like me to add or change to make the merge.