### PR TITLE
Pessimistic test framework versions for bundle gem command

### DIFF
--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -2,6 +2,11 @@ require 'pathname'
 
 module Bundler
   class CLI::Gem
+    TEST_FRAMEWORK_VERSIONS = {
+      'rspec' => '3.0',
+      'minitest' => '5.0'
+    }
+
     attr_reader :options, :gem_name, :thor, :name, :target
 
     def initialize(options, gem_name, thor)
@@ -63,6 +68,8 @@ module Bundler
 
       if test_framework = ask_and_set_test_framework
         config[:test] = test_framework
+        config[:test_framework_version] = TEST_FRAMEWORK_VERSIONS[test_framework]
+
         templates.merge!(".travis.yml.tt" => ".travis.yml")
 
         case test_framework

--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -38,6 +38,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake-compiler"
 <%- end -%>
 <%- if config[:test] && config[:test] != "false" -%>
-  spec.add_development_dependency "<%=config[:test]%>"
+  spec.add_development_dependency "<%=config[:test]%>", "~> <%=config[:test_framework_version]%>"
 <%- end -%>
 end

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -50,6 +50,14 @@ describe "bundle gem" do
     end
   end
 
+  shared_examples_for "following best practices for gem dependencies" do
+    it "only adds development dependencies with specific version requirements" do
+      unspecific_dev_dependencies = generated_gem.gemspec.development_dependencies.reject(&:specific?)
+
+      expect(unspecific_dev_dependencies).to eq([])
+    end
+  end
+
   it "generates a valid gemspec" do
     system_gems ["rake-10.0.2"]
 
@@ -234,6 +242,8 @@ describe "bundle gem" do
         bundle "gem #{gem_name} --test=rspec"
       end
 
+      it_should_behave_like("following best practices for gem dependencies")
+
       it "builds spec skeleton" do
         expect(bundled_app("test_gem/.rspec")).to exist
         expect(bundled_app("test_gem/spec/test_gem_spec.rb")).to exist
@@ -284,6 +294,8 @@ describe "bundle gem" do
         in_app_root
         bundle "gem #{gem_name} --test=minitest"
       end
+
+      it_should_behave_like("following best practices for gem dependencies")
 
       it "builds spec skeleton" do
         expect(bundled_app("test_gem/test/test_gem_test.rb")).to exist


### PR DESCRIPTION
Here's a first draft of the change discussed in #3806.

Use a pessimistic version requirement for RSpec and Minitest in
gemspecs generated by the `bundle gem` command. It is best practice to
at least depend on major versions of development dependency gems.

* Hard code major versions of the two testing frameworks.
* Add a spec that tests that only specific version requirements are
  used in development dependencies.

Some questions:
* The test for`bundle gem` contains some duplication for cases concerning different gem names (with dash, with underscore etc). The shared example group that I added could have been used in more of the nested contexts, but I did not feel that those were testing different paths in my case.
* I mostly struggled with the naming of the shared example group. Probably someone could come up with something a little less stilted...

Looking forward to your feedback.
