### PR TITLE
Custom console

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -354,6 +354,8 @@ module Bundler
     method_option :mit, :type => :boolean, :desc => "Generate an MIT license file"
     method_option :test, :type => :string, :lazy_default => 'rspec', :aliases => '-t', :banner => "rspec",
       :desc => "Generate a test directory for your library, either rspec or minitest. Set a default with `bundle config gem.test rspec`."
+    method_option :console, :type => :string, :aliases => "-c", :required => false, :banner => "console",
+      :desc => "Select default console. (Defaults to `bundle config console`)"
     def gem(name)
       require 'bundler/cli/gem'
       Gem.new(options, name, self).run

--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -112,6 +112,8 @@ module Bundler
         )
       end
 
+      config[:console], config[:opposite_console] = *resolve_consoles
+
       templates.each do |src, dst|
         thor.template("newgem/#{src}", target.join(dst), config)
       end
@@ -197,5 +199,11 @@ module Bundler
       end
     end
 
+    def resolve_consoles
+      selection = options[:console] || Bundler.settings[:console]
+      consoles = ["IRB", "Pry"]
+      consoles.reverse! if selection =~ /pry/i
+      consoles
+    end
   end
 end

--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -200,10 +200,20 @@ module Bundler
     end
 
     def resolve_consoles
-      selection = options[:console] || Bundler.settings[:console]
-      consoles = ["IRB", "Pry"]
-      consoles.reverse! if selection =~ /pry/i
-      consoles
+      selection = options[:console]
+      selection = Bundler.settings[:console] if selection.nil? || selection.empty?
+      irb = format_console_name("IRB")
+      if selection =~ /irb/i
+        [irb, format_console_name("Pry")]
+      else
+        [format_console_name(selection), irb]
+      end
+    end
+
+    def format_console_name(name)
+      namespaced_path = name.tr('-', '/')
+      constant_name = name.gsub(/-[_-]*(?![_-]|$)/){ '::' }.gsub(/([_-]+|(::)|^)(.|$)/){ $2.to_s + $3.upcase }
+      {namespaced: namespaced_path, constant: constant_name, name: name}
     end
   end
 end

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -4,7 +4,7 @@ module Bundler
   class Settings
     BOOL_KEYS = %w(frozen cache_all no_prune disable_local_branch_check ignore_messages gem.mit gem.coc).freeze
     NUMBER_KEYS = %w(retry timeout redirect).freeze
-    DEFAULT_CONFIG = {:retry => 3, :timeout => 10, :redirect => 5}
+    DEFAULT_CONFIG = {:retry => 3, :timeout => 10, :redirect => 5, :console => "irb" }
 
     def initialize(root = nil)
       @root          = root

--- a/lib/bundler/templates/newgem/bin/console.tt
+++ b/lib/bundler/templates/newgem/bin/console.tt
@@ -6,11 +6,11 @@ require "<%= config[:namespaced_path] %>"
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
 
-<%- if config[:console] =~ /pry/i -%>
+<%- if config[:console][:opposite_console] =~ /pry/i -%>
 # (If you use this, don't forget to add pry to your Gemfile!)
 <%- end -%>
-# require "<%= config[:opposite_console].downcase %>"
-# <%= config[:opposite_console] %>.start
+# require "<%= config[:opposite_console][:namespaced] %>"
+# <%= config[:opposite_console][:constant] %>.start
 
-require "<%= config[:console].downcase %>"
-<%= config[:console] %>.start
+require "<%= config[:console][:namespaced] %>"
+<%= config[:console][:constant] %>.start

--- a/lib/bundler/templates/newgem/bin/console.tt
+++ b/lib/bundler/templates/newgem/bin/console.tt
@@ -6,9 +6,11 @@ require "<%= config[:namespaced_path] %>"
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
 
+<%- if config[:console] =~ /pry/i -%>
 # (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
-# Pry.start
+<%- end -%>
+# require "<%= config[:opposite_console].downcase %>"
+# <%= config[:opposite_console] %>.start
 
-require "irb"
-IRB.start
+require "<%= config[:console].downcase %>"
+<%= config[:console] %>.start

--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
 <%- if config[:test] && config[:test] != "false" -%>
   spec.add_development_dependency "<%=config[:test]%>"
 <%- end -%>
-<%- if config[:console] =~ /pry/i -%>
-  spec.add_development_dependency "pry"
+<%- if config[:console][:name] !~ /irb/i -%>
+  spec.add_development_dependency "<%= config[:console][:namespaced] %>"
 <%- end -%>
 end

--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -40,4 +40,7 @@ Gem::Specification.new do |spec|
 <%- if config[:test] && config[:test] != "false" -%>
   spec.add_development_dependency "<%=config[:test]%>"
 <%- end -%>
+<%- if config[:console] =~ /pry/i -%>
+  spec.add_development_dependency "pry"
+<%- end -%>
 end


### PR DESCRIPTION
It might just be me, but switching to Pry is the first thing I do when I make a new gem so I thought this would be helpful to others as well.
It's done in a little strange of a manner to allow any console library to work—a new console shouldn't have to come to us for their users to be able to use it, that would be unfair.