### PR TITLE
Use 755 on bin folder for `bundler gem`

### DIFF
--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -107,6 +107,8 @@ module Bundler
       templates.each do |src, dst|
         thor.template("newgem/#{src}", target.join(dst), config)
       end
+      thor.chmod target.join("bin/setup"), 0755
+      thor.chmod target.join("bin/console"), 0755
 
       Bundler.ui.info "Initializing git repo in #{target}"
       Dir.chdir(target) { `git init`; `git add .` }


### PR DESCRIPTION
[fixes #3511]

@indirect 

I couldnt find the tests that test the bin folder, AFAICT, `bin` was added in https://github.com/bundler/bundler/commit/ab3e21784c6c18702869c771fbe7ae23c82cc7c0 , and no tests were added.
If thats true, I can add full test for it. Or tell me why we would not need tests for it.

thanks