### PR TITLE
remove unneeded conditional for path

### DIFF
--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -135,15 +135,8 @@ module Bundler
     # Always returns an absolute path to the bundle directory
     # TODO: Document and refactor this method
     def path
-      key  = key_for(:path)
-      path = ENV[key] || @global_config[key]
       set_path = ""
       install_path = ""
-
-      if path && !@local_config.key?(key)
-        path = "#{path}/#{Bundler.ruby_scope}" if path != Bundler.rubygems.gem_dir
-        set_path = path
-      end
 
       if path = self[:path]
         path = "#{path}/#{Bundler.ruby_scope}" if path != Bundler.rubygems.gem_dir


### PR DESCRIPTION
the `self[:path]` call already returns the configured path with the correct priority, i.e. local, env, global, default.