### PR TITLE
Add test files to default rake test task

### DIFF
--- a/lib/bundler/templates/newgem/Rakefile.tt
+++ b/lib/bundler/templates/newgem/Rakefile.tt
@@ -4,6 +4,8 @@ require "rake/testtask"
 
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
+  t.libs << "lib"
+  t.test_files = FileList['test/**/*_test.rb']
 end
 
 task :default => :test

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -522,6 +522,8 @@ describe "bundle gem" do
 
           Rake::TestTask.new(:test) do |t|
             t.libs << "test"
+            t.libs << "lib"
+            t.test_files = FileList['test/**/*_test.rb']
           end
 
           task :default => :test


### PR DESCRIPTION
After this PR, we can run `bundle gem foo; cd foo; bundle exec rake` and it should run all the tests.

(this needs to go after https://github.com/bundler/bundler/pull/3513)

review @indirect @andremedeiros 