### PR TITLE
Remove Gemfile.lock updates outside of bundle explicit commands

### DIFF
--- a/lib/bundler/cli/check.rb
+++ b/lib/bundler/cli/check.rb
@@ -26,7 +26,7 @@ module Bundler
         Bundler.ui.error "This bundle has been frozen, but there is no #{Bundler.default_lockfile.relative_path_from(SharedHelpers.pwd)} present"
         exit 1
       else
-        Bundler.load.lock unless options[:"dry-run"]
+        Bundler.load unless options[:"dry-run"]
         Bundler.ui.info "The Gemfile's dependencies are satisfied"
       end
     end

--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -41,8 +41,6 @@ module Bundler
 
       setup_manpath
 
-      lock
-
       self
     end
 

--- a/spec/commands/check_spec.rb
+++ b/spec/commands/check_spec.rb
@@ -23,7 +23,7 @@ describe "bundle check" do
     expect(out).to eq("The Gemfile's dependencies are satisfied")
   end
 
-  it "creates a Gemfile.lock by default if one does not exist" do
+  it "does not creates a Gemfile.lock by default if one does not exist" do
     install_gemfile <<-G
       source "file://#{gem_repo1}"
       gem "rails"
@@ -33,7 +33,7 @@ describe "bundle check" do
 
     bundle "check"
 
-    expect(bundled_app("Gemfile.lock")).to exist
+    expect(bundled_app("Gemfile.lock")).not_to exist
   end
 
   it "does not create a Gemfile.lock if --dry-run was passed" do

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -214,7 +214,7 @@ describe "bundle install with git sources" do
       expect(out).to eq("LOCAL")
     end
 
-    it "updates specs on runtime" do
+    it "doesn't update specs on runtime" do
       system_gems "nokogiri-1.4.2"
 
       build_git "rack", "0.8"
@@ -235,7 +235,7 @@ describe "bundle install with git sources" do
       run "require 'rack'"
 
       lockfile1 = File.read(bundled_app("Gemfile.lock"))
-      expect(lockfile1).not_to eq(lockfile0)
+      expect(lockfile1).to eq(lockfile0)
     end
 
     it "updates ref on install" do

--- a/spec/other/platform_spec.rb
+++ b/spec/other/platform_spec.rb
@@ -982,7 +982,7 @@ G
       ENV['BUNDLER_FORCE_TTY'] = "true"
     end
 
-    it "makes a Gemfile.lock if setup succeeds" do
+    it "doesn't make a Gemfile.lock if setup succeeds" do
       install_gemfile <<-G
         source "file://#{gem_repo1}"
         gem "yard"
@@ -994,10 +994,10 @@ G
       FileUtils.rm(bundled_app("Gemfile.lock"))
 
       run "1"
-      expect(bundled_app("Gemfile.lock")).to exist
+      expect(bundled_app("Gemfile.lock")).not_to exist
     end
 
-    it "makes a Gemfile.lock if setup succeeds for any engine" do
+    it "doesn't make a Gemfile.lock if setup succeeds for any engine" do
       simulate_ruby_engine "jruby" do
         install_gemfile <<-G
           source "file://#{gem_repo1}"
@@ -1010,7 +1010,7 @@ G
         FileUtils.rm(bundled_app("Gemfile.lock"))
 
         run "1"
-        expect(bundled_app("Gemfile.lock")).to exist
+        expect(bundled_app("Gemfile.lock")).not_to exist
       end
     end
 

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -168,7 +168,7 @@ describe "Bundler.setup" do
     expect(File.read(bundled_app("Gemfile.lock"))).to eq(lockfile)
   end
 
-  it "makes a Gemfile.lock if setup succeeds" do
+  it "doesn't make a Gemfile.lock if setup succeeds" do
     install_gemfile <<-G
       source "file://#{gem_repo1}"
       gem "rack"
@@ -179,7 +179,7 @@ describe "Bundler.setup" do
     FileUtils.rm(bundled_app("Gemfile.lock"))
 
     run "1"
-    expect(bundled_app("Gemfile.lock")).to exist
+    expect(bundled_app("Gemfile.lock")).not_to exist
   end
 
   it "uses BUNDLE_GEMFILE to locate the gemfile if present" do


### PR DESCRIPTION
Thanks a lot for awesome work to each of you!

I feel it's counterintuitive to update the `Gemfile.lock` outside of explicit `bundle` commands like `install`, `update` or `lock`. For instance, you don't really expect `bundle exec rails server` or just `require "bundler/setup"` to actually change your lock file. I feel it breaks in a way the principle of least surprise.

Even if I don't really get the use cases of having the lock updated at runtime, I feel it might be edge cases that can be moved to an opt in (like `:force_lock_generation`) whereas now everyone has their `Gemfile.lock` regenerated.

It might also improve performance a bit specially in tools like Spring or Zeus that's continuously reloading rails environment. 

Sorry, I might be missing something obvious.

References:
- https://github.com/bundler/bundler/pull/3722
- https://github.com/bundler/bundler/issues/3697
- https://github.com/rails/spring/issues/409

 