### PR TITLE
fix "rake spec:deps" fails on MinGW Ruby 2.0

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -87,8 +87,8 @@ namespace :spec do
     end
 
     deps.sort_by{|name, _| name }.each do |name, version|
-      sh "#{Gem.ruby} -S gem list -i '^#{name}$' -v '#{version}' || " \
-         "#{Gem.ruby} -S gem install #{name} -v '#{version}' --no-ri --no-rdoc"
+      sh %{#{Gem.ruby} -S gem list -i "^#{name}$" -v "#{version}" || } +
+         %{#{Gem.ruby} -S gem install #{name} -v "#{version}" --no-ri --no-rdoc}
     end
 
     # Download and install gems used inside tests


### PR DESCRIPTION
```
$ ruby --version
ruby 2.0.0p598 (2014-11-13) [x64-mingw32]

$ rake spec:deps
DL is deprecated, please use Fiddle
c:/Ruby200-x64/bin/ruby.exe -S gem list -i '^mustache$' -v '= 0.99.6' || c:/Ruby
200-x64/bin/ruby.exe -S gem install mustache -v '= 0.99.6' --no-ri --no-rdoc
true
c:/Ruby200-x64/bin/ruby.exe -S gem list -i '^rdiscount$' -v '~> 1.6' || c:/Ruby2
00-x64/bin/ruby.exe -S gem install rdiscount -v '~> 1.6' --no-ri --no-rdoc
ERROR:  While executing gem ... (Gem::Requirement::BadRequirementError)
    Illformed requirement ["~ "]
ERROR:  While executing gem ... (Gem::Requirement::BadRequirementError)
    Illformed requirement ["~ --no-ri --no-rdoc"]
rake aborted!
Command failed with status (1): [c:/Ruby200-x64/bin/ruby.exe -S gem list -i...]
c:/workdir/git-workdir/bundler/Rakefile:90:in `block (3 levels) in <top (require
d)>'
c:/workdir/git-workdir/bundler/Rakefile:89:in `each'
c:/workdir/git-workdir/bundler/Rakefile:89:in `block (2 levels) in <top (require
d)>'
c:/workdir/git-workdir/bundler/Rakefile:23:in `block in invoke'
c:/workdir/git-workdir/bundler/Rakefile:22:in `invoke'
Tasks: TOP => spec:deps
(See full trace by running task with --trace)
```