### PR TITLE
Add man page for `bundle gem`

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -51,6 +51,7 @@ module Bundler
           bundle
           bundle-config
           bundle-exec
+          bundle-gem
           bundle-install
           bundle-package
           bundle-update

--- a/man/bundle-gem.ronn
+++ b/man/bundle-gem.ronn
@@ -1,0 +1,77 @@
+bundle-gem(1) -- Generate a project skeleton for creating a rubygem
+====================================================================
+
+## SYNOPSIS
+
+`bundle gem` <GEM_NAME> [OPTIONS]
+
+## DESCRIPTION
+
+Generates a directory named `GEM_NAME` with a `Rakefile`, `GEM_NAME.gemspec`,
+and other supporting files and directories that can be used to develop a
+rubygem with that name.
+
+Run `rake -T` in the resulting project for a list of Rake tasks that can used
+to test and publish the gem to rubygems.org.
+
+The generated project skeleton can be customized with OPTIONS, as explained
+below. Note that these options can also be specified via Bundler's global
+configuration file using the following names:
+
+* `gem.coc`
+* `gem.mit`
+* `gem.test`
+
+## OPTIONS
+
+* `-b` or `--bin`:
+  Specify that Bundler should create a binary (as `exe/GEM_NAME`) in the
+  generated rubygem project. This binary will also be added to the
+  `GEM_NAME.gemspec` manifest. This behavior is disabled by default.
+
+* `--no-bin`:
+  Do not create a binary (overrides `--bin` specified in the global config).
+
+* `--coc`:
+  Add a `CODE_OF_CONDUCT.md` file to the root of the generated project. If
+  this option is unspecified, an interactive prompt will be displayed and the
+  answer will be saved in Bundler's global config for future `bundle gem` use.
+
+* `--no-coc`:
+  Do not create a `CODE_OF_CONDUCT.md` (overrides `--coc` specified in the
+  global config).
+
+* `--ext`:
+  Add boilerplate for C extension code to the generated project. This behavior
+  is disabled by default.
+
+* `--no-ext`:
+  Do not add C extension code (overrides `--ext` specified in the global
+  config).
+
+* `--mit`:
+  Add an MIT license to a `LICENSE.txt` file in the root of the generated
+  project. Your name from the global git config is used for the copyright
+  statement. If this option is unspecified, an interactive prompt will be
+  displayed and the answer will be saved in Bundler's global config for future
+  `bundle gem` use.
+
+* `--no-mit`:
+  Do not create a `LICENSE.txt` (overrides `--mit` specified in the global
+  config).
+
+* `-t`, `--test=minitest`, `--test=rspec`:
+  Specify the test framework that Bundler should use when generating the
+  project. Acceptable values are `minitest` and `rspec`. The `GEM_NAME.gemspec`
+  will be configured and a skeleton test/spec directory will be created based
+  on this option. If this option is unspecified, an interactive prompt will be
+  displayed and the answer will be saved in Bundler's global config for future
+  `bundle gem` use.
+
+* `-e`, `--edit[=EDITOR]`:
+  Open the resulting GEM_NAME.gemspec in EDITOR, or the default editor if not
+  specified. The default is `$BUNDLER_EDITOR`, `$VISUAL`, or `$EDITOR`.
+
+## SEE ALSO
+
+* bundle-config(1)

--- a/man/bundle.ronn
+++ b/man/bundle.ronn
@@ -76,7 +76,7 @@ We divide `bundle` subcommands into primary commands and utilities.
 * `bundle init(1)`:
   Generate a simple `Gemfile`, placed in the current directory
 
-* `bundle gem(1)`:
+* [bundle gem(1)][bundle-gem]:
   Create a simple gem, suitable for development with bundler
 
 * [bundle platform(1)][bundle-platform]:

--- a/man/index.txt
+++ b/man/index.txt
@@ -5,3 +5,4 @@ bundle-package     bundle-package.1
 bundle-exec        bundle-exec.1
 bundle-config      bundle-config.1
 bundle-platform    bundle-platform.1
+bundle-gem         bundle-gem.1


### PR DESCRIPTION
This is my first time working with man pages, so please let me know if I missed something obvious here. I tested `bundle help gem` and the man page appeared as expected with the correct format. Is there anything else I can check?