### PR TITLE
Deprecate Bundler's built-in Capistrano integration

### DIFF
--- a/bin/bundle_ruby
+++ b/bin/bundle_ruby
@@ -41,7 +41,7 @@ module Bundler
   end
 end
 
-puts "Warning: bundle_ruby will be deprecated in Bundler 2.0.0."
+STDERR.puts "Warning: bundle_ruby will be deprecated in Bundler 2.0.0."
 
 dsl = Bundler::Dsl.new
 begin

--- a/bin/bundle_ruby
+++ b/bin/bundle_ruby
@@ -41,6 +41,8 @@ module Bundler
   end
 end
 
+puts "Warning: bundle_ruby will be deprecated in Bundler 2.0.0."
+
 dsl = Bundler::Dsl.new
 begin
   dsl.eval_gemfile(Bundler::SharedHelpers.default_gemfile)

--- a/lib/bundler/deployment.rb
+++ b/lib/bundler/deployment.rb
@@ -1,3 +1,7 @@
+$stderr.puts "DEPRECATION: Bundler no longer integrates with " \
+  "Capistrano, but Capistrano provides its own integration with " \
+  "Bundler via the capistrano-bundler gem. Use it instead."
+
 module Bundler
   class Deployment
     def self.define_task(context, task_method = :task, opts = {})

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -109,12 +109,6 @@ module Bundler
   private
 
     def find_gemfile
-      #Bundler.ui.warn "Warning: Gemfile and Gemfile.lock will be deprecated "\
-      # "and replaced with gems.rb and gems.locked in Bundler 2.0.0.\n"
-      # TODO: The problem with putting the warning here is that it makes a
-      # lot of specs fail, and for several specs the warning is printed
-      # several times. Ideally, we want to print the warning only once.
-      # How are module accessor variables used?
       given = ENV['BUNDLE_GEMFILE']
       return given if given && !given.empty?
       find_file('Gemfile', 'gems.rb')

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -21,14 +21,9 @@ module Bundler
     @@warning_printed = false
 
     def default_gemfile
-
-      unless @@warning_printed
-        $stderr.puts "DEPRECATION: Gemfile and Gemfile.lock will be " \
-         "deprecated and replaced with gems.rb and gems.locked in " \
-         "Bundler 2.0.0.\n"
-        @@warning_printed = true
-      end
-
+      Bundler.ui.deprecate("Gemfile and Gemfile.lock will be " \
+                           "deprecated and replaced with gems.rb and " \
+                           "gems.locked in Bundler 2.0.0.\n")
       gemfile = find_gemfile
       raise GemfileNotFound, "Could not locate Gemfile" unless gemfile
       Pathname.new(gemfile)

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -18,8 +18,17 @@ end
 module Bundler
   module SharedHelpers
     attr_accessor :gem_loaded
+    @@warning_printed = false
 
     def default_gemfile
+
+      unless @@warning_printed
+        $stderr.puts "DEPRECATION: Gemfile and Gemfile.lock will be " \
+         "deprecated and replaced with gems.rb and gems.locked in " \
+         "Bundler 2.0.0.\n"
+        @@warning_printed = true
+      end
+
       gemfile = find_gemfile
       raise GemfileNotFound, "Could not locate Gemfile" unless gemfile
       Pathname.new(gemfile)
@@ -100,9 +109,14 @@ module Bundler
   private
 
     def find_gemfile
+      #Bundler.ui.warn "Warning: Gemfile and Gemfile.lock will be deprecated "\
+      # "and replaced with gems.rb and gems.locked in Bundler 2.0.0.\n"
+      # TODO: The problem with putting the warning here is that it makes a
+      # lot of specs fail, and for several specs the warning is printed
+      # several times. Ideally, we want to print the warning only once.
+      # How are module accessor variables used?
       given = ENV['BUNDLE_GEMFILE']
       return given if given && !given.empty?
-
       find_file('Gemfile', 'gems.rb')
     end
 

--- a/lib/bundler/ui/shell.rb
+++ b/lib/bundler/ui/shell.rb
@@ -3,7 +3,7 @@ module Bundler
     class Shell
       LEVELS = %w(silent error warn confirm info debug)
 
