### PR TITLE
Api source index fix

### DIFF
--- a/lib/bundler/index.rb
+++ b/lib/bundler/index.rb
@@ -101,11 +101,15 @@ module Bundler
 
     # returns a list of the dependencies
     def unmet_dependency_names
-      names = []
-      each{|s| names.push(*s.dependencies.map{|d| d.name }) }
-      names.uniq!
+      names = dependency_names
       names.delete_if{|n| n == "bundler" }
       names.select{|n| search(n).empty? }
+    end
+
+    def dependency_names
+      names = []
+      each{|s| names.push(*s.dependencies.map{|d| d.name }) }
+      names.uniq
     end
 
     def use(other, override_dupes = false)

--- a/lib/bundler/source/rubygems.rb
+++ b/lib/bundler/source/rubygems.rb
@@ -309,6 +309,18 @@ module Bundler
               Bundler.ui.info "" if !Bundler.ui.debug? # new line now that the dots are over
             end
 
+            # Suppose the gem Foo depends on the gem Bar.  Foo exists in Source A.  Bar has some versions that exist in both
+            # sources A and B.  At this point, the API request will have found all the versions of Bar in source A,
+            # but will not have found any versions of Bar from source B, which is a problem if the requested version
+            # of Foo specifically depends on a version of Bar that is only found in source B. This ensures that for
+            # each spec we found, we add all possible versions from all sources to the index.
+            begin
+              idxcount = idx.size
+              api_fetchers.each do |f|
+                idx.use f.specs(idx.dependency_names, self), true
+              end
+            end until idxcount == idx.size
+
             if api_fetchers.any? && api_fetchers.all?{|f| f.use_api }
               # it's possible that gems from one source depend on gems from some
               # other source, so now we download gemspecs and iterate over those

--- a/spec/install/gems/dependency_api_spec.rb
+++ b/spec/install/gems/dependency_api_spec.rb
@@ -260,6 +260,30 @@ describe "gemcutter's dependency API" do
     should_be_installed "back_deps 1.0"
   end
 
+  it "considers all possible versions of dependencies from all api gem sources" do
+    # In this scenario, the gem "somegem" only exists in repo4.  It depends on specific version of activesupport that
+    # exists only in repo1.  There happens also be a version of activesupport in repo4, but one that version 1.0.0
+    # of somegem wants. This test makes sure that bundler actually finds version 1.2.3 of active support in the other
+    # repo and installs it.
+    build_repo4 do
+      build_gem "activesupport", "1.2.0"
+      build_gem "somegem", "1.0.0" do |s|
+        s.add_dependency "activesupport", "1.2.3"  #This version exists only in repo1
+      end
+    end
+
+    gemfile <<-G
+      source "#{source_uri}"
+      source "#{source_uri}/extra"
+      gem 'somegem', '1.0.0'
+    G
+
+    bundle :install, :artifice => "endpoint_extra_api"
+
+    should_be_installed "somegem 1.0.0"
+    should_be_installed "activesupport 1.2.3"
+  end
+
   it "prints API output properly with back deps" do
     build_repo2 do
       build_gem "back_deps" do |s|

--- a/spec/install/gems/dependency_api_spec.rb
+++ b/spec/install/gems/dependency_api_spec.rb
@@ -262,7 +262,7 @@ describe "gemcutter's dependency API" do
 
   it "considers all possible versions of dependencies from all api gem sources" do
     # In this scenario, the gem "somegem" only exists in repo4.  It depends on specific version of activesupport that
-    # exists only in repo1.  There happens also be a version of activesupport in repo4, but one that version 1.0.0
+    # exists only in repo1.  There happens also be a version of activesupport in repo4, but not the one that version 1.0.0
     # of somegem wants. This test makes sure that bundler actually finds version 1.2.3 of active support in the other
     # repo and installs it.
     build_repo4 do

--- a/spec/support/artifice/endpoint.rb
+++ b/spec/support/artifice/endpoint.rb
@@ -14,14 +14,14 @@ require 'sinatra/base'
 class Endpoint < Sinatra::Base
 
   helpers do
-    def dependencies_for(gem_names, marshal = gem_repo1("specs.4.8"))
+    def dependencies_for(gem_names, gem_repo = gem_repo1)
       return [] if gem_names.nil? || gem_names.empty?
 
       require 'rubygems'
       require 'bundler'
       Bundler::Deprecate.skip_during do
