### PR TITLE
loop through the spec list to find gems with a certain name

### DIFF
--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -480,7 +480,9 @@ module Bundler
       end
 
       def find_name(name)
-        Gem::Specification.find_all_by_name name
+        Gem::Specification.stubs.find_all { |spec|
+          spec.name == name
+        }.map(&:to_spec)
       end
     end
 
@@ -521,7 +523,9 @@ module Bundler
       end
 
       def find_name(name)
-        Gem::Specification.find_all_by_name name
+        Gem::Specification.stubs.find_all { |spec|
+          spec.name == name
+        }.map(&:to_spec)
       end
 
       def fetch_specs(source, name)


### PR DESCRIPTION
Since rubygems/rubygems@4fa03bb7aac9f25f44394e818433fdda9962ae8d
rubygems lazily loads specs from the filesystem for a particular name.
So if you request the "foo" gem, then rubygems will go to the FS and
find the gemspecs with the "foo" name.  **Before** the change, rubygems
would search through the loaded spec list for a gem with that name.
Bundler assumed that rubygems would always search through that spec
list, so it sets the specs and relies on that internal behavior.  Since
the internal behavior changed, we need to take that in to account in the
bundler internals.

This patch changes bundler to search through the spec list for a gem
with a particular name.  Gem::Specification.stubs should be supported in
the future (though not recommended because loading every spec isn't
super performant).