### PR TITLE
Show revision on bundle install from git

### DIFF
--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -70,7 +70,7 @@ module Bundler
         else
           ref
         end
-        "#{uri} (at #{at} - #{revision})"
+        "#{uri} (at #{at})"
       end
 
       def name
@@ -171,7 +171,7 @@ module Bundler
         if requires_checkout? && spec.post_install_message
           Installer.post_install_messages[spec.name] = spec.post_install_message
         end
-        ["Using #{version_message(spec)} from #{to_s}", nil, debug]
+        ["Using #{version_message(spec)} from #{to_s} - #{revision}", nil, debug]
       end
 
       def cache(spec, custom_path = nil)

--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -70,7 +70,7 @@ module Bundler
         else
           ref
         end
-        "#{uri} (at #{at})"
+        "#{uri} (at #{at} - #{revision})"
       end
 
       def name

--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -68,9 +68,19 @@ module Bundler
         elsif options["ref"]
           shortref_for_display(options["ref"])
         else
-          ref
+          ref_with_rev
         end
         "#{uri} (at #{at})"
+      end
+
+      def ref_with_rev
+        rev = @copied ? revision : cached_revision
+
+        if rev
+          "#{ref} - #{rev}"
+        else
+          ref
+        end
       end
 
       def name
@@ -171,7 +181,7 @@ module Bundler
         if requires_checkout? && spec.post_install_message
           Installer.post_install_messages[spec.name] = spec.post_install_message
         end
-        ["Using #{version_message(spec)} from #{to_s} - #{revision}", nil, debug]
+        ["Using #{version_message(spec)} from #{to_s}", nil, debug]
       end
 
       def cache(spec, custom_path = nil)


### PR DESCRIPTION
A possible solution for issue #3433 - which requests that the git revision (provided that git is the source) is displayed when `bundle install`ing in addition to the branch name.  I agree that such information might be of assistance.