### PR TITLE
[CLI] Print help as the default no-args command

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -34,7 +34,7 @@ module Bundler
     check_unknown_options!(:except => [:config, :exec])
     stop_on_unknown_option! :exec
 
-    default_task :install
+    default_command :help
     class_option "no-color", :type => :boolean, :desc => "Disable colorization in output"
     class_option "retry",    :type => :numeric, :aliases => "-r", :banner => "NUM",
       :desc => "Specify the number of times you wish to attempt network commands"

--- a/spec/bundler/cli_spec.rb
+++ b/spec/bundler/cli_spec.rb
@@ -24,4 +24,11 @@ describe "bundle executable" do
     expect(exitstatus).to be_zero if exitstatus
     expect(out).to eq('Hello, world')
   end
+
+  it "prints help when ARGV is empty" do
+    bundle :help
+    help_output = out
+    bundle ''
+    expect(out).to eq(help_output)
+  end
 end


### PR DESCRIPTION
Addresses https://trello.com/c/OpuOdTZl/112-print-help-when-bundle-is-run-without-arguments.