### PR TITLE
LocalRubygems is required for source options

### DIFF
--- a/lib/bundler/source_list.rb
+++ b/lib/bundler/source_list.rb
@@ -19,7 +19,7 @@ module Bundler
     end
 
     def add_rubygems_source(options = {})
-      add_source_to_list Source::Rubygems.new(options), @rubygems_sources
+      add_source_to_list Source::LocalRubygems.new(options), @rubygems_sources
     end
 
     def add_rubygems_remote(uri)

--- a/spec/bundler/source_list_spec.rb
+++ b/spec/bundler/source_list_spec.rb
@@ -69,7 +69,7 @@ describe Bundler::SourceList do
       end
 
       it "returns the new rubygems source" do
-        expect(@new_source).to be_instance_of(Bundler::Source::Rubygems)
+        expect(@new_source).to be_instance_of(Bundler::Source::LocalRubygems)
       end
 
       it "passes the provided options to the new source" do


### PR DESCRIPTION
Since the `:path` option forces to re-resolve dependencies each time,
the index for source options has to see local gems index even in
`bundle check` or `bundle exec` mode.

It should fix #3414 and #3417 .