### PR TITLE
Implemented use-oldest feature. (#82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Features:
 
   - prefer gemspecs closest to the directory root (#3428, @segiddins)
   - debug log for API request limits (#3452, @neerfri)
+  - implemented use-oldest feature (#82, @sxl1092)
 
 "Features":
 

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -149,6 +149,8 @@ module Bundler
     method_option "trust-policy", :alias => "P", :type => :string, :banner =>
       "Gem trust policy (like gem install -P). Must be one of " +
         Bundler.rubygems.security_policy_keys.join('|')
+    method_option "use-oldest", :type => :boolean, :banner =>
+      "Install oldest gems that fit dependency list rather than newest"
     method_option "without", :type => :array, :banner =>
       "Exclude gems that are part of the specified named group."
 

--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -69,6 +69,7 @@ module Bundler
       Bundler.settings[:no_install] = true if options["no-install"]
       Bundler.settings[:clean]    = options["clean"] if options["clean"]
       Bundler.settings.without    = options[:without]
+      Bundler.settings[:use_oldest]     = options["use-oldest"]
       Bundler::Fetcher.disable_endpoint = options["full-index"]
       Bundler.settings[:disable_shared_gems] = Bundler.settings[:path] ? '1' : nil
 

--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -266,6 +266,9 @@ module Bundler
             end
             nested.last << spec
           end
+          if Bundler.settings[:use_oldest]
+            nested.reverse!
+          end
           groups = nested.map { |a| SpecGroup.new(a) }
           !locked_requirement ? groups : groups.select { |sg| locked_requirement.satisfied_by? sg.version }
         else

--- a/spec/resolver/basic_spec.rb
+++ b/spec/resolver/basic_spec.rb
@@ -82,6 +82,7 @@ describe "Resolving" do
     dep "rack", ">= 0.9.1"
     Bundler.settings[:use_oldest] = true
     should_resolve_and_include %w(rack-0.9.1)
+    Bundler.settings[:use_oldest] = false
   end
 
 end

--- a/spec/resolver/basic_spec.rb
+++ b/spec/resolver/basic_spec.rb
@@ -76,4 +76,12 @@ describe "Resolving" do
     should_resolve_and_include %w(foo-3.0.5)
   end
 
+  # Feature #82
+  it "should install the oldest possible version of requirements with constraints given when --use oldest flag is set" do
+    @index = an_awesome_index
+    dep "rack", ">= 0.9.1"
+    Bundler.settings[:use_oldest] = true
+    should_resolve_and_include %w(rack-0.9.1)
+  end
+
 end


### PR DESCRIPTION
@ajgrover, @rrperez, @bgott, and I are 4 Stanford Students who in issue #82 requested a feature where we can use the flag --use-oldest to run out code using the oldest versions of the gems our gemfile claims. This will be used to test to ensure that our code works with the oldest versions it claims it does. We added the code to make this small addition and have a test to go along with it. The only issue right now is that running bundle with this flag will not properly work if the Gemfile.lock file is present, because it will simply install the most recent versions again. The fix currently is to delete the file before running bundle --use-oldest. Thanks in advance for any feedback!