### PR TITLE
Remove unused dups

### DIFF
--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -2,7 +2,7 @@ module Bundler
   class CLI::Install
     attr_reader :options
     def initialize(options)
-      @options = options.dup
+      @options = options
     end
 
     def run


### PR DESCRIPTION
Hello!

I've started looking into bundler sources recently and found that dups call in cli/install.rb can be removed, options already dups in cli.rb before passing into cli/install.rb initializer.

Tests successfully passes locally and I hope I've no broke anything.

Thank you for your hard work!

Sincerelly, Nikolay.