### PR TITLE
Ensure two RemoteSpecifications are comparable

### DIFF
--- a/lib/bundler/remote_specification.rb
+++ b/lib/bundler/remote_specification.rb
@@ -52,8 +52,6 @@ module Bundler
       @_remote_specification = spec
     end
 
-  private
-
     # Create a delegate used for sorting. This strategy is copied from
     # RubyGems 2.23 and ensures that Bundler's specifications can be
     # compared and sorted with RubyGems' own specifications.
@@ -66,6 +64,8 @@ module Bundler
     def sort_obj
       [@name, @version, @platform == Gem::Platform::RUBY ? -1 : 1]
     end
+
+  private
 
     def _remote_specification
       @_remote_specification ||= @spec_fetcher.fetch_spec([@name, @version, @platform])

--- a/spec/bundler/remote_specification_spec.rb
+++ b/spec/bundler/remote_specification_spec.rb
@@ -27,8 +27,8 @@ describe Bundler::RemoteSpecification do
 
       context "which is different by name" do
         let(:other_name) { "a" }
-        it "doesn't return 0" do
-          expect(subject <=> other).not_to eq(0)
+        it "returns 1" do
+          expect(subject <=> other).to eq(1)
         end
       end
 
@@ -48,8 +48,8 @@ describe Bundler::RemoteSpecification do
 
       context "which has a different platform" do
         let(:other_platform) { Gem::Platform.new("x86-mswin32") }
-        it "doesn't return 0" do
-          expect(subject <=> other).not_to eq(0)
+        it "returns -1" do
+          expect(subject <=> other).to eq(-1)
         end
       end
     end

--- a/spec/bundler/remote_specification_spec.rb
+++ b/spec/bundler/remote_specification_spec.rb
@@ -16,6 +16,49 @@ describe Bundler::RemoteSpecification do
       Bundler::RemoteSpecification.new(name, version, platform, nil)
     end
 
+    context "given a Bundler::RemoteSpecification" do
+      let(:same_gem) do
+        Bundler::RemoteSpecification.new(name, version, platform, nil)
+      end
+
+      let(:different_name) do
+        Bundler::RemoteSpecification.new("bar", version, platform, nil)
+      end
+
+      let(:newer_gem) do
+        Bundler::RemoteSpecification.new(name, newer_version, platform, nil)
+      end
+
+      let(:older_gem) do
+        Bundler::RemoteSpecification.new(name, older_version, platform, nil)
+      end
+
+      let(:different_platform) do
+        plt = Gem::Platform.new "x86-mswin32"
+        Bundler::RemoteSpecification.new(name, version, plt, nil)
+      end
+
+      it "compares based on name" do
+        expect(subject <=> different_name).not_to eq(0)
+      end
+
+      it "compares based on the same version" do
+        expect(subject <=> same_gem).to eq(0)
+      end
+
+      it "compares based on an older version" do
+        expect(subject).to be < newer_gem
+      end
+
+      it "compares based on a newer version" do
+        expect(subject).to be > older_gem
+      end
+
+      it "compares based on platform" do
+        expect(subject <=> different_platform).not_to eq(0)
+      end
+    end
+
     context "given a Gem::Specification" do
       let(:same_gem) do
         Gem::Specification.new(name, version)


### PR DESCRIPTION
The `RemoteSpecification#sort_obj` method was added in e5d936e (which was cherry-picked from #3767) to fix #3762, but it still fails when comparing two instances of `RemoteSpecification`.

As `#sort_obj` is private, the check for `other.respond_to?(:sort_obj)` returns `false`, which means the `<=>` check falls back to the default (from `Object`) which returns `nil` if the objects being compared don't match. This then results in an `ArgumentError` when (e.g.) sorting an array containing multiple instances of `RemoteSpecification`.

The fix is simple: make `RemoteSpecification#sort_obj` public.