### PR TITLE
Implicit lock preservation

### DIFF
--- a/lib/bundler/cli/check.rb
+++ b/lib/bundler/cli/check.rb
@@ -26,7 +26,7 @@ module Bundler
         Bundler.ui.error "This bundle has been frozen, but there is no Gemfile.lock present"
         exit 1
       else
-        Bundler.load.lock unless options[:"dry-run"]
+        Bundler.load.lock(:preserve_bundled_with => true) unless options[:"dry-run"]
         Bundler.ui.info "The Gemfile's dependencies are satisfied"
       end
     end

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -1,3 +1,4 @@
+require "bundler/lockfile_parser"
 require "digest/sha1"
 require "set"
 
@@ -661,7 +662,7 @@ module Bundler
 
     def lockfiles_equal?(current, proposed, preserve_bundled_with)
       if preserve_bundled_with
-        pattern = /\n\nBUNDLED WITH\n.*\n/
+        pattern = /\n\n#{LockfileParser::BUNDLED}\n\s+#{Gem::Version::VERSION_PATTERN}\n/
         current.sub(pattern, "\n") == proposed.sub(pattern, "\n")
       else
         current == proposed

--- a/lib/bundler/environment.rb
+++ b/lib/bundler/environment.rb
@@ -30,8 +30,8 @@ module Bundler
       @definition.current_dependencies
     end
 
-    def lock
-      @definition.lock(Bundler.default_lockfile)
+    def lock(opts = {})
+      @definition.lock(Bundler.default_lockfile, opts[:preserve_bundled_with])
     end
 
     def update(*gems)

--- a/lib/bundler/inline.rb
+++ b/lib/bundler/inline.rb
@@ -39,7 +39,7 @@ def gemfile(install = false, &gemfile)
   builder.instance_eval(&gemfile)
 
   definition = builder.to_definition(nil, true)
-  def definition.lock(file); end
+  def definition.lock(*); end
   definition.validate_ruby!
 
   if install

--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -41,7 +41,7 @@ module Bundler
 
       setup_manpath
 
-      lock
+      lock(:preserve_bundled_with => true)
 
       self
     end

--- a/spec/commands/check_spec.rb
+++ b/spec/commands/check_spec.rb
@@ -314,9 +314,11 @@ describe "bundle check" do
     end
 
     context "is newer" do
-      it "does not change the lock" do
+      it "does not change the lock but warns" do
         lockfile lock_with(Bundler::VERSION.succ)
         bundle :check
+        expect(out).to include("Bundler is older than the version that created the lockfile")
+        expect(err).to eq("")
         lockfile_should_be lock_with(Bundler::VERSION.succ)
       end
     end

--- a/spec/commands/check_spec.rb
+++ b/spec/commands/check_spec.rb
@@ -275,4 +275,59 @@ describe "bundle check" do
       expect(out).to include("* rack (1.0")
     end
   end
+
+  describe "BUNDLED WITH" do
+    def lock_with(bundler_version = nil)
+      lock = <<-L
+        GEM
+          remote: file:#{gem_repo1}/
+          specs:
+            rack (1.0.0)
+
+        PLATFORMS
+          #{generic(Gem::Platform.local)}
+
+        DEPENDENCIES
+          rack
+      L
+
+      if bundler_version
+        lock << "\n        BUNDLED WITH\n           #{bundler_version}\n"
+      end
+
+      lock
+    end
+
+    before do
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem "rack"
+      G
+    end
+
+    context "is not present" do
+      it "does not change the lock" do
+        lockfile lock_with(nil)
+        bundle :check
+        lockfile_should_be lock_with(nil)
+      end
+    end
+
+    context "is newer" do
+      it "does not change the lock" do
+        lockfile lock_with(Bundler::VERSION.succ)
+        bundle :check
+        lockfile_should_be lock_with(Bundler::VERSION.succ)
+      end
+    end
+
+    context "is older" do
+      it "does not change the lock" do
+        lockfile lock_with("1.10.1")
+        bundle :check
+        lockfile_should_be lock_with("1.10.1")
+      end
+    end
+  end
+
 end

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -937,9 +937,11 @@ describe "Bundler.setup" do
     end
 
     context "is newer" do
-      it "does not change the lock" do
+      it "does not change the lock or warn" do
         lockfile lock_with(Bundler::VERSION.succ)
         ruby "require 'bundler/setup'"
+        expect(out).to eq("")
+        expect(err).to eq("")
         lockfile_should_be lock_with(Bundler::VERSION.succ)
       end
     end

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -899,4 +899,58 @@ describe "Bundler.setup" do
     end
   end
 
+  describe "when BUNDLED WITH" do
+    def lock_with(bundler_version = nil)
+      lock = <<-L
+        GEM
+          remote: file:#{gem_repo1}/
+          specs:
+            rack (1.0.0)
+
+        PLATFORMS
+          #{generic(Gem::Platform.local)}
+
+        DEPENDENCIES
+          rack
+      L
+
+      if bundler_version
+        lock << "\n        BUNDLED WITH\n           #{bundler_version}\n"
+      end
+
+      lock
+    end
+
+    before do
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem "rack"
+      G
+    end
+
+    context "is not present" do
+      it "does not change the lock" do
+        lockfile lock_with(nil)
+        ruby "require 'bundler/setup'"
+        lockfile_should_be lock_with(nil)
+      end
+    end
+
+    context "is newer" do
+      it "does not change the lock" do
+        lockfile lock_with(Bundler::VERSION.succ)
+        ruby "require 'bundler/setup'"
+        lockfile_should_be lock_with(Bundler::VERSION.succ)
+      end
+    end
+
+    context "is older" do
+      it "does not change the lock" do
+        lockfile lock_with("1.10.1")
+        ruby "require 'bundler/setup'"
+        lockfile_should_be lock_with("1.10.1")
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
When either `bundle check` is run, or any application requires the `bundler/setup` file, Bundler will automatically check whether it is possible to lock the Bundle. During the lock process, Bundler updates the lock if the implicit locking changes the lock file.

Starting with the 1.10 release, Bundler includes a lockfile section named BUNDLED WITH that includes the version of Bundler that generated the lockfile. In order to minimize git churn, and guarantee that the lockfile will only be changed when the user runs an explicit Bundler command, Bundler will now only add or update the BUNDLED WITH section during commands where the user asks for changes to the lock. This includes, but is not limited to, `install`, `update`, `lock`, and `package`.

Running the `check` command or loading an application that uses Bundler will still now add or update the BUNDLED WITH section if, and only if, the lockfile has also changed for a different reason (such as a gem being updated).

Simply using an application, by running `bundle exec` commands or by running `bin/rails` and the like, will not change the lockfile. As a result, the intended workflow with the BUNDLED WITH section is now slightly different than it was before:

1. When running `bundle install`, Bundler will update the version in the lockfile if newer than the version present.

2. Then, check in the lockfile change, exactly as you would after running install to change any other gem version.

3. Older versions of Bundler will not change the number in the lock, but will warn the user that they are out of date.

refs bundler/bundler-features#80
refs #3697