### PR TITLE
[Inline] Add bundler/inline to allow using Bundler without a Gemfile

### DIFF
--- a/lib/bundler/inline.rb
+++ b/lib/bundler/inline.rb
@@ -16,5 +16,6 @@ def gemfile(install = false, &blk)
   runtime.setup_environment
   runtime.setup.require
 
-  Bundler.send(:define_singleton_method, :root, old_root)
+  bundler_module = class << Bundler; self; end
+  bundler_module.send(:define_method, :root, old_root)
 end

--- a/lib/bundler/inline.rb
+++ b/lib/bundler/inline.rb
@@ -1,4 +1,33 @@
-def gemfile(install = false, &blk)
+# Allows for declaring a Gemfile inline in a ruby script, optionally installing
+# any gems that aren't already installed on the user's system.
+#
+# @note Every gem that is specified in this 'Gemfile' will be `require`d, as if
+#       the user had manually called `Bundler.require`. To avoid a requested gem
+#       being automatically required, add the `:require => false` option to the
+#       `gem` dependency declaration.
+#
+# @param install [Boolean] whether gems that aren't already installed on the
+#                          user's system should be installed.
+#                          Defaults to `false`.
+#
+# @param gemfile [Proc]    a block that is evaluated as a `Gemfile`.
+#
+# @example Using an inline Gemfile
+#
+#          #!/usr/bin/env ruby
+#
+#          require 'bundler/inline'
+#
+#          gemfile do
+#            source 'https://rubygems.org'
+#            gem 'json', require: false
+#            gem 'nap', require: 'rest'
+#            gem 'cocoapods', '~> 0.34.1'
+#          end
+#
+#          puts Pod::VERSION => "0.34.4"
+#
+def gemfile(install = false, &gemfile)
   require 'bundler'
   old_root = Bundler.method(:root)
   def Bundler.root
@@ -7,7 +36,7 @@ def gemfile(install = false, &blk)
   ENV['BUNDLE_GEMFILE'] ||= 'Gemfile'
 
   builder = Bundler::Dsl.new
-  builder.instance_eval(&blk)
+  builder.instance_eval(&gemfile)
   definition = builder.to_definition(nil, true)
   def definition.lock(file); end
   definition.validate_ruby!

--- a/lib/bundler/inline.rb
+++ b/lib/bundler/inline.rb
@@ -1,0 +1,20 @@
+def gemfile(install = false, &blk)
+	require 'bundler'
+	old_root = Bundler.method(:root)
+	def Bundler.root
+		Pathname.pwd.expand_path
+	end
+	ENV['BUNDLE_GEMFILE'] ||= 'Gemfile'
+
+	builder = Bundler::Dsl.new
+	builder.instance_eval(&blk)
+	definition = builder.to_definition(nil, true)
+	def definition.lock(*); end
+	definition.validate_ruby!
+	Bundler::Installer.install(Bundler.root, definition, :system => true) if install
+	runtime = Bundler::Runtime.new(nil, definition)
+	runtime.setup_environment
+	runtime.setup.require
+
+	Bundler.send(:define_singleton_method, :root, old_root)
+end

--- a/lib/bundler/inline.rb
+++ b/lib/bundler/inline.rb
@@ -1,20 +1,20 @@
 def gemfile(install = false, &blk)
-	require 'bundler'
-	old_root = Bundler.method(:root)
-	def Bundler.root
-		Pathname.pwd.expand_path
-	end
-	ENV['BUNDLE_GEMFILE'] ||= 'Gemfile'
+  require 'bundler'
+  old_root = Bundler.method(:root)
+  def Bundler.root
+    Pathname.pwd.expand_path
+  end
+  ENV['BUNDLE_GEMFILE'] ||= 'Gemfile'
 
-	builder = Bundler::Dsl.new
-	builder.instance_eval(&blk)
-	definition = builder.to_definition(nil, true)
-	def definition.lock(*); end
-	definition.validate_ruby!
-	Bundler::Installer.install(Bundler.root, definition, :system => true) if install
-	runtime = Bundler::Runtime.new(nil, definition)
-	runtime.setup_environment
-	runtime.setup.require
+  builder = Bundler::Dsl.new
+  builder.instance_eval(&blk)
+  definition = builder.to_definition(nil, true)
+  def definition.lock(file); end
+  definition.validate_ruby!
+  Bundler::Installer.install(Bundler.root, definition, :system => true) if install
+  runtime = Bundler::Runtime.new(nil, definition)
+  runtime.setup_environment
+  runtime.setup.require
 