-      attr_writer :shell
+      attr_writer :shell, :deprecation_messages
 
       def initialize(options = {})
         if options["no-color"] || !STDOUT.tty?
@@ -23,6 +23,13 @@ module Bundler
 
       def warn(msg, newline = nil)
         tell_me(msg, :yellow, newline) if level("warn")
+      end
+
+      def deprecate(msg, newline = nil)
+        unless @deprecation_messages.key?(msg)
+          @deprecation_messages[msg] = nil
+          warn(msg, newline)
+        end
       end
 
       def error(msg, newline = nil)

--- a/lib/bundler/ui/shell.rb
+++ b/lib/bundler/ui/shell.rb
@@ -11,6 +11,7 @@ module Bundler
         end
         @shell = Thor::Base.shell.new
         @level = ENV['DEBUG'] ? "debug" : "info"
+        @deprecation_messages = Hash.new
       end
 
       def info(msg, newline = nil)
@@ -25,10 +26,10 @@ module Bundler
         tell_me(msg, :yellow, newline) if level("warn")
       end
 
-      def deprecate(msg, newline = nil)
+      def deprecate(msg)
         unless @deprecation_messages.key?(msg)
           @deprecation_messages[msg] = nil
-          warn(msg, newline)
+          $stderr.puts("DEPRECATION: " + msg)
         end
       end
 

--- a/lib/bundler/ui/silent.rb
+++ b/lib/bundler/ui/silent.rb
@@ -10,6 +10,9 @@ module Bundler
       def warn(message, newline = nil)
       end
 
+      def deprecate(message)
+      end
+
       def error(message, newline = nil)
       end
 

--- a/spec/bundler/bundler_spec.rb
+++ b/spec/bundler/bundler_spec.rb
@@ -3,6 +3,41 @@ require 'spec_helper'
 require 'bundler'
 
 describe Bundler do
+  describe "version 1.99" do
+    context "when bundle is run" do
+      it "should print a single deprecation warning" do
+        # install_gemfile calls `bundle :install, opts`
+        install_gemfile <<-G
+          source "file://#{gem_repo1}"
+          gem "rack"
+        G
+
+        expect(err).to lack_errors
+      end
+    end
+
+    context "when Bundler.setup is run in a ruby script" do
+
+      it "should print a single deprecation warning" do
+        install_gemfile <<-G
+          source "file://#{gem_repo1}"
+          gem "rack", :group => :test
+        G
+
+        ruby <<-RUBY
+          require 'rubygems'
+          require 'bundler'
+          Bundler.setup
+
+          #require 'rack'
+          #puts RACK
+        RUBY
+
+        expect(err).to lack_errors
+      end
+    end
+  end
+
   describe "#load_gemspec_uncached" do
     let(:app_gemspec_path) { tmp("test.gemspec") }
     subject { Bundler.load_gemspec_uncached(app_gemspec_path) }

--- a/spec/bundler/bundler_spec.rb
+++ b/spec/bundler/bundler_spec.rb
@@ -20,14 +20,13 @@ describe Bundler do
     end
 
     context "when Bundler.setup is run in a ruby script" do
-
       it "should print a single deprecation warning" do
         install_gemfile <<-G
           source "file://#{gem_repo1}"
           gem "rack", :group => :test
         G
 
-        ruby <<-RUBY
+        ruby(<<-RUBY, { expect_err: true })
           require 'rubygems'
           require 'bundler'
           Bundler.setup

--- a/spec/bundler/bundler_spec.rb
+++ b/spec/bundler/bundler_spec.rb
@@ -39,6 +39,26 @@ describe Bundler do
         expect(err).to lack_errors
       end
     end
+
+    context "when `bundler/deployment` is required in a ruby script" do
+      it "should print a capistrano deprecation warning" do
+        install_gemfile <<-G
+          source "file://#{gem_repo1}"
+          gem "rack", :group => :test
+        G
+
+        ruby(<<-RUBY, { expect_err: true })
+          require 'bundler/deployment'
+        RUBY
+
+        expect(err).to include("DEPRECATION: Bundler no longer integrates " \
+                               "with Capistrano, but Capistrano provides " \
+                               "its own integration with Bundler via the " \
+                               "capistrano-bundler gem. Use it instead.")
+        expect(err).to lack_errors
+      end
+    end
+
   end
 
   describe "#load_gemspec_uncached" do

