### PR TITLE
Allow dev versions when creating a new gem

### DIFF
--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -164,10 +164,10 @@ module Bundler
     end
 
     def bundler_dependency_version
-      major, minor, *etc = Bundler::VERSION.split(".")
-      version = [major, minor]
-      version << etc.last if etc.last =~ /[a-z]/i
-      version.join(".")
+      v = Gem::Version.new(Bundler::VERSION)
+      req = v.segments[0..1]
+      req << v.segments.last if v.prerelease?
+      req.join(".")
     end
 
   end

--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -37,7 +37,8 @@ module Bundler
         :email            => git_user_email.empty? ? "TODO: Write your email address" : git_user_email,
         :test             => options[:test],
         :ext              => options[:ext],
-        :bin              => options[:bin]
+        :bin              => options[:bin],
+        :bundler_version  => bundler_dependency_version
       }
 
       templates = {
@@ -160,6 +161,13 @@ module Bundler
 
       return if test_framework == "false"
       test_framework
+    end
+
+    def bundler_dependency_version
+      major, minor, *etc = Bundler::VERSION.split(".")
+      version = [major, minor]
+      version << etc.last if etc.last =~ /[a-z]/i
+      version.join(".")
     end
 
   end

--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.extensions    = ["ext/<%=config[:underscored_name]%>/extconf.rb"]
 <%- end -%>
 
-  spec.add_development_dependency "bundler", "~> <%= Bundler::VERSION.split(".")[0..1].join(".") %>"
+  spec.add_development_dependency "bundler", "~> <%= config[:bundler_version] %>"
   spec.add_development_dependency "rake", "~> 10.0"
 <%- if config[:ext] -%>
   spec.add_development_dependency "rake-compiler"


### PR DESCRIPTION
The changed behaviour is to see if the last segment in the Bundler version contains any letters, and if so, tack it on.

So with Bundler 1.9.0.dev, you get:

```ruby
  spec.add_development_dependency "bundler", "~> 1.9.dev"
```

and with Bundler 1.8.2, you get the same as before:

```ruby
  spec.add_development_dependency "bundler", "~> 1.8"
```