### PR TITLE
Remove ref from git cache path

### DIFF
--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -183,6 +183,7 @@ module Bundler
         git_proxy.checkout if requires_checkout?
         git_proxy.copy_to(app_cache_path, @submodules)
         serialize_gemspecs_in(app_cache_path)
+        File.write(app_cache_path.join(".bundlecache"), cached_revision || revision)
       end
 
       def load_spec_files
@@ -209,7 +210,7 @@ module Bundler
       end
 
       def app_cache_dirname
-        "#{base_name}-#{shortref_for_path(cached_revision || revision)}"
+        base_name
       end
 
       def revision


### PR DESCRIPTION
When using `bundle cache --all` with git dependencies, bundler includes the ref as part of the path in `vendor/cache`. When `bundle update` is run, the old cache is removed and the new cache is added, making diffs very noisy. This is a proposal to remove the ref from the path and store it in `.bundlercache`.

This is potentially a breaking change, so it might be best to put it behind a config option.