### PR TITLE
Fix warnings in test suite and gemspec

### DIFF
--- a/bundler.gemspec
+++ b/bundler.gemspec
@@ -3,28 +3,28 @@ lib = File.expand_path('../lib/', __FILE__)
 $:.unshift lib unless $:.include?(lib)
 require 'bundler/version'
 
-Gem::Specification.new do |spec|
-  spec.name        = 'bundler'
-  spec.version     = Bundler::VERSION
-  spec.licenses    = ['MIT']
-  spec.authors     = ["André Arko", "Terence Lee", "Carl Lerche", "Yehuda Katz"]
-  spec.email       = ["andre@arko.net"]
-  spec.homepage    = "http://bundler.io"
-  spec.summary     = %q{The best way to manage your application's dependencies}
-  spec.description = %q{Bundler manages an application's dependencies through its entire life, across many machines, systematically and repeatably}
+Gem::Specification.new do |s|
+  s.name        = 'bundler'
+  s.version     = Bundler::VERSION
+  s.licenses    = ['MIT']
+  s.authors     = ["André Arko", "Terence Lee", "Carl Lerche", "Yehuda Katz"]
+  s.email       = ["andre@arko.net"]
+  s.homepage    = "http://bundler.io"
+  s.summary     = %q{The best way to manage your application's dependencies}
+  s.description = %q{Bundler manages an application's dependencies through its entire life, across many machines, systematically and repeatably}
 
-  spec.required_ruby_version     = '>= 1.8.7'
-  spec.required_rubygems_version = '>= 1.3.6'
+  s.required_ruby_version     = '>= 1.8.7'
+  s.required_rubygems_version = '>= 1.3.6'
 
-  spec.add_development_dependency 'mustache', '0.99.6'
-  spec.add_development_dependency 'rdiscount', '~> 1.6'
-  spec.add_development_dependency 'ronn', '~> 0.7.3'
-  spec.add_development_dependency 'rspec', '~> 3.0'
+  s.add_development_dependency 'mustache', '0.99.6'
+  s.add_development_dependency 'rdiscount', '~> 1.6'
+  s.add_development_dependency 'ronn', '~> 0.7.3'
+  s.add_development_dependency 'rspec', '~> 3.0'
 
-  spec.files       = `git ls-files -z`.split("\x0")
-  spec.files      += Dir.glob('lib/bundler/man/**/*') # man/ is ignored by git
-  spec.test_files  = spec.files.grep(%r{^spec/})
+  s.files       = `git ls-files -z`.split("\x0")
+  s.files      += Dir.glob('lib/bundler/man/**/*') # man/ is ignored by git
+  s.test_files  = s.files.grep(%r{^spec/})
 
-  spec.executables   = %w(bundle bundler)
-  spec.require_paths = ["lib"]
+  s.executables   = %w(bundle bundler)
+  s.require_paths = ["lib"]
 end


### PR DESCRIPTION
Backport changes by hand from ccb06d14451c0e762dfc207f93ac2286881d168a(#3318) to fix a warning on `1.7.x`.