### PR TITLE
Allow vendor/cache override 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Features:
   - generates a `.consolerc` file with new gems and tries to load it on `bundle console` (@andremedeiros)
   - tries to find `gems.rb` and it's new counterpart, `gems.locked` (@andremedeiros)
   - Change the initial version of new gems from `0.0.1` to `0.1.0` (@petedmarsh)
+  - add support for setting cache path via --cache-path or BUNDLE_CACHE_PATH (@jnraine)
 
 Documentation:
   - add missing Gemfile global `path` explanation (@agenteo)

--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -210,7 +210,7 @@ module Bundler
 
     def app_cache(custom_path = nil)
       path = custom_path || root
-      path.join("vendor/cache")
+      path.join(Bundler.settings.cache_path)
     end
 
     def tmp(name = Process.pid.to_s)

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -243,6 +243,8 @@ module Bundler
     desc "package [OPTIONS]", "Locks and then caches all of the gems into vendor/cache"
     method_option "all",  :type => :boolean, :banner => "Include all sources (including path, git and svn)."
     method_option "all-platforms", :type => :boolean, :banner => "Include gems for all platforms, not just the current one"
+    method_option "cache-path", :type => :string, :banner =>
+      "Specify a different cache path than the system default ($BUNDLE_CACHE_PATH or vendor/cache)."
     method_option "gemfile", :type => :string, :banner => "Use the specified gemfile instead of Gemfile"
     method_option "no-install",  :type => :boolean, :banner => "Don't actually install the gems, just package."
     method_option "no-prune",  :type => :boolean, :banner => "Don't remove stale gems from the cache."

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -118,6 +118,8 @@ module Bundler
     D
     method_option "binstubs", :type => :string, :lazy_default => "bin", :banner =>
       "Generate bin stubs for bundled gems to ./bin"
+    method_option "cache-path", :type => :string, :banner =>
+      "Specify a different cache path than the system default ($BUNDLE_CACHE_PATH or vendor/cache)."
     method_option "clean", :type => :boolean, :banner =>
       "Run bundle clean automatically after install"
     method_option "deployment", :type => :boolean, :banner =>
@@ -230,6 +232,8 @@ module Bundler
     desc "cache [OPTIONS]", "Cache all the gems to vendor/cache", :hide => true
     method_option "all",  :type => :boolean, :banner => "Include all sources (including path, git and svn)."
     method_option "all-platforms", :type => :boolean, :banner => "Include gems for all platforms, not just the current one"
+    method_option "cache-path", :type => :string, :banner =>
+      "Specify a different cache path than the system default ($BUNDLE_CACHE_PATH or vendor/cache)."
     method_option "no-prune",  :type => :boolean, :banner => "Don't remove stale gems from the cache."
     def cache
       require 'bundler/cli/cache'

--- a/lib/bundler/cli/cache.rb
+++ b/lib/bundler/cli/cache.rb
@@ -8,6 +8,7 @@ module Bundler
     def run
       Bundler.definition.validate_ruby!
       Bundler.definition.resolve_with_cache!
+      Bundler.settings[:cache_path] = options["cache-path"]
       setup_cache_all
       Bundler.settings[:cache_all_platforms] = options["all-platforms"] if options.key?("all-platforms")
       Bundler.load.cache

--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -36,6 +36,8 @@ module Bundler
         Bundler.settings["trust-policy"] = nil if Bundler.settings["trust-policy"]
       end
 
+      Bundler.settings[:cache_path] = options["cache-path"]
+
       if options[:deployment] || options[:frozen]
         unless Bundler.default_lockfile.exist?
           flag = options[:deployment] ? '--deployment' : '--frozen'
@@ -44,7 +46,7 @@ module Bundler
                                  "before deploying."
         end
 
-        if Bundler.root.join("vendor/cache").exist?
+        if Bundler.app_cache.exist?
           options[:local] = true
         end
 
@@ -57,18 +59,18 @@ module Bundler
         options[:system] = true
       end
 
