### PR TITLE
allow for finding git sources on $GEM_PATH

### DIFF
--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -84,6 +84,10 @@ module Bundler
         @install_path ||= begin
           git_scope = "#{base_name}-#{shortref_for_path(revision)}"
           path = Bundler.install_path.join(git_scope)
+          unless path.exist?
+            candidates = find_in_gem_path("bundler", "gems", git_scope)
+            path = candidates.first unless candidates.empty?
+          end
 
           if !path.exist? && Bundler.requires_sudo?
             Bundler.user_bundle_path.join(Bundler.ruby_scope).join(git_scope)
@@ -202,7 +206,15 @@ module Bundler
           if Bundler.requires_sudo?
             Bundler.user_bundle_path.join("cache/git", git_scope)
           else
-            Bundler.cache.join("git", git_scope)
+            default_cache_path = Bundler.cache.join("git", git_scope)
+
+            candidates = [default_cache_path] + find_in_gem_path("cache", "bundler", "git", git_scope)
+            cache_path = candidates.detect do |path|
+              proxy = GitProxy.new(path, uri, ref, cached_revision, self)
+              proxy.has_revision_cached?
+            end
+
+            cache_path || default_cache_path
           end
         end
       end
@@ -220,6 +232,17 @@ module Bundler
       end
 
       private
+
+      def find_in_gem_path(*path_parts)
+        rel_path = Pathname.new(File.join(path_parts))
+        paths = Bundler.rubygems.gem_path.map do |path|
+          expanded_path = rel_path.expand_path(path)
+          expanded_path if expanded_path.exist?
+        end
+        paths.compact!
+
+        paths
+      end
 
       def serialize_gemspecs_in(destination)
         expanded_path = destination.expand_path(Bundler.root)

--- a/lib/bundler/source/git/git_proxy.rb
+++ b/lib/bundler/source/git/git_proxy.rb
@@ -96,6 +96,14 @@ module Bundler
           end
         end
 
+        def has_revision_cached?
+          return unless @revision
+          in_path { git("cat-file -e #{@revision}") }
+          true
+        rescue GitError
+          false
+        end
+
       private
 
         # TODO: Do not rely on /dev/null.
@@ -118,14 +126,6 @@ module Bundler
           out = SharedHelpers.with_clean_git_env { %x{git #{command}} }
           raise GitCommandError.new(command, path) if check_errors && !$?.success?
           out
-        end
-
-        def has_revision_cached?
-          return unless @revision
-          in_path { git("cat-file -e #{@revision}") }
-          true
-        rescue GitError
-          false
         end
 
         # Escape the URI for git commands


### PR DESCRIPTION
__This is still a work-in-progress, and needs tests.__

------

## Feature Description

This PR makes it possible for Bundler to find caches and installation paths for git sources in `$GEM_PATH`.

## Motivation

RubyGems/Bundler already allows for finding normal gem installations across both `$GEM_HOME` and `$GEM_PATH`; this makes git sources behave the same way.

More importantly, to package Ruby applications on [NixOS](http://nixos.org/) (and similar distros, like [GuixSD](http://www.gnu.org/software/guix/)), we need a deterministic way to fetch git sources. This means that we must fetch git sources individually, given a sha256 hash of directory contents. As of right now, I maintain an unsustainable set of monkey-patches which, prior to `bundle install`ing, point Bundler at the pre-fetched git repos instead of allowing Bundler to fetch repos across the network. Ideally, our package infrastructure would direct `gem install` to install gems into the right places to then be picked up from `$GEM_PATH` (without additional hacks, we can't use `$GEM_HOME`: Nix-like distros install packages into unique prefixes, so it's not possible to point `$GEM_HOME` to a single all encompassing file path).

## Feedback?

Would this be a welcome contribution? If so, I'll write up some tests.