### PR TITLE
Fix for warning on jruby 9k

### DIFF
--- a/lib/bundler/cli/exec.rb
+++ b/lib/bundler/cli/exec.rb
@@ -9,7 +9,7 @@ module Bundler
       @cmd = args.shift
       @args = args
 
-      if Bundler.current_ruby.ruby_2?
+      if Bundler.current_ruby.ruby_2? && (!Bundler.current_ruby.jruby?)
         @args << { :close_others => !options.keep_file_descriptors? }
       elsif options.keep_file_descriptors?
         Bundler.ui.warn "Ruby version #{RUBY_VERSION} defaults to keeping non-standard file descriptors on Kernel#exec."

--- a/lib/bundler/cli/exec.rb
+++ b/lib/bundler/cli/exec.rb
@@ -9,7 +9,7 @@ module Bundler
       @cmd = args.shift
       @args = args
 
-      if Bundler.current_ruby.ruby_2? && (!Bundler.current_ruby.jruby?)
+      if Bundler.current_ruby.ruby_2? && !Bundler.current_ruby.jruby?
         @args << { :close_others => !options.keep_file_descriptors? }
       elsif options.keep_file_descriptors?
         Bundler.ui.warn "Ruby version #{RUBY_VERSION} defaults to keeping non-standard file descriptors on Kernel#exec."


### PR DESCRIPTION
Jruby 9k is ruby 2.2.2, but doesn't support processes. 

So running `bundle exec` leads to a warning `warning: unsupported exec option: close_others`.

This should fix that warning.