### PR TITLE
Force remote resolution for GitHub repo usage.

### DIFF
--- a/lib/bundler/inline.rb
+++ b/lib/bundler/inline.rb
@@ -44,6 +44,7 @@ def gemfile(install = false, &gemfile)
 
   if install
     Bundler.ui = Bundler::UI::Shell.new
+    definition.resolve_remotely!
     Bundler::Installer.install(Bundler.root, definition, :system => true)
     Bundler::Installer.post_install_messages.each do |name, message|
       Bundler.ui.info "Post-install message from #{name}:\n#{message}"


### PR DESCRIPTION
In `installer.rb`, this branch dictates the definition of the `local` variable:

```ruby
      if Bundler.default_lockfile.exist? && !options["update"]
        local = Bundler.ui.silence do
          begin
            tmpdef = Definition.build(Bundler.default_gemfile, Bundler.default_lockfile, nil)
            true unless tmpdef.new_platform? || tmpdef.missing_specs.any?
          rescue BundlerError => e
          end
        end
      end
```

On normal runs, it appears that the `Definition.build` line results in this error:

```
The git source git://github.com/neo/rails_setup.git is not yet checked out. Please run `bundle install` before trying to start your application
```

Which makes `local` set to `nil`, and triggers remote resolution a few lines later:

```ruby
      unless local
        options["local"] ? @definition.resolve_with_cache! : @definition.resolve_remotely!
      end
```

Remote resolution is required for checkout of GitHub repos, since the `requires_checkout?` method in `source/git.rb` relies on `allow_git_ops?`, which in turn relies on `@allow_remote`, which is only set to `true` when `resolve_remotely!` is called.

There's probably a healthier way to fix this bug, but I am not sure what it is!