### PR TITLE
Display "with native extensions" log output correctly

### DIFF
--- a/lib/bundler/endpoint_specification.rb
+++ b/lib/bundler/endpoint_specification.rb
@@ -70,6 +70,14 @@ module Bundler
       end
     end
 
+    def extensions
+      if @remote_specification
+        @remote_specification.extensions
+      elsif _local_specification
+        _local_specification.extensions
+      end
+    end
+
     def _local_specification
       if @loaded_from && File.exist?(local_specification_path)
         eval(File.read(local_specification_path)).tap do |spec|

--- a/lib/bundler/source/rubygems.rb
+++ b/lib/bundler/source/rubygems.rb
@@ -158,7 +158,9 @@ module Bundler
           installed_spec.loaded_from = loaded_from(spec)
         end
         spec.loaded_from = loaded_from(spec)
-        ["Installing #{version_message(spec)}", spec.post_install_message]
+        install_message = "Installing #{version_message(spec)}"
+        install_message << " with native extensions" unless spec.extensions.empty?
+        [install_message, spec.post_install_message]
       ensure
         Bundler.rm_rf(install_path) if Bundler.requires_sudo?
       end

--- a/lib/bundler/ui/rg_proxy.rb
+++ b/lib/bundler/ui/rg_proxy.rb
@@ -8,14 +8,6 @@ module Bundler
         @ui = ui
         super()
       end
-
-      def say(message)
-        if message =~ /native extensions/
-          @ui.info "with native extensions "
-        else
-          @ui.debug(message)
-        end
-      end
     end
   end
 end

--- a/spec/install/gems/c_ext_spec.rb
+++ b/spec/install/gems/c_ext_spec.rb
@@ -41,6 +41,7 @@ describe "installing a gem with C extensions" do
     bundle "install"
 
     expect(out).not_to include("extconf.rb failed")
+    expect(out).to include("Installing c_extension 1.0 with native extensions")
 
     run "Bundler.require; puts CExtension.new.its_true"
     expect(out).to eq("true")


### PR DESCRIPTION
This is my attempt at fixing the log output from building extensions. (see #3709).

Instead of using `RGProxy` to silence the messages and output "with native extensions", this PR attempts to see if the gem being installed has extensions and appends that message to the end of bundler's install message if so.