### PR TITLE
Fixes a build failure introduced in a72df72

### DIFF
--- a/spec/bundler/gem_helper_spec.rb
+++ b/spec/bundler/gem_helper_spec.rb
@@ -71,16 +71,20 @@ describe Bundler::GemHelper do
     let(:app_version) { "0.1.0" }
     let(:app_gem_dir) { app_path.join("pkg") }
     let(:app_gem_path) { app_gem_dir.join("#{app_name}-#{app_version}.gem") }
-    let(:app_gemspec_content) { File.read(app_gemspec_path) }
+    let(:app_gemspec_content) { remove_push_guard(File.read(app_gemspec_path)) }
 
     before(:each) do
       content = app_gemspec_content.gsub("TODO: ", "")
       content.sub!(/homepage\s+= ".*"/, 'homepage = ""')
+      File.open(app_gemspec_path, "w") { |file| file << content }
+    end
+
+    def remove_push_guard(gemspec_content)
       # Remove exception that prevents public pushes on older RubyGems versions
       if Gem::Version.new(Gem::VERSION) < Gem::Version.new("2.0")
-        content.sub!(/raise "RubyGems 2\.0 or newer.*/, "")
+        gemspec_content.sub!(/raise "RubyGems 2\.0 or newer.*/, "")
       end
-      File.open(app_gemspec_path, "w") { |file| file << content }
+      gemspec_content
     end
 
     it "uses a shell UI for output" do

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -57,7 +57,6 @@ describe "bundle gem" do
     bundle "gem newgem --bin"
 
     process_file(bundled_app('newgem', "newgem.gemspec")) do |line|
-      next line unless line =~ /TODO/
       # Simulate replacing TODOs with real values
       case line
       when /spec\.metadata\['allowed_push_host'\]/, /spec\.homepage/


### PR DESCRIPTION
a72df72c7719bcb7677e5cb140cf7cdb11be652d removes the exception that prevents public pushes on RubyGems < 2.0, but one test was restoring the gemspec back to the original contents (https://github.com/bundler/bundler/commit/a72df72c7719bcb7677e5cb140cf7cdb11be652d#diff-7e091e8293b0ca921df62d6995b5b909R137).

Now it restores the TODOs, but not the removed exception.