### PR TITLE
gemspec should accept a glob option in its argument hash

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -225,7 +225,7 @@ module Bundler
     end
 
     def valid_keys
-      @valid_keys ||= %w(branch git glob group development_group groups name path platform platforms ref require source submodules tag type)
+      @valid_keys ||= %w(group groups git path glob name branch ref tag require submodules platform platforms type source)
     end
 
     def normalize_options(name, version, opts)

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -225,7 +225,7 @@ module Bundler
     end
 
     def valid_keys
-      @valid_keys ||= %w(group groups git path glob name branch ref tag require submodules platform platforms type source)
+      @valid_keys ||= %w(branch git glob group development_group groups name path platform platforms ref require source submodules tag type)
     end
 
     def normalize_options(name, version, opts)

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -329,4 +329,5 @@ module Bundler
     end
 
   end
+
 end

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -52,7 +52,8 @@ module Bundler
       when 1
         spec = Bundler.load_gemspec(gemspecs.first)
         raise InvalidOption, "There was an error loading the gemspec at #{gemspecs.first}." unless spec
-        gem spec.name, :path => path
+        opts ||= {}
+        gem spec.name, opts.merge(:path => path)
         group(development_group) do
           spec.development_dependencies.each do |dep|
             gem dep.name, *(dep.requirement.as_list + [:type => :development])
@@ -224,7 +225,7 @@ module Bundler
     end
 
     def valid_keys
-      @valid_keys ||= %w(group groups git path name branch ref tag require submodules platform platforms type source)
+      @valid_keys ||= %w(group groups git path glob name branch ref tag require submodules platform platforms type source)
     end
 
     def normalize_options(name, version, opts)

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -42,7 +42,7 @@ module Bundler
 
     def gemspec(opts = nil)
       path              = opts && opts[:path] || '.'
-      glob              = opts && opts[:glob] #|| nil
+      glob              = opts && opts[:glob]
       name              = opts && opts[:name] || '{,*}'
       development_group = opts && opts[:development_group] || :development
       expanded_path     = File.expand_path(path, Bundler.default_gemfile.dirname)

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -53,7 +53,7 @@ module Bundler
       when 1
         spec = Bundler.load_gemspec(gemspecs.first)
         raise InvalidOption, "There was an error loading the gemspec at #{gemspecs.first}." unless spec
-        gem spec.name, path: path, glob: glob
+        gem spec.name, :path => path, :glob => glob
         group(development_group) do
           spec.development_dependencies.each do |dep|
             gem dep.name, *(dep.requirement.as_list + [:type => :development])

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -42,6 +42,7 @@ module Bundler
 
     def gemspec(opts = nil)
       path              = opts && opts[:path] || '.'
+      glob              = opts && opts[:glob] #|| nil
       name              = opts && opts[:name] || '{,*}'
       development_group = opts && opts[:development_group] || :development
       expanded_path     = File.expand_path(path, Bundler.default_gemfile.dirname)
@@ -52,8 +53,7 @@ module Bundler
       when 1
         spec = Bundler.load_gemspec(gemspecs.first)
         raise InvalidOption, "There was an error loading the gemspec at #{gemspecs.first}." unless spec
-        opts ||= {}
-        gem spec.name, opts.merge(:path => path)
+        gem spec.name, path: path, glob: glob
         group(development_group) do
           spec.development_dependencies.each do |dep|
             gem dep.name, *(dep.requirement.as_list + [:type => :development])

--- a/man/gemfile.5.ronn
+++ b/man/gemfile.5.ronn
@@ -453,10 +453,10 @@ files in your test code as you would if the project were installed as a gem; you
 need not manipulate the load path manually or require project files via relative
 paths.
 
-The `gemspec` method supports optional `:path`, `:name`, and `:development_group`
-options, which control where bundler looks for the `.gemspec`, what named
-`.gemspec` it uses (if more than one is present), and which group development
-dependencies are included in.
+The `gemspec` method supports optional `:path`, `:glob`, `:name`, and `:development_group`
+options, which control where bundler looks for the `.gemspec`, the glob it uses to look 
+for the gemspec (defaults to: "{,*,*/*}.gemspec"), what named `.gemspec` it uses 
+(if more than one is present), and which group development dependencies are included in.
 
 ## SOURCE PRIORITY
 

--- a/man/gemfile.5.ronn
+++ b/man/gemfile.5.ronn
@@ -454,8 +454,8 @@ need not manipulate the load path manually or require project files via relative
 paths.
 
 The `gemspec` method supports optional `:path`, `:glob`, `:name`, and `:development_group`
-options, which control where bundler looks for the `.gemspec`, the glob it uses to look 
-for the gemspec (defaults to: "{,*,*/*}.gemspec"), what named `.gemspec` it uses 
+options, which control where bundler looks for the `.gemspec`, the glob it uses to look
+for the gemspec (defaults to: "{,*,*/*}.gemspec"), what named `.gemspec` it uses
 (if more than one is present), and which group development dependencies are included in.
 
 ## SOURCE PRIORITY


### PR DESCRIPTION
This allows a glob option for gemspec to pass through.

An example case for when this is useful would be a lazy static test suite where running `bundle exec rake test` for a second time is a no-op and changing some source files will only cause its dependent test to be rerun on the next `bundle exec test`. That can be done by mapping test outputs to textfiles such as something_test.rb.txt (mainly for the timestamp ) and a) keeping file dependencies of tests explicitly in rake/make/whatever b) plugging in a build system like tup or fabricate.py, which handles such dependencies implicitly by tracking file reads that take place during each build (build = test run). This can be a huge time-saver for repos with large test-suites that take a long time, especially if the tests only `require` the part of the app they really need. 

Therein is a problem with the current bundler implementation without this patch. In a repo that has a Gemfile with a gemspec in it, running bundle exec to invoke a test will cause  a call to Dir['{,*,**}.gemspec'] (DEFAULT_GLOB), which will recursively scan the whole repo for more gemspec files. Since `bundle exec` would be used to invoke each test, this would make, in the eyes of build system that track file reads, each test dependent on every other file (it does for tup, anyway). Allowing the glob option to pass through and giving  it a value of  '*.gemspec' solves this problem, and it's only a small change to the codebase for that can be used to save a lot of wasted CPU time.