--- a/spec/bundler/bundler_spec.rb
+++ b/spec/bundler/bundler_spec.rb
@@ -12,6 +12,9 @@ describe Bundler do
           gem "rack"
         G
 
+        expect(err).to eq("DEPRECATION: Gemfile and Gemfile.lock will be " \
+         "deprecated and replaced with gems.rb and gems.locked in " \
+         "Bundler 2.0.0.")
         expect(err).to lack_errors
       end
     end
@@ -28,11 +31,12 @@ describe Bundler do
           require 'rubygems'
           require 'bundler'
           Bundler.setup
-
-          #require 'rack'
-          #puts RACK
+          Bundler.setup
         RUBY
 
+        expect(err).to eq("DEPRECATION: Gemfile and Gemfile.lock will be " \
+         "deprecated and replaced with gems.rb and gems.locked in " \
+         "Bundler 2.0.0.")
         expect(err).to lack_errors
       end
     end

--- a/spec/cache/git_spec.rb
+++ b/spec/cache/git_spec.rb
@@ -59,7 +59,7 @@ end
       bundle "#{cmd} --all"
       bundle "#{cmd} --all"
 
-      expect(err).to eq("")
+      expect(err).to lack_errors
       FileUtils.rm_rf lib_path("foo-1.0")
       should_be_installed "foo 1.0"
     end

--- a/spec/commands/check_spec.rb
+++ b/spec/commands/check_spec.rb
@@ -210,7 +210,7 @@ describe "bundle check" do
     3.times do |i|
       bundle :check
       expect(out).to eq(last_out)
-      expect(err).to be_empty
+      expect(err).to lack_errors
     end
   end
 

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -85,14 +85,14 @@ describe "bundle exec" do
       expect(out).to eq("Ruby version #{RUBY_VERSION} defaults to keeping non-standard file descriptors on Kernel#exec.")
     end
 
-    expect(err).to eq("")
+    expect(err).to lack_errors
   end
 
   it "accepts --keep-file-descriptors" do
     install_gemfile ''
     bundle "exec --keep-file-descriptors echo foobar"
 
-    expect(err).to eq("")
+    expect(err).to lack_errors
   end
 
   it "can run a command named --verbose" do

--- a/spec/commands/package_spec.rb
+++ b/spec/commands/package_spec.rb
@@ -100,7 +100,7 @@ describe "bundle install with gem sources" do
       end
 
       bundle :install
-      expect(err).to be_empty
+      expect(err).to lack_errors
       should_be_installed "rack 1.0"
     end
 

--- a/spec/commands/show_spec.rb
+++ b/spec/commands/show_spec.rb
@@ -121,7 +121,7 @@ describe "bundle show" do
 
     it "does not output git errors" do
       bundle :show
-      expect(err).to be_empty
+      expect(err).to lack_errors
     end
   end
 

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -162,7 +162,7 @@ describe "bundle install with git sources" do
           gem "foo"
         end
       G
-      expect(err).to eq("")
+      expect(err).to lack_errors
 
       run <<-RUBY
         require 'foo'
@@ -782,7 +782,7 @@ describe "bundle install with git sources" do
 
       bundle :install, :expect_err => true,
         :requires => [lib_path('install_hooks.rb')]
-      expect(err).to eq("Ran pre-install hook: foo-1.0")
+      expect(err).to eq_err("Ran pre-install hook: foo-1.0")
     end
 
     it "runs post-install hooks" do
@@ -802,7 +802,7 @@ describe "bundle install with git sources" do
 
       bundle :install, :expect_err => true,
         :requires => [lib_path('install_hooks.rb')]
-      expect(err).to eq("Ran post-install hook: foo-1.0")
+      expect(err).to eq_err("Ran post-install hook: foo-1.0")
     end
 
     it "complains if the install hook fails" do

--- a/spec/install/gemfile/path_spec.rb
+++ b/spec/install/gemfile/path_spec.rb
@@ -262,7 +262,7 @@ describe "bundle install with explicit source paths" do
     install_gemfile <<-G
       gem 'foo', '1.0', :path => "#{lib_path('foo-1.0')}"
     G
-    expect(err).to eq("")
+    expect(err).to lack_errors
   end
 
   it "removes the .gem file after installing" do
