### PR TITLE
Clarify the purpose of --deployment

### DIFF
--- a/man/bundle-install.ronn
+++ b/man/bundle-install.ronn
@@ -77,8 +77,8 @@ update process below under [CONSERVATIVE UPDATING][].
 
 * `--deployment`:
   In [deployment mode][DEPLOYMENT MODE], Bundler will 'roll-out' the bundle for
-  `production` use. Please check carefully if you want to have this option
-  enabled in `development` or `test` environments.
+  production or CI use. Please check carefully if you want to have this option
+  enabled in your development environment.
 
 * `--system`:
   Installs the gems specified in the bundle to the system's Rubygems location.
@@ -142,8 +142,8 @@ update process below under [CONSERVATIVE UPDATING][].
 ## DEPLOYMENT MODE
 
 Bundler's defaults are optimized for development. To switch to
-defaults optimized for deployment, use the `--deployment` flag.
-Do not activate deployment mode on development machines, as it
+defaults optimized for deployment and for CI, use the `--deployment`
+flag. Do not activate deployment mode on development machines, as it
 will cause an error when the Gemfile(5) is modified.
 
 1. A `Gemfile.lock` is required.


### PR DESCRIPTION
The man page originally explained that `--deployment` is not appropriate for the `test` environment, which is misleading. In a CI environment, you *do* want to use `--deployment`, despite the fact that CI will likely be using `RAILS_ENV=test` when running tests.

This PR clarifies that `--deployment` is for production and CI, and avoids explicitly referencing Rails environment names.