### PR TITLE
Fix `--source` option causing incorrect gem unlocking

### DIFF
--- a/lib/bundler/cli/update.rb
+++ b/lib/bundler/cli/update.rb
@@ -30,7 +30,7 @@ module Bundler
 
         if groups.any?
           specs = Bundler.definition.specs_for groups
-          sources.concat(specs.map(&:name))
+          gems.concat(specs.map(&:name))
         end
 
         Bundler.definition(:gems => gems, :sources => sources)

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -557,6 +557,11 @@ module Bundler
         # Don't add a spec to the list if its source is expired. For example,
         # if you change a Git gem to Rubygems.
         next if s.source.nil? || @unlock[:sources].include?(s.source.name)
+
+        # XXX This is a backwards-compatibility fix to preserve the ability to
+        # unlock a single gem by passing its name via `--source`. See issue #3759
+        next if s.source.nil? || @unlock[:sources].include?(s.name)
+
         # If the spec is from a path source and it doesn't exist anymore
         # then we just unlock it.
 

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -556,7 +556,7 @@ module Bundler
 
         # Don't add a spec to the list if its source is expired. For example,
         # if you change a Git gem to Rubygems.
-        next if s.source.nil? || @unlock[:sources].include?(s.name)
+        next if s.source.nil? || @unlock[:sources].include?(s.source.name)
         # If the spec is from a path source and it doesn't exist anymore
         # then we just unlock it.
 

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -132,6 +132,8 @@ describe "bundle update" do
 
   describe "with --source option" do
     it "should not update gems not included in the source that happen to have the same name" do
+      pending("Allowed to fail to preserve backwards-compatibility")
+
       install_gemfile <<-G
         source "file://#{gem_repo2}"
         gem "activesupport"
@@ -140,6 +142,81 @@ describe "bundle update" do
 
       bundle "update --source activesupport"
       should_not_be_installed "activesupport 3.0"
+    end
+
+    it "should update gems not included in the source that happen to have the same name" do
+      install_gemfile <<-G
+        source "file://#{gem_repo2}"
+        gem "activesupport"
+      G
+      update_repo2 { build_gem "activesupport", "3.0" }
+
+      bundle "update --source activesupport"
+      should_be_installed "activesupport 3.0"
+    end
+  end
+
+  context "when there is a child dependency that is also in the gemfile" do
+    before do
+      build_repo2 do
+        build_gem "fred", "1.0"
+        build_gem "harry", "1.0" do |s|
+          s.add_dependency "fred"
+        end
+      end
+
+      install_gemfile <<-G
+        source "file://#{gem_repo2}"
+        gem "harry"
+        gem "fred"
+      G
+    end
+
+    it "should not update the child dependencies of a gem that has the same name as the source" do
+      update_repo2 do
+        build_gem "fred", "2.0"
+        build_gem "harry", "2.0" do |s|
+          s.add_dependency "fred"
+        end
+      end
+
+      bundle "update --source harry"
+      should_be_installed "harry 2.0"
+      should_be_installed "fred 1.0"
+    end
+  end
+
+  context "when there is a child dependency that appears elsewhere in the dependency graph" do
+    before do
+      build_repo2 do
+        build_gem "fred", "1.0" do |s|
+          s.add_dependency "george"
+        end
+        build_gem "george", "1.0"
+        build_gem "harry", "1.0" do |s|
+          s.add_dependency "george"
+        end
+      end
+
+      install_gemfile <<-G
+        source "file://#{gem_repo2}"
+        gem "harry"
+        gem "fred"
+      G
+    end
+
+    it "should not update the child dependencies of a gem that has the same name as the source" do
+      update_repo2 do
+        build_gem "george", "2.0"
+        build_gem "harry", "2.0" do |s|
+          s.add_dependency "george"
+        end
+      end
+
+      bundle "update --source harry"
+      should_be_installed "harry 2.0"
+      should_be_installed "fred 1.0"
+      should_be_installed "george 1.0"
     end
   end
 end

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -98,6 +98,26 @@ describe "bundle update" do
       should_be_installed "activesupport 3.0"
       should_not_be_installed "rack 1.2"
     end
+
+    context "when there is a source with the same name as a gem in a group" do
+      before :each do
+        build_git "foo", :path => lib_path("activesupport")
+        install_gemfile <<-G
+          source "file://#{gem_repo2}"
+          gem "activesupport", :group => :development
+          gem "foo", :git => "#{lib_path("activesupport")}"
+        G
+      end
+
+      it "should not update the gems from that source" do
+        update_repo2 { build_gem "activesupport", "3.0" }
+        update_git "foo", "2.0", :path => lib_path("activesupport")
+
+        bundle "update --group development"
+        should_be_installed "activesupport 3.0"
+        should_not_be_installed "foo 2.0"
+      end
+    end
   end
 
   describe "in a frozen bundle" do

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -129,6 +129,19 @@ describe "bundle update" do
       expect(exitstatus).not_to eq(0) if exitstatus
     end
   end
