### PR TITLE
[LazySpecification] Uniq dependencies in lockfile representation

### DIFF
--- a/lib/bundler/lazy_specification.rb
+++ b/lib/bundler/lazy_specification.rb
@@ -41,7 +41,7 @@ module Bundler
         out = "    #{name} (#{version}-#{platform})\n"
       end
 
-      dependencies.sort_by {|d| d.to_s }.each do |dep|
+      dependencies.sort_by {|d| d.to_s }.uniq.each do |dep|
         next if dep.type == :development
         out << "    #{dep.to_lock}\n"
       end


### PR DESCRIPTION
Closes https://github.com/bundler/bundler/issues/3522, but I'm not convinced this is the right thing to do.