### PR TITLE
Check for bool value as well

### DIFF
--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -136,7 +136,7 @@ module Bundler
     end
 
     def to_bool(value)
-      !(value.nil? || value == '' || value =~ /^(false|f|no|n|0)$/i)
+      !(value.nil? || value == '' || value =~ /^(false|f|no|n|0)$/i || value == false)
     end
 
     def set_key(key, value, hash, file)


### PR DESCRIPTION
When being asked for the first time whether you want to have a COC or license file added to your gems or not, the value is a boolean and will always return true even if you chose not to generate the file. Because the config file is read on future gem creations, the value is a string and will work as intended, so it the issue only occurs the first time you create a gem.