### PR TITLE
Update checked rails version in realworld spec to make it pass

### DIFF
--- a/spec/realworld/edgecases_spec.rb
+++ b/spec/realworld/edgecases_spec.rb
@@ -43,7 +43,7 @@ describe "real world edgecases", :realworld => true do
       gem 'rails', '~> 3.0'
       gem 'capybara', '~> 2.2.0'
     G
-    expect(out).to include("rails 3.2.21")
+    expect(out).to include("rails 3.2.22")
     expect(out).to include("capybara 2.2.1")
   end
 


### PR DESCRIPTION
I noticed that the spec fails because rails has updated to `3.2.22`.