### PR TITLE
Remove `bundle install --cache`

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -134,6 +134,7 @@ module Bundler
       "Specify the number of jobs to run in parallel"
     method_option "local", :type => :boolean, :banner =>
       "Do not attempt to fetch gems remotely and use the gem cache instead"
+    # TODO: Remove the "cache" method_option?
     method_option "cache", :type => :boolean, :banner =>
       "Update the existing gem cache."
     method_option "force", :type => :boolean, :banner =>

--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -16,6 +16,12 @@ module Bundler
         end
       end
 
+      if options[:cache]
+        Bundler.ui.error "Please use `bundle cache` instead of `bundle "\
+         "install --cache`."
+        exit 1
+      end
+
       if options[:without] && options[:with]
         conflicting_groups = options[:without] & options[:with]
         unless conflicting_groups.empty?
@@ -103,7 +109,7 @@ module Bundler
       definition.validate_ruby!
 
       Installer.install(Bundler.root, definition, options)
-      Bundler.load.cache if Bundler.app_cache.exist? && options["cache"] && !Bundler.settings[:frozen]
+      Bundler.load.cache if Bundler.app_cache.exist? && Bundler.settings[:cache] && !Bundler.settings[:frozen]
 
       Bundler.ui.confirm "Using #{Installer.using_gems.size} already installed gems" if Installer.using_gems.size > 0
       Bundler.ui.confirm "Bundle complete! #{dependencies_count_for(definition)}, #{gems_installed_for(definition)}."

--- a/spec/cache/gems_spec.rb
+++ b/spec/cache/gems_spec.rb
@@ -176,7 +176,8 @@ describe "bundle cache" do
 
     it "re-caches during install" do
       cached_gem("rack-1.0.0").rmtree
-      bundle :install, :cache => true
+      bundle :install
+      bundle :cache
       expect(out).to include("Updating files in vendor/cache")
       expect(cached_gem("rack-1.0.0")).to exist
     end
@@ -189,19 +190,22 @@ describe "bundle cache" do
     end
 
     it "adds new gems and dependencies" do
-      install_gemfile <<-G, :cache => true
+      install_gemfile <<-G
         source "file://#{gem_repo2}"
         gem "rails"
       G
+      bundle :cache
       expect(cached_gem("rails-2.3.2")).to exist
       expect(cached_gem("activerecord-2.3.2")).to exist
     end
 
     it "removes .gems for removed gems and dependencies" do
-      install_gemfile <<-G, :cache => true
+      install_gemfile <<-G
         source "file://#{gem_repo2}"
         gem "rack"
       G
+      bundle :cache
+
       expect(cached_gem("rack-1.0.0")).to exist
       expect(cached_gem("actionpack-2.3.2")).not_to exist
       expect(cached_gem("activesupport-2.3.2")).not_to exist
@@ -210,11 +214,13 @@ describe "bundle cache" do
     it "removes .gems when gem changes to git source" do
       build_git "rack"
 
-      install_gemfile <<-G, :cache => true
+      install_gemfile <<-G
         source "file://#{gem_repo2}"
         gem "rack", :git => "#{lib_path("rack-1.0")}"
         gem "actionpack"
       G
+      bundle :cache
+
       expect(cached_gem("rack-1.0.0")).not_to exist
       expect(cached_gem("actionpack-2.3.2")).to exist
       expect(cached_gem("activesupport-2.3.2")).to exist
@@ -222,20 +228,22 @@ describe "bundle cache" do
 
     it "doesn't remove gems that are for another platform" do
       simulate_platform "java" do
-        install_gemfile <<-G, :cache => true
+        install_gemfile <<-G
           source "file://#{gem_repo1}"
           gem "platform_specific"
         G
+        bundle :cache
 
         bundle :cache
         expect(cached_gem("platform_specific-1.0-java")).to exist
       end
 
       simulate_new_machine
-      install_gemfile <<-G, :cache => true
+      install_gemfile <<-G
         source "file://#{gem_repo1}"
         gem "platform_specific"
       G
+      bundle :cache
 
       expect(cached_gem("platform_specific-1.0-#{Gem::Platform.local}")).to exist
       expect(cached_gem("platform_specific-1.0-java")).to exist

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -383,7 +383,7 @@ describe "bundle install with gem sources" do
 
       bundle "install --cache"
 
-      expect (err).to include("Please use `bundle cache` instead")
+      expect(err).to include("Please use `bundle cache` instead")
     end
   end
 end

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -374,4 +374,16 @@ describe "bundle install with gem sources" do
       expect(err).to_not include("Your Gemfile has no gem server sources")
     end
   end
+
+  describe "when using the --cache flag" do
+    it "prints an error and exits" do
+      gemfile <<-G
+        gem 'rack'
+      G
+
+      bundle "install --cache"
+
+      expect (err).to include("Please use `bundle cache` instead")
+    end
+  end
 end

--- a/spec/commands/package_spec.rb
+++ b/spec/commands/package_spec.rb
@@ -125,7 +125,7 @@ describe "bundle install with gem sources" do
       end
     end
 
-    it "does not update the cache if --cache is not passed" do
+    it "does not update the cache if `bundle cache` is not run" do
       gemfile <<-G
         source "file://#{gem_repo1}"
         gem "rack"
@@ -137,7 +137,7 @@ describe "bundle install with gem sources" do
       expect(bundled_app("vendor/cache").children).to be_empty
     end
 
-    it "updates the cache if --cache is passed" do
+    it "updates the cache if `bundle cache` is run" do
       gemfile <<-G
         source "file://#{gem_repo1}"
         gem "rack"
@@ -145,7 +145,8 @@ describe "bundle install with gem sources" do
       bundled_app("vendor/cache").mkpath
       expect(bundled_app("vendor/cache").children).to be_empty
 
-      bundle "install --cache"
+      bundle "install"
+      bundle "cache"
       expect(bundled_app("vendor/cache").children).not_to be_empty
     end
   end


### PR DESCRIPTION
Removes the --cache option and replaces it with an error that asks the user to run `bundle cache`.