### PR TITLE
Use `#!/usr/bin/env bash`

### DIFF
--- a/lib/bundler/templates/newgem/bin/setup.tt
+++ b/lib/bundler/templates/newgem/bin/setup.tt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 IFS=$'\n\t'
 


### PR DESCRIPTION
bash may not always be located at `/bin/bash`.