### PR TITLE
Fix rubygems 2.2+ compatibility

### DIFF
--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -130,6 +130,19 @@ module Bundler
       yield
     end
 
+    def loaded_gem_paths
+      # RubyGems 2.2+ can put binary extension into dedicated folders,
+      # therefore use RubyGems facilities to obtain their load paths.
+      if Gem::Specification.method_defined? :full_require_paths
+        loaded_gem_paths = Gem.loaded_specs.map {|n, s| s.full_require_paths}
+        loaded_gem_paths.flatten!
+      else
+        $LOAD_PATH.select do |p|
+          Bundler.rubygems.gem_path.any?{|gp| p =~ /^#{Regexp.escape(gp)}/ }
+        end
+      end
+    end
+
     def ui=(obj)
       Gem::DefaultUserInteraction.ui = obj
     end

--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -135,7 +135,7 @@ module Bundler
       # therefore use RubyGems facilities to obtain their load paths.
       if Gem::Specification.method_defined? :full_require_paths
         loaded_gem_paths = Gem.loaded_specs.map {|n, s| s.full_require_paths}
-        loaded_gem_paths.flatten!
+        loaded_gem_paths.flatten
       else
         $LOAD_PATH.select do |p|
           Bundler.rubygems.gem_path.any?{|gp| p =~ /^#{Regexp.escape(gp)}/ }

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -643,6 +643,9 @@ describe "Bundler.setup" do
       if Gem::Specification.method_defined? :extension_dir
         s = Gem::Specification.find_by_name '#{gem_name}'
         s.extension_dir = '#{ext_dir}'
+
+        # Don't build extensions.
+        s.class.send(:define_method, :build_extensions) { nil }
       end
 
       require 'bundler'

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -628,6 +628,36 @@ describe "Bundler.setup" do
     expect(out).to eq("yay")
   end
 
+  it "should clean $LOAD_PATH properly" do
+    gem_name = 'very_simple_binary'
+    full_gem_name = gem_name + '-1.0'
+    ext_dir = File.join(tmp "extenstions", full_gem_name)
+
+    install_gem full_gem_name
+
+    install_gemfile <<-G
+      source "file://#{gem_repo1}"
+    G
+
+    ruby <<-R
+      if Gem::Specification.method_defined? :extension_dir
+        s = Gem::Specification.find_by_name '#{gem_name}'
+        s.extension_dir = '#{ext_dir}'
+      end
+
+      require 'bundler'
+      gem '#{gem_name}'
+
+      puts $LOAD_PATH.count {|path| path =~ /#{gem_name}/} >= 2
+
+      Bundler.setup
+
+      puts $LOAD_PATH.count {|path| path =~ /#{gem_name}/} == 0
+    R
+
+    expect(out).to eq("true\ntrue")
+  end
+
   it "stubs out Gem.refresh so it does not reveal system gems" do
     system_gems "rack-1.0.0"
 


### PR DESCRIPTION
This is follow up of #3237 including the fix to the last test failure on Ruby 1.8.7 and RubyGems 2.2.2.