### PR TITLE
Expose setup with friendly errors and custom groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.11.0 (2015-06-20)
+
+Features:
+
+  - add setup\_friendly method, to setup load paths with custom groups and friendly errors (@habibalamin)
+
 ## 1.10.4 (2015-06-16)
 
 Workarounds:

--- a/bin/bundle
+++ b/bin/bundle
@@ -15,7 +15,7 @@ $LOAD_PATH.each do |path|
 end
 
 require 'bundler/friendly_errors'
-Bundler.with_friendly_errors do
+Bundler.with_friendly_errors debug: true do
   require 'bundler/cli'
   Bundler::CLI.start(ARGV, :debug => true)
 end

--- a/bin/bundler
+++ b/bin/bundler
@@ -15,7 +15,7 @@ $LOAD_PATH.each do |path|
 end
 
 require 'bundler/friendly_errors'
-Bundler.with_friendly_errors do
+Bundler.with_friendly_errors debug: true do
   require 'bundler/cli'
   Bundler::CLI.start(ARGV, :debug => true)
 end

--- a/lib/bundler/setup.rb
+++ b/lib/bundler/setup.rb
@@ -1,26 +1,3 @@
-require 'bundler/shared_helpers'
+require 'bundler/setup_friendly'
 
-if Bundler::SharedHelpers.in_bundle?
-  require 'bundler'
-
-  if STDOUT.tty? || ENV['BUNDLER_FORCE_TTY']
-    begin
-      Bundler.setup
-    rescue Bundler::BundlerError => e
-      puts "\e[31m#{e.message}\e[0m"
-      puts e.backtrace.join("\n") if ENV["DEBUG"]
-      if e.is_a?(Bundler::GemNotFound)
-        puts "\e[33mRun `bundle install` to install missing gems.\e[0m"
-      end
-      exit e.status_code
-    end
-  else
-    Bundler.setup
-  end
-
-  # Add bundler to the load path after disabling system gems
-  bundler_lib = File.expand_path("../..", __FILE__)
-  $LOAD_PATH.unshift(bundler_lib) unless $LOAD_PATH.include?(bundler_lib)
-
-  Bundler.ui = nil
-end
+Bundler.setup_friendly

--- a/lib/bundler/setup_friendly.rb
+++ b/lib/bundler/setup_friendly.rb
@@ -4,10 +4,9 @@ module Bundler
   def self.setup_friendly *groups
     if SharedHelpers.in_bundle?
       require 'bundler'
+      require_relative 'friendly_errors'
       require 'bundler/ui/shell'
       require 'bundler/ui/silent'
-
-      groups << :default if groups.empty?
 
       Bundler.ui = if STDOUT.tty? || ENV['BUNDLER_FORCE_TTY']
         Bundler::UI::Shell.new
@@ -16,7 +15,11 @@ module Bundler
       end
 
       Bundler.with_friendly_errors do
-        Bundler.setup groups
+        if groups.empty?
+          Bundler.setup
+        else
+          Bundler.setup groups
+        end
       end
 
       # Add bundler to the load path after disabling system gems

--- a/lib/bundler/setup_friendly.rb
+++ b/lib/bundler/setup_friendly.rb
@@ -1,0 +1,29 @@
+require 'bundler/shared_helpers'
+
+module Bundler
+  def self.setup_friendly *groups
+    if SharedHelpers.in_bundle?
+      require 'bundler'
+      require 'bundler/ui/shell'
+      require 'bundler/ui/silent'
+
+      groups << :default if groups.empty?
+
+      Bundler.ui = if STDOUT.tty? || ENV['BUNDLER_FORCE_TTY']
+        Bundler::UI::Shell.new
+      else
+        Bundler::UI::Silent.new
+      end
+
+      Bundler.with_friendly_errors do
+        Bundler.setup groups
+      end
+
+      # Add bundler to the load path after disabling system gems
+      bundler_lib = File.expand_path("../..", __FILE__)
+      $LOAD_PATH.unshift(bundler_lib) unless $LOAD_PATH.include?(bundler_lib)
+
+      Bundler.ui = nil
+    end
+  end
+end

