### PR TITLE
Fix Lint/UnusedMethodArgument

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -25,11 +25,6 @@ Lint/NonLocalExitFromIterator:
 Lint/RescueException:
   Enabled: false
 
-# Offense count: 38
-# Cop supports --auto-correct.
-Lint/UnusedMethodArgument:
-  Enabled: false
-
 # Offense count: 7
 Lint/UselessAssignment:
   Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ require "benchmark"
 RUBYGEMS_REPO = File.expand_path("tmp/rubygems")
 BUNDLER_SPEC = Gem::Specification.load("bundler.gemspec")
 
-def safe_task(&block)
+def safe_task(&_block)
   yield
   true
 rescue

--- a/exe/bundle_ruby
+++ b/exe/bundle_ruby
@@ -30,13 +30,13 @@ module Bundler
         " and Bundler cannot continue."
     end
 
-    def source(source, options = {})
+    def source(_source, _options = {})
     end
 
-    def gem(name, *args)
+    def gem(_name, *_args)
     end
 
-    def group(*args, &blk)
+    def group(*_args, &_block)
     end
   end
 end

--- a/lib/bundler/dependency.rb
+++ b/lib/bundler/dependency.rb
@@ -54,7 +54,7 @@ module Bundler
       :x64_mingw_23 => Gem::Platform::X64_MINGW
     }.freeze
 
-    def initialize(name, version, options = {}, &blk)
+    def initialize(name, version, options = {}, &_block)
       type = options["type"] || :runtime
       super(name, version, type)
 

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -166,7 +166,7 @@ module Bundler
       Definition.new(lockfile, @dependencies, @sources, unlock, @ruby_version, @optional_groups)
     end
 
-    def group(*args, &blk)
+    def group(*args, &_block)
       opts = Hash === args.last ? args.pop.dup : {}
       normalize_group_options(opts, args)
 
@@ -204,7 +204,7 @@ module Bundler
       @env = old
     end
 
-    def method_missing(name, *args)
+    def method_missing(name, *_args)
       raise GemfileError, "Undefined local variable or method `#{name}' for Gemfile"
     end
 

--- a/lib/bundler/environment.rb
+++ b/lib/bundler/environment.rb
@@ -34,7 +34,7 @@ module Bundler
       @definition.lock(Bundler.default_lockfile, opts[:preserve_bundled_with])
     end
 
-    def update(*gems)
+    def update(*_gems)
       # Nothing
     end
   end

--- a/lib/bundler/gem_installer.rb
+++ b/lib/bundler/gem_installer.rb
@@ -2,7 +2,7 @@ require "rubygems/installer"
 
 module Bundler
   class GemInstaller < Gem::Installer
-    def check_executable_overwrite(filename)
+    def check_executable_overwrite(_filename)
       # Bundler needs to install gems regardless of binstub overwriting
     end
   end

--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -274,7 +274,7 @@ module Bundler
       Bundler.default_lockfile.basename.to_s rescue "Gemfile.lock"
     end
 
-    def requirement_satisfied_by?(requirement, activated, spec)
+    def requirement_satisfied_by?(requirement, _activated, spec)
       requirement.matches_spec?(spec)
     end
 

--- a/lib/bundler/rubygems_ext.rb
+++ b/lib/bundler/rubygems_ext.rb
@@ -77,7 +77,7 @@ module Gem
       " #{source.revision[0..6]}"
     end
 
-    def to_gemfile(path = nil)
+    def to_gemfile(_path = nil)
       gemfile = "source 'https://rubygems.org'\n"
       gemfile << dependencies_to_gemfile(nondevelopment_dependencies)
       unless development_dependencies.empty?

--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -168,7 +168,7 @@ module Bundler
       EXT_LOCK
     end
 
-    def fetch_specs(all, pre, &blk)
+    def fetch_specs(all, pre, &_block)
       specs = Gem::SpecFetcher.new.list(all, pre)
       specs.each { yield } if block_given?
       specs
@@ -223,12 +223,12 @@ module Bundler
       end
     end
 
-    def build(spec, skip_validation = false)
+    def build(spec, _skip_validation = false)
       require "rubygems/builder"
       Gem::Builder.new(spec).build
     end
 
-    def build_gem(gem_dir, spec)
+    def build_gem(_gem_dir, spec)
       build(spec)
     end
 
@@ -463,7 +463,7 @@ module Bundler
         Gem.source_index.find_name(name)
       end
 
-      def validate(spec)
+      def validate(_spec)
         # These versions of RubyGems always validate in "packaging" mode,
         # which is too strict for the kinds of checks we care about. As a
         # result, validation is disabled on versions of RubyGems below 1.7.

--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -168,7 +168,7 @@ module Bundler
         requires_checkout? ? spec.post_install_message : nil
       end
 
-      def cache(spec, custom_path = nil)
+      def cache(_spec, custom_path = nil)
         app_cache_path = app_cache_path(custom_path)
         return unless Bundler.settings[:cache_all]
         return if path == app_cache_path

--- a/lib/bundler/source/path.rb
+++ b/lib/bundler/source/path.rb
@@ -68,7 +68,7 @@ module Bundler
         File.basename(expanded_path.to_s)
       end
 
-      def install(spec, force = false)
+      def install(spec, _force = false)
         Bundler.ui.info "Using #{version_message(spec)} from #{self}"
         generate_bin(spec, :disable_extensions)
         nil # no post-install message

--- a/lib/bundler/spec_set.rb
+++ b/lib/bundler/spec_set.rb
@@ -62,7 +62,7 @@ module Bundler
       lookup[key].reverse
     end
 
-    def []=(key, value)
+    def []=(_key, value)
       @specs << value
       @lookup = nil
       @sorted = nil

--- a/lib/bundler/ui/silent.rb
+++ b/lib/bundler/ui/silent.rb
@@ -1,19 +1,19 @@
 module Bundler
   module UI
     class Silent
-      def info(message, newline = nil)
+      def info(_message, _newline = nil)
       end
 
-      def confirm(message, newline = nil)
+      def confirm(_message, _newline = nil)
       end
 
-      def warn(message, newline = nil)
+      def warn(_message, _newline = nil)
       end
 
-      def error(message, newline = nil)
+      def error(_message, _newline = nil)
       end
 
-      def debug(message, newline = nil)
+      def debug(_message, _newline = nil)
       end
 
       def debug?
@@ -24,16 +24,16 @@ module Bundler
         false
       end
 
-      def ask(message)
+      def ask(_message)
       end
 
-      def level=(name)
+      def level=(_name)
       end
 
-      def level(name = nil)
+      def level(_name = nil)
       end
 
-      def trace(message, newline = nil)
+      def trace(_message, _newline = nil)
       end
 
       def silence

--- a/spec/support/builders.rb
+++ b/spec/support/builders.rb
@@ -333,10 +333,6 @@ module Spec
       end
     end
 
-    def build_dep(name, requirements = Gem::Requirement.default, type = :runtime)
-      Bundler::Dependency.new(name, :version => requirements)
-    end
-
     def build_lib(name, *args, &blk)
       build_with(LibBuilder, name, args, &blk)
     end
@@ -359,7 +355,7 @@ module Spec
 
   private
 
-    def build_with(builder, name, args, &blk)
+    def build_with(builder, name, args, &_block)
       @_build_path ||= nil
       options  = args.last.is_a?(Hash) ? args.pop : {}
       versions = args.last || "1.0"


### PR DESCRIPTION
* ~~Remove non-referenced explicit block arguments in favor of depending on the   implicit block provided to every method.~~
* Remove unused method `Spec::Builders#build_dep`.