-        Marshal.load(File.open(marshal).read).map do |name, version, platform|
-          spec = load_spec(name, version, platform)
+        Marshal.load(File.open(gem_repo.join("specs.4.8")).read).map do |name, version, platform|
+          spec = load_spec(name, version, platform, gem_repo)
           if gem_names.include?(spec.name)
             {
               :name         => spec.name,
@@ -36,10 +36,10 @@ class Endpoint < Sinatra::Base
       end
     end
 
-    def load_spec(name, version, platform)
+    def load_spec(name, version, platform, gem_repo)
       full_name = "#{name}-#{version}"
       full_name += "-#{platform}" if platform != "ruby"
-      Marshal.load(Gem.inflate(File.open(gem_repo1("quick/Marshal.4.8/#{full_name}.gemspec.rz")).read))
+      Marshal.load(Gem.inflate(File.open(gem_repo.join("quick/Marshal.4.8/#{full_name}.gemspec.rz")).read))
     end
   end
 

--- a/spec/support/artifice/endpoint_extra_api.rb
+++ b/spec/support/artifice/endpoint_extra_api.rb
@@ -1,0 +1,32 @@
+require File.expand_path("../endpoint", __FILE__)
+
+Artifice.deactivate
+
+class EndpointExtraApi < Endpoint
+  get "/extra/api/v1/dependencies" do
+    deps = dependencies_for(params[:gems], gem_repo4)
+    Marshal.dump(deps)
+  end
+
+  get "/extra/specs.4.8.gz" do
+    File.read("#{gem_repo4}/specs.4.8.gz")
+  end
+
+  get "/extra/prerelease_specs.4.8.gz" do
+    File.read("#{gem_repo4}/prerelease_specs.4.8.gz")
+  end
+
+  get "/extra/quick/Marshal.4.8/:id" do
+    redirect "/extra/fetch/actual/gem/#{params[:id]}"
+  end
+
+  get "/extra/fetch/actual/gem/:id" do
+    File.read("#{gem_repo4}/quick/Marshal.4.8/#{params[:id]}")
+  end
+
+  get "/extra/gems/:id" do
+    File.read("#{gem_repo4}/gems/#{params[:id]}")
+  end
+end
+
+Artifice.activate_with(EndpointExtraApi)

--- a/spec/support/builders.rb
+++ b/spec/support/builders.rb
@@ -260,6 +260,12 @@ module Spec
       FileUtils.rm_rf Dir[gem_repo3("prerelease*")]
     end
 
+    # A repo that has no pre-installed gems included.  (The caller completely determines the contents with the block)
+    def build_repo4(&blk)
+      FileUtils.rm_rf gem_repo4
+      build_repo(gem_repo4, &blk)
+    end
+
     def update_repo2
       update_repo gem_repo2 do
         build_gem "rack", "1.2" do |s|

--- a/spec/support/path.rb
+++ b/spec/support/path.rb
@@ -60,6 +60,10 @@ module Spec
       tmp("gems/remote3", *args)
     end
 
+    def gem_repo4(*args)
+      tmp("gems/remote4", *args)
+    end
+
     def security_repo(*args)
       tmp("gems/security_repo", *args)
     end


### PR DESCRIPTION
Consider the following scenario:

* You have two API gem sources named A and B.  (It is important that both sources are API sources).
* Source A and only source A contains version 1.0.0 of a gem named foo.
* The foo gem explicitly depends on version 1.2.0 of a gem named bar.
* Version 1.2.0 of bar exists only in source B.  However, another version of bar exists in source A.  (The version in source A does not satisfy the dependency of the foo gem).

In this case, a bundle install of the following Gemfile will fail with an error message saying it can't find version 1.2.0 of bar in any sources:

    source "http://sourcea.example.com"
    source "http://sourceb.example.com"
    
    gem 'foo', '1.0.0'
 
Removing the bar gem from source A causes the error to stop happening.
 
We ran into this situation in real life with an in-house geminabox gem server as the first source and rubygems.org as the second source.  We have an in-house gem (that I'll call foo) located in our in-house gem server.  The foo gem depends on thor ~>19.0.  Our in-house gem server happens to have a forked version of thor with a version number less than 19 that doesn't exist on rubygems.org.  When we do a bundle install, we get an error message stating that thor ~> 19.0 cannot be found in any of the sources.

This pull request adds a test that exposes the problem, and then in a subsequent commit adds code that makes the test start working.