### PR TITLE
Make test suite work with local git configs

### DIFF
--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -28,7 +28,7 @@ describe "bundle gem" do
   end
 
   after do
-    `rm "#{ENV['GIT_CONFIG']}"` if File.exist?(ENV["GIT_CONFIG"])
+    `rm "#{ENV["GIT_CONFIG"]}"` if File.exist?(ENV["GIT_CONFIG"])
     ENV["GIT_CONFIG"] = @git_config_location
   end
 

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -16,15 +16,20 @@ describe "bundle gem" do
   end
 
   before do
-    @git_name = `git config --global user.name`.chomp
-    `git config --global user.name "Bundler User"`
-    @git_email = `git config --global user.email`.chomp
-    `git config --global user.email user@example.com`
+    git_config_content = <<-EOF
+    [user]
+      name = "Bundler User"
+      email = user@example.com
+    EOF
+    @git_config_location = ENV["GIT_CONFIG"]
+    path = "#{File.expand_path("../../tmp", File.dirname(__FILE__))}/test_git_config.txt"
+    File.open(path, "w") {|f| f.write(git_config_content) }
+    ENV["GIT_CONFIG"] = path
   end
 
   after do
-    `git config --global user.name "#{@git_name}"`
-    `git config --global user.email "#{@git_email}"`
+    `rm "#{ENV['GIT_CONFIG']}"` if File.exist?(ENV["GIT_CONFIG"])
+    ENV["GIT_CONFIG"] = @git_config_location
   end
 
   shared_examples_for "git config is present" do
@@ -156,8 +161,8 @@ describe "bundle gem" do
 
     context "git config user.{name,email} is not set" do
       before do
-        `git config --global --unset user.name`
-        `git config --global --unset user.email`
+        `git config --unset user.name`
+        `git config --unset user.email`
         reset!
         in_app_root
         bundle "gem #{gem_name}"
@@ -406,8 +411,8 @@ describe "bundle gem" do
 
     context "git config user.{name,email} is not set" do
       before do
-        `git config --global --unset user.name`
-        `git config --global --unset user.email`
+        `git config --unset user.name`
+        `git config --unset user.email`
         reset!
         in_app_root
         bundle "gem #{gem_name}"


### PR DESCRIPTION
On my work laptop, I was seeing failures in `spec/commands/newgem_spec.rb` due to the presence of  local `.git/config` files.

On my work computer, my global config is my work (private gitlab) credentials. Each github repo has a local config with my “cdwort” credentials. For example, I have one placed in `/Path/To/Bundler/.git/config`. 

Unfortunately, when a new gem is created within the test file noted above, it is created within the /Path/To/Bundler/ directory. This means it picks up my local config. All the tests for when there is no git config information fail because instead of getting nothing (which those tests expect because the test overrides my global amy.unger@corporatecompany.com setting), it gets my GitHub email.

I am using the `--remove-section` flag because if you only `--unset user.email` and `--unset user.name`, you get the following junk in your .git/config file. Yes, at the very bottom is the appropriate config.

<img width="481" alt="screen shot 2015-07-24 at 11 51 41 pm" src="https://cloud.githubusercontent.com/assets/1014482/8887995/6fe3be74-3260-11e5-999b-286d82c41844.png">

This has one drawback - it rearranges your file. I prefer my `[user]` section at the top of the file (good for troubleshooting when I've done stupid things). This places it at the bottom of the file, because the section is removed and then recreated each time for each test.

I'll take that trade-off for running my tests on my work laptop, but I can see that this is unexpected behavior and might prohibit this PR from going forward. Thoughts?