### PR TITLE
Clean up parallel installer

### DIFF
--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -269,7 +269,7 @@ module Bundler
     end
 
     def install_in_parallel(size, standalone)
-      ParallelInstaller.call(size, standalone)
+      ParallelInstaller.call(self, specs, size, standalone)
     end
 
 

--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -1,6 +1,7 @@
 require 'erb'
 require 'rubygems/dependency_installer'
 require 'bundler/worker'
+require 'bundler/installer/parallel_installer'
 
 module Bundler
   class Installer < Environment

--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -1,6 +1,5 @@
 require 'erb'
 require 'rubygems/dependency_installer'
-require 'bundler/worker'
 require 'bundler/installer/parallel_installer'
 
 module Bundler
@@ -86,6 +85,7 @@ module Bundler
       # installation is just SO MUCH FASTER. so we let people opt in.
       jobs = [Bundler.settings[:jobs].to_i-1, 1].max
       if jobs > 1 && can_install_in_parallel?
+        require 'bundler/installer/parallel_installer'
         install_in_parallel jobs, options[:standalone]
       else
         install_sequentially options[:standalone]

--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -269,48 +269,7 @@ module Bundler
     end
 
     def install_in_parallel(size, standalone)
-      name2spec = {}
-      remains = {}
-      enqueued = {}
-      specs.each do |spec|
-        name2spec[spec.name] = spec
-        remains[spec.name] = true
-      end
-
-      worker_pool = Worker.new size, lambda { |name, worker_num|
-        spec = name2spec[name]
-        message = install_gem_from_spec spec, standalone, worker_num
-        { :name => spec.name, :post_install => message }
-      }
-
-      # Keys in the remains hash represent uninstalled gems specs.
-      # We enqueue all gem specs that do not have any dependencies.
-      # Later we call this lambda again to install specs that depended on
-      # previously installed specifications. We continue until all specs
-      # are installed.
-      enqueue_remaining_specs = lambda do
-        remains.keys.each do |name|
-          next if enqueued[name]
-          spec = name2spec[name]
-          if ready_to_install?(spec, remains)
-            worker_pool.enq name
-            enqueued[name] = true
-          end
-        end
-      end
-      enqueue_remaining_specs.call
-
-      until remains.empty?
-        message = worker_pool.deq
-        remains.delete message[:name]
-        if message[:post_install]
-          Installer.post_install_messages[message[:name]] = message[:post_install]
-        end
-        enqueue_remaining_specs.call
-      end
-      message
-    ensure
-      worker_pool && worker_pool.stop
+      ParallelInstaller.call(size, standalone)
     end
 
     # We only want to install a gem spec if all its dependencies are met.

--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -272,15 +272,6 @@ module Bundler
       ParallelInstaller.call(size, standalone)
     end
 
-    # We only want to install a gem spec if all its dependencies are met.
-    # If the dependency is no longer in the `remains` hash then it has been met.
-    # If a dependency is only development or is self referential it can be ignored.
-    def ready_to_install?(spec, remains)
-      spec.dependencies.none? do |dep|
-        next if dep.type == :development || dep.name == spec.name
-        remains[dep.name]
-      end
-    end
 
     def create_bundle_path
       Bundler.mkdir_p(Bundler.bundle_path.to_s) unless Bundler.bundle_path.exist?

--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -260,7 +260,7 @@ module Bundler
 
     def install_sequentially(standalone)
       specs.each do |spec|
-        message = install_gem_from_spec spec, standalone, 0
+        message = install_gem_from_spec spec, standalone
         if message
           Installer.post_install_messages[spec.name] = message
         end

