### PR TITLE
Specify the actual exception to test for

### DIFF
--- a/spec/commands/lock_spec.rb
+++ b/spec/commands/lock_spec.rb
@@ -92,6 +92,6 @@ describe "bundle lock" do
 
     expect(out).to match(/Writing lockfile to.+lock/)
     expect(read_lockfile "lock").to eq(@lockfile)
-    expect { read_lockfile }.to raise_error
+    expect { read_lockfile }.to raise_error(Errno::ENOENT)
   end
 end


### PR DESCRIPTION
Gets rid of the following RSpec warning:

    Using the `raise_error` matcher without providing a specific error or
    message risks false positives, since `raise_error` will match when Ruby
    raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially
    allowing the expectation to pass without even executing the method you
    are intending to call. Instead consider providing a specific error class
    or message.