### PR TITLE
rails command is already aware of Bundler

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ gem install bundler
 bundle init
 echo "gem 'rails'" >> Gemfile
 bundle install
-bundle exec rails new myapp
+rails new myapp
 ```
 
 See [bundler.io](http://bundler.io) for the full documentation.


### PR DESCRIPTION
Do not do `bundle exec rails ...`, rails command is already aware of this.

Not sure if I'd apply this change or you should just change the example and use a gem where running it with bundle exec makes sense