### PR TITLE
Update man-pages with new options

### DIFF
--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -102,9 +102,15 @@ learn more about their operation in [bundle install(1)][bundle-install].
 * `ssl_client_cert` (`BUNDLE_SSL_CLIENT_CERT`):
   Path to a designated file containing a X.509 client certificate
   and key in PEM format.
+* `cache_path` (`BUNDLE_CACHE_PATH`): The directory that bundler will place
+  cached gems in when running <code>bundle package</code>, and that bundler
+  will look in when installing gems.
+* `disable_multisource` (`BUNDLE_DISABLE_MULTISOURCE`): When set, Gemfiles
+  containing multiple sources will produce errors instead of warnings. Use
+  `bundle config --delete disable_multisource` to unset.
 
 In general, you should set these settings per-application by using the applicable
-flag to the [bundle install(1)][bundle-install] command.
+flag to the [bundle install(1)][bundle-install] or [bundle package(1)][bundle-package] command.
 
 You can set them globally either via environment variables or `bundle config`,
 whichever is preferable for your setup. If you use both, environment variables

--- a/man/bundle-install.ronn
+++ b/man/bundle-install.ronn
@@ -8,10 +8,13 @@ bundle-install(1) -- Install the dependencies specified in your Gemfile
                  [--full-index]
                  [--gemfile=GEMFILE]
                  [--jobs=NUMBER]
-                 [--local] [--deployment]
+                 [--frozen]
+                 [--local]
+                 [--deployment]
                  [--no-cache]
                  [--no-prune]
-                 [--path PATH] [--system]
+                 [--path PATH]
+                 [--system]
                  [--quiet]
                  [--retry=NUMBER]
                  [--shebang]
@@ -65,6 +68,10 @@ update process below under [CONSERVATIVE UPDATING][].
 
 * `--jobs=[<number>]`:
   Install gems by starting <number> of workers parallely.
+
+* `--frozen`:
+  Do not allow the Gemfile.lock to be updated after this install. Remembered in
+  the local configuration.
 
 * `--local`:
   Do not attempt to connect to `rubygems.org`. Instead, Bundler will use the


### PR DESCRIPTION
Some of the commands’ supported options were not reflected in the respective manpages.
I believe I got them all, but automating this would probably we worthwile (keep bundler.io, manpages and optparse in sync).