### PR TITLE
Improves the message displayed when cannot create config

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -85,6 +85,20 @@ module Bundler
 
   class MarshalError < StandardError; end
 
+  class PermissionError < BundlerError
+    def initialize(file)
+      @file = file
+    end
+
+    def message
+      "There was an error while trying to write to `#{File.basename(@file)}`. It is likely that \n" \
+      "you need to allow write permissions for the file at path: \n" \
+      "#{File.expand_path(@file)}"
+    end
+
+    status_code(23)
+  end
+
   class << self
     attr_writer :bundle_path
 

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -266,10 +266,7 @@ module Bundler
 
       File.open(file, 'wb'){|f| f.puts(contents) }
     rescue Errno::EACCES
-      raise Bundler::InstallError,
-        "There was an error while trying to write to #{File.basename(file)}. It is likely that \n" \
-        "you need to allow write permissions for the file at path: \n" \
-        "#{File.expand_path(file)}"
+      raise PermissionError.new(file)
     end
 
     # Returns the version of Bundler that is creating or has created

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -211,6 +211,8 @@ module Bundler
       end
 
       value
+    rescue Errno::EACCES
+      raise PermissionError.new(file)
     end
 
     def global_config_file

--- a/spec/bundler/definition_spec.rb
+++ b/spec/bundler/definition_spec.rb
@@ -12,11 +12,11 @@ describe Bundler::Definition do
     context "when it's not possible to write to the file" do
       subject{ Bundler::Definition.new(nil, [], Bundler::SourceList.new, []) }
 
-      it "raises an InstallError with explanation" do
+      it "raises an PermissionError with explanation" do
         expect(File).to receive(:open).with("Gemfile.lock", "wb").
           and_raise(Errno::EACCES)
         expect{ subject.lock("Gemfile.lock") }.
-          to raise_error(Bundler::InstallError)
+          to raise_error(Bundler::PermissionError, /Gemfile\.lock/)
       end
     end
   end

--- a/spec/bundler/settings_spec.rb
+++ b/spec/bundler/settings_spec.rb
@@ -40,8 +40,27 @@ describe Bundler::Settings do
         end
       end
     end
+
+    context "when it's not possible to write to the file" do
+      it "raises an PermissionError with explanation" do
+        expect(FileUtils).to receive(:mkdir_p).with(settings.send(:local_config_file).dirname).
+          and_raise(Errno::EACCES)
+        expect{ settings[:frozen] = "1" }.
+          to raise_error(Bundler::PermissionError, /config/)
+      end
+    end
   end
 
+  describe "#set_global" do
+    context "when it's not possible to write to the file" do
+      it "raises an PermissionError with explanation" do
+        expect(FileUtils).to receive(:mkdir_p).with(settings.send(:global_config_file).dirname).
+          and_raise(Errno::EACCES)
+        expect{ settings.set_global(:frozen, "1") }.
+          to raise_error(Bundler::PermissionError, /\.bundle\/config/)
+      end
+    end
+  end
 
   describe "#mirror_for" do
     let(:uri) { URI("https://rubygems.org/") }


### PR DESCRIPTION
I moved the message display when there is not permission to write to `Gemfile.lock` to `Bundler::SharedHelpers` (is there a better place?) and reused for when writing to `config` (local or global) fails for the same reason (or the directory path cannot be created).

Should I also write specs to cover the `File.open(file, "w")` ?

Fixes #3703

