### PR TITLE
Always use source credentials

### DIFF
--- a/spec/install/gems/dependency_api_spec.rb
+++ b/spec/install/gems/dependency_api_spec.rb
@@ -162,6 +162,17 @@ describe "gemcutter's dependency API" do
     should_be_installed "rack 1.0.0"
   end
 
+  it "falls back when the API URL returns 403 Forbidden" do
+    gemfile <<-G
+      source "#{source_uri}"
+      gem "rack"
+    G
+
+    bundle :install, :verbose => true, :artifice => "endpoint_api_forbidden"
+    expect(out).to include("Fetching source index from #{source_uri}")
+    should_be_installed "rack 1.0.0"
+  end
+
   it "handles host redirects" do
     gemfile <<-G
       source "#{source_uri}"

--- a/spec/support/artifice/endpoint_api_forbidden.rb
+++ b/spec/support/artifice/endpoint_api_forbidden.rb
@@ -1,0 +1,11 @@
+require File.expand_path("../endpoint", __FILE__)
+
+Artifice.deactivate
+
+class EndpointApiForbidden < Endpoint
+  get "/api/v1/dependencies" do
+    halt 403
+  end
+end
+
+Artifice.activate_with(EndpointApiForbidden)


### PR DESCRIPTION
Previously, it tried to make an unauthenticated request first, then retried with authentication if the first request failed.

This causes issues on some gem servers. For example, Gemfury supports the dependency API and allows a mix of public and private gems in the same repository. It does not forbid unauthenticated requests, but it returns partial information.

Now configured credentials are always used.

Fixes #3297, #3296, #3180.