### PR TITLE
Added backward compatibility for BUNDLE_* config keys

### DIFF
--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -228,12 +228,18 @@ module Bundler
         config_regex = /^(BUNDLE_.+): (['"]?)(.*(?:\n(?!BUNDLE).+)?)\2$/
         config_pairs = config_file.read.scan(config_regex).map do |m|
           key, _, value = m
-          [key, value.gsub(/\s+/, " ").tr('"', "'")]
+          [convert_to_backward_compatible_key(key), value.gsub(/\s+/, " ").tr('"', "'")]
         end
         Hash[config_pairs]
       else
         {}
       end
+    end
+
+    def convert_to_backward_compatible_key(key)
+      key = "#{key}/" if key =~ /https?:/i && key !~ %r[/\Z]
+      key = key.gsub(".", "__") if key.include?(".")
+      key
     end
 
     # TODO: duplicates Rubygems#normalize_uri

--- a/spec/bundler/settings_spec.rb
+++ b/spec/bundler/settings_spec.rb
@@ -141,6 +141,24 @@ describe Bundler::Settings do
       settings["mirror.https://rubygems.org"] = "http://rubygems-mirror.org"
       expect(settings.gem_mirrors).to eq(URI("https://rubygems.org/") => URI("http://rubygems-mirror.org/"))
     end
+  end
 
+  describe "BUNDLE_ keys format" do
+    let(:settings) { described_class.new(bundled_app('.bundle')) }
+
+    it "converts older keys without double dashes" do
+      config("BUNDLE_MY__PERSONAL.RACK" => "~/Work/git/rack")
+      expect(settings["my.personal.rack"]).to eq("~/Work/git/rack")
+    end
+
+    it "converts older keys without trailing slashes and double dashes" do
+      config("BUNDLE_MIRROR__HTTPS://RUBYGEMS.ORG" => "http://rubygems-mirror.org")
+      expect(settings["mirror.https://rubygems.org/"]).to eq("http://rubygems-mirror.org")
+    end
+
+    it "reads newer keys format properly" do
+      config("BUNDLE_MIRROR__HTTPS://RUBYGEMS__ORG/" => "http://rubygems-mirror.org")
+      expect(settings["mirror.https://rubygems.org/"]).to eq("http://rubygems-mirror.org")
+    end
   end
 end


### PR DESCRIPTION
Mirrors and other config options in 1.6.2 

```yaml
---
BUNDLE_MIRROR__HTTPS://RUBYGEMS.ORG: https://tao-bao.org
BUNDLE_MY__PERSONAL.RACK: "/root/Work/git/rack"
```

After 1.9.2

```yaml
---
BUNDLE_MIRROR__HTTPS://RUBYGEMS__ORG/: https://tao-bao.org
BUNDLE_MY__PERSONAL__RACK: "/root/Work/git/rack"
```

Closes #3557