### PR TITLE
Considerate .gemrc when determine http_proxy.

### DIFF
--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -172,6 +172,14 @@ module Bundler
       @fetchers ||= FETCHERS.map { |f| f.new(downloader, remote_uri, fetch_uri, uri) }
     end
 
+    def http_proxy
+      if uri = connection.proxy_uri
+        uri.to_s
+      else
+        nil
+      end
+    end
+
     def inspect
       "#<#{self.class}:0x#{object_id} uri=#{uri}>"
     end

--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -203,7 +203,7 @@ module Bundler
         raise SSLError if needs_ssl && !defined?(OpenSSL::SSL)
 
         con = Net::HTTP::Persistent.new "bundler", :ENV
-        if gem_proxy = Gem.configuration[:http_proxy]
+        if gem_proxy = Bundler.rubygems.configuration[:http_proxy]
           con.proxy = URI.parse(gem_proxy)
         end
 

--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -203,6 +203,9 @@ module Bundler
         raise SSLError if needs_ssl && !defined?(OpenSSL::SSL)
 
         con = Net::HTTP::Persistent.new "bundler", :ENV
+        if gem_proxy = Gem.configuration[:http_proxy]
+          con.proxy = URI.parse(gem_proxy)
+        end
 
         if remote_uri.scheme == "https"
           con.verify_mode = (Bundler.settings[:ssl_verify_mode] ||

--- a/spec/bundler/fetcher_spec.rb
+++ b/spec/bundler/fetcher_spec.rb
@@ -8,6 +8,32 @@ describe Bundler::Fetcher do
     allow(Bundler).to receive(:root){ Pathname.new("root") }
   end
 
+  describe "#connection" do
+    context "when Gem.configuration doesn't specify http_proxy" do
+      it "specify no http_proxy" do
+        expect(fetcher.http_proxy).to be_nil
+      end
+      it "consider environment vars when determine proxy" do
+        with_env_vars({"HTTP_PROXY" => "http://proxy-example.com"}) do
+          expect(fetcher.http_proxy).to match("http://proxy-example.com")
+        end
+      end
+    end
+    context "when Gem.configuration specifies http_proxy " do
+      before do
+        allow(Bundler.rubygems.configuration).to receive(:[]).and_return("http://proxy-example2.com")
+      end
+      it "consider Gem.configuration when determine proxy" do
+        expect(fetcher.http_proxy).to match("http://proxy-example2.com")
+      end
+      it "consider Gem.configuration when determine proxy" do
+        with_env_vars({"HTTP_PROXY" => "http://proxy-example.com"}) do
+          expect(fetcher.http_proxy).to match("http://proxy-example2.com")
+        end
+      end
+    end
+  end
+
   describe "#user_agent" do
     it "builds user_agent with current ruby version and Bundler settings" do
       allow(Bundler.settings).to receive(:all).and_return(["foo", "bar"])

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -361,7 +361,7 @@ module Spec
     def with_env_vars(env_hash, &block)
       current_values = {}
       env_hash.each do |k,v|
-        current_values[k] = v
+        current_values[k] = ENV[k]
         ENV[k] = v
       end
       block.call if block_given?


### PR DESCRIPTION
Bundler doesn't see http_proxy written in .gemrc. So I have to set environment var corresponding to each host. I think, usually, host specific setting of rubygem is customize and adjust using .gemrc.
This patch consider http_proxy written in .gemrc when determine proxy.