### PR TITLE
Depend on major version of test gems

### DIFF
--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -2,6 +2,11 @@ require "pathname"
 
 module Bundler
   class CLI::Gem
+    TEST_FRAMEWORK_VERSIONS = {
+      'rspec' => '3.0',
+      'minitest' => '5.0'
+    }
+
     attr_reader :options, :gem_name, :thor, :name, :target
 
     def initialize(options, gem_name, thor)
@@ -63,6 +68,8 @@ module Bundler
 
       if test_framework = ask_and_set_test_framework
         config[:test] = test_framework
+        config[:test_framework_version] = TEST_FRAMEWORK_VERSIONS[test_framework]
+
         templates.merge!(".travis.yml.tt" => ".travis.yml")
 
         case test_framework

--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -3,8 +3,8 @@ require "pathname"
 module Bundler
   class CLI::Gem
     TEST_FRAMEWORK_VERSIONS = {
-      'rspec' => '3.0',
-      'minitest' => '5.0'
+      "rspec" => "3.0",
+      "minitest" => "5.0"
     }
 
     attr_reader :options, :gem_name, :thor, :name, :target

--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -38,6 +38,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake-compiler"
 <%- end -%>
 <%- if config[:test] -%>
-  spec.add_development_dependency "<%=config[:test]%>"
+  spec.add_development_dependency "<%=config[:test]%>", "~> <%=config[:test_framework_version]%>"
 <%- end -%>
 end

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -54,14 +54,6 @@ describe "bundle gem" do
     end
   end
 
-  shared_examples_for "following best practices for gem dependencies" do
-    it "only adds development dependencies with specific version requirements" do
-      unspecific_dev_dependencies = generated_gem.gemspec.development_dependencies.reject(&:specific?)
-
-      expect(unspecific_dev_dependencies).to eq([])
-    end
-  end
-
   it "generates a valid gemspec" do
     system_gems ["rake-10.0.2"]
 
@@ -246,12 +238,16 @@ describe "bundle gem" do
         bundle "gem #{gem_name} --test=rspec"
       end
 
-      it_should_behave_like("following best practices for gem dependencies")
-
       it "builds spec skeleton" do
         expect(bundled_app("test_gem/.rspec")).to exist
         expect(bundled_app("test_gem/spec/test_gem_spec.rb")).to exist
         expect(bundled_app("test_gem/spec/spec_helper.rb")).to exist
+      end
+
+      it "depends on a specific version of rspec", :rubygems => ">= 1.8.1" do
+        remove_push_guard(gem_name)
+        rspec_dep = generated_gem.gemspec.development_dependencies.find{|d| d.name == "rspec" }
+        expect(rspec_dep).to be_specific
       end
 
       it "requires 'test-gem'" do
@@ -299,7 +295,11 @@ describe "bundle gem" do
         bundle "gem #{gem_name} --test=minitest"
       end
 
-      it_should_behave_like("following best practices for gem dependencies")
+      it "depends on a specific version of minitest", :rubygems => ">= 1.8.1" do
+        remove_push_guard(gem_name)
+        rspec_dep = generated_gem.gemspec.development_dependencies.find{|d| d.name == "minitest" }
+        expect(rspec_dep).to be_specific
+      end
 
       it "builds spec skeleton" do
         expect(bundled_app("test_gem/test/test_gem_test.rb")).to exist

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -54,6 +54,14 @@ describe "bundle gem" do
     end
   end
 
+  shared_examples_for "following best practices for gem dependencies" do
+    it "only adds development dependencies with specific version requirements" do
+      unspecific_dev_dependencies = generated_gem.gemspec.development_dependencies.reject(&:specific?)
+
+      expect(unspecific_dev_dependencies).to eq([])
+    end
+  end
+
   it "generates a valid gemspec" do
     system_gems ["rake-10.0.2"]
 
@@ -238,6 +246,8 @@ describe "bundle gem" do
         bundle "gem #{gem_name} --test=rspec"
       end
 
+      it_should_behave_like("following best practices for gem dependencies")
+
       it "builds spec skeleton" do
         expect(bundled_app("test_gem/.rspec")).to exist
         expect(bundled_app("test_gem/spec/test_gem_spec.rb")).to exist
@@ -288,6 +298,8 @@ describe "bundle gem" do
         in_app_root
         bundle "gem #{gem_name} --test=minitest"
       end
+
+      it_should_behave_like("following best practices for gem dependencies")
 
       it "builds spec skeleton" do
         expect(bundled_app("test_gem/test/test_gem_test.rb")).to exist

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -246,7 +246,7 @@ describe "bundle gem" do
 
       it "depends on a specific version of rspec", :rubygems => ">= 1.8.1" do
         remove_push_guard(gem_name)
-        rspec_dep = generated_gem.gemspec.development_dependencies.find{|d| d.name == "rspec" }
+        rspec_dep = generated_gem.gemspec.development_dependencies.find {|d| d.name == "rspec" }
         expect(rspec_dep).to be_specific
       end
 
@@ -297,7 +297,7 @@ describe "bundle gem" do
 
       it "depends on a specific version of minitest", :rubygems => ">= 1.8.1" do
         remove_push_guard(gem_name)
-        rspec_dep = generated_gem.gemspec.development_dependencies.find{|d| d.name == "minitest" }
+        rspec_dep = generated_gem.gemspec.development_dependencies.find {|d| d.name == "minitest" }
         expect(rspec_dep).to be_specific
       end
 


### PR DESCRIPTION
Use a pessimistic version requirement for RSpec and Minitest in
gemspecs generated by the bundle gem command. It is best practice to
at least depend on major versions of development dependency gems.

refs #3811