### PR TITLE
[Documentation] Add suggestion to remove pre-installed bundler

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -20,15 +20,23 @@ bugs](https://github.com/bundler/bundler/issues?labels=small&state=open) and [sm
 
 Bundler doesn't use a Gemfile to list development dependencies, because when we tried it we couldn't tell if we were awake or it was just another level of dreams. To work on Bundler, you'll probably want to do a couple of things.
 
-  1. Install Bundler's development dependencies
+  1. Make sure Bundler is not already installed in your gemset
+
+     We'll be using Rake to set up Bundler's development dependencies. If there is already a version of Bundler installed alongside your version of Rake, the following commnands can find the classes defined in the pre-installed version of Bundler.
+
+     Make sure that when you run the following command you get a warning that Bundler is not installed.
+
+        $ bundle -V
+
+  2. Install Bundler's development dependencies
 
         $ rake spec:deps
 
-  2. Run the test suite, to make sure things are working
+  3. Run the test suite, to make sure things are working
 
         $ rake spec
 
-  3. Set up a shell alias to run Bundler from your clone, e.g. a Bash alias:
+  4. Set up a shell alias to run Bundler from your clone, e.g. a Bash alias:
 
         $ alias dbundle='ruby -I /path/to/bundler/lib /path/to/bundler/bin/bundle'
 


### PR DESCRIPTION
Hi all, 

I ran into all sorts of errors getting my development environment set up due to the fact that I chose a ruby at random and forgot that I had bundler installed in that ruby. 

`rake spec:deps` did call the code in the local repo, but that code found the classes defined by that pre-installed version. Given that it was quite a few versions back, things broke pretty badly.

I'm not sure if uninstalling bundler in the version of ruby you're using is the best solution, but it was the best one I could think of.

I'm new to bundler, but I'm not new to ruby. I recognize that this is ultimately a completely obvious mistake and good for a chuckle, but I do think it's important to provide some sort of warning.

Let me know if you'd rather handle this as an issue first and then a PR, or if you have suggestions for how to improve what I've written.

Thanks, 
Amy