### PR TITLE
Distinguish CI command runs

### DIFF
--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -155,6 +155,8 @@ module Bundler
 
         agent << " options/#{Bundler.settings.all.join(",")}"
 
+        agent << " ci/#{cis.join(",")}" if cis.any?
+
         # add a random ID so we can consolidate runs server-side
         agent << " " << SecureRandom.hex(8)
 
@@ -177,6 +179,21 @@ module Bundler
   private
 
     FETCHERS = [Dependency, Index]
+
+    def cis
+      env_cis = {
+        "TRAVIS" => "travis",
+        "CIRCLECI" => "circle",
+        "SEMAPHORE" => "semaphore",
+        "JENKINS_URL" => "jenkins",
+        "BUILDBOX" => "buildbox",
+        "GO_SERVER_URL" => "go",
+        "SNAP_CI" => "snap",
+        "CI_NAME" => ENV["CI_NAME"],
+        "CI" => "ci"
+      }
+      env_cis.find_all{ |env, ci| ENV[env]}.map{ |env, ci| ci }
+    end
 
     def connection
       @connection ||= begin

--- a/spec/bundler/fetcher_spec.rb
+++ b/spec/bundler/fetcher_spec.rb
@@ -16,5 +16,21 @@ describe Bundler::Fetcher do
       expect(fetcher.user_agent).to match(/ruby\/(\d.)/)
       expect(fetcher.user_agent).to match(/options\/foo,bar/)
     end
+
+    describe "include CI information" do
+      it "from one CI" do
+        ENV["JENKINS_URL"] = "foo"
+        ci_part = fetcher.user_agent.split(' ').find{|x| x.match(/\Aci\//)}
+        expect(ci_part).to match("jenkins")
+      end
+
+      it "from many CI" do
+        ENV["TRAVIS"] = "foo"
+        ENV["CI_NAME"] = "my_ci"
+        ci_part = fetcher.user_agent.split(' ').find{|x| x.match(/\Aci\//)}
+        expect(ci_part).to match("travis")
+        expect(ci_part).to match("my_ci")
+      end
+    end
   end
 end

--- a/spec/bundler/fetcher_spec.rb
+++ b/spec/bundler/fetcher_spec.rb
@@ -22,6 +22,7 @@ describe Bundler::Fetcher do
         ENV["JENKINS_URL"] = "foo"
         ci_part = fetcher.user_agent.split(' ').find{|x| x.match(/\Aci\//)}
         expect(ci_part).to match("jenkins")
+        ENV["JENKINS_URL"] = nil
       end
 
       it "from many CI" do
@@ -30,6 +31,8 @@ describe Bundler::Fetcher do
         ci_part = fetcher.user_agent.split(' ').find{|x| x.match(/\Aci\//)}
         expect(ci_part).to match("travis")
         expect(ci_part).to match("my_ci")
+        ENV["TRAVIS"] = nil
+        ENV["CI_NAME"] = nil
       end
     end
   end

--- a/spec/bundler/fetcher_spec.rb
+++ b/spec/bundler/fetcher_spec.rb
@@ -19,20 +19,18 @@ describe Bundler::Fetcher do
 
     describe "include CI information" do
       it "from one CI" do
-        ENV["JENKINS_URL"] = "foo"
-        ci_part = fetcher.user_agent.split(' ').find{|x| x.match(/\Aci\//)}
-        expect(ci_part).to match("jenkins")
-        ENV["JENKINS_URL"] = nil
+        with_env_vars({"JENKINS_URL" => "foo"}) do
+          ci_part = fetcher.user_agent.split(' ').find{|x| x.match(/\Aci\//)}
+          expect(ci_part).to match("jenkins")
+        end
       end
 
       it "from many CI" do
-        ENV["TRAVIS"] = "foo"
-        ENV["CI_NAME"] = "my_ci"
-        ci_part = fetcher.user_agent.split(' ').find{|x| x.match(/\Aci\//)}
-        expect(ci_part).to match("travis")
-        expect(ci_part).to match("my_ci")
-        ENV["TRAVIS"] = nil
-        ENV["CI_NAME"] = nil
+        with_env_vars({"TRAVIS" => "foo", "CI_NAME" => "my_ci"}) do
+          ci_part = fetcher.user_agent.split(' ').find{|x| x.match(/\Aci\//)}
+          expect(ci_part).to match("travis")
+          expect(ci_part).to match("my_ci")
+        end
       end
     end
   end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -357,5 +357,17 @@ module Spec
       end
       File.open(pathname, 'w') { |file| file.puts(changed_lines.join) }
     end
+
+    def with_env_vars(env_hash, &block)
+      current_values = {}
+      env_hash.each do |k,v|
+        current_values[k] = v
+        ENV[k] = v
+      end
+      block.call if block_given?
+      env_hash.each do |k,v|
+        ENV[k] = current_values[k]
+      end
+    end
   end
 end


### PR DESCRIPTION
This patch add CI information on the user_agent in order for us to track
if a given command was run by a CI, as discussed in #3233.