### PR TITLE
Only use first line of error messages in the issue search URL

### DIFF
--- a/lib/bundler/friendly_errors.rb
+++ b/lib/bundler/friendly_errors.rb
@@ -70,7 +70,7 @@ module Bundler
 
   def self.issues_url(exception)
     'https://github.com/bundler/bundler/search?q=' \
-    "#{CGI.escape(exception.message)}&type=Issues"
+    "#{CGI.escape(exception.message.lines.first.chomp)}&type=Issues"
   end
 
 end

--- a/spec/bundler/friendly_errors_spec.rb
+++ b/spec/bundler/friendly_errors_spec.rb
@@ -10,4 +10,21 @@ describe Bundler, "friendly errors" do
       end
     }.to raise_error(SystemExit)
   end
+
+  describe "#issues_url" do
+    it "generates a search URL for the exception message" do
+      exception = Exception.new("Exception message")
+
+      expect(Bundler.issues_url(exception)).to eq("https://github.com/bundler/bundler/search?q=Exception+message&type=Issues")
+    end
+
+    it "generates a search URL for only the first line of a multi-line exception message" do
+      exception = Exception.new(<<END)
+First line of the exception message
+Second line of the exception message
+END
+
+      expect(Bundler.issues_url(exception)).to eq("https://github.com/bundler/bundler/search?q=First+line+of+the+exception+message&type=Issues")
+    end
+  end
 end


### PR DESCRIPTION
This is to prevent super-long error messages like in #3554.