### PR TITLE
path caching: make sure intersecting paths are copied

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -239,6 +239,7 @@ module Bundler
     method_option "all",  :type => :boolean, :banner => "Include all sources (including path and git)."
     method_option "all-platforms", :type => :boolean, :banner => "Include gems for all platforms, not just the current one"
     method_option "no-prune",  :type => :boolean, :banner => "Don't remove stale gems from the cache."
+    method_option "no-copy-paths", :type => :boolean, :banner => "Do not include paths when caching gems using --all"
     def cache
       require "bundler/cli/cache"
       Cache.new(options).run
@@ -255,6 +256,7 @@ module Bundler
     method_option "path", :type => :string, :banner =>
       "Specify a different path than the system default ($BUNDLE_PATH or $GEM_HOME). Bundler will remember this value for future installs on this machine"
     method_option "quiet", :type => :boolean, :banner => "Only output warnings and errors."
+    method_option "no-copy-paths", :type => :boolean, :banner => "Do not include paths when caching gems using --all"
     long_desc <<-D
       The package command will copy the .gem files for every gem in the bundle into the
       directory ./vendor/cache. If you then check that directory into your source

--- a/lib/bundler/cli/cache.rb
+++ b/lib/bundler/cli/cache.rb
@@ -9,6 +9,7 @@ module Bundler
       Bundler.definition.validate_ruby!
       Bundler.definition.resolve_with_cache!
       setup_cache_all
+      Bundler.settings[:no_copy_paths] = options["no-copy-paths"] if options.key?("no-copy-paths")
       Bundler.settings[:cache_all_platforms] = options["all-platforms"] if options.key?("all-platforms")
       Bundler.load.cache
       Bundler.settings[:no_prune] = true if options["no-prune"]

--- a/lib/bundler/cli/package.rb
+++ b/lib/bundler/cli/package.rb
@@ -11,6 +11,7 @@ module Bundler
       Bundler.settings[:path] = File.expand_path(options[:path]) if options[:path]
       Bundler.settings[:cache_all_platforms] = options["all-platforms"] if options.key?("all-platforms")
       Bundler.settings[:cache_path] = options["cache-path"] if options.key?("cache-path")
+      Bundler.settings[:no_copy_paths] = options["no-copy-paths"] if options.key?("no-copy-paths")
 
       setup_cache_all
       install

--- a/lib/bundler/source/path.rb
+++ b/lib/bundler/source/path.rb
@@ -76,7 +76,7 @@ module Bundler
 
       def cache(spec, custom_path = nil)
         app_cache_path = app_cache_path(custom_path)
-        return unless Bundler.settings[:cache_all]
+        return if !Bundler.settings[:cache_all] || Bundler.settings[:no_copy_paths]
         return if expand(@original_path).to_s.index(Bundler.root.to_s + '/') == 0
 
         unless @original_path.exist?

--- a/lib/bundler/source/path.rb
+++ b/lib/bundler/source/path.rb
@@ -77,7 +77,7 @@ module Bundler
       def cache(spec, custom_path = nil)
         app_cache_path = app_cache_path(custom_path)
         return unless Bundler.settings[:cache_all]
-        return if expand(@original_path).to_s.index(Bundler.root.to_s) == 0
+        return if expand(@original_path).to_s.index(Bundler.root.to_s + '/') == 0
 
         unless @original_path.exist?
           raise GemNotFound, "Can't cache gem #{version_message(spec)} because #{self} is missing!"

--- a/spec/cache/path_spec.rb
+++ b/spec/cache/path_spec.rb
@@ -29,6 +29,24 @@ require "spec_helper"
       should_be_installed "foo 1.0"
     end
 
+    it "copies when the path is outside the bundle and the paths intersect" do
+      libname = File.basename(Dir.pwd) + '_gem'
+      libpath = File.join(File.dirname(Dir.pwd), libname)
+
+      build_lib libname, :path => libpath
+
+      install_gemfile <<-G
+        gem "#{libname}", :path => '#{libpath}'
+      G
+
+      bundle "#{cmd} --all"
+      expect(bundled_app("vendor/cache/#{libname}")).to exist
+      expect(bundled_app("vendor/cache/#{libname}/.bundlecache")).to be_file
+
+      FileUtils.rm_rf libpath
+      should_be_installed "#{libname} 1.0"
+    end
+
     it "updates the path on each cache" do
       build_lib "foo"
 

--- a/spec/cache/path_spec.rb
+++ b/spec/cache/path_spec.rb
@@ -135,5 +135,16 @@ require "spec_helper"
       bundle "#{cmd} --no-all"
       expect(bundled_app("vendor/cache/baz-1.0")).not_to exist
     end
+
+    it "does not copy path when no-copy-paths option is set" do
+      build_lib "foo"
+
+      install_gemfile <<-G
+        gem "foo", :path => '#{lib_path("foo-1.0")}'
+      G
+
+      bundle "#{cmd} --no-copy-paths --all"
+      expect(bundled_app("vendor/cache/foo-1.0")).to_not exist
+    end
   end
 end


### PR DESCRIPTION
This is part bug-fix, part feature request.

971edd3 fixes a bug where a gem with a path that is similar to the bundled application path would not be copied on `package --all`. For example, a gem with path `/test_gem/` would not be copied into `/test/vendor/cache`.

570e60d is a feature request to preserve the buggy behavior with an option. In my case, it would be helpful because we can restart a docker container that has the gem path mapped in without having to rerun `package` and copy it into `vendor/cache`.