### PR TITLE
Remove white space at the end of the line

### DIFF
--- a/lib/bundler/templates/newgem/README.md.tt
+++ b/lib/bundler/templates/newgem/README.md.tt
@@ -26,7 +26,7 @@ TODO: Write usage instructions here
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `bin/console` for an interactive prompt that will allow you to experiment. <% if config[:bin] %>Run `bundle exec <%= config[:name] %>` to use the code located in this directory, ignoring other installed copies of this gem.<% end %>
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `bin/console` for an interactive prompt that will allow you to experiment.<% if config[:bin] %> Run `bundle exec <%= config[:name] %>` to use the code located in this directory, ignoring other installed copies of this gem.<% end %>
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release` to create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 


### PR DESCRIPTION
If you create a gem without `config[:bin]`, then your README file will have an extra white character at the end of the line.

This commit removes that extra character.