### PR TITLE
add before_install to .travis.yml template for new gems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Bugfixes:
 
   - make Bundler.which stop finding directories (@nohoho)
   - handle Bundler prereleases correctly (#3470, @segiddins)
+  - add before_install to .travis.yml template for new gems (@kodnin)
 
 ## 1.9.0.pre.1 (2015-03-11)
 

--- a/lib/bundler/templates/newgem/.travis.yml.tt
+++ b/lib/bundler/templates/newgem/.travis.yml.tt
@@ -1,3 +1,4 @@
 language: ruby
 rvm:
   - <%= RUBY_VERSION %>
+before_install: gem install bundler -v <%= Bundler::VERSION %>


### PR DESCRIPTION
As seen in [this](https://travis-ci.org/kodnin/defekt/jobs/55475451) Travis CI build and the screenshot below, Bundler 1.9 is not installed by default on Travis CI. This leaves us a problem, which can be resolved by installing Bundler 1.9 [before](http://docs.travis-ci.com/user/languages/ruby/#Dependency-Management) running Bundler.

![screen shot 2015-03-23 at 13 49 15](https://cloud.githubusercontent.com/assets/3286234/6780627/38941270-d167-11e4-98a9-d5ea57a97104.png)