--- a/lib/bundler/installer/parallel_installer.rb
+++ b/lib/bundler/installer/parallel_installer.rb
@@ -1,0 +1,96 @@
+require 'bundler/worker'
+
+module Bundler
+  class Installer < Environment
+    class ParallelInstaller
+      attr_accessor :installed, :spec, :name, :post_install_message, :enqueued
+
+      class SpecInstallation
+        def initialize(spec)
+          @spec, @name = spec, spec.name
+          @installed = false
+          @enqueued = false
+          @post_install_message = ""
+        end
+
+        def installed?
+          !!installed
+        end
+
+        def has_post_install_message?
+          post_install_message.empty?
+        end
+
+        def enqueued?
+          !!enqueued
+        end
+
+        def installing?
+          !installed? && enqueued?
+        end
+
+        def ready_to_install?(specs)
+          @spec.dependencies.none? do |dep|
+            next if dep.type == :development || dep.name == @name
+            specs.reject(:installed?).map(:name).included? dep.name
+          end
+        end
+      end
+
+      def self.call(*options)
+        new(*options).call
+      end
+
+      def self.max_threads
+        @@max_threads ||= [Bundler.settings[:jobs].to_i-1, 1].max
+      end
+
+      def initialize(specs = Installer.specs, size = max_threads, standalone)
+        @size = size
+        @standalone = standalone
+        @specs = spec.map { |s| SpecInstallation.new(s) }
+      end
+
+      def call
+        enqueue_specs
+        process_specs until @specs.all?(:installed?)
+      ensure
+        worker_pool && worker_pool.stop
+      end
+
+      def worker_pool
+        @worker_pool ||= Worker.new @size, lambda { |spec_install, worker_num|
+          message = Installer.install_gem_from_spec spec_install.spec, @standalone, worker_num
+          spec_install.post_install_message = message
+          spec_install.installed = true
+          spec_install
+        }
+      end
+
+      def process_specs
+        spec = worker_pool.deq
+        collect_post_install_message spec if spec.has_post_install_message?
+        enqueue_specs
+      end
+
+      def collect_post_install_message(spec)
+        Installer.post_install_messages[spec.name] = spec.post_install_message
+      end
+
+      # Keys in the remains hash represent uninstalled gems specs.
+      # We enqueue all gem specs that do not have any dependencies.
+      # Later we call this lambda again to install specs that depended on
+      # previously installed specifications. We continue until all specs
+      # are installed.
+      def enqueue_specs
+        @specs.select(:installed?) do |spec|
+          next if spec.enqueued?
+          if spec.ready_to_install? @specs
+            worker_pool.enq spec
+            spec.enqueued = true
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/bundler/installer/parallel_installer.rb
+++ b/lib/bundler/installer/parallel_installer.rb
@@ -44,7 +44,7 @@ class ParallelInstaller
     @@max_threads ||= [Bundler.settings[:jobs].to_i-1, 1].max
   end
 
-  def initialize(all_specs = Installer.specs, size = max_threads, standalone)
+  def initialize(all_specs = Installer.specs, size = ParallelInstaller.max_threads, standalone)
     @size = size
     @standalone = standalone
     @specs = all_specs.map { |s| SpecInstallation.new(s) }

--- a/lib/bundler/installer/parallel_installer.rb
+++ b/lib/bundler/installer/parallel_installer.rb
@@ -44,10 +44,10 @@ class ParallelInstaller
     @@max_threads ||= [Bundler.settings[:jobs].to_i-1, 1].max
   end
 
-  def initialize(specs = Installer.specs, size = max_threads, standalone)
+  def initialize(all_specs = Installer.specs, size = max_threads, standalone)
     @size = size
     @standalone = standalone
-    @specs = specs.map { |s| SpecInstallation.new(s) }
+    @specs = all_specs.map { |s| SpecInstallation.new(s) }
   end
 
   def call

--- a/lib/bundler/installer/parallel_installer.rb
+++ b/lib/bundler/installer/parallel_installer.rb
@@ -1,95 +1,92 @@
 require 'bundler/worker'
 
-module Bundler
-  class Installer < Environment
-    class ParallelInstaller
-      attr_accessor :installed, :spec, :name, :post_install_message, :enqueued
 
-      class SpecInstallation
-        def initialize(spec)
-          @spec, @name = spec, spec.name
-          @installed = false
-          @enqueued = false
-          @post_install_message = ""
-        end
+class ParallelInstaller
+  attr_accessor :installed, :spec, :name, :post_install_message, :enqueued
 
-        def installed?
-          !!installed
-        end
+  class SpecInstallation
+    def initialize(spec)
+      @spec, @name = spec, spec.name
+      @installed = false
+      @enqueued = false
+      @post_install_message = ""
+    end
 
-        def has_post_install_message?
-          post_install_message.empty?
-        end
+    def installed?
+      !!installed
+    end
 
-        def enqueued?
-          !!enqueued
-        end
+    def has_post_install_message?
+      post_install_message.empty?
+    end
 
-        def installing?
-          !installed? && enqueued?
-        end
+    def enqueued?
+      !!enqueued
+    end
 
-        def ready_to_install?(specs)
-          @spec.dependencies.none? do |dep|
-            next if dep.type == :development || dep.name == @name
-            specs.reject(:installed?).map(:name).included? dep.name
-          end
-        end
+    def installing?
+      !installed? && enqueued?
+    end
+
+    def ready_to_install?(specs)
+      @spec.dependencies.none? do |dep|
+        next if dep.type == :development || dep.name == @name
+        specs.reject(:installed?).map(:name).included? dep.name
       end
+    end
+  end
 
-      def self.call(*options)
-        new(*options).call
-      end
+  def self.call(*options)
+    new(*options).call
+  end
 
