### PR TITLE
Removes a warning in jruby

### DIFF
--- a/lib/bundler/cli/exec.rb
+++ b/lib/bundler/cli/exec.rb
@@ -1,3 +1,5 @@
+require 'bundler/current_ruby'
+
 module Bundler
   class CLI::Exec
     attr_reader :options, :args, :cmd
@@ -7,7 +9,7 @@ module Bundler
       @cmd = args.shift
       @args = args
 
-      if RUBY_VERSION >= "2.0"
+      if Bundler.current_ruby.ruby_2?
         @args << { :close_others => !options.keep_file_descriptors? }
       elsif options.keep_file_descriptors?
         Bundler.ui.warn "Ruby version #{RUBY_VERSION} defaults to keeping non-standard file descriptors on Kernel#exec."

--- a/lib/bundler/current_ruby.rb
+++ b/lib/bundler/current_ruby.rb
@@ -27,6 +27,10 @@ module Bundler
       RUBY_VERSION =~ /^2\.2/
     end
 
+    def on_2?
+      on_20? || on_21? || on_22?
+    end
+
     def ruby?
       !mswin? && (!defined?(RUBY_ENGINE) || RUBY_ENGINE == "ruby" || RUBY_ENGINE == "rbx" || RUBY_ENGINE == "maglev")
     end
@@ -49,6 +53,10 @@ module Bundler
 
     def ruby_22?
       ruby? && on_22?
+    end
+
+    def ruby_2?
+      ruby? && on_2?
     end
 
     def mri?

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -79,7 +79,7 @@ describe "bundle exec" do
     install_gemfile ''
     sys_exec("#{Gem.ruby} #{command.path}")
 
-    if RUBY_VERSION >= "2.0"
+    if Bundler.current_ruby.ruby_2?
       expect(out).to eq("")
     else
       expect(out).to eq("Ruby version #{RUBY_VERSION} defaults to keeping non-standard file descriptors on Kernel#exec.")


### PR DESCRIPTION
It seems that jruby's exec does not understand that option:

```
uri:classloader:/jruby/kernel/kernel.rb:28: warning: unsupported exec option: close_others

```

The warning was skipped for rubies under 2.0 (like latest released
jruby) but the new jruby 9.0.0.0 is 2.0 compatible by default so the
check needs to be refined.