### PR TITLE
update test to check for rails-3.2.22

### DIFF
--- a/spec/realworld/edgecases_spec.rb
+++ b/spec/realworld/edgecases_spec.rb
@@ -43,7 +43,7 @@ describe "real world edgecases", :realworld => true do
       gem 'rails', '~> 3.0'
       gem 'capybara', '~> 2.2.0'
     G
-    expect(out).to include("rails 3.2.21")
+    expect(out).to include("rails 3.2.22")
     expect(out).to include("capybara 2.2.1")
   end
 


### PR DESCRIPTION
Since Rails 3.2.22 has been released, [this](https://github.com/bundler/bundler/blob/master/spec/realworld/edgecases_spec.rb#L39) test has been broken, since it matched against 3.2.21.

Now we match against 3.2.22