### PR TITLE
[QualitySpec] Properly ignore warnings coming from vendored libs

### DIFF
--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -97,7 +97,7 @@ describe "The library itself" do
       end
     end
 
-    expect(@err.split("\n").reject { |f| f =~ %r{lib/bundler/vendor} }).to eq([])
+    expect(@err.split("\n").reject { |f| f =~ %r{(lib|\.)/bundler/vendor} }).to eq([])
     expect(@out).to eq("")
   end
 end


### PR DESCRIPTION
\c @indirect 