### PR TITLE
Don't add extra quotes to quoted wrapped config values

### DIFF
--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -155,9 +155,10 @@ module Bundler
     def load_config(config_file)
       valid_file = config_file && config_file.exist? && !config_file.size.zero?
       if !ignore_config? && valid_file
-        config_regex = /^(BUNDLE_.+): (?:['"](.*)['"]|(.+(?:\n(?!BUNDLE).+))|(.+))$/
+        config_regex = /^(BUNDLE_.+): (['"]?)(.*(?:\n(?!BUNDLE).+)?)\2$/
         config_pairs = config_file.read.scan(config_regex).map do |m|
-          m.compact.map { |n| n.gsub(/\s+/, " ").tr('"', "'") }
+          key, _, value = m
+          [key, value.gsub(/\s+/, " ").tr('"', "'")]
         end
         Hash[config_pairs]
       else


### PR DESCRIPTION
Long config values get wrapped to a second line. If they contain certain special characters they will also get surrounded by quotes. When this happened, we would add extra quotes to the value each time the config file was saved. 94fd250935314aee86759de3e9b0e98a709823ed fixed this issue for non-wrapped lines. Now it is fixed for wrapped lines as well.

/cc @indirect #3261