### PR TITLE
Bindir is bin

### DIFF
--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
 <%- end -%>
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = "exe"
+  spec.bindir        = "bin"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 <%- if config[:ext] -%>


### PR DESCRIPTION
When 'bundle gem' is invoked, /bin dir is created for gem executable scripts. Then spec.bindir should be set to "bin" instead of "exe".