### PR TITLE
Add instructions for running tests; fixes #3596

### DIFF
--- a/lib/bundler/templates/newgem/README.md.tt
+++ b/lib/bundler/templates/newgem/README.md.tt
@@ -1,6 +1,6 @@
 # <%=config[:constant_name]%>
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/<%=config[:namespaced_path]%>`. To experiment with that code, run `bin/console` for an interactive prompt.
+Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/<%=config[:namespaced_path]%>`. To experiment with that code, run `bin/console` for an interactive prompt.<% if %w[minitest rspec].include?(config[:test]) %> Run <% if config[:test] == 'rspec' %>`rake spec`<% else %>`rake test`<% end %> to run the test suite.<% end %>
 
 TODO: Delete this and the text above, and describe your gem
 
@@ -26,7 +26,7 @@ TODO: Write usage instructions here
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `bin/console` for an interactive prompt that will allow you to experiment.<% if config[:bin] %> Run `bundle exec <%= config[:name] %>` to use the code located in this directory, ignoring other installed copies of this gem.<% end %>
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `bin/console` for an interactive prompt that will allow you to experiment.<% if config[:bin] %> Run `bundle exec <%= config[:name] %>` to use the code located in this directory, ignoring other installed copies of this gem.<% end %><% if %w[minitest rspec].include?(config[:test]) %> Run <% if config[:test] == 'rspec' %>`rake spec`<% else %>`rake test`<% end %> to run the test suite.<% end %>
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release` to create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 


### PR DESCRIPTION
This adds instructions for running tests to the README template. Note that the instructions are conditional depending on whether RSpec or Minitest was selected as the default test runner.