### PR TITLE
allow a gem with a source to override a gem without a source

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -96,10 +96,14 @@ module Bundler
             @dependencies.delete current
           elsif dep.type == :development
             return
+          elsif !dep.source
+            return
+          elsif !current.source
+            @dependencies.delete current
           else
             raise GemfileError, "You cannot specify the same gem twice coming from different sources.\n" \
                             "You specified that #{dep.name} (#{dep.requirement}) should come from " \
-                            "#{current.source || 'an unspecified source'} and #{dep.source}\n"
+                            "#{current.source} and #{dep.source}\n"
           end
         end
       end


### PR DESCRIPTION
In a complex dependency structure, a project could have plugins (that are gems), but also allow inclusion of Gemfile fragments from that plugin, so that it can specify the source of its (unreleased) further dependencies. However, if the plugin depends on a development version of the same gem that the main project depends on, bundler won't allow the same gem to be listed with multiple sources, even though the project itself doesn't care where the gem comes from. This PR allows that.

Note that this also fixes the Gemfile 
```ruby
gem 'bob', github: 'bob'
gem 'bob'
```
producing the incomprehensible error
```
You specified that bob (>= 0) should come from https://github.com/bob/bob.git (at master) and 
```