### PR TITLE
Autoconfig gemfile

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -145,6 +145,7 @@ module Bundler
       @definition = nil if unlock
       @definition ||= begin
         configure
+        ENV['BUNDLE_GEMFILE'] ||= Bundler.settings[:gemfile]
         upgrade_lockfile
         Definition.build(default_gemfile, default_lockfile, unlock)
       end

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -16,8 +16,10 @@ module Bundler
     def initialize(*args)
       super
       current_cmd = args.last[:current_command].name
-      custom_gemfile = options[:gemfile] || Bundler.settings[:gemfile]
-      ENV['BUNDLE_GEMFILE']   = File.expand_path(custom_gemfile) if custom_gemfile
+      if custom_gemfile = options[:gemfile]
+        Bundler.settings[:gemfile] = custom_gemfile
+        ENV['BUNDLE_GEMFILE'] = File.expand_path(custom_gemfile)
+      end 
       Bundler.settings[:retry] = options[:retry] if options[:retry]
       Bundler.rubygems.ui = UI::RGProxy.new(Bundler.ui)
       auto_install if AUTO_INSTALL_CMDS.include?(current_cmd)


### PR DESCRIPTION
This finishes off the work with different Gemfiles. Now if you do a

```
bundle install --gemfile Gemfile.dev
```

the new ```Gemfile.dev``` will be saved to the configuration and be used automatically for all further references.