### PR TITLE
Delete bundle path if using bundle install --force

### DIFF
--- a/lib/bundler/source/rubygems.rb
+++ b/lib/bundler/source/rubygems.rb
@@ -98,7 +98,7 @@ module Bundler
           end
         end
 
-        if installed_specs[spec].any? && !force
+        if (installed_specs[spec].any? && !force) || bundler?(spec)
           Bundler.ui.info "Using #{version_message(spec)}"
           return nil # no post-install message
         end
@@ -411,6 +411,10 @@ module Bundler
 
         # Ruby 2.0, where gemspecs are stored in specifications/default/
         spec.loaded_from && spec.loaded_from.include?("specifications/default/")
+      end
+
+      def bundler?(spec)
+        spec.name.eql?('bundler')
       end
 
     end

--- a/spec/install/force_spec.rb
+++ b/spec/install/force_spec.rb
@@ -33,5 +33,14 @@ describe "bundle install" do
       expect(out).to include "Using bundler 1.10.4"
     end
 
+    it "works on first bundle install" do
+      bundle "install --force"
+
+      expect(out).to include "Installing rack 1.0.0"
+      should_be_installed "rack 1.0.0"
+      expect(exitstatus).to eq(0) if exitstatus
+    end
+
+
   end
 end

--- a/spec/install/force_spec.rb
+++ b/spec/install/force_spec.rb
@@ -7,14 +7,15 @@ describe "bundle install" do
         source "file://#{gem_repo1}"
         gem "rack"
       G
-
-      bundle "install"
     end
 
     it "re-installs installed gems" do
+      bundle "install"
       bundle "install --force"
+
       expect(out).to include "Installing rack 1.0.0"
       should_be_installed "rack 1.0.0"
+      expect(exitstatus).to eq(0) if exitstatus
     end
   end
 end

--- a/spec/install/force_spec.rb
+++ b/spec/install/force_spec.rb
@@ -17,5 +17,13 @@ describe "bundle install" do
       should_be_installed "rack 1.0.0"
       expect(exitstatus).to eq(0) if exitstatus
     end
+
+    it "doesn't reinstall bundler" do
+      bundle "install"
+      bundle "install --force"
+      expect(out).to_not include "Installing bundler 1.10.4"
+      expect(out).to include "Using bundler 1.10.4"
+    end
+
   end
 end

--- a/spec/install/force_spec.rb
+++ b/spec/install/force_spec.rb
@@ -18,6 +18,14 @@ describe "bundle install" do
       expect(exitstatus).to eq(0) if exitstatus
     end
 
+    it "overwrites old gem code" do
+      bundle "install"
+      default_bundle_path("gems/rack-1.0.0/lib/rack.rb").open('w'){|f| f.write("blah blah blah") }
+      bundle "install --force"
+
+      expect(default_bundle_path("gems/rack-1.0.0/lib/rack.rb").open{|f| f.read }).to eq("RACK = '1.0.0'\n")
+    end
+
     it "doesn't reinstall bundler" do
       bundle "install"
       bundle "install --force"


### PR DESCRIPTION
#3715

EDIT: #3715 doesn't apply anymore. But a new bug was found regarding `bundle install --force` reinstalling bundler. This pull request is for that.