-	Bundler.send(:define_singleton_method, :root, old_root)
+  Bundler.send(:define_singleton_method, :root, old_root)
 end

--- a/spec/runtime/inline_spec.rb
+++ b/spec/runtime/inline_spec.rb
@@ -58,11 +58,10 @@ describe "bundler/inline#gemfile" do
         path "#{lib_path}"
         gem "two"
       end
-
-      puts "success"
     RUBY
 
-    expect(out).to eq("two\nsuccess")
+    expect(out).to eq("two")
+    expect(exitstatus).to be_zero if exitstatus
 
     script <<-RUBY, :expect_err => true
       gemfile do
@@ -81,10 +80,9 @@ describe "bundler/inline#gemfile" do
         source "file://#{gem_repo1}"
         gem "rack"
       end
-
-      puts "success"
     RUBY
 
-    expect(out).to eq("Rack's post install message\nsuccess")
+    expect(out).to eq("Rack's post install message")
+    expect(exitstatus).to be_zero if exitstatus
   end
 end

--- a/spec/runtime/inline_spec.rb
+++ b/spec/runtime/inline_spec.rb
@@ -1,0 +1,90 @@
+require "spec_helper"
+
+describe "bundler/inline#gemfile" do
+  def script(code, options = {})
+    @out = ruby("require 'bundler/inline'\n\n" << code, options)
+  end
+
+  before :each do
+    build_lib "one", "1.0.0" do |s|
+      s.write "lib/baz.rb", "puts 'baz'"
+      s.write "lib/qux.rb", "puts 'qux'"
+    end
+
+    build_lib "two", "1.0.0" do |s|
+      s.write "lib/two.rb", "puts 'two'"
+      s.add_dependency "three", "= 1.0.0"
+    end
+
+    build_lib "three", "1.0.0" do |s|
+      s.write "lib/three.rb", "puts 'three'"
+      s.add_dependency "seven", "= 1.0.0"
+    end
+
+    build_lib "four", "1.0.0" do |s|
+      s.write "lib/four.rb", "puts 'four'"
+    end
+
+    build_lib "five", "1.0.0", :no_default => true do |s|
+      s.write "lib/mofive.rb", "puts 'five'"
+    end
+
+    build_lib "six", "1.0.0" do |s|
+      s.write "lib/six.rb", "puts 'six'"
+    end
+
+    build_lib "seven", "1.0.0" do |s|
+      s.write "lib/seven.rb", "puts 'seven'"
+    end
+
+    build_lib "eight", "1.0.0" do |s|
+      s.write "lib/eight.rb", "puts 'eight'"
+    end
+
+    build_lib "four", "1.0.0" do |s|
+      s.write "lib/four.rb", "puts 'four'"
+    end
+
+    @gemfile = <<-G
+      path "#{lib_path}"
+      gem "two"
+      gem "four", :require => false
+    G
+  end
+
+  it "requires the gems" do
+    script <<-RUBY
+      gemfile do
+        path "#{lib_path}"
+        gem "two"
+      end
+
+      puts "success"
+    RUBY
+
+    expect(out).to eq("two\nsuccess")
+
+    script <<-RUBY, :expect_err => true
+      gemfile do
+        path "#{lib_path}"
+        gem "eleven"
+      end
+
+      puts "success"
+    RUBY
+
+    expect(err).to include "Could not find gem 'eleven (>= 0) ruby'"
+    expect(out).not_to include "success"
+
+    script <<-RUBY
+      gemfile(true) do
+        source "file://#{gem_repo1}"
+        gem "rack"
+      end
+
+      puts "success"
+    RUBY
+
+    expect(out).to eq("Rack's post install message\nsuccess")
+  end
+end


### PR DESCRIPTION
Closes https://github.com/bundler/bundler-features/issues/47.

Enables scripts such as the following to work on their own, as long as bundler is installed:

```ruby
#!/usr/bin/env ruby

require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'
  gem 'json'
  gem 'nap', require: 'rest'
  gem 'cocoapods', '> 0.pre'
end

puts Pod::VERSION
```