### PR TITLE
Undo changes in initial "stop autoremembering flags" commit

### DIFF
--- a/spec/bundler/settings_spec.rb
+++ b/spec/bundler/settings_spec.rb
@@ -15,24 +15,6 @@ describe Bundler::Settings do
     end
   end
 
-  describe "#[]=" do
-    if Bundler::VERSION.split(".")[0].to_i >= 2
-      context "when on Bundler 2.0" do
-        it "should not write to local config file" do
-          settings[:foo] = :bar
-          expect(settings.locations(:foo)[:local]).to be_nil
-        end
-      end
-    else
-      context "when not on Bundler 2.0" do
-        it "should not write to local config file" do
-          settings[:foo] = :bar
-          expect(settings.locations(:foo)[:local]).to eq(:bar)
-        end
-      end
-    end
-  end
-
   describe "#[]" do
     context "when not set" do
       context "when default value present" do


### PR DESCRIPTION
Undoes changes made in https://github.com/bundler/bundler/commit/3d76c8fefb4eed7a082719e693396b7cdb0d58b0. 2-0-dev isn't quite ready for them, yet.