### PR TITLE
[Travis] Ruby 1.8.7 and 1.9.3 have been retired

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ rvm:
   - 2.2
   - 2.1
   - 2.0.0
-  - 1.9.3
   - 1.8.7
 
 # Rubygems versions MUST be available as rake tasks

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ rvm:
   - 2.2
   - 2.1
   - 2.0.0
-  - 1.8.7
 
 # Rubygems versions MUST be available as rake tasks
 # see Rakefile:66 for the list of possible RGV values


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2013/06/30/we-retire-1-8-7/

https://www.ruby-lang.org/en/news/2015/02/23/support-for-ruby-1-9-3-has-ended/