### PR TITLE
Change default install path to ./.bundle/gems

### DIFF
--- a/lib/bundler/cli/config.rb
+++ b/lib/bundler/cli/config.rb
@@ -49,6 +49,18 @@ module Bundler
         new_value = args.join(" ")
         locations = Bundler.settings.locations(name)
 
+
+        if name == "path.system" and Bundler.settings[:path] and new_value == "true"
+          Bundler.ui.warn "`path` is already configured, so it will be unset."
+          Bundler.settings.set_local("path", nil)
+          Bundler.settings.set_global("path", nil)
+        elsif name == "path" and Bundler.settings["path.system"]
+          Bundler.ui.warn "`path.system` is already configured, so it will be unset."
+          Bundler.settings.set_local("path.system", nil)
+          Bundler.settings.set_global("path.system", nil)
+        end
+
+
         if scope == "global"
           if locations[:local]
             Bundler.ui.info "Your application has set #{name} to #{locations[:local].inspect}. " \

--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -82,7 +82,7 @@ module Bundler
         options[:system] = true
       end
 
-      Bundler.settings[:path]     = nil if options[:system]
+      Bundler.settings[:path]     = Bundler.rubygems.gem_dir if options[:system]
       Bundler.settings[:path]     = "vendor/bundle" if options[:deployment]
       Bundler.settings[:path]     = options["path"] if options["path"]
       Bundler.settings[:path]     ||= "bundle" if options["standalone"]

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -136,9 +136,9 @@ module Bundler
       return path if path && !@local_config.key?(key)
 
       if path = self[:path]
-        "#{path}/#{Bundler.ruby_scope}"
+        path == Bundler.rubygems.gem_dir ? path : "#{path}/#{Bundler.ruby_scope}"
       else
-        Bundler.rubygems.gem_dir
+        File.join(@root, Bundler.ruby_scope)
       end
     end
 

--- a/spec/commands/clean_spec.rb
+++ b/spec/commands/clean_spec.rb
@@ -324,15 +324,17 @@ describe "bundle clean" do
       gem "thin"
       gem "rack"
     G
-    bundle :install
+    bundle "install --system"
+    sys_exec "gem list"
+    expect(out).to include("rack (1.0.0)")
+    expect(out).to include("thin (1.0)")
 
     gemfile <<-G
       source "file://#{gem_repo1}"
 
       gem "rack"
     G
-    bundle :install
-
+    bundle "install --system"
     sys_exec "gem list"
     expect(out).to include("rack (1.0.0)")
     expect(out).to include("thin (1.0)")
@@ -423,7 +425,7 @@ describe "bundle clean" do
 
       gem "foo"
     G
-    bundle "install"
+    bundle "install --system"
 
     update_repo2 do
       build_gem 'foo', '1.0.1'
@@ -441,14 +443,14 @@ describe "bundle clean" do
       gem "foo"
       gem "rack"
     G
-    bundle :install
+    bundle "install --system"
 
     gemfile <<-G
       source "file://#{gem_repo1}"
 
       gem "rack"
     G
-    bundle :install
+    bundle "install --system"
     bundle "clean --force"
 
     expect(out).to include("Removing foo (1.0)")
@@ -501,7 +503,7 @@ describe "bundle clean" do
 
       gem "bindir"
     G
-    bundle :install
+    bundle "install --system"
 
     bundle "clean --force"
 

--- a/spec/commands/config_spec.rb
+++ b/spec/commands/config_spec.rb
@@ -282,6 +282,36 @@ E
       expect(out).to match(long_string_without_special_characters)
     end
   end
+
+  describe "conflicting path settings" do
+    before(:each) { bundle :install }
+
+    describe "setting `path` when `path.system` is already set" do
+      it "should print a warning and remove the `path.system` setting" do
+        bundle "config path.system true"
+        # Note that if a path is used that does not include the installed gems,
+        # we'll get an error when we pass _any_ command to `run` below.
+        bundle "config path #{default_bundle_path}"
+
+        expect(out).to include("`path.system` is already configured")
+        run "puts Bundler.settings['path.system'] == nil"
+        expect(out).to eq("true")
+      end
+    end
+
+    describe "setting `path.system` when `path` is already set" do
+      it "should print a warning and remove the `path` setting" do
+        # Here, the path does not matter, since the option gets overwritten
+        # when we set `path.system`. We could choose 'any/path/'.
+        bundle "config path #{default_bundle_path}"
+        bundle "config path.system true"
+
+        expect(out).to include("`path` is already configured")
+        run "puts Bundler.settings[:path] == nil"
+        expect(out).to eq("true")
+      end
+    end
+  end
 end
 
 describe "setting gemfile via config" do

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -114,13 +114,16 @@ describe "bundle exec" do
       end
     end
 
-    install_gemfile <<-G
+    # We added :system => true here and in the block below, since the
+    # (old default) system gem directory was implicitly used in previous
+    # versions of Bundler.
+    install_gemfile <<-G, :system => true
       source "file://#{gem_repo1}"
       gem "rack", "0.9.1"
     G
 
     Dir.chdir bundled_app2 do
