### PR TITLE
[RubyGemsIntegration] Check for chdir monitor after its been backported

### DIFF
--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -614,13 +614,13 @@ module Bundler
 
         Gem::Ext::Builder.class_eval do
           if !const_defined?(:CHDIR_MONITOR)
-            const_set(:CHDIR_MONITOR, Monitor.new)
+            const_set(:CHDIR_MONITOR, EXT_LOCK)
           end
 
           if const_defined?(:CHDIR_MUTEX)
             remove_const(:CHDIR_MUTEX)
-            const_set(:CHDIR_MUTEX, const_get(:CHDIR_MONITOR))
           end
+          const_set(:CHDIR_MUTEX, const_get(:CHDIR_MONITOR))
         end
       end
 

--- a/spec/bundler/rubygems_integration_spec.rb
+++ b/spec/bundler/rubygems_integration_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe Bundler::RubygemsIntegration do
+  it "uses the same chdir lock as rubygems", :rubygems => "2.1" do
+    expect(Bundler.rubygems.ext_lock).to eq(Gem::Ext::Builder::CHDIR_MONITOR)
+  end
+end


### PR DESCRIPTION
Closes https://github.com/bundler/bundler/issues/3680.

Fixes a regression introduced in https://github.com/bundler/bundler/commit/73cec1c5b51dd6f9a7d6712ea6832f89ce9cb4f8.

\c @indirect @rafaelfranca 