### PR TITLE
Remove "with native extensions" message (UI::RGProxy)

### DIFF
--- a/lib/bundler/ui/rg_proxy.rb
+++ b/lib/bundler/ui/rg_proxy.rb
@@ -8,14 +8,6 @@ module Bundler
         @ui = ui
         super()
       end
-
-      def say(message)
-        if message =~ /native extensions/
-          @ui.info "with native extensions "
-        else
-          @ui.debug(message)
-        end
-      end
     end
   end
 end

--- a/man/bundle-update.ronn
+++ b/man/bundle-update.ronn
@@ -125,12 +125,12 @@ on `rack ~> 1.0`. If you run bundle install, you get:
 
     Fetching source index for https://rubygems.org/
     Installing daemons (1.1.0)
-    Installing eventmachine (0.12.10) with native extensions
+    Installing eventmachine (0.12.10)
     Installing open4 (1.0.1)
-    Installing perftools.rb (0.4.7) with native extensions
+    Installing perftools.rb (0.4.7)
     Installing rack (1.2.1)
     Installing rack-perftools_profiler (0.0.2)
-    Installing thin (1.2.7) with native extensions
+    Installing thin (1.2.7)
     Using bundler (1.0.0.rc.3)
 
 In this case, the two gems have their own set of dependencies, but they share


### PR DESCRIPTION
Using version 1.10.1, I noticed the console output was a little different. There are these `with native extensions` output:
```
Installing rake 0.9.2
with native extensions Installing RedCloth 4.2.8
Using posix-spawn 0.3.6
Installing albino 1.3.3
Installing chunky_png 1.3.0
with native extensions Installing fast-stemmer 1.0.0
Installing classifier 1.3.3
Installing fssm 0.2.10
Installing sass 3.2.14
Using compass 0.12.2
Installing directory_watcher 1.4.0
Installing haml 3.1.2
with native extensions Installing iconv 1.0.3
Installing kramdown 0.13.3
...
```

After some digging around, I believe the output we would want is something like: `Installing iconv 1.0.3 with native extensions`. However, since the `install_message` is output after the [gem in installed](https://github.com/bundler/bundler/blob/49dd255b977fbf3dda5ac2ff84efa5c995137fc4/lib/bundler/installer.rb#L107-L122), it doesn't seem like it would be a straightforward fix.

I also think that `UI::RGProxy` was not used in some of the previous versions and was reintroduced by [this fix](https://github.com/bundler/bundler/commit/3ac4215617aca867f33f1b4e46c29421001bb07a). This means that previous versions did not display `with native extensions` at all. 

That's why I decided to remove `UI::RGProxy` entirely. If I am mistaken and we should keep that class, I could revise this PR to only include the documentation (.ronn) changes.

Edit: I saw that tests were failing when I removed `UI::RGProxy`. I've updated this PR to remove the `say` overriding method