-      Bundler.settings[:path]     = nil if options[:system]
-      Bundler.settings[:path]     = "vendor/bundle" if options[:deployment]
-      Bundler.settings[:path]     = options["path"] if options["path"]
-      Bundler.settings[:path]     ||= "bundle" if options["standalone"]
-      Bundler.settings[:bin]      = options["binstubs"] if options["binstubs"]
-      Bundler.settings[:bin]      = nil if options["binstubs"] && options["binstubs"].empty?
-      Bundler.settings[:shebang]  = options["shebang"] if options["shebang"]
-      Bundler.settings[:jobs]     = options["jobs"] if options["jobs"]
-      Bundler.settings[:no_prune] = true if options["no-prune"]
+      Bundler.settings[:path]       = nil if options[:system]
+      Bundler.settings[:path]       = "vendor/bundle" if options[:deployment]
+      Bundler.settings[:path]       = options["path"] if options["path"]
+      Bundler.settings[:path]       ||= "bundle" if options["standalone"]
+      Bundler.settings[:bin]        = options["binstubs"] if options["binstubs"]
+      Bundler.settings[:bin]        = nil if options["binstubs"] && options["binstubs"].empty?
+      Bundler.settings[:shebang]    = options["shebang"] if options["shebang"]
+      Bundler.settings[:jobs]       = options["jobs"] if options["jobs"]
+      Bundler.settings[:no_prune]   = true if options["no-prune"]
       Bundler.settings[:no_install] = true if options["no-install"]
-      Bundler.settings[:clean]    = options["clean"] if options["clean"]
-      Bundler.settings.without    = options[:without]
+      Bundler.settings[:clean]      = options["clean"] if options["clean"]
+      Bundler.settings.without      = options[:without]
       Bundler::Fetcher.disable_endpoint = options["full-index"]
       Bundler.settings[:disable_shared_gems] = Bundler.settings[:path] ? '1' : nil
 
@@ -78,7 +80,7 @@ module Bundler
       definition = Bundler.definition
       definition.validate_ruby!
       Installer.install(Bundler.root, definition, options)
-      Bundler.load.cache if Bundler.root.join("vendor/cache").exist? && !options["no-cache"] && !Bundler.settings[:frozen]
+      Bundler.load.cache if Bundler.app_cache.exist? && !options["no-cache"] && !Bundler.settings[:frozen]
 
       Bundler.ui.confirm "Bundle complete! #{dependencies_count_for(definition)}, #{gems_installed_for(definition)}."
       confirm_without_groups
@@ -112,7 +114,7 @@ module Bundler
       end
     rescue GemNotFound, VersionConflict => e
       if options[:local] && Bundler.app_cache.exist?
-        Bundler.ui.warn "Some gems seem to be missing from your vendor/cache directory."
+        Bundler.ui.warn "Some gems seem to be missing from your #{Bundler.settings.cache_path} directory."
       end
 
       unless Bundler.definition.has_rubygems_remotes?

--- a/lib/bundler/cli/package.rb
+++ b/lib/bundler/cli/package.rb
@@ -9,6 +9,7 @@ module Bundler
     def run
       Bundler.ui.level = "error" if options[:quiet]
       Bundler.settings[:path] = File.expand_path(options[:path]) if options[:path]
+      Bundler.settings[:path] = options["cache-path"]
       Bundler.settings[:cache_all_platforms] = options["all-platforms"] if options.key?("all-platforms")
 
       setup_cache_all

--- a/lib/bundler/cli/update.rb
+++ b/lib/bundler/cli/update.rb
@@ -49,7 +49,7 @@ module Bundler
 
       Bundler.definition.validate_ruby!
       Installer.install Bundler.root, Bundler.definition, opts
-      Bundler.load.cache if Bundler.root.join("vendor/cache").exist?
+      Bundler.load.cache if Bundler.app_cache.exist?
 
       if Bundler.settings[:clean] && Bundler.settings[:path]
         require "bundler/cli/clean"

--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -109,7 +109,7 @@ module Bundler
       cache_path = cache_path(custom_path)
       FileUtils.mkdir_p(cache_path) unless File.exist?(cache_path)
 
-      Bundler.ui.info "Updating files in vendor/cache"
+      Bundler.ui.info "Updating files in #{Bundler.settings.cache_path}"
       specs.each do |spec|
         next if spec.name == 'bundler'
         spec.source.send(:fetch_gem, spec) if Bundler.settings[:cache_all_platforms] && spec.source.respond_to?(:fetch_gem, true)
@@ -240,7 +240,7 @@ module Bundler
       end
 
       if cached.any?
-        Bundler.ui.info "Removing outdated .gem files from vendor/cache"
+        Bundler.ui.info "Removing outdated .gem files from #{Bundler.settings.cache_path}"
 
         cached.each do |path|
           Bundler.ui.info "  * #{File.basename(path)}"
@@ -262,7 +262,7 @@ module Bundler
       end
 
       if cached.any?
-        Bundler.ui.info "Removing outdated git and path gems from vendor/cache"
+        Bundler.ui.info "Removing outdated git and path gems from #{Bundler.settings.cache_path}"
 
         cached.each do |path|
           path = File.dirname(path)
@@ -291,7 +291,7 @@ module Bundler
 
     def cache_path(custom_path = nil)
       path = custom_path || root
