### PR TITLE
untaint gem path loaded from github

### DIFF
--- a/lib/bundler/rubygems_ext.rb
+++ b/lib/bundler/rubygems_ext.rb
@@ -23,7 +23,7 @@ module Gem
 
     def full_gem_path
       source.respond_to?(:path) ?
-        Pathname.new(loaded_from).dirname.expand_path(Bundler.root).to_s :
+        Pathname.new(loaded_from).dirname.expand_path(Bundler.root).to_s.untaint :
         rg_full_gem_path
     end
 


### PR DESCRIPTION
require fails by security error, in condition of:

* $SAFE is 1
* gems from git or github. ex: gem 'bar', :github => 'foo/bar'

original full_gem_path method in rubygems is untaint all paths of gems (in find_full_gem_path method), but Bundler override the method without untaint.