@@ -472,7 +472,7 @@ describe "bundle install with explicit source paths" do
 
       bundle :install, :expect_err => true,
         :requires => [lib_path('install_hooks.rb')]
-      expect(err).to eq("Ran pre-install hook: foo-1.0")
+      expect(err).to eq_err("Ran pre-install hook: foo-1.0")
     end
 
     it "runs post-install hooks" do
@@ -492,7 +492,7 @@ describe "bundle install with explicit source paths" do
 
       bundle :install, :expect_err => true,
         :requires => [lib_path('install_hooks.rb')]
-      expect(err).to eq("Ran post-install hook: foo-1.0")
+      expect(err).to eq_err("Ran post-install hook: foo-1.0")
     end
 
     it "complains if the install hook fails" do

--- a/spec/install/gems/groups_spec.rb
+++ b/spec/install/gems/groups_spec.rb
@@ -26,7 +26,7 @@ describe "bundle install with groups" do
         puts ACTIVESUPPORT
       R
 
-      expect(err).to eq("ZOMG LOAD ERROR")
+      expect(err).to eq_err("ZOMG LOAD ERROR")
     end
 
     it "installs gems with inline :groups into those groups" do
@@ -37,7 +37,7 @@ describe "bundle install with groups" do
         puts THIN
       R
 
-      expect(err).to eq("ZOMG LOAD ERROR")
+      expect(err).to eq_err("ZOMG LOAD ERROR")
     end
 
     it "sets up everything if Bundler.setup is used with no groups" do
@@ -58,7 +58,7 @@ describe "bundle install with groups" do
         puts THIN
       RUBY
 
-      expect(err).to eq("ZOMG LOAD ERROR")
+      expect(err).to eq_err("ZOMG LOAD ERROR")
     end
 
     it "sets up old groups when they have previously been removed" do
@@ -301,7 +301,7 @@ describe "bundle install with groups" do
     it "does not hit the remote a second time" do
       FileUtils.rm_rf gem_repo2
       bundle "install --without rack"
-      expect(err).to be_empty
+      expect(err).to lack_errors
     end
   end
 

--- a/spec/install/gems/simple_case_spec.rb
+++ b/spec/install/gems/simple_case_spec.rb
@@ -16,7 +16,7 @@ describe "bundle install with gem sources" do
         raise StandardError, "FAIL"
       G
 
-      expect(err).to eq ""
+      expect(err).to lack_errors
       expect(out).to match(/StandardError, "FAIL"/)
       expect(bundled_app("Gemfile.lock")).not_to exist
     end

--- a/spec/install/gemspecs_spec.rb
+++ b/spec/install/gemspecs_spec.rb
@@ -15,7 +15,7 @@ describe "bundle install" do
         gem "yaml_spec"
       G
       bundle :install
-      expect(err).to be_empty
+      expect(err).to lack_errors
     end
 
     it "still installs correctly when using path" do
@@ -24,7 +24,7 @@ describe "bundle install" do
       install_gemfile <<-G
         gem 'yaml_spec', :path => "#{lib_path('yaml_spec-1.0')}"
       G
-      expect(err).to eq("")
+      expect(err).to lack_errors
     end
   end
 

--- a/spec/other/bundle_ruby_spec.rb
+++ b/spec/other/bundle_ruby_spec.rb
@@ -12,8 +12,8 @@ describe "bundle_ruby" do
 
       bundle_ruby
 
-      expect(out).to include("Warning: bundle_ruby will be deprecated in " \
-                             "Bundler 2.0.0.")
+      expect(err).to eq("Warning: bundle_ruby will be deprecated in " \
+                        "Bundler 2.0.0.")
     end
   end
 

--- a/spec/other/bundle_ruby_spec.rb
+++ b/spec/other/bundle_ruby_spec.rb
@@ -12,7 +12,7 @@ describe "bundle_ruby" do
 
       bundle_ruby
 
