### PR TITLE
Handle double underscores in new gem's name

### DIFF
--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -20,7 +20,7 @@ module Bundler
 
       underscored_name = name.tr('-', '_')
       namespaced_path = name.tr('-', '/')
-      constant_name = name.split('_').map{|p| p[0..0].upcase + p[1..-1] }.join
+      constant_name = name.split('_').map{|p| p[0..0].upcase + p[1..-1] unless p.empty?}.join
       constant_name = constant_name.split('-').map{|q| q[0..0].upcase + q[1..-1] }.join('::') if constant_name =~ /-/
       constant_array = constant_name.split('::')
       git_user_name = `git config user.name`.chomp

--- a/spec/bundler/gem_helper_spec.rb
+++ b/spec/bundler/gem_helper_spec.rb
@@ -3,7 +3,7 @@ require 'rake'
 require 'bundler/gem_helper'
 
 describe Bundler::GemHelper do
-  let(:app_name) { "test" }
+  let(:app_name) { "lorem__ipsum" }
   let(:app_path) { bundled_app app_name }
   let(:app_gemspec_path) { app_path.join("#{app_name}.gemspec") }
 
@@ -43,7 +43,7 @@ describe Bundler::GemHelper do
       app_path = bundled_app "#{app_name}-foo_bar"
 
       lib = app_path.join("lib/#{app_name}/foo_bar.rb").read
-      expect(lib).to include("module #{app_name.capitalize}")
+      expect(lib).to include("module LoremIpsum")
       expect(lib).to include("module FooBar")
     end
   end


### PR DESCRIPTION
Fix #3374

Fix an issue where double underscores in gem's name throw error while building a new gem skeleton via ```bundle gem lorem__ipsum``` command.