### PR TITLE
Skip second build of definition

### DIFF
--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -66,8 +66,7 @@ module Bundler
       if Bundler.default_lockfile.exist? && !options["update"]
         local = Bundler.ui.silence do
           begin
-            tmpdef = Definition.build(Bundler.default_gemfile, Bundler.default_lockfile, nil)
-            true unless tmpdef.new_platform? || tmpdef.missing_specs.any?
+            true unless @definition.new_platform? || @definition.missing_specs.any?
           rescue BundlerError
           end
         end


### PR DESCRIPTION
This is just a trivial optimization to save some milliseconds.

If you run `bundle install`, Gemfile is evaluated [here](https://github.com/bundler/bundler/blob/13d5e08de1e1b957bbf4c5fecd8d3e532a09c121/lib/bundler/cli/install.rb#L78) for the first time.
In [`Bundler.definition`](https://github.com/bundler/bundler/blob/13d5e08de1e1b957bbf4c5fecd8d3e532a09c121/lib/bundler.rb#L155), it creates `Definition.build(default_gemfile, default_lockfile, nil)`.
Even though `Bundler::Installer` has it in `@definition`, it evaluates the same thing again [here](https://github.com/bundler/bundler/blob/13d5e08de1e1b957bbf4c5fecd8d3e532a09c121/lib/bundler/installer.rb#L69). I think this can be skipped.
