### PR TITLE
Fix failing help specs

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -55,12 +55,12 @@ module Bundler
           gemfile.5)
 
       if manpages.include?(command)
-        root = File.expand_path("../man", __FILE__)
+        root = File.expand_path("../../../man", __FILE__)
 
         if Bundler.which("man") && root !~ %r{^file:/.+!/META-INF/jruby.home/.+}
           Kernel.exec "man #{root}/#{command}"
         else
-          puts File.read("#{root}/#{command}.txt")
+          puts File.read("#{root}/#{command}.ronn")
         end
       else
         super

--- a/spec/commands/help_spec.rb
+++ b/spec/commands/help_spec.rb
@@ -15,21 +15,21 @@ describe "bundle help" do
     fake_man!
 
     bundle "help gemfile"
-    expect(out).to eq(%|["#{root}/lib/bundler/man/gemfile.5"]|)
+    expect(out).to eq(%|["#{root}/man/gemfile.5"]|)
   end
 
   it "prefixes bundle commands with bundle- when finding the groff files" do
     fake_man!
 
     bundle "help install"
-    expect(out).to eq(%|["#{root}/lib/bundler/man/bundle-install"]|)
+    expect(out).to eq(%|["#{root}/man/bundle-install"]|)
   end
 
-  it "simply outputs the txt file when there is no man on the path" do
+  it "simply outputs the ronn file when there is no man on the path" do
     kill_path!
 
     bundle "help install", :expect_err => true
-    expect(out).to match(/BUNDLE-INSTALL/)
+    expect(out).to match(/BUNDLE-INSTALL/i)
   end
 
   it "still outputs the old help for commands that do not have man pages yet" do


### PR DESCRIPTION
When running the test suite, I encountered a failing test.

```
 1) bundle help simply outputs the txt file when there is no man on the path
     Failure/Error: expect(out).to match(/BUNDLE-INSTALL/)
       expected "--- ERROR REPORT TEMPLATE -------------------------------------------------------\n
- What did you do?\n\n  

I ran the command `/Users/nickb/OSS/bundler/bin/bundle help install --no-color`\n\n

- What did you expect to happen?\n\n 

I expected Bundler to...\n\n

- What happened instead?\n\n  

Instead, what actually happened was...\n\n\n

Error details\n\n    Errno::ENOENT: No such file or directory @ rb_sysopen - /Users/nick/OSS/bundler/lib/bundler/man/bundle-install.txt\n      
/Users/nickb/OSS/bundler/lib/bundler/cli.rb:63:in `read'\n      
/Users/nickb/OSS/bundler/lib/bundler/cli.rb:63:in `help'\n    
/Users/nickb/OSS/bundler/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'\n
/Users/nickb/OSS/bundler/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in invoke_command'\n     
/Users/nickb/OSS/bundler/lib/bundler/vendor/thor/lib/thor.rb:359:in `dispatch'\n      
/Users/nickb/OSS/bundler/lib/bundler/vendor/thor/lib/thor/base.rb:440:in `start'\n     
/Users/nickb/OSS/bundler/lib/bundler/cli.rb:10:in `start'\n      
/Users/nickb/OSS/bundler/bin/bundle:20:in `block in <main>'\n      
/Users/nickb/OSS/bundler/lib/bundler/friendly_errors.rb:7:in `with_friendly_errors'\n      
/Users/nickb/OSS/bundler/bin/bundle:18:in `<main>'\n\nEnvironment\n\n    Bundler   1.10.0.rc\n    
Rubygems  2.2.2\n    Ruby      2.1.3p242 (2014-09-19 revision 47630) [x86_64-darwin14.0]\n    GEM_HOME  /Users/nickb/OSS/bundler/tmp/gems/system\n    RVM       1.25.34 (master)\n    
Git       not installed\n\nBundler settings\n\n    spec_run\n      
Set via BUNDLE_SPEC_RUN: \"true\"\n
--- TEMPLATE END ----------------------------------------------------------------\n\n

Unfortunately, an unexpected error occurred, and Bundler cannot continue.\n\nFirst, try this link to see if there are any existing issue reports for this error:\nhttps://github.com/bundler/bundler/search?q=No+such+file+or+directory+%40+rb_sysopen+-+%2FUsers%2Fnickb%2FOSS%2Fbundler%2Flib%2Fbundler%2Fman%2Fbundle-install.txt&type=Issues

If there aren't any reports for this error yet, please create copy and paste the report template above into a new issue. Don't forget to anonymize any private data! The new issue form is located at:
https://github.com/bundler/bundler/issues/new" to match /BUNDLE-INSTALL/
       Diff:
       @@ -1,2 +1,51 @@
       -/BUNDLE-INSTALL/
       +--- ERROR REPORT TEMPLATE -------------------------------------------------------
```
I looked into it a bit and it seemed that it was still looking for the
man page file in `lib/bunlder/man` however it seems to now live in the
`/man` directory, plus it now uses the `ronn` file extension instead of
`txt`.

I changed the root definition in `cli#help` to point to the new
directory that holds all the *.ronn files. I also had to modify a couple
of tests that were still referencing the old directory.

I am not sure if this is failing only on my machine, since the build
passes on github, but there are no txt files anymore for the man pages,
the change should still be valid.