### PR TITLE
Use bang methods for speed and memory efficiency

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -235,8 +235,8 @@ module Bundler
         ENV['MANPATH'] = ENV['BUNDLE_ORIG_MANPATH']
         ENV.delete_if { |k,_| k[0,7] == 'BUNDLE_' }
         if ENV.has_key? 'RUBYOPT'
-          ENV['RUBYOPT'] = ENV['RUBYOPT'].sub '-rbundler/setup', ''
-          ENV['RUBYOPT'] = ENV['RUBYOPT'].sub "-I#{File.expand_path('..', __FILE__)}", ''
+          ENV['RUBYOPT'].sub! '-rbundler/setup', ''
+          ENV['RUBYOPT'].sub! "-I#{File.expand_path('..', __FILE__)}", ''
         end
         yield
       end

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -415,7 +415,7 @@ module Bundler
         description = self.description
         if dsl_path && description =~ /((#{Regexp.quote File.expand_path(dsl_path)}|#{Regexp.quote dsl_path.to_s}):\d+)/
           trace_line = Regexp.last_match[1]
-          description = description.sub(/#{Regexp.quote trace_line}:\s*/, '').sub("\n", ' - ')
+          description.sub!(/#{Regexp.quote trace_line}:\s*/, '').sub("\n", ' - ')
         end
         [trace_line, description]
       end


### PR DESCRIPTION
The bang methods will edit the string in place so it won't allocate more memory and is much faster because of it.  I will try to find more places where this can be done, maybe we can make some small speed improvements across the entire codebase this way.