### PR TITLE
use `Minitest::Test` instead of deprectaed `MiniTest::Unit::TestCase`

### DIFF
--- a/lib/bundler/templates/newgem/test/test_newgem.rb.tt
+++ b/lib/bundler/templates/newgem/test/test_newgem.rb.tt
@@ -1,6 +1,6 @@
 require 'minitest_helper'
 
-class Test<%= config[:constant_name] %> < MiniTest::Unit::TestCase
+class Test<%= config[:constant_name] %> < Minitest::Test
   def test_that_it_has_a_version_number
     refute_nil ::<%= config[:constant_name] %>::VERSION
   end


### PR DESCRIPTION
`MiniTest::Unit::TestCase` was renamed to `Minitest::Test` in minitest 5.0.