### PR TITLE
Issue #3353 - Print error messages to STDERR

### DIFF
--- a/spec/bundler/ui/shell_spec.rb
+++ b/spec/bundler/ui/shell_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+require 'bundler/vendored_thor'
+
+describe Bundler::UI::Shell do
+  let(:shell) { Bundler::UI::Shell.new }
+
+  before do
+    shell.level = "debug"
+  end
+
+  %w(info confirm warn debug).each do |method_name|
+    describe "##{method_name}" do
+      it "outputs to STDOUT" do
+        expect {
+          shell.send(method_name, "Boom")
+        }.to output(/Boom/).to_stdout
+      end
+    end
+  end
+
+  describe "#error" do
+    it "outputs to STDERR" do
+      expect {
+        shell.error("Boom")
+      }.to output(/Boom/).to_stderr
+    end
+  end
+end


### PR DESCRIPTION
This solution uses a less-than-ideal method to add Thor-formatted printing to STDERR. Because Thor doesn't offer this out-of-the-box, I've used Thor's internals to format a message and pass it to Thor's stderr.

Since this uses protected methods, changes under the hood in Thor may break this. If this happens, tests will fail.

I also added basic tests to ensure other print methods from `Bundler::UI::Shell` continue printing to STDOUT.

#3353 