### PR TITLE
Fix `bundle gem` boolean settings

### DIFF
--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -139,7 +139,7 @@ module Bundler
 
       if choice.nil?
         Bundler.ui.confirm header
-        choice = (Bundler.ui.ask("#{message} y/(n):") =~ /y|yes/)
+        choice = Bundler.ui.yes? "#{message} y/(n):"
         Bundler.settings.set_global("gem.#{key}", choice)
       end
 

--- a/lib/bundler/ui/shell.rb
+++ b/lib/bundler/ui/shell.rb
@@ -46,6 +46,14 @@ module Bundler
         @shell.ask(msg)
       end
 
+      def yes?(msg)
+        @shell.yes?(msg)
+      end
+
+      def no?
+        @shell.no?(msg)
+      end
+
       def level=(level)
         raise ArgumentError unless LEVELS.include?(level.to_s)
         @level = level


### PR DESCRIPTION
Fixes #3443 (nmarley's problem at the bottom)
The issue was that `alpha =~ beta` returns nil if `alpha` doesn't contain `beta` and the position—e.g. 6—instead of `false` and `true` respectively like was assumed by whomever wrote the original logic. It coincidentely worked for yes because everything—like 6 using my above example—except for `false` and `nil` resolve to `true`. However, when they selected no for coc or mit they were always reasked because it resolved to `nil` which for boolean settings doesn't get transformed into `false`.