### PR TITLE
Distinguish CI command runs

### DIFF
--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -183,18 +183,16 @@ module Bundler
     def cis
       env_cis = {
         "TRAVIS" => "travis",
-        "HAS_JOSH_K_SEAL_OF_APPROVAL" => "josh_k_seal",
         "CIRCLECI" => "circle",
         "SEMAPHORE" => "semaphore",
         "JENKINS_URL" => "jenkins",
         "BUILDBOX" => "buildbox",
         "GO_SERVER_URL" => "go",
-        "SNAP_CI" => "snap"
+        "SNAP_CI" => "snap",
+        "CI_NAME" => ENV["CI_NAME"],
+        "CI" => "ci"
       }
-      cis = env_cis.find_all{ |env, ci| ENV[env]}.map{ |env, ci| ci }
-      cis << ENV["CI_NAME"] if ENV["CI_NAME"]
-      cis << "ci" if ENV["CI"]
-      cis
+      env_cis.find_all{ |env, ci| ENV[env]}.map{ |env, ci| ci }
     end
 
     def connection

--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -155,6 +155,8 @@ module Bundler
 
         agent << " options/#{Bundler.settings.all.join(",")}"
 
+        agent << " ci/#{cis.join(",")}" if cis.any?
+
         # add a random ID so we can consolidate runs server-side
         agent << " " << SecureRandom.hex(8)
 
@@ -177,6 +179,23 @@ module Bundler
   private
 
     FETCHERS = [Dependency, Index]
+
+    def cis
+      env_cis = {
+        "TRAVIS" => "travis",
+        "HAS_JOSH_K_SEAL_OF_APPROVAL" => "josh_k_seal",
+        "CIRCLECI" => "circle",
+        "SEMAPHORE" => "semaphore",
+        "JENKINS_URL" => "jenkins",
+        "BUILDBOX" => "buildbox",
+        "GO_SERVER_URL" => "go",
+        "SNAP_CI" => "snap"
+      }
+      cis = env_cis.find_all{ |env, ci| ENV[env]}.map{ |env, ci| ci }
+      cis << ENV["CI_NAME"] if ENV["CI_NAME"]
+      cis << "ci" if ENV["CI"]
+      cis
+    end
 
     def connection
       @connection ||= begin

--- a/spec/bundler/fetcher_spec.rb
+++ b/spec/bundler/fetcher_spec.rb
@@ -16,5 +16,18 @@ describe Bundler::Fetcher do
       expect(fetcher.user_agent).to match(/ruby\/(\d.)/)
       expect(fetcher.user_agent).to match(/options\/foo,bar/)
     end
+
+    describe "include CI information" do
+      it "from one CI" do
+        ENV["TRAVIS"] = "foo"
+        expect(fetcher.user_agent).to match("ci/travis")
+      end
+
+      it "from many CI" do
+        ENV["TRAVIS"] = "foo"
+        ENV["CI"] = "bar"
+        expect(fetcher.user_agent).to match("ci/travis,ci")
+      end
+    end
   end
 end

--- a/spec/bundler/fetcher_spec.rb
+++ b/spec/bundler/fetcher_spec.rb
@@ -19,14 +19,17 @@ describe Bundler::Fetcher do
 
     describe "include CI information" do
       it "from one CI" do
-        ENV["TRAVIS"] = "foo"
-        expect(fetcher.user_agent).to match("ci/travis")
+        ENV["JENKINS_URL"] = "foo"
+        ci_part = fetcher.user_agent.split(' ').find{|x| x.match(/\Aci\//)}
+        expect(ci_part).to match("jenkins")
       end
 
       it "from many CI" do
         ENV["TRAVIS"] = "foo"
-        ENV["CI"] = "bar"
-        expect(fetcher.user_agent).to match("ci/travis,ci")
+        ENV["CI_NAME"] = "my_ci"
+        ci_part = fetcher.user_agent.split(' ').find{|x| x.match(/\Aci\//)}
+        expect(ci_part).to match("travis")
+        expect(ci_part).to match("my_ci")
       end
     end
   end


### PR DESCRIPTION
This patch add CI information on the user_agent in order for us to track if a given command was run by a CI, as discussed in #3233.