-      install_gemfile bundled_app2('Gemfile'), <<-G
+      install_gemfile bundled_app2('Gemfile'), <<-G, :system => true
         source "file://#{gem_repo2}"
         gem "rack_two", "1.0.0"
       G

--- a/spec/commands/show_spec.rb
+++ b/spec/commands/show_spec.rb
@@ -31,7 +31,7 @@ describe "bundle show" do
     end
 
     it "warns if path no longer exists on disk" do
-      FileUtils.rm_rf("#{system_gem_path}/gems/rails-2.3.2")
+      FileUtils.rm_rf("#{default_bundle_path}/gems/rails-2.3.2")
 
       bundle "show rails"
 

--- a/spec/install/gems/sudo_spec.rb
+++ b/spec/install/gems/sudo_spec.rb
@@ -10,7 +10,7 @@ describe "when using sudo", :sudo => true do
       end
 
       it "installs" do
-        install_gemfile <<-G
+        install_gemfile <<-G, :system => true
           source "file://#{gem_repo1}"
           gem "rack"
         G
@@ -28,7 +28,7 @@ describe "when using sudo", :sudo => true do
     end
 
     it "installs" do
-      install_gemfile <<-G
+      install_gemfile <<-G, :system => true
         source "file://#{gem_repo1}"
         gem "rack", '1.0'
         gem "thin"
@@ -45,7 +45,7 @@ describe "when using sudo", :sudo => true do
           gem "rake"
           gem "another_implicit_rake_dep"
       G
-      bundle "install"
+      bundle "install --system"
       expect(system_gem_path("gems/another_implicit_rake_dep-1.0")).to exist
     end
 
@@ -84,7 +84,7 @@ describe "when using sudo", :sudo => true do
     end
 
     it "installs extensions/ compiled by Rubygems 2.2", :rubygems => "2.2" do
-      install_gemfile <<-G
+      install_gemfile <<-G, :system => true
         source "file://#{gem_repo1}"
         gem "very_simple_binary"
       G
@@ -137,7 +137,7 @@ describe "when using sudo", :sudo => true do
         gem "rack", '1.0'
       G
 
-      bundle :install, :env => {'GEM_HOME' => gem_home.to_s, 'GEM_PATH' => nil}
+      bundle :install, :env => {'GEM_HOME' => gem_home.to_s, 'GEM_PATH' => nil}, :system => true
       expect(gem_home.join('bin/rackup')).to exist
       should_be_installed "rack 1.0", :env => {'GEM_HOME' => gem_home.to_s, 'GEM_PATH' => nil}
     end

--- a/spec/other/platform_spec.rb
+++ b/spec/other/platform_spec.rb
@@ -540,7 +540,7 @@ G
 
   context "bundle show" do
     before do
-      install_gemfile <<-G
+      install_gemfile <<-G, :system => true
         source "file://#{gem_repo1}"
         gem "rails"
       G
@@ -555,7 +555,7 @@ G
       G
 
       bundle "show rails"
-      expect(out).to eq(default_bundle_path('gems', 'rails-2.3.2').to_s)
+      expect(out).to eq(system_gem_path('gems', 'rails-2.3.2').to_s)
     end
 
     it "prints path if ruby version is correct for any engine" do
@@ -568,7 +568,13 @@ G
         G
 
         bundle "show rails"
-        expect(out).to eq(default_bundle_path('gems', 'rails-2.3.2').to_s)
+        # Previously, gems had been installed to the system gem path,
+        # since `bundle install` (see the `before` block above) used
+        # the system gem path by default.
+
+        # Also, the default_bundle_path used to be the system gem path,
+        # so we now expect the system_gem_path below.
+        expect(out).to eq(system_gem_path('gems', 'rails-2.3.2').to_s)
       end
     end
 
@@ -868,7 +874,7 @@ G
 
   context "bundle console" do
     before do
-      install_gemfile <<-G
+      install_gemfile <<-G, :system => true
         source "file://#{gem_repo1}"
         gem "rack"
         gem "activesupport", :group => :test
@@ -1104,7 +1110,7 @@ G
         build_git "foo", :path => lib_path("foo")
       end
 
-      install_gemfile <<-G
+      install_gemfile <<-G, :system => true
         source "file://#{gem_repo2}"
         gem "activesupport", "2.3.5"
         gem "foo", :git => "#{lib_path('foo')}"

--- a/spec/support/path.rb
+++ b/spec/support/path.rb
@@ -15,7 +15,7 @@ module Spec
     end
 
     def default_bundle_path(*path)
-      system_gem_path(*path)
+      bundled_app(".bundle", Bundler.ruby_scope, *path)
     end
 
     def bundled_app(*path)


### PR DESCRIPTION
See https://github.com/bundler/bundler/pull/3784.

In addition, this will:

- Handle conflicting path config settings; behavior may be undefined if the user sets both manually in their config file

- Ensure that all specs pass