### PR TITLE
fix bug that causes "run `rake false`" to appear in README.md

### DIFF
--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -162,8 +162,14 @@ module Bundler
       exit 1
     end
 
-    def ask_and_set_test_framework
+    def sanitized_test_framework
       test_framework = options[:test] || Bundler.settings["gem.test"]
+      
+      test_framework == "false" ? false : test_framework
+    end
+
+    def ask_and_set_test_framework
+      test_framework = sanitized_test_framework
 
       if test_framework.nil?
         Bundler.ui.confirm "Do you want to generate tests with your gem?"

--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -162,14 +162,8 @@ module Bundler
       exit 1
     end
 
-    def sanitized_test_framework
-      test_framework = options[:test] || Bundler.settings["gem.test"]
-      
-      test_framework == "false" ? false : test_framework
-    end
-
     def ask_and_set_test_framework
-      test_framework = sanitized_test_framework
+      test_framework = options[:test] || Bundler.settings["gem.test"]
 
       if test_framework.nil?
         Bundler.ui.confirm "Do you want to generate tests with your gem?"

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -17,9 +17,11 @@ module Bundler
       value = (@local_config[key] || ENV[key] || @global_config[key] || DEFAULT_CONFIG[name])
 
       case
-      when !value.nil? && is_bool(name)
+      when value.nil?
+        nil
+      when is_bool(name) || value == "false" 
         to_bool(value)
-      when !value.nil? && is_num(name)
+      when is_num(name)
         value.to_i
       else
         value

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -19,7 +19,7 @@ module Bundler
       case
       when value.nil?
         nil
-      when is_bool(name) || value == "false" 
+      when is_bool(name) || value == "false"
         to_bool(value)
       when is_num(name)
         value.to_i

--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
 <%- if config[:ext] -%>
   spec.add_development_dependency "rake-compiler"
 <%- end -%>
-<%- if config[:test] && config[:test] != "false" -%>
+<%- if config[:test] -%>
   spec.add_development_dependency "<%=config[:test]%>"
 <%- end -%>
 end


### PR DESCRIPTION
If `BUNDLE_GEM__TEST: false` or `BUNDLE_GEM__TEST: "false"` are in `~/.bundle/config`, the README.md that is generated when creating a new gem includes instructions under the Development heading that say "Then, run \`rake false\` to run the tests."

The logic on line 29 of  README.md.tt (`if config[:test]`) fails because `config[:test]` returns the string "false" instead of the boolean.

As a patch, I changed the logic of `Bundler::Settings#[]` to convert the string "false" to a boolean.

It seems that the root of the issue is that `Bundler::Settings::BOOL_KEYS` does not include "gem.test", and it can't because it is only sometimes a boolean (when it is not 'rspec' or 'minitest'). A future fix for this could be to have two separate options, a boolean for whether or not the gem has tests and another for the type of test framework.