### PR TITLE
downgrade invalid specs to a warning for now

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -367,11 +367,15 @@ module Bundler
         else
           spec = eval_gemspec(path, contents)
         end
-        Bundler.rubygems.validate(spec) if spec && validate
+        warn_on_invalid_specs(spec) if validate
         spec
       end
+    end
+
+    def warn_on_invalid_specs(spec)
+      spec && Bundler.rubygems.validate(spec)
     rescue Gem::InvalidSpecificationException => e
-      raise InvalidOption, "The gemspec at #{file} is not valid. " \
+      Bundler.ui.warn "The gemspec at #{file} is not valid. " \
         "The validation error was '#{e.message}'"
     end
 

--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -367,16 +367,13 @@ module Bundler
         else
           spec = eval_gemspec(path, contents)
         end
-        warn_on_invalid_specs(spec) if validate
+        Bundler.rubygems.validate(spec) if spec && validate
         spec
       end
-    end
-
-    def warn_on_invalid_specs(spec)
-      spec && Bundler.rubygems.validate(spec)
     rescue Gem::InvalidSpecificationException => e
       Bundler.ui.warn "The gemspec at #{file} is not valid. " \
         "The validation error was '#{e.message}'"
+      nil
     end
 
     def clear_gemspec_cache

--- a/spec/install/gemfile/path_spec.rb
+++ b/spec/install/gemfile/path_spec.rb
@@ -141,7 +141,7 @@ describe "bundle install with explicit source paths" do
     should_be_installed "premailer 1.0.0"
   end
 
-  it "errors on invalid specs", :rubygems => "1.7" do
+  it "warns on invalid specs", :rubygems => "1.7" do
     build_lib "foo"
 
     gemspec = lib_path("foo-1.0").join("foo.gemspec").to_s
@@ -158,7 +158,7 @@ describe "bundle install with explicit source paths" do
     G
 
     expect(out).to match(/missing value for attribute version/)
-    should_not_be_installed("foo 1.0")
+    expect(out).to_not include("ERROR REPORT")
   end
 
   it "supports gemspec syntax" do


### PR DESCRIPTION
since invalid specs were allowed by 1.0-1.9, this change allows them in all 1.x versions. we'll go back to throwing an exception on invalid gemspecs in Bundler 2.0.

/cc @segiddins @smlance 