### PR TITLE
Allow bundle viz to work with dependencies satisfied by prereleases

### DIFF
--- a/lib/bundler/graph.rb
+++ b/lib/bundler/graph.rb
@@ -36,6 +36,9 @@ module Bundler
         else
           tmp = Set.new
           parent_dependencies.each do |dependency|
+            # if the dependency is a prerelease, allow to_spec to be non-nil
+            dependency.prerelease = true
+
             child_dependencies = dependency.to_spec.runtime_dependencies.to_set
             @relations[dependency.name] += child_dependencies.map(&:name).to_set
             tmp += child_dependencies

--- a/spec/commands/viz_spec.rb
+++ b/spec/commands/viz_spec.rb
@@ -1,0 +1,46 @@
+require "spec_helper"
+
+describe "bundle viz" do
+  before :each do
+    `gem install ruby-graphviz`
+  end
+
+  context "with a standard Gemfile" do
+    before :each do
+      `gem install httpi -v "= 2.2.7"` # requires any rack
+      `gem install rack -v "= 1.1.1"`
+      # TODO: this whole approach is bad
+
+      install_gemfile <<-G
+        source "file://#{system_gem_path}"
+        gem "httpi", "= 2.2.7"
+        gem "rack", "= 1.1.1"
+      G
+    end
+
+    it "correctly generates a graph" do
+      bundle "viz"
+
+      expect(out).to include("gem_graph.png")
+    end
+  end
+
+  context "with a Gemfile that has a prerelease as a satisfying dependency" do
+    before :each do
+      `gem install httpi -v "= 2.2.7"` # requires any rack
+      `gem install rack -v "= 1.1.1.pre"`
+
+      install_gemfile <<-G
+        source "file://#{system_gem_path}"
+        gem "httpi", "= 2.2.7"
+        gem "rack", "= 1.1.1.pre"
+      G
+    end
+
+    it "correctly generates a graph" do
+      bundle "viz"
+
+      expect(out).to include("gem_graph.png")
+    end
+  end
+end


### PR DESCRIPTION
Suppose a Gemfile specifies a dependency, `foo`:

```
foo
```

Let's say `foo` requires a certain `bar`:

```
foo
  bar (>= 0.5)
```

If this dependency happens to be satisfied by a prerelease `bar`, e.g., 0.6.pre, then `bundle viz` will error.

The cause of this error is that `Bundler::Graph#_populate_relations` executes

```ruby
child_dependencies = dependency.to_spec.runtime_dependencies.to_set
```

and if `dependency` (here, `bar`), is a prerelease, then `dependency.to_spec` will be `nil` on Rubygems 2.4.0 and higher because of changes to `#to_spec`.

By forcing `dependency.prerelease = true`, then `to_spec` won't ignore the prerelease `bar` dependency, which prevents `dependency.to_spec` to from being `nil`.

This should address #3621 and #3217.