### PR TITLE
Make sure that monkeypatch of Gem::Platform gets loaded on subshells

### DIFF
--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -56,6 +56,10 @@ module Spec
       File.expand_path("../../../lib", __FILE__)
     end
 
+    def spec
+      File.expand_path("../../../spec", __FILE__)
+    end
+
     def bundle(cmd, options = {})
       expect_err = options.delete(:expect_err)
       sudo       = "sudo" if options.delete(:sudo)
@@ -66,6 +70,7 @@ module Spec
       requires = options.delete(:requires) || []
       requires << File.expand_path("../fakeweb/" + options.delete(:fakeweb) + ".rb", __FILE__) if options.key?(:fakeweb)
       requires << File.expand_path("../artifice/" + options.delete(:artifice) + ".rb", __FILE__) if options.key?(:artifice)
+      requires << "support/hax"
       requires_str = requires.map {|r| "-r#{r}" }.join(" ")
 
       env = (options.delete(:env) || {}).map {|k, v| "#{k}='#{v}'" }.join(" ")
@@ -73,7 +78,7 @@ module Spec
         v == true ? " --#{k}" : " --#{k} #{v}" if v
       end.join
 
-      cmd = "#{env} #{sudo} #{Gem.ruby} -I#{lib} #{requires_str} #{bundle_bin} #{cmd}#{args}"
+      cmd = "#{env} #{sudo} #{Gem.ruby} -I#{lib}:#{spec} #{requires_str} #{bundle_bin} #{cmd}#{args}"
       sys_exec(cmd, expect_err) {|i| yield i if block_given? }
     end
 


### PR DESCRIPTION
When running `spec/cache/gems_spec.rb:213` on master, I got the following error due to the monkey patch of `Gem::Platform::local` in `spec/support/hax.rb` not getting loaded when the spec runs `bundle :install`.

```
➜ ~/dev/bundler (master)↑⚡ $ /Users/aunger/.rvm/rubies/ruby-2.2.0/bin/ruby -S rspec ./spec/cache/gems_spec.rb:213

Run options:
  include {:focused=>true, :locations=>{"./spec/cache/gems_spec.rb"=>[213]}}
  exclude {:rubygems_master=>true, :rubygems=>"=< 2.4.5", :ruby=>"=< 2.2.0", :realworld=>true, :sudo=>true}

bundle cache
  when previously cached

Updating files in vendor/cache
    doesn't remove gems that are for another platform (FAILED - 1)

Failures:

  1) bundle cache when previously cached doesn't remove gems that are for another platform
     Failure/Error: expect(cached_gem("platform_specific-1.0-java")).to exist
       expected #<Pathname:/Users/aunger/dev/bundler/tmp/bundled_app/vendor/cache/platform_specific-1.0-java.gem> to exist
     # ./spec/cache/gems_spec.rb:221:in `block (4 levels) in <top (required)>'
     # ./spec/support/helpers.rb:305:in `simulate_platform'
     # ./spec/cache/gems_spec.rb:214:in `block (3 levels) in <top (required)>'

Finished in 1.95 seconds (files took 0.20268 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/cache/gems_spec.rb:213 # bundle cache when previously cached doesn't remove gems that are for another platform
```