--- a/lib/bundler/version.rb
+++ b/lib/bundler/version.rb
@@ -2,5 +2,5 @@ module Bundler
   # We're doing this because we might write tests that deal
   # with other versions of bundler and we are unsure how to
   # handle this better.
-  VERSION = "1.10.4" unless defined?(::Bundler::VERSION)
+  VERSION = "1.11.0" unless defined?(::Bundler::VERSION)
 end

--- a/spec/runtime/setup_friendly_spec.rb
+++ b/spec/runtime/setup_friendly_spec.rb
@@ -1,0 +1,37 @@
+require "spec_helper"
+
+describe "Bundler.setup_friendly" do
+  describe "with no arguments" do
+    it "makes all groups available" do
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem "rack", :group => :test
+      G
+
+      ruby <<-RUBY
+        require 'rubygems'
+        require 'bundler/setup_friendly'
+        Bundler.setup_friendly
+
+        require 'rack'
+        puts RACK
+      RUBY
+      expect(err).to eq("")
+      expect(out).to eq("1.0.0")
+    end
+
+    it "adds Bundler itself to the load path" do
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem "rack", :group => :test
+      G
+
+      ruby <<-RUBY
+        require 'rubygems'
+        require 'bundler/setup_friendly'
+        Bundler.setup_friendly
+      RUBY
+      expect($LOAD_PATH.first).to eq(File.expand_path '../../../lib', __FILE__) # dunno
+    end
+  end
+end

--- a/spec/runtime/setup_friendly_spec.rb
+++ b/spec/runtime/setup_friendly_spec.rb
@@ -1,6 +1,8 @@
 require "spec_helper"
 
 describe "Bundler.setup_friendly" do
+  # install_gemfile in before(:each) block won't take an RSpec let argument,
+  # which I need, because the last example's Gemfile is different
   describe "with no arguments" do
     it "makes all groups available" do
       install_gemfile <<-G
@@ -32,6 +34,25 @@ describe "Bundler.setup_friendly" do
         Bundler.setup_friendly
       RUBY
       expect($LOAD_PATH.first).to eq(File.expand_path '../../../lib', __FILE__) # dunno
+    end
+
+    it "prints friendly errors" do
+      Dir.mktmpdir do |tmp_dir|
+        with_gem_path_as tmp_dir do
+          gemfile <<-G
+            source "file://#{gem_repo1}"
+            gem "rack", :group => :test
+          G
+
+          ruby <<-RUBY
+            require 'rubygems'
+            require 'bundler/setup_friendly'
+            Bundler.setup_friendly
+          RUBY
+          expect(out).to include('Could not find rack')
+          expect(out).to include('Run `bundle install` to install missing gems.')
+        end
+      end
     end
   end
 end

--- a/spec/runtime/setup_friendly_spec.rb
+++ b/spec/runtime/setup_friendly_spec.rb
@@ -55,4 +55,30 @@ describe "Bundler.setup_friendly" do
       end
     end
   end
+
+  describe "with called with groups" do
+    before(:each) do
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem "yard"
+        gem "rack", :group => :test
+      G
+    end
+
+    it "doesn't make all groups available" do
+      ruby <<-RUBY
+        require 'rubygems'
+        require 'bundler/setup_friendly'
+        Bundler.setup_friendly :development
+
+        begin
+          require 'rack'
+        rescue LoadError
+          puts "WIN"
+        end
+      RUBY
+      expect(err).to eq("")
+      expect(out).to eq("WIN")
+    end
+  end
 end


### PR DESCRIPTION
Allows user to `require 'bundler/setup_friendly` and just call Bundler.setup_friendly with custom groups, while still adding Bundler to the load path and printing friendly errors.

#3770.