### PR TITLE
Be stricter when accepting rubygems source URIs

### DIFF
--- a/lib/bundler/source/rubygems.rb
+++ b/lib/bundler/source/rubygems.rb
@@ -262,7 +262,8 @@ module Bundler
         uri = uri.to_s
         uri = "#{uri}/" unless uri =~ %r'/$'
         uri = URI(uri)
-        raise ArgumentError, "The source must be an absolute URI" unless uri.absolute?
+        raise ArgumentError, "The source must be an absolute URI. For example:\n" \
+          "source 'https://rubygems.org'" if !uri.absolute? || (uri.is_a?(URI::HTTP) && uri.host.nil?)
         uri
       end
 

--- a/spec/bundler/source/rubygems_spec.rb
+++ b/spec/bundler/source/rubygems_spec.rb
@@ -22,4 +22,12 @@ describe Bundler::Source::Rubygems do
       end
     end
   end
+
+  describe "#add_remote" do
+    context "when the source is an HTTP(s) URI with no host" do
+      it "raises error" do
+        expect { subject.add_remote("https:rubygems.org") }.to raise_error(ArgumentError)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Since `URI#parse` accepts URIs such as *http:rubygems.org* as per RFC 2396,
we reject such sources manually early in the process, in order to provide more
helpful error messages.

Fixes #3925.