+
+  describe "with --source option" do
+    it "should not update gems not included in the source that happen to have the same name" do
+      install_gemfile <<-G
+        source "file://#{gem_repo2}"
+        gem "activesupport"
+      G
+      update_repo2 { build_gem "activesupport", "3.0" }
+
+      bundle "update --source activesupport"
+      should_not_be_installed "activesupport 3.0"
+    end
+  end
 end
 
 describe "bundle update in more complicated situations" do

--- a/spec/update/git_spec.rb
+++ b/spec/update/git_spec.rb
@@ -278,5 +278,56 @@ describe "bundle update" do
       bundle "update --source foo"
       should_be_installed "rack 1.0"
     end
+
+    context "when the gem and the repository have different names" do
+      before :each do
+        build_repo2
+        @git = build_git "foo", :path => lib_path("bar")
+
+        install_gemfile <<-G
+          source "file://#{gem_repo2}"
+          git "#{lib_path("bar")}" do
+            gem 'foo'
+          end
+          gem 'rack'
+        G
+      end
+
+      it "updates version of gems that were originally pulled in by the source" do
+        spec_lines = lib_path("foo/foo.gemspec").read.split("\n")
+        spec_lines[5] = "s.version = '2.0'"
+
+        update_git "foo", "2.0", :path => @git.path do |s|
+          s.write "foo.gemspec", spec_lines.join("\n")
+        end
+
+        ref = @git.ref_for "master"
+
+        bundle "update --source bar"
+
+        lockfile_should_be <<-G
+          GIT
+            remote: #{@git.path}
+            revision: #{ref}
+            specs:
+              foo (2.0)
+
+          GEM
+            remote: file:#{gem_repo2}/
+            specs:
+              rack (1.0.0)
+
+          PLATFORMS
+            ruby
+
+          DEPENDENCIES
+            foo!
+            rack
+
+          BUNDLED WITH
+             #{Bundler::VERSION}
+        G
+      end
+    end
   end
 end

--- a/spec/update/git_spec.rb
+++ b/spec/update/git_spec.rb
@@ -278,56 +278,56 @@ describe "bundle update" do
       bundle "update --source foo"
       should_be_installed "rack 1.0"
     end
+  end
 
-    context "when the gem and the repository have different names" do
-      before :each do
-        build_repo2
-        @git = build_git "foo", :path => lib_path("bar")
+  context "when the gem and the repository have different names" do
+    before :each do
+      build_repo2
+      @git = build_git "foo", :path => lib_path("bar")
 
-        install_gemfile <<-G
-          source "file://#{gem_repo2}"
-          git "#{lib_path("bar")}" do
-            gem 'foo'
-          end
-          gem 'rack'
-        G
-      end
-
-      it "updates version of gems that were originally pulled in by the source" do
-        spec_lines = lib_path("foo/foo.gemspec").read.split("\n")
-        spec_lines[5] = "s.version = '2.0'"
-
-        update_git "foo", "2.0", :path => @git.path do |s|
-          s.write "foo.gemspec", spec_lines.join("\n")
+      install_gemfile <<-G
+        source "file://#{gem_repo2}"
+        git "#{lib_path("bar")}" do
+          gem 'foo'
         end
+        gem 'rack'
+      G
+    end
 
-        ref = @git.ref_for "master"
+    it "the --source flag updates version of gems that were originally pulled in by the source" do
+      spec_lines = lib_path("bar/foo.gemspec").read.split("\n")
+      spec_lines[5] = "s.version = '2.0'"
 
-        bundle "update --source bar"
-
-        lockfile_should_be <<-G
-          GIT
-            remote: #{@git.path}
-            revision: #{ref}
-            specs:
-              foo (2.0)
-
-          GEM
-            remote: file:#{gem_repo2}/
-            specs:
-              rack (1.0.0)
-
-          PLATFORMS
-            ruby
-
-          DEPENDENCIES
-            foo!
-            rack
-
-          BUNDLED WITH
-             #{Bundler::VERSION}
-        G
+      update_git "foo", "2.0", :path => @git.path do |s|
+        s.write "foo.gemspec", spec_lines.join("\n")
       end
+
+      ref = @git.ref_for "master"
+
+      bundle "update --source bar"
+
+      lockfile_should_be <<-G
+        GIT
+          remote: #{@git.path}
+          revision: #{ref}
+          specs:
+            foo (2.0)
+
+        GEM
+          remote: file:#{gem_repo2}/
+          specs:
+            rack (1.0.0)
+
+        PLATFORMS
+          ruby
+
+        DEPENDENCIES
+          foo!
+          rack
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      G
     end
   end
 end


### PR DESCRIPTION
Fixes #3759 and #3761.

And also another issue I found where if:

1. You have a Gemfile with a group,
2. That group contains a gem with the same name as a source
3. And you run `bundle update --group group_name`
4. Then all gems associated with the source will be updated.

The 3 cases fixed here are all pretty subtle. The specs should make it clearer, and the github issues above add more context.

Note that this PR removes the ability to use `bundle update --source gem_name` as a hacky way to update a gem 'conservatively'. This is detailed in #3759.