### PR TITLE
Bundler >= 1.9.0 fails to create gem plugins

### DIFF
--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -21,8 +21,8 @@ module Bundler
       underscored_name = name.tr('-', '_')
       namespaced_path = name.tr('-', '/')
       constant_name = name.gsub(/-[_-]*(?![_-]|$)/){ '::' }.gsub(/([_-]+|(::)|^)(.|$)/){ $2.to_s + $3.upcase }
-
       constant_array = constant_name.split('::')
+
       git_user_name = `git config user.name`.chomp
       git_user_email = `git config user.email`.chomp
 
@@ -188,7 +188,7 @@ module Bundler
       if name =~ /^\d/
         Bundler.ui.error "Invalid gem name #{name} Please give a name which does not start with numbers."
         exit 1
-      elsif Object.const_defined?(constant_array.first)
+      elsif constant_array.inject(Object) {|c, s| (c.const_defined?(s) && c.const_get(s)) || break }
         Bundler.ui.error "Invalid gem name #{name} constant #{constant_array.join("::")} is already in use. Please choose another gem name."
         exit 1
       end

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -605,6 +605,35 @@ describe "bundle gem" do
     end
   end
 
+  describe "#ensure_safe_gem_name" do
+    before do
+      bundle "gem #{subject}"
+    end
+    after do
+      Bundler.clear_gemspec_cache
+    end
+
+    context "with an existing const name" do
+      subject { "gem" }
+      it { expect(out).to include("Invalid gem name #{subject}") }
+    end
+
+    context "with an existing hyphenated const name" do
+      subject { "gem-specification" }
+      it { expect(out).to include("Invalid gem name #{subject}") }
+    end
+
+    context "starting with an existing const name" do
+      subject { "gem-somenewconstantname" }
+      it { expect(out).not_to include("Invalid gem name #{subject}") }
+    end
+
+    context "ending with an existing const name" do
+      subject { "somenewconstantname-gem" }
+      it { expect(out).not_to include("Invalid gem name #{subject}") }
+    end
+  end
+
   context "on first run" do
     before do
       in_app_root


### PR DESCRIPTION
Since 17a4fc47bfad02de553e5a53b00ad38b4c905e18 (#3123), any gem name starting with an
existing const name has been regarded as "Invalid gem name" by `bundle gem` command.
However, "gem-foo" or "rails-bar" should be totally valid and rather preferable
naming for plugins for RubyGems/Rails.

This patch changes the rule to raise error only when the new gem name fully
matches an existing const name.

invalid: `gem`, `gem-version` (because `Gem::Version` already exists)
valid : `gem-foobar`, `gem-version-foobar` (when `FooBar`module does not exist)
