### PR TITLE
Tweaks git checkout UI output

### DIFF
--- a/lib/bundler/source/git/git_proxy.rb
+++ b/lib/bundler/source/git/git_proxy.rb
@@ -66,7 +66,7 @@ module Bundler
         def checkout
           if path.exist?
             return if has_revision_cached?
-            Bundler.ui.confirm "Updating #{uri}"
+            Bundler.ui.info "Fetching #{uri}"
             in_path do
               git_retry %|fetch --force --quiet --tags #{uri_escaped_with_configured_credentials} "refs/heads/*:refs/heads/*"|
             end

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -74,7 +74,7 @@ describe "bundle outdated" do
       FileUtils.rm_rf(gem_repo2)
 
       bundle "outdated --local"
-      expect(out).not_to match(/Fetching/)
+      expect(out).not_to match(/Fetching (gem|version|dependency) metadata from/)
     end
   end
 


### PR DESCRIPTION
Tweaking the "Updating ..." output of the checkout method to reduce
confusion when running `outdated`. Opting instead for "Fetching" as it
does when doing a clone operation.