### PR TITLE
make sure intersecting gem paths are cached

### DIFF
--- a/lib/bundler/source/path.rb
+++ b/lib/bundler/source/path.rb
@@ -77,7 +77,7 @@ module Bundler
       def cache(spec, custom_path = nil)
         app_cache_path = app_cache_path(custom_path)
         return unless Bundler.settings[:cache_all]
-        return if expand(@original_path).to_s.index(Bundler.root.to_s) == 0
+        return if expand(@original_path).to_s.index(Bundler.root.to_s + '/') == 0
 
         unless @original_path.exist?
           raise GemNotFound, "Can't cache gem #{version_message(spec)} because #{self} is missing!"

--- a/lib/bundler/source/path.rb
+++ b/lib/bundler/source/path.rb
@@ -77,7 +77,7 @@ module Bundler
       def cache(spec, custom_path = nil)
         app_cache_path = app_cache_path(custom_path)
         return unless Bundler.settings[:cache_all]
-        return if expand(@original_path).to_s.index(Bundler.root.to_s + '/') == 0
+        return if expand(@original_path).to_s.index(Bundler.root.to_s + "/") == 0
 
         unless @original_path.exist?
           raise GemNotFound, "Can't cache gem #{version_message(spec)} because #{self} is missing!"

--- a/spec/cache/path_spec.rb
+++ b/spec/cache/path_spec.rb
@@ -29,6 +29,24 @@ require "spec_helper"
       should_be_installed "foo 1.0"
     end
 
+    it "copies when the path is outside the bundle and the paths intersect" do
+      libname = File.basename(Dir.pwd) + '_gem'
+      libpath = File.join(File.dirname(Dir.pwd), libname)
+
+      build_lib libname, :path => libpath
+
+      install_gemfile <<-G
+        gem "#{libname}", :path => '#{libpath}'
+      G
+
+      bundle "#{cmd} --all"
+      expect(bundled_app("vendor/cache/#{libname}")).to exist
+      expect(bundled_app("vendor/cache/#{libname}/.bundlecache")).to be_file
+
+      FileUtils.rm_rf libpath
+      should_be_installed "#{libname} 1.0"
+    end
+
     it "updates the path on each cache" do
       build_lib "foo"
 

--- a/spec/cache/path_spec.rb
+++ b/spec/cache/path_spec.rb
@@ -30,7 +30,7 @@ require "spec_helper"
     end
 
     it "copies when the path is outside the bundle and the paths intersect" do
-      libname = File.basename(Dir.pwd) + '_gem'
+      libname = File.basename(Dir.pwd) + "_gem"
       libpath = File.join(File.dirname(Dir.pwd), libname)
 
       build_lib libname, :path => libpath


### PR DESCRIPTION
When a gem has the same path prefix as the application that is being bundled,
the gem will not be added to vendor/cache.

For example: a gem with a path /home/test/src/bundled_gem and an application with a path
/home/test/src/bundled that references it.