### PR TITLE
Improve error message for circular dependency case

### DIFF
--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -202,7 +202,7 @@ module Bundler
       raise VersionConflict.new(e.conflicts.keys.uniq, e.message)
     rescue Molinillo::CircularDependencyError => e
       names = e.dependencies.sort_by(&:name).map { |d| "gem '#{d.name}'"}
-      raise CyclicDependencyError, "Your Gemfile requires gems that depend" \
+      raise CyclicDependencyError, "Your bundle requires gems that depend" \
         " on each other, creating an infinite loop. Please remove" \
         " #{names.count > 1 ? 'either ' : '' }#{names.join(' or ')}" \
         " and try again."

--- a/lib/bundler/spec_set.rb
+++ b/lib/bundler/spec_set.rb
@@ -113,7 +113,7 @@ module Bundler
         @sorted ||= ([rake] + tsort).compact.uniq
       rescue TSort::Cyclic => error
         cgems = extract_circular_gems(error)
-        raise CyclicDependencyError, "Your Gemfile requires gems that depend" \
+        raise CyclicDependencyError, "Your bundle requires gems that depend" \
           " depend on each other, creating an infinite loop. Please remove" \
           " either gem '#{cgems[1]}' or gem '#{cgems[0]}' and try again."
       end


### PR DESCRIPTION
Makes it more clear that the circular dependent gems are not necessarily declared in the `Gemfile` (they could be in the `Gemfile.lock`).

Closes #3738.