-      path.join("vendor/cache")
+      path.join(Bundler.settings.cache_path)
     end
   end
 end

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -107,6 +107,16 @@ module Bundler
       end
     end
 
+    def cache_path
+      @cache_path = self[:cache_path] || ENV["BUNDLE_CACHE_PATH"] || "vendor/cache"
+
+      if @cache_path.start_with?("/")
+        fail Thor::Error, "Cache path must be relative: #{self[:cache_path]}"
+      end
+
+      @cache_path
+    end
+
     def allow_sudo?
       !@local_config.key?(key_for(:path))
     end

--- a/spec/cache/cache_path_spec.rb
+++ b/spec/cache/cache_path_spec.rb
@@ -1,0 +1,37 @@
+require "spec_helper"
+
+describe "bundle cache" do
+  before do
+    install_gemfile <<-G
+      source "file://#{gem_repo1}"
+      gem "rack"
+    G
+  end
+
+  context "with --cache-path" do
+    it "caches gems at given path" do
+      bundle :cache, "cache-path" => "vendor/cache-foo"
+      expect(bundled_app("vendor/cache-foo/rack-1.0.0.gem")).to exist
+    end
+  end
+
+  context "with BUNDLE_CACHE_PATH" do
+    it "caches gems at given path" do
+      ENV["BUNDLE_CACHE_PATH"] = "vendor/cache-bar"
+      bundle :cache
+      expect(bundled_app("vendor/cache-bar/rack-1.0.0.gem")).to exist
+    end
+  end
+
+  context "when given an absolute path" do
+    it "prints an error" do
+      out = bundle :cache, "cache-path" => "/tmp/cache-foo"
+      expect(out).to match(/must be relative/)
+    end
+
+    it "exits with non-zero status" do
+      exit_status = bundle :cache, "cache-path" => "/tmp/cache-foo", :exitstatus => true
+      expect(exit_status).to eq(1)
+    end
+  end
+end

--- a/spec/cache/cache_path_spec.rb
+++ b/spec/cache/cache_path_spec.rb
@@ -24,14 +24,16 @@ describe "bundle cache" do
   end
 
   context "when given an absolute path" do
+    before do
+      bundle :cache, "cache-path" => "/tmp/cache-foo"
+    end
+    
     it "prints an error" do
-      out = bundle :cache, "cache-path" => "/tmp/cache-foo"
       expect(out).to match(/must be relative/)
     end
 
     it "exits with non-zero status" do
-      exit_status = bundle :cache, "cache-path" => "/tmp/cache-foo", :exitstatus => true
-      expect(exit_status).to eq(1)
+      expect(exitstatus).to eq(1)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -103,6 +103,7 @@ RSpec.configure do |config|
     ENV['PATH']                  = original_path
     ENV['GEM_HOME']              = original_gem_home
     ENV['GEM_PATH']              = original_gem_home
+    ENV['BUNDLE_CACHE_PATH']     = nil
     ENV['BUNDLE_PATH']           = nil
     ENV['BUNDLE_GEMFILE']        = nil
     ENV['BUNDLE_FROZEN']         = nil

--- a/spec/support/path.rb
+++ b/spec/support/path.rb
@@ -36,8 +36,8 @@ module Spec
       bundled_app(*["vendor/bundle", Gem.ruby_engine, Gem::ConfigMap[:ruby_version], path].compact)
     end
 
-    def cached_gem(path)
-      bundled_app("vendor/cache/#{path}.gem")
+    def cached_gem(path, options = {})
+      bundled_app("#{Bundler.settings.cache_path}/#{path}.gem")
     end
 
     def base_system_gems


### PR DESCRIPTION
I found myself needing to temporarily maintain two Gemfile for a project and needed to maintain two separate vendor/cache directories. I was able to get around this by symlinking `vendor/cache` to the appropriate directory before running `bundle install` or by monkey-patching `Bundler.app_cache`. However, neither are ideal so I've added a flag to the install command:

```bash
$ bundle install --path Gemfile-rails4 --vendor-cache vendor/cache-rails4
```

It can also be set via environment variable:

```bash
$ BUNDLE_VENDOR_CACHE=vendor/cache-rails4 bundle install --path Gemfile-rails4
```

This PR doesn't have any tests – my specs didn't end up caching the gems for some reason. Perhaps I'm misusing the test helpers?

```ruby
it "caches gems at given path" do
  gemfile bundled_app("Gemfile"), <<-G
    source 'https://rubygems.org/'
    gem 'rack'
  G

  bundle "install --vendor-cache vendor/cache-foo"
  expect(bundled_app("vendor/cache-foo/rack-1.0.0.gem")).to exist
end
```

Before I continue work on the tests, I wanted to gauge interesting in this feature. I'd be happy to add tests if there is interest in merging.