-      expect(err).to eq("Warning: bundle_ruby will be deprecated in " \
+      expect(err).to eq_err("Warning: bundle_ruby will be deprecated in " \
                         "Bundler 2.0.0.")
     end
   end

--- a/spec/other/bundle_ruby_spec.rb
+++ b/spec/other/bundle_ruby_spec.rb
@@ -1,6 +1,22 @@
 require "spec_helper"
 
 describe "bundle_ruby" do
+  context "when run" do
+    it "displays a deprecation warning" do
+      gemfile <<-G
+        source "file://#{gem_repo1}"
+        ruby "1.9.3", :engine => 'ruby', :engine_version => '1.9.3'
+
+        gem "foo"
+      G
+
+      bundle_ruby
+
+      expect(out).to include("Warning: bundle_ruby will be deprecated in " \
+                             "Bundler 2.0.0.")
+    end
+  end
+
   context "without patchlevel" do
     it "returns the ruby version" do
       gemfile <<-G
@@ -12,7 +28,7 @@ describe "bundle_ruby" do
 
       bundle_ruby
 
-      expect(out).to eq("ruby 1.9.3")
+      expect(out).to include("ruby 1.9.3")
     end
 
     it "engine defaults to MRI" do
@@ -25,7 +41,7 @@ describe "bundle_ruby" do
 
       bundle_ruby
 
-      expect(out).to eq("ruby 1.9.3")
+      expect(out).to include("ruby 1.9.3")
     end
 
     it "handles jruby" do
@@ -38,7 +54,7 @@ describe "bundle_ruby" do
 
       bundle_ruby
 
-      expect(out).to eq("ruby 1.8.7 (jruby 1.6.5)")
+      expect(out).to include("ruby 1.8.7 (jruby 1.6.5)")
     end
 
     it "handles rbx" do
@@ -51,7 +67,7 @@ describe "bundle_ruby" do
 
       bundle_ruby
 
-      expect(out).to eq("ruby 1.8.7 (rbx 1.2.4)")
+      expect(out).to include("ruby 1.8.7 (rbx 1.2.4)")
     end
 
     it "raises an error if engine is used but engine version is not" do
@@ -66,7 +82,7 @@ describe "bundle_ruby" do
       expect(exitstatus).not_to eq(0) if exitstatus
 
       bundle_ruby
-      expect(out).to eq("Please define :engine_version")
+      expect(out).to include("Please define :engine_version")
     end
 
     it "raises an error if engine_version is used but engine is not" do
@@ -81,7 +97,7 @@ describe "bundle_ruby" do
       expect(exitstatus).not_to eq(0) if exitstatus
 
       bundle_ruby
-      expect(out).to eq("Please define :engine")
+      expect(out).to include("Please define :engine")
     end
 
     it "raises an error if engine version doesn't match ruby version for MRI" do
@@ -96,7 +112,7 @@ describe "bundle_ruby" do
       expect(exitstatus).not_to eq(0) if exitstatus
 
       bundle_ruby
-      expect(out).to eq("ruby_version must match the :engine_version for MRI")
+      expect(out).to include("ruby_version must match the :engine_version for MRI")
     end
 
     it "should print if no ruby version is specified" do
@@ -108,7 +124,7 @@ describe "bundle_ruby" do
 
       bundle_ruby
 
-      expect(out).to eq("No ruby version specified")
+      expect(out).to include("No ruby version specified")
     end
   end
 
@@ -123,7 +139,7 @@ describe "bundle_ruby" do
 
       bundle_ruby
 
-      expect(out).to eq("ruby 1.9.3p429")
+      expect(out).to include("ruby 1.9.3p429")
     end
 
     it "handles an engine" do
@@ -136,7 +152,7 @@ describe "bundle_ruby" do
 
       bundle_ruby
 
-      expect(out).to eq("ruby 1.9.3p392 (jruby 1.7.4)")
+      expect(out).to include("ruby 1.9.3p392 (jruby 1.7.4)")
     end
   end
 end

--- a/spec/other/cli_dispatch_spec.rb
+++ b/spec/other/cli_dispatch_spec.rb
@@ -3,19 +3,19 @@ require "spec_helper"
 describe "bundle command names" do
   it "work when given fully" do
     bundle "install"
-    expect(err).to eq("")
+    expect(err).to lack_errors
     expect(out).not_to match(/Ambiguous command/)
   end
 
   it "work when not ambiguous" do
     bundle "ins"
-    expect(err).to eq("")
+    expect(err).to lack_errors
     expect(out).not_to match(/Ambiguous command/)
   end
 
   it "print a friendly error when ambiguous" do
     bundle "i"
-    expect(err).to eq("")
+    expect(err).to lack_errors
     expect(out).to match(/Ambiguous command/)
   end
 end

--- a/spec/realworld/edgecases_spec.rb
+++ b/spec/realworld/edgecases_spec.rb
@@ -7,7 +7,7 @@ describe "real world edgecases", :realworld => true do
       source :rubygems
       gem "linecache", "0.46"
     G
-    expect(err).to eq("")
+    expect(err).to lack_errors
   end
 
   # https://github.com/bundler/bundler/issues/1202
@@ -81,7 +81,7 @@ describe "real world edgecases", :realworld => true do
 
     bundle "install --path vendor/bundle", :expect_err => true
     expect(err).not_to include("Could not find rake")
-    expect(err).to be_empty
+    expect(err).to lack_errors
   end
 
   it "checks out git repos when the lockfile is corrupted" do

--- a/spec/runtime/require_spec.rb
+++ b/spec/runtime/require_spec.rb
@@ -95,7 +95,7 @@ describe "Bundler.require" do
       Bundler.require
     R
 
-    expect(err).to eq("ZOMG LOAD ERROR")
+    expect(err).to eq_err("ZOMG LOAD ERROR")
   end
 
   it "doesn't swallow the error when the library has an unrelated error" do
@@ -117,7 +117,7 @@ describe "Bundler.require" do
     RUBY
     run(cmd, :expect_err => true)
 
-    expect(err).to eq("ZOMG LOAD ERROR: cannot load such file -- load-bar")
+    expect(err).to eq_err("ZOMG LOAD ERROR: cannot load such file -- load-bar")
   end
 
   describe "with namespaced gems" do
@@ -153,7 +153,7 @@ describe "Bundler.require" do
       RUBY
       ruby(cmd, :expect_err => true)
 
-      expect(err).to be_empty
+      expect(err).to lack_errors
     end
 
     it "does not mangle explictly given requires" do
@@ -165,7 +165,7 @@ describe "Bundler.require" do
       load_error_run <<-R, 'jquery-rails'
         Bundler.require
       R
-      expect(err).to eq("ZOMG LOAD ERROR")
+      expect(err).to eq_err("ZOMG LOAD ERROR")
     end
 
     it "handles the case where regex fails" do
@@ -187,7 +187,7 @@ describe "Bundler.require" do
       RUBY
       run(cmd, :expect_err => true)
 
-      expect(err).to eq("ZOMG LOAD ERROR")
+      expect(err).to eq_err("ZOMG LOAD ERROR")
     end
 
     it "doesn't swallow the error when the library has an unrelated error" do
@@ -210,7 +210,7 @@ describe "Bundler.require" do
       RUBY
       run(cmd, :expect_err => true)
 
-      expect(err).to eq("ZOMG LOAD ERROR: cannot load such file -- load-bar")
+      expect(err).to eq_err("ZOMG LOAD ERROR: cannot load such file -- load-bar")
     end
   end
 
@@ -316,7 +316,7 @@ describe "Bundler.require" do
         load_error_run <<-R, 'no_such_file_omg'
           Bundler.require
         R
-        expect(err).to eq('ZOMG LOAD ERROR')
+        expect(err).to eq_err('ZOMG LOAD ERROR')
       end
     end
   end
@@ -335,7 +335,7 @@ describe "Bundler.require with platform specific dependencies" do
     G
 
     run "Bundler.require", :expect_err => true
-    expect(err).to be_empty
+    expect(err).to lack_errors
   end
 
   it "requires gems pinned to multiple platforms, including the current one" do
@@ -350,6 +350,6 @@ describe "Bundler.require with platform specific dependencies" do
     run "Bundler.require; puts RACK", :expect_err => true
 
     expect(out).to eq("1.0.0")
-    expect(err).to be_empty
+    expect(err).to lack_errors
   end
 end

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -16,7 +16,7 @@ describe "Bundler.setup" do
         require 'rack'
         puts RACK
       RUBY
-      expect(err).to eq("")
+      expect(err).to lack_errors
       expect(out).to eq("1.0.0")
     end
   end
@@ -42,7 +42,7 @@ describe "Bundler.setup" do
           puts "WIN"
         end
       RUBY
-      expect(err).to eq("")
+      expect(err).to lack_errors
       expect(out).to eq("WIN")
     end
 
@@ -55,7 +55,7 @@ describe "Bundler.setup" do
         require 'rack'
         puts RACK
       RUBY
-      expect(err).to eq("")
+      expect(err).to lack_errors
       expect(out).to eq("1.0.0")
     end
 
@@ -69,7 +69,7 @@ describe "Bundler.setup" do
         require 'rack'
         puts RACK
       RUBY
-      expect(err).to eq("")
+      expect(err).to lack_errors
       expect(out).to eq("1.0.0")
     end
 
@@ -87,7 +87,7 @@ describe "Bundler.setup" do
           puts "FAIL"
         end
       RUBY
-      expect(err).to eq("")
+      expect(err).to lack_errors
       expect(out).to match("WIN")
     end
   end
@@ -230,7 +230,7 @@ describe "Bundler.setup" do
           end
         R
 
-        expect(err).to be_empty
+        expect(err).to lack_errors
       end
 
       it "replaces #gem but raises when the version is wrong" do
@@ -256,7 +256,7 @@ describe "Bundler.setup" do
           end
         R
 
-        expect(err).to be_empty
+        expect(err).to lack_errors
       end
     end
 
@@ -572,7 +572,7 @@ describe "Bundler.setup" do
           end
         R
 
-        expect(err).to be_empty
+        expect(err).to lack_errors
       end
     end
   end
@@ -607,7 +607,7 @@ describe "Bundler.setup" do
     ENV["GEM_HOME"] = ""
     bundle %{exec ruby -e "require 'set'"}
 
-    expect(err).to be_empty
+    expect(err).to lack_errors
   end
 
   it "should prepend gemspec require paths to $LOAD_PATH in order" do
@@ -663,7 +663,7 @@ describe "Bundler.setup" do
           require 'foo'
         R
       end
-      expect(err).to eq("")
+      expect(err).to lack_errors
     end
 
     it "should make sure the Bundler.root is really included in the path relative to the Gemfile" do
@@ -688,7 +688,7 @@ describe "Bundler.setup" do
         R
       end
 
-      expect(err).to eq("")
+      expect(err).to lack_errors
     end
   end
 
@@ -834,7 +834,7 @@ describe "Bundler.setup" do
         Bundler.load
       RUBY
 
-      expect(err).to eq("")
+      expect(err).to lack_errors
       expect(out).to eq("")
     end
   end
@@ -846,7 +846,7 @@ describe "Bundler.setup" do
       G
 
       bundle %|exec ruby -e "require 'bundler'; Bundler.setup"|
-      expect(err).to be_empty
+      expect(err).to lack_errors
     end
   end
 

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -1,5 +1,17 @@
 module Spec
   module Matchers
+    RSpec::Matchers.define :lack_errors do
+      match do |actual|
+        actual.gsub(/(^DEPRECATION:.+)/, '') == ''
+      end
+    end
+
+    RSpec::Matchers.define :eq_err do |expected|
+      match do |actual|
+        actual.gsub(/(^DEPRECATION:.+\n)/, '') == expected
+      end
+    end
+
     RSpec::Matchers.define :have_dep do |*args|
       dep = Bundler::Dependency.new(*args)
 

--- a/spec/update/gems_spec.rb
+++ b/spec/update/gems_spec.rb
@@ -157,7 +157,7 @@ describe "bundle update when a gem depends on a newer version of bundler" do
 
   it "should not explode" do
     bundle "update"
-    expect(err).to be_empty
+    expect(err).to lack_errors
   end
 
   it "should explain that bundler conflicted" do

--- a/spec/update/git_spec.rb
+++ b/spec/update/git_spec.rb
@@ -89,7 +89,7 @@ describe "bundle update" do
         gem "foo", "1.0", :git => "#{lib_path('foo_two')}"
       G
 
-      expect(err).to be_empty
+      expect(err).to lack_errors
       expect(out).to include("Fetching #{lib_path}/foo_two")
       expect(out).to include("Bundle complete!")
     end


### PR DESCRIPTION
And add a deprecation warning.

There are a lot of commits, because https://github.com/bundler/bundler/pull/3535 hasn't been merged yet.