### PR TITLE
Slightly more secure github git sources

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -140,7 +140,7 @@ module Bundler
               "either use the :git option on a gem, or specify the gems that \n" \
               "bundler should find in the git source by passing a block to \n" \
               "the git method, like: \n\n" \
-              "  git 'git://github.com/rails/rails.git' do\n" \
+              "  git 'https://github.com/rails/rails.git' do\n" \
               "    gem 'rails'\n" \
               "  end"
         raise DeprecatedError, msg
@@ -194,7 +194,7 @@ module Bundler
     def add_git_sources
       git_source(:github) do |repo_name|
         repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
-        "git://github.com/#{repo_name}.git"
+        "https://github.com/#{repo_name}.git"
       end
 
       git_source(:gist){ |repo_name| "https://gist.github.com/#{repo_name}.git" }


### PR DESCRIPTION
Pulling code into production over an insecure protocol usually isn't a good idea, so this PR moves from git -> https.  As a smaller side-benefit, this change also allows Gemfiles including github sources to pass bundler-audit.

(Granted there is not yet any checking of commits' or tags' GPG signatures in bundler, and more non-git sourced gems authors signing their gems would also be a good idea.)