### PR TITLE
allow comparing StubSpecification with Gem::Specification

### DIFF
--- a/lib/bundler/spec_set.rb
+++ b/lib/bundler/spec_set.rb
@@ -71,6 +71,14 @@ module Bundler
       self
     end
 
+    def delete(spec)
+      # TODO: implement? (called from Gem::Specification.remove_spec)
+    end
+
+    def delete_if
+      # TODO: implement? (called from Gem::Specification.remove_spec)
+    end
+
     def to_a
       sorted.dup
     end

--- a/lib/bundler/stub_specification.rb
+++ b/lib/bundler/stub_specification.rb
@@ -14,6 +14,12 @@ module Bundler
       _remote_specification.to_yaml
     end
 
+    def ==(other)
+      name == other.name &&
+        version.to_s == other.version.to_s &&
+        platform == other.platform
+    end
+
   private
 
     def _remote_specification


### PR DESCRIPTION
Fixes #3728

Allows RubyGems to properly detect an installed gem when instead of `Gem::Specification` it gets `Bundler::StubSpecification`.

PR for discussion (lacks tests, but seems to solve the issue).