### PR TITLE
Implement --no-version flag

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -35,6 +35,7 @@ module Bundler
 
     default_task :install
     class_option "no-color", :type => :boolean, :banner => "Disable colorization in output"
+    class_option "no-version", :type => :boolean, :banner => "Disable version names in vendor cache"
     class_option "retry",    :type => :numeric, :aliases => "-r", :banner =>
       "Specify the number of times you wish to attempt network commands"
     class_option "verbose",  :type => :boolean, :banner => "Enable verbose output mode", :aliases => "-V"

--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -82,7 +82,7 @@ module Bundler
       # repos, this is set to the local repo.
       def install_path
         @install_path ||= begin
-          git_scope = "#{base_name}-#{shortref_for_path(revision)}"
+          git_scope = options["no-version"] ? base_name : extension_dir_name
           path = Bundler.install_path.join(git_scope)
 
           if !path.exist? && Bundler.requires_sudo?

--- a/lib/bundler/source/svn.rb
+++ b/lib/bundler/source/svn.rb
@@ -76,7 +76,7 @@ module Bundler
       # repos, this is set to the local repo.
       def install_path
         @install_path ||= begin
-          svn_scope = "#{base_name}-#{revision}"
+          svn_scope = options["no-version"] ? base_name : extension_dir_name
 
           if Bundler.requires_sudo?
             Bundler.user_bundle_path.join(Bundler.ruby_scope).join(svn_scope)


### PR DESCRIPTION
Removes the SHA/revision from directories in vendor/cache.

See https://github.com/bundler/bundler-features/issues/76 for motivation and
explanation.

I suspect I probably need to update documentation (and possibly tests) etc. as well, but I figured I'd ask for feedback on the idea before putting in that work.