### PR TITLE
Add option to use docker to run specs

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -20,6 +20,8 @@ bugs](https://github.com/bundler/bundler/issues?labels=small&state=open) and [sm
 
 Bundler doesn't use a Gemfile to list development dependencies, because when we tried it we couldn't tell if we were awake or it was just another level of dreams. To work on Bundler, you'll probably want to do a couple of things.
 
+## Standard method
+
   1. Install Bundler's development dependencies
 
         $ rake spec:deps
@@ -27,6 +29,14 @@ Bundler doesn't use a Gemfile to list development dependencies, because when we 
   2. Run the test suite, to make sure things are working
 
         $ rake spec
+
+## Docker method
+
+  1. Make sure you have [docker](https://www.github.com/docker/docker) and [docker-compose](https://docs.docker.com/compose/install) then run the following:
+
+        $ docker-compose up
+
+        > This will mount the current directory and run the specs against it.
 
   3. Set up a shell alias to run Bundler from your clone, e.g. a Bash alias:
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -36,9 +36,9 @@ Bundler doesn't use a Gemfile to list development dependencies, because when we 
 
         $ docker-compose up
 
-        > This will mount the current directory and run the specs against it.
+## Running bundler from your clone
 
-  3. Set up a shell alias to run Bundler from your clone, e.g. a Bash alias:
+  1. Set up a shell alias to run Bundler from your clone, e.g. a Bash alias:
 
         $ alias dbundle='ruby -I /path/to/bundler/lib /path/to/bundler/bin/bundle'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM ruby:2.0.0
+MAINTAINER Steven Jack <stevenmajack@gmail.com>
+
+ADD . /app
+WORKDIR /app
+RUN rake spec:deps
+
+ENTRYPOINT ["rake"]
+CMD ["spec"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,4 @@
+spec:
+  build: .
+  volumes:
+    - .:/app


### PR DESCRIPTION
### Problem

I was trying to run the specs but the version of `rspec` I had on my machine wasn't correct and I couldn't use `bundle exec` to select the correct version of the gems as I was testing `bundler` itself and `bundler` doesn't use a `Gemfile`.

### Solution

Have a containerised, predictable environment to run the specs in. The `Dockerfile` adds the spec dependencies then adds `rake` as the entry point and `spec` as the command. To aid running the specs I've also added `docker-compose.yml` so you don't have to construct the whole `docker` command.

There could be another option instead of having `docker-compose` installed as it's  couple of dependencies, an image could be created in the hub on each push to `master` so you could run the following:

`docker run -v /path/to/my/clone:app bundler`

Which mounts your version of bundler, then uses the publisher bundler image that would be updated on each push to master to run the specs.