### PR TITLE
Fix install_if not clearing install conditions

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -186,7 +186,7 @@ module Bundler
       @install_conditionals.concat args
       blk.call
     ensure
-      args.each { @groups.pop }
+      args.each { @install_conditionals.pop }
     end
 
     def platforms(*platforms)

--- a/spec/install/gems/install_if.rb
+++ b/spec/install/gems/install_if.rb
@@ -4,21 +4,26 @@ describe "bundle install with install_if conditionals" do
   it "follows the install_if DSL" do
     install_gemfile <<-G
       source "file://#{gem_repo1}"
-      gem "rack"
       install_if(lambda { true }) do
         gem "activesupport", "2.3.5"
       end
       gem "thin", :install_if => false
+      install_if(lambda { false }) do
+        gem "foo"
+      end
+      gem "rack"
     G
 
     should_be_installed("rack 1.0", "activesupport 2.3.5")
     should_not_be_installed("thin")
+    should_not_be_installed("foo")
 
     lockfile_should_be <<-L
       GEM
         remote: file:#{gem_repo1}/
         specs:
           activesupport (2.3.5)
+          foo (1.0)
           rack (1.0.0)
           thin (1.0)
             rack
@@ -28,6 +33,7 @@ describe "bundle install with install_if conditionals" do
 
       DEPENDENCIES
         activesupport (= 2.3.5)
+        foo
         rack
         thin
 


### PR DESCRIPTION
The new `install_if` command was not clearing `install_conditions` properly.
All gems defined after a `install_if -> false do ... end` would not be installed.

I think that fixes the problem.