### PR TITLE
Fix universal gem installation issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ before_script: travis_retry rake spec:travis:deps
 
 branches:
   only:
+    - universal
     - master
     - 1-9-stable
     - 1-8-stable

--- a/lib/bundler/gem_helpers.rb
+++ b/lib/bundler/gem_helpers.rb
@@ -6,6 +6,7 @@ module Bundler
       [Gem::Platform.new('java'), Gem::Platform.new('java')],
       [Gem::Platform.new('mswin32'), Gem::Platform.new('mswin32')],
       [Gem::Platform.new('mswin64'), Gem::Platform.new('mswin64')],
+      [Gem::Platform.new('universal-mingw32'), Gem::Platform.new('universal-mingw32')],
       [Gem::Platform.new('x64-mingw32'), Gem::Platform.new('x64-mingw32')],
       [Gem::Platform.new('x86_64-mingw32'), Gem::Platform.new('x64-mingw32')],
       [Gem::Platform.new('mingw32'), Gem::Platform.new('x86-mingw32')]

--- a/lib/bundler/match_platform.rb
+++ b/lib/bundler/match_platform.rb
@@ -7,7 +7,8 @@ module Bundler
     def match_platform(p)
       Gem::Platform::RUBY == platform or
       platform.nil? or p == platform or
-      generic(Gem::Platform.new(platform)) == p
+      generic(Gem::Platform.new(platform)) == p or
+      platform === p
     end
   end
 end

--- a/spec/resolver/platform_spec.rb
+++ b/spec/resolver/platform_spec.rb
@@ -35,6 +35,7 @@ describe "Resolving platform craziness" do
         platforms "mingw32 mswin32 x64-mingw32" do |platform|
           gem "thin", "1.2.7", platform
         end
+        gem "win32-api", "1.5.1", "universal-mingw32"
       end
     end
 
@@ -56,6 +57,18 @@ describe "Resolving platform craziness" do
       platforms "x64-mingw32"
       dep "thin"
       should_resolve_as %w(thin-1.2.7-x64-mingw32)
+    end
+
+    it "finds universal-mingw gems on x86-mingw" do
+      platform "x86-mingw32"
+      dep "win32-api"
+      should_resolve_as %w(win32-api-1.5.1-universal-mingw32)
+    end
+
+    it "finds universal-mingw gems on x64-mingw" do
+      platform "x64-mingw32"
+      dep "win32-api"
+      should_resolve_as %w(win32-api-1.5.1-universal-mingw32)
     end
   end
 


### PR DESCRIPTION
Trying to install `win32-api` on windows 64-bit ruby since it is published as a `universal-mingw32` gem instead of `x64-mingw32`.
This patch should fix https://github.com/bundler/bundler/issues/3066