### PR TITLE
Setting to ignore post_install messages per-gem

### DIFF
--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -92,8 +92,7 @@ module Bundler
       end
 
       Installer.post_install_messages.to_a.each do |name, msg|
-        Bundler.ui.confirm "Post-install message from #{name}:"
-        Bundler.ui.info msg
+        print_post_install_message(name, msg) unless Bundler.settings["ignore_messages.#{name}"]
       end
 
       Installer.ambiguous_gems.to_a.each do |name, installed_from_uri, *also_found_in_uris|
@@ -150,6 +149,11 @@ module Bundler
     def gems_installed_for(definition)
       count = definition.specs.count
       "#{count} #{count == 1 ? 'gem' : 'gems'} now installed"
+    end
+
+    def print_post_install_message(name, msg)
+      Bundler.ui.confirm "Post-install message from #{name}:"
+      Bundler.ui.info msg
     end
 
   end

--- a/spec/install/gems/post_install_spec.rb
+++ b/spec/install/gems/post_install_spec.rb
@@ -1,121 +1,136 @@
 require 'spec_helper'
 
-describe "bundle install with gem sources" do
-  describe "when gems include post install messages" do
-    it "should display the post-install messages after installing" do
-      gemfile <<-G
-        source "file://#{gem_repo1}"
-        gem 'rack'
-        gem 'thin'
-        gem 'rack-obama'
-      G
+describe "bundle install" do
+  context "with gem sources" do
+    context "when gems include post install messages" do
+      it "should display the post-install messages after installing" do
+        gemfile <<-G
+          source "file://#{gem_repo1}"
+          gem 'rack'
+          gem 'thin'
+          gem 'rack-obama'
+        G
 
-      bundle :install
-      expect(out).to include("Post-install message from rack:")
-      expect(out).to include("Rack's post install message")
-      expect(out).to include("Post-install message from thin:")
-      expect(out).to include("Thin's post install message")
-      expect(out).to include("Post-install message from rack-obama:")
-      expect(out).to include("Rack-obama's post install message")
+        bundle :install
+        expect(out).to include("Post-install message from rack:")
+        expect(out).to include("Rack's post install message")
+        expect(out).to include("Post-install message from thin:")
+        expect(out).to include("Thin's post install message")
+        expect(out).to include("Post-install message from rack-obama:")
+        expect(out).to include("Rack-obama's post install message")
+      end
+    end
+
+    context "when gems do not include post install messages" do
+      it "should not display any post-install messages" do
+        gemfile <<-G
+          source "file://#{gem_repo1}"
+          gem "activesupport"
+        G
+
+        bundle :install
+        expect(out).not_to include("Post-install message")
+      end
+    end
+
+    context "when a dependecy includes a post install message" do
+      it "should display the post install message" do
+        gemfile <<-G
+          source "file://#{gem_repo1}"
+          gem 'rack_middleware'
+        G
+
+        bundle :install
+        expect(out).to include("Post-install message from rack:")
+        expect(out).to include("Rack's post install message")
+      end
     end
   end
 
-  describe "when gems do not include post install messages" do
-    it "should not display any post-install messages" do
+  context "with git sources" do
+    context "when gems include post install messages" do
+      it "should display the post-install messages after installing" do
+        build_git "foo" do |s|
+          s.post_install_message = "Foo's post install message"
+        end
+        gemfile <<-G
+          source "file://#{gem_repo1}"
+          gem 'foo', :git => '#{lib_path("foo-1.0")}'
+        G
+
+        bundle :install
+        expect(out).to include("Post-install message from foo:")
+        expect(out).to include("Foo's post install message")
+      end
+
+      it "should display the post-install messages if repo is updated" do
+        build_git "foo" do |s|
+          s.post_install_message = "Foo's post install message"
+        end
+        gemfile <<-G
+          source "file://#{gem_repo1}"
+          gem 'foo', :git => '#{lib_path("foo-1.0")}'
+        G
+        bundle :install
+
+        build_git "foo", "1.1" do |s|
+          s.post_install_message = "Foo's 1.1 post install message"
+        end
+        gemfile <<-G
+          source "file://#{gem_repo1}"
+          gem 'foo', :git => '#{lib_path("foo-1.1")}'
+        G
+        bundle :install
+
+        expect(out).to include("Post-install message from foo:")
+        expect(out).to include("Foo's 1.1 post install message")
+      end
+
+      it "should not display the post-install messages if repo is not updated" do
+        build_git "foo" do |s|
+          s.post_install_message = "Foo's post install message"
+        end
+        gemfile <<-G
+          source "file://#{gem_repo1}"
+          gem 'foo', :git => '#{lib_path("foo-1.0")}'
+        G
+
+        bundle :install
+        expect(out).to include("Post-install message from foo:")
+        expect(out).to include("Foo's post install message")
+
+        bundle :install
+        expect(out).not_to include("Post-install message")
+      end
+    end
+
+    context "when gems do not include post install messages" do
+      it "should not display any post-install messages" do
+        build_git "foo" do |s|
+          s.post_install_message = nil
+        end
+        gemfile <<-G
+          source "file://#{gem_repo1}"
+          gem 'foo', :git => '#{lib_path("foo-1.0")}'
+        G
+
+        bundle :install
+        expect(out).not_to include("Post-install message")
+      end
+    end
+  end
+
+  context "when ignore post-install messages for gem is set" do
+    it "doesn't display any post-install messages" do
       gemfile <<-G
         source "file://#{gem_repo1}"