-      def self.max_threads
-        @@max_threads ||= [Bundler.settings[:jobs].to_i-1, 1].max
-      end
+  def self.max_threads
+    @@max_threads ||= [Bundler.settings[:jobs].to_i-1, 1].max
+  end
 
-      def initialize(specs = Installer.specs, size = max_threads, standalone)
-        @size = size
-        @standalone = standalone
-        @specs = spec.map { |s| SpecInstallation.new(s) }
-      end
+  def initialize(specs = Installer.specs, size = max_threads, standalone)
+    @size = size
+    @standalone = standalone
+    @specs = specs.map { |s| SpecInstallation.new(s) }
+  end
 
-      def call
-        enqueue_specs
-        process_specs until @specs.all?(:installed?)
-      ensure
-        worker_pool && worker_pool.stop
-      end
+  def call
+    enqueue_specs
+    process_specs until @specs.all?(:installed?)
+  ensure
+    worker_pool && worker_pool.stop
+  end
 
-      def worker_pool
-        @worker_pool ||= Worker.new @size, lambda { |spec_install, worker_num|
-          message = Installer.install_gem_from_spec spec_install.spec, @standalone, worker_num
-          spec_install.post_install_message = message
-          spec_install.installed = true
-          spec_install
-        }
-      end
+  def worker_pool
+    @worker_pool ||= Worker.new @size, lambda { |spec_install, worker_num|
+      message = Installer.install_gem_from_spec spec_install.spec, @standalone, worker_num
+      spec_install.post_install_message = message
+      spec_install.installed = true
+      spec_install
+    }
+  end
 
-      def process_specs
-        spec = worker_pool.deq
-        collect_post_install_message spec if spec.has_post_install_message?
-        enqueue_specs
-      end
+  def process_specs
+    spec = worker_pool.deq
+    collect_post_install_message spec if spec.has_post_install_message?
+    enqueue_specs
+  end
 
-      def collect_post_install_message(spec)
-        Installer.post_install_messages[spec.name] = spec.post_install_message
-      end
+  def collect_post_install_message(spec)
+    Installer.post_install_messages[spec.name] = spec.post_install_message
+  end
 
-      # Keys in the remains hash represent uninstalled gems specs.
-      # We enqueue all gem specs that do not have any dependencies.
-      # Later we call this lambda again to install specs that depended on
-      # previously installed specifications. We continue until all specs
-      # are installed.
-      def enqueue_specs
-        @specs.select(:installed?) do |spec|
-          next if spec.enqueued?
-          if spec.ready_to_install? @specs
-            worker_pool.enq spec
-            spec.enqueued = true
-          end
-        end
+  # Keys in the remains hash represent uninstalled gems specs.
+  # We enqueue all gem specs that do not have any dependencies.
+  # Later we call this lambda again to install specs that depended on
+  # previously installed specifications. We continue until all specs
+  # are installed.
+  def enqueue_specs
+    @specs.select(:installed?) do |spec|
+      next if spec.enqueued?
+      if spec.ready_to_install? @specs
+        worker_pool.enq spec
+        spec.enqueued = true
       end
     end
   end

--- a/spec/realworld/parallel_spec.rb
+++ b/spec/realworld/parallel_spec.rb
@@ -6,7 +6,7 @@ describe "parallel", :realworld => true do
       source "https://rubygems.org"
       gem 'activesupport', '~> 3.2.13'
       gem 'faker', '~> 1.1.2'
-      gem 'i18n', '~> 0.6.0' # Because 1.7+ requires Ruby 1.9.3+
+      gem 'i18n', '~> 0.7.0' # Because 1.7+ requires Ruby 1.9.3+
     G
 
     bundle :install, :jobs => 4, :env => {"DEBUG" => "1"}
@@ -38,7 +38,7 @@ describe "parallel", :realworld => true do
       source "https://rubygems.org"
       gem 'activesupport', '~> 3.2.12'
       gem 'faker', '~> 1.1.2'
-      gem 'i18n', '~> 0.6.0' # Because 1.7+ requires Ruby 1.9.3+
+      gem 'i18n', '~> 0.7.0' # Because 1.7+ requires Ruby 1.9.3+
     G
 
     bundle :update, :jobs => 4, :env => {"DEBUG" => "1"}


### PR DESCRIPTION
So I was going through the Installer code and thought it was confusing and hard to read (and I guess CodeClimate agreed) and I thought that the parallel code was especially complex. So to get the class more closely aligned with SOLID and Sandi Metz's principles I ripped out that part into a new section.

Parallel code is very hard to test and I'm not always sure about whether things work on older versions of Ruby so i'm just as interested as anyone on how the tests turn out. I'm going to keep researching the best way to test parallelization but for right now I just left it. 