### PR TITLE
Fix the path to the Gemfile during evaluation.

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -24,10 +24,12 @@ module Bundler
       @platforms       = []
       @env             = nil
       @ruby_version    = nil
+      @gemfile         = nil
       add_git_sources
     end
 
     def eval_gemfile(gemfile, contents = nil)
+      @gemfile = Pathname.new(gemfile)
       contents ||= Bundler.read_file(gemfile.to_s)
       instance_eval(contents, gemfile.to_s, 1)
     rescue SyntaxError => e
@@ -44,7 +46,8 @@ module Bundler
       path              = opts && opts[:path] || '.'
       name              = opts && opts[:name] || '{,*}'
       development_group = opts && opts[:development_group] || :development
-      expanded_path     = File.expand_path(path, Bundler.default_gemfile.dirname)
+      gemfile           = @gemfile || Bundler.default_gemfile
+      expanded_path     = File.expand_path(path, gemfile.dirname)
 
       gemspecs = Dir[File.join(expanded_path, "#{name}.gemspec")]
 

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -46,8 +46,7 @@ module Bundler
       path              = opts && opts[:path] || '.'
       name              = opts && opts[:name] || '{,*}'
       development_group = opts && opts[:development_group] || :development
-      gemfile           = @gemfile || Bundler.default_gemfile
-      expanded_path     = File.expand_path(path, gemfile.dirname)
+      expanded_path     = path_relative_to_gemfile(path)
 
       gemspecs = Dir[File.join(expanded_path, "#{name}.gemspec")]
 
@@ -133,7 +132,7 @@ module Bundler
     end
 
     def path(path, options = {}, &blk)
-      with_source(@sources.add_path_source(normalize_hash(options).merge("path" => Pathname.new(path))), &blk)
+      with_source(@sources.add_path_source(normalize_hash(options).merge("path" => path_relative_to_gemfile(path))), &blk)
     end
 
     def git(uri, options = {}, &blk)
@@ -287,6 +286,10 @@ module Bundler
         opts["git"] = @git_sources[git_name].call(opts[git_name])
       end
 
+      if opts.key?("path")
+        opts["path"] = path_relative_to_gemfile(opts["path"])
+      end
+
       ["git", "path", "svn"].each do |type|
         if param = opts[type]
           if version.first && version.first =~ /^\s*=?\s*(\d[^\s]*)\s*$/
@@ -317,6 +320,11 @@ module Bundler
       else
         raise GemfileError, "Unknown source '#{source}'"
       end
+    end
+
+    def path_relative_to_gemfile(path)
+      @gemfile ||= Bundler.default_gemfile
+      @gemfile.dirname + path
     end
   end
 end


### PR DESCRIPTION
`Bundler.default_gemfile` was being used instead of the explicitly passed Gemfile path.

This prevents errors like the following when `gemfile` argument isn't `"$PWD/Gemfile"`:

    /nix/store/na27qjv9g32rg2nh98m51jd7ihrg7w7n-ruby-2.1.3-p0-bundler-1.7.9/lib/ruby/gems/2.1.3/gems/bundler-1.7.9/lib/bundler/shared_helpers.rb:26:in `default_gemfile': Could not locate Gemfile (Bundler::GemfileNotFound)
            from /nix/store/na27qjv9g32rg2nh98m51jd7ihrg7w7n-ruby-2.1.3-p0-bundler-1.7.9/lib/ruby/gems/2.1.3/gems/bundler-1.7.9/lib/bundler.rb:262:in `default_gemfile'
            from /nix/store/na27qjv9g32rg2nh98m51jd7ihrg7w7n-ruby-2.1.3-p0-bundler-1.7.9/lib/ruby/gems/2.1.3/gems/bundler-1.7.9/lib/bundler/dsl.rb:27:in `initialize'
            from /nix/store/na27qjv9g32rg2nh98m51jd7ihrg7w7n-ruby-2.1.3-p0-bundler-1.7.9/lib/ruby/gems/2.1.3/gems/bundler-1.7.9/lib/bundler/dsl.rb:9:in `new'
            from /nix/store/na27qjv9g32rg2nh98m51jd7ihrg7w7n-ruby-2.1.3-p0-bundler-1.7.9/lib/ruby/gems/2.1.3/gems/bundler-1.7.9/lib/bundler/dsl.rb:9:in `evaluate'
            from /nix/store/na27qjv9g32rg2nh98m51jd7ihrg7w7n-ruby-2.1.3-p0-bundler-1.7.9/lib/ruby/gems/2.1.3/gems/bundler-1.7.9/lib/bundler/definition.rb:25:in `build'
            from /nix/store/yzpjmgpc5fdhll3rbacq5r5ay9kjxxym-ruby-2.1.3-p0-bundix-0.1.0/lib/ruby/gems/2.1.3/gems/bundix-0.1.0/lib/bundix/cli.rb:55:in `expr'
            from /nix/store/hkqpgmrq1x2c8icjhl433d2yhkzy33rn-ruby-2.1.3-p0-thor-0.19.1/lib/ruby/gems/2.1.3/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
            from /nix/store/hkqpgmrq1x2c8icjhl433d2yhkzy33rn-ruby-2.1.3-p0-thor-0.19.1/lib/ruby/gems/2.1.3/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
            from /nix/store/hkqpgmrq1x2c8icjhl433d2yhkzy33rn-ruby-2.1.3-p0-thor-0.19.1/lib/ruby/gems/2.1.3/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
            from /nix/store/hkqpgmrq1x2c8icjhl433d2yhkzy33rn-ruby-2.1.3-p0-thor-0.19.1/lib/ruby/gems/2.1.3/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
            from /nix/store/yzpjmgpc5fdhll3rbacq5r5ay9kjxxym-ruby-2.1.3-p0-bundix-0.1.0/lib/ruby/gems/2.1.3/gems/bundix-0.1.0/bin/bundix:4:in `<main>'
