### PR TITLE
platform can be of type string so it must be cast into a Gem::Platform

### DIFF
--- a/lib/bundler/match_platform.rb
+++ b/lib/bundler/match_platform.rb
@@ -7,8 +7,7 @@ module Bundler
     def match_platform(p)
       Gem::Platform::RUBY == platform or
       platform.nil? or p == platform or
-      generic(Gem::Platform.new(platform)) == p or
-      Gem::Platform.new(platform) === p
+      generic(Gem::Platform.new(platform)) === p
     end
   end
 end

--- a/lib/bundler/match_platform.rb
+++ b/lib/bundler/match_platform.rb
@@ -8,7 +8,7 @@ module Bundler
       Gem::Platform::RUBY == platform or
       platform.nil? or p == platform or
       generic(Gem::Platform.new(platform)) == p or
-      platform === p
+      Gem::Platform.new(platform) === p
     end
   end
 end

--- a/spec/other/ext_spec.rb
+++ b/spec/other/ext_spec.rb
@@ -5,6 +5,14 @@ describe "Gem::Specification#match_platform" do
     darwin = gem "lol", "1.0", "platform_specific-1.0-x86-darwin-10"
     expect(darwin.match_platform(pl('java'))).to eq(false)
   end
+
+  context "when platform is a string" do
+    it "matches when platform is a string" do
+      lazy_spec = Bundler::LazySpecification.new("lol", "1.0", "universal-mingw32")
+      expect(lazy_spec.match_platform(pl('x86-mingw32'))).to eq(true)
+      expect(lazy_spec.match_platform(pl('x64-mingw32'))).to eq(true)
+    end
+  end
 end
 
 describe "Bundler::GemHelpers#generic" do


### PR DESCRIPTION
#3553 didn't actually fix anything and made things worse (universal gems no longer work on 32 bit ruby on windows)

It seems that the platform can be of type string, so wrapping in in Gem::Platform is necessary.

sorry for the regression