### PR TITLE
more secure suggestion for spec.metadata['allowed_push_host']

### DIFF
--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -24,9 +24,11 @@ Gem::Specification.new do |spec|
   spec.extensions    = ["ext/<%=config[:underscored_name]%>/extconf.rb"]
 <%- end -%>
 
-  if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com' to prevent pushes to rubygems.org, or delete to allow pushes to any server."
-  end
+  # If this is a private gem, you can prevent accidental pushes to rubygems.org with this section (otherwise delete it)
+  # Note: "required_rubygems_version" is important because "allowed_push_host" won't be respected in earlier versions.
+  # Note: If you use gemfury, you can set "allowed_push_host" to "use.gemfury". Then `fury push` will work but `gem push` won't.
+  #   spec.required_rubygems_version = '>=2.2'
+  #   spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
 
   spec.add_development_dependency "bundler", "~> <%= config[:bundler_version] %>"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -150,11 +150,6 @@ describe "bundle gem" do
       it_should_behave_like "git config is absent"
     end
 
-    it "sets gemspec metadata['allowed_push_host']", :rubygems => "2.0" do
-      expect(generated_gem.gemspec.metadata['allowed_push_host']).
-        to match("delete to allow pushes to any server")
-    end
-
     it "requires the version file" do
       expect(bundled_app("test_gem/lib/test_gem.rb").read).to match(/require "test_gem\/version"/)
     end
@@ -395,11 +390,6 @@ describe "bundle gem" do
       end
 
       it_should_behave_like "git config is absent"
-    end
-
-    it "sets gemspec metadata['allowed_push_host']", :rubygems => "2.0" do
-      expect(generated_gem.gemspec.metadata['allowed_push_host']).
-        to match("delete to allow pushes to any server")
     end
 
     it "requires the version file" do


### PR DESCRIPTION
if you use the option but fail to require rubygems >=2.2, then accidental pushes are **still possible** with old versions that don't respect it