### PR TITLE
Add command plugin support to help command

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -66,6 +66,8 @@ module Bundler
         else
           puts File.read("#{root}/#{command}.txt")
         end
+      elsif command_path = Bundler.which("bundler-#{cli}")
+        Kernel.exec(command_path, "--help")
       else
         super
       end

--- a/spec/commands/help_spec.rb
+++ b/spec/commands/help_spec.rb
@@ -36,4 +36,17 @@ describe "bundle help" do
     bundle "help check"
     expect(out).to include("Check searches the local machine")
   end
+
+  it "looks for a binary and executes it with --help option if it's named bundler-<task>" do
+    File.open(tmp("bundler-testtasks"), "w", 0755) do |f|
+      f.puts "#!/usr/bin/env ruby\nputs ARGV.join(' ')\n"
+    end
+
+    with_path_as(tmp) do
+      bundle "help testtasks"
+    end
+
+    expect(exitstatus).to be_zero if exitstatus
+    expect(out).to eq("--help")
+  end
 end


### PR DESCRIPTION
Bundler already delegates to executables of the form `bundler-<command>` when called as `bundle <command>` with an unknown command. Allow viewing help entries for such command plugins by
turning calls of the form `bundle help <command>` into `bundler-<command> --help`.