### PR TITLE
Fix s3 source url parsing / auth

### DIFF
--- a/spec/bundler/s3_fetcher_spec.rb
+++ b/spec/bundler/s3_fetcher_spec.rb
@@ -8,13 +8,16 @@ describe Bundler::S3Fetcher do
   describe "sign" do
     it "requires authentication" do
       url = "s3://foo"
-      expect { Bundler::S3Fetcher.new(url).sign(URI(url))}.to raise_error(Bundler::Fetcher::AuthenticationRequiredError)
+      expect { Bundler::S3Fetcher.new(url).sign(URI(url))}.to raise_error(Bundler::GemspecError)
     end
 
     it "signs S3 requests" do
-      accessId = "a"
-      secretKey = "b"
-      url = "s3://#{accessId}:#{secretKey}@foo"
+      accessId = "AKHAJIHAFOW6WWJUV5RA"
+      Gem.configuration[:s3_source] = {"foo" => {
+        id: accessId,
+        secret: "7UVCy7cYjEzwfwLwwQR/DlOdJ7V+c7GFWKZDn8yx9"
+      } }
+      url = "s3://foo/"
       time = Time.utc(2014, 6, 1).to_i
 
       actual = Bundler::S3Fetcher.new(url).sign(URI(url), time)
@@ -23,7 +26,7 @@ describe Bundler::S3Fetcher do
       query = CGI.parse(actual.query)
       expect(query['AWSAccessKeyId']).to eq [accessId]
       expect(query['Expires']).to eq [time.to_s]
-      expect(query['Signature']).to eq ["2ZFX8vg7E04u/UqUH9F/cKiQjJA="]
+      expect(query['Signature']).to eq ["9IrED0v8ae/VwAr0E9eoy9mcE4Y="]
     end
   end
 end

--- a/spec/bundler/s3_fetcher_spec.rb
+++ b/spec/bundler/s3_fetcher_spec.rb
@@ -14,8 +14,8 @@ describe Bundler::S3Fetcher do
     it "signs S3 requests" do
       accessId = "AKHAJIHAFOW6WWJUV5RA"
       Gem.configuration[:s3_source] = {"foo" => {
-        id: accessId,
-        secret: "7UVCy7cYjEzwfwLwwQR/DlOdJ7V+c7GFWKZDn8yx9"
+        :id => accessId,
+        :secret => "7UVCy7cYjEzwfwLwwQR/DlOdJ7V+c7GFWKZDn8yx9"
       } }
       url = "s3://foo/"
       time = Time.utc(2014, 6, 1).to_i


### PR DESCRIPTION
The URI class will not actually parse a url in the format s3://AKHAJIHAFOW6WWJUV5RA:7UVCy7cYjEzwfwLwwQR/DlOdJ7V+c7GFWKZDn8yx9@bucket/ because s3 secrets are generated with characters like / in them that are invalid as a password in http simple auth.

I've made the corresponding change in a pull request in Rubygems: https://github.com/rubygems/rubygems/pull/1134

PS. the AWS keys above are based on (but not precisely) an actual key pair.