### PR TITLE
Add instructions for getting prerelease notifications

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -82,7 +82,7 @@ If you don't hear back immediately, don’t get discouraged! We all have day job
 
 Early releases require heavy testing, especially across various system setups. We :heart: testers, and are big fans of anyone who can run `gem install bundler --pre` and try out upcoming releases in their development and staging environments.
 
-There may not always be prereleases or beta versions of Bundler. That said, you are always welcome to try checking out master and building a gem yourself if you want to try out the latest changes.
+There may not always be prereleases or beta versions of Bundler. The Bundler team will tweet from the [@bundlerio account](http://twitter.com/bundlerio) when a prerelease or beta version becomes available. You are also always welcome to try checking out master and building a gem yourself if you want to try out the latest changes.
 
 
 # Translations


### PR DESCRIPTION
Quick documentation change to let people know where they can get notifications when there is a prerelease or beta release to test.

I'm happy to update wording - I just took a first stab.