### PR TITLE
Set spec.bindir to the new executables location in the new gem template

### DIFF
--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 <%- if config[:ext] -%>

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -30,7 +30,7 @@ describe "bundle gem" do
     end
   end
 
-  shared_examples_for "git config is absent" do |hoge|
+  shared_examples_for "git config is absent" do
     it "sets gemspec author to default message if git user.name is not set or empty" do
       expect(generated_gem.gemspec.authors.first).to eq("TODO: Write your name")
     end
@@ -38,6 +38,38 @@ describe "bundle gem" do
     it "sets gemspec email to default message if git user.email is not set or empty" do
       expect(generated_gem.gemspec.email.first).to eq("TODO: Write your email address")
     end
+  end
+
+  it "generates a valid gemspec" do
+    system_gems ["rake-10.0.2"]
+
+    in_app_root
+    bundle "gem newgem --bin"
+
+    process_file(bundled_app('newgem', "newgem.gemspec")) do |line|
+      next line unless line =~ /TODO/
+      # Simulate replacing TODOs with real values
+      case line
+      when /spec\.metadata\['allowed_push_host'\]/
+        line.gsub(/\=.*$/, "= 'http://example.org'")
+      when /spec\.summary/
+        line.gsub(/\=.*$/, "= %q{A short summary of my new gem.}")
+      when /spec\.description/
+        line.gsub(/\=.*$/, "= %q{A longer description of my new gem.}")
+      when /spec\.homepage/
+        line.gsub(/\=.*$/, "= 'http://example.org'")
+      else
+        line
+      end
+    end
+
+    Dir.chdir(bundled_app('newgem')) do
+      bundle "exec rake build"
+    end
+
+    expect(exitstatus).to be_zero if exitstatus
+    expect(out).not_to include("ERROR")
+    expect(err).not_to include("ERROR")
   end
 
   context "gem naming with relative paths" do

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -50,14 +50,12 @@ describe "bundle gem" do
       next line unless line =~ /TODO/
       # Simulate replacing TODOs with real values
       case line
-      when /spec\.metadata\['allowed_push_host'\]/
+      when /spec\.metadata\['allowed_push_host'\]/, /spec\.homepage/
         line.gsub(/\=.*$/, "= 'http://example.org'")
       when /spec\.summary/
         line.gsub(/\=.*$/, "= %q{A short summary of my new gem.}")
       when /spec\.description/
         line.gsub(/\=.*$/, "= %q{A longer description of my new gem.}")
-      when /spec\.homepage/
-        line.gsub(/\=.*$/, "= 'http://example.org'")
       else
         line
       end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -349,5 +349,12 @@ module Spec
     ensure
       Dir[pattern].each(&chmod[0755, 0644])
     end
+
+    def process_file(pathname)
+      changed_lines = pathname.readlines.map do |line|
+        yield line
+      end
+      File.open(pathname, 'w') { |file| file.puts(changed_lines.join) }
+    end
   end
 end


### PR DESCRIPTION
Also adds an integration test to make sure that generated gem templates can build.

Fixes #3392.