### PR TITLE
Clarify BUNDLE_PATH documentation.

### DIFF
--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -84,8 +84,10 @@ The following is a list of all configuration keys and their purpose. You can
 learn more about their operation in [bundle install(1)][bundle-install].
 
 * `path` (`BUNDLE_PATH`):
-  The location on disk to install gems. Defaults to `$GEM_HOME` in development
-  and `vendor/bundle` when `--deployment` is used
+  The location on disk where all gems in your bundle will be located regardless
+  of `$GEM_HOME` or `$GEM_PATH` values. Bundle gems not found in this location
+  will be installed by bundle install. Defaults to `Gem.dir`. When --deployment is
+  used, defaults to vendor/bundle.
 * `frozen` (`BUNDLE_FROZEN`):
   Disallow changes to the `Gemfile`. Defaults to `true` when `--deployment`
   is used.


### PR DESCRIPTION
My team recently ran into this and wanted to help clarify this.

I'm not intimately familiar with all the use cases for BUNDLE_PATH but I think I have the gist of what I needed clarified.

* BUNDLE_PATH is used for installing AND finding gems
* It's easy to confuse GEM_PATH and BUNDLE_PATH
 * GEM_PATH is an array of paths in addition to GEM_HOME that rubygems
   uses to find gems.
 * BUNDLE_PATH is a single path used for gem installs and retrieval.
 * GEM_PATH is ignored when you have BUNDLE_PATH set by enabling
   BUNDLE_DISABLE_SHARED_GEMS