### PR TITLE
Improve generating module name from gem name in gem generator

### DIFF
--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -20,8 +20,8 @@ module Bundler
 
       underscored_name = name.tr('-', '_')
       namespaced_path = name.tr('-', '/')
-      constant_name = name.split('_').map{|p| p[0..0].upcase + p[1..-1] unless p.empty?}.join
-      constant_name = constant_name.split('-').map{|q| q[0..0].upcase + q[1..-1] }.join('::') if constant_name =~ /-/
+      constant_name = name.gsub(/-[_-]*(?![_-]|$)/){ '::' }.gsub(/([_-]+|(::)|^)(.|$)/){ $2.to_s + $3.upcase }
+
       constant_array = constant_name.split('::')
       git_user_name = `git config user.name`.chomp
       git_user_email = `git config user.email`.chomp

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -578,6 +578,15 @@ describe "bundle gem" do
     end
   end
 
+  describe "uncommon gem names" do
+    it "can deal with two dashes" do
+      bundle "gem a--a"
+      Bundler.clear_gemspec_cache
+
+      expect(bundled_app("a--a/a--a.gemspec")).to exist
+    end
+  end
+
   context "on first run" do
     before do
       in_app_root


### PR DESCRIPTION
I encountered the bug that the gem generator would fail on gem names containing two dashes (like `a--a`). I updated the module name generator to use a more robust regex based approach. 