-        gem "activesupport"
+        gem "rack"
       G
+
+      bundle "config ignore_messages.rack true"
 
       bundle :install
       expect(out).not_to include("Post-install message")
     end
   end
-
-  describe "when a dependecy includes a post install message" do
-    it "should display the post install message" do
-      gemfile <<-G
-        source "file://#{gem_repo1}"
-        gem 'rack_middleware'
-      G
-
-      bundle :install
-      expect(out).to include("Post-install message from rack:")
-      expect(out).to include("Rack's post install message")
-    end
-  end
-end
-
-describe "bundle install with git sources" do
-  describe "when gems include post install messages" do
-    it "should display the post-install messages after installing" do
-      build_git "foo" do |s|
-        s.post_install_message = "Foo's post install message"
-      end
-      gemfile <<-G
-        source "file://#{gem_repo1}"
-        gem 'foo', :git => '#{lib_path("foo-1.0")}'
-      G
-
-      bundle :install
-      expect(out).to include("Post-install message from foo:")
-      expect(out).to include("Foo's post install message")
-    end
-
-    it "should display the post-install messages if repo is updated" do
-      build_git "foo" do |s|
-        s.post_install_message = "Foo's post install message"
-      end
-      gemfile <<-G
-        source "file://#{gem_repo1}"
-        gem 'foo', :git => '#{lib_path("foo-1.0")}'
-      G
-      bundle :install
-
-      build_git "foo", "1.1" do |s|
-        s.post_install_message = "Foo's 1.1 post install message"
-      end
-      gemfile <<-G
-        source "file://#{gem_repo1}"
-        gem 'foo', :git => '#{lib_path("foo-1.1")}'
-      G
-      bundle :install
-
-      expect(out).to include("Post-install message from foo:")
-      expect(out).to include("Foo's 1.1 post install message")
-    end
-
-    it "should not display the post-install messages if repo is not updated" do
-      build_git "foo" do |s|
-        s.post_install_message = "Foo's post install message"
-      end
-      gemfile <<-G
-        source "file://#{gem_repo1}"
-        gem 'foo', :git => '#{lib_path("foo-1.0")}'
-      G
-
-      bundle :install
-      expect(out).to include("Post-install message from foo:")
-      expect(out).to include("Foo's post install message")
-
-      bundle :install
-      expect(out).not_to include("Post-install message")
-    end
-  end
-
-  describe "when gems do not include post install messages" do
-    it "should not display any post-install messages" do
-      build_git "foo" do |s|
-        s.post_install_message = nil
-      end
-      gemfile <<-G
-        source "file://#{gem_repo1}"
-        gem 'foo', :git => '#{lib_path("foo-1.0")}'
-      G
-
-      bundle :install
-      expect(out).not_to include("Post-install message")
-    end
-  end
-
 end


### PR DESCRIPTION
Implements this [Trello Card](https://trello.com/c/FPapFE0I) on ignoring specific gem's post-install messages.

```bash
bundle config ignore_messages.rack true
```

Oh and I also cleaned up gem/post_install_spec.rb by consolidating two describe groups and switching it to context blocks but git wasn't a fan so the commits got mixed together...sorry.