### PR TITLE
[2.0] Don't persist install options

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -137,8 +137,6 @@ module Bundler
       "Force downloading every gem."
     method_option "no-prune", :type => :boolean, :banner =>
       "Don't remove stale gems from the cache."
-    method_option "path", :type => :string, :banner =>
-      "Specify a different path than the system default ($BUNDLE_PATH or $GEM_HOME)."
     method_option "quiet", :type => :boolean, :banner =>
       "Only output warnings and errors."
     method_option "shebang", :type => :string, :banner =>

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -143,8 +143,6 @@ module Bundler
       "Specify a different shebang executable name than the default (usually 'ruby')"
     method_option "standalone", :type => :array, :lazy_default => [], :banner =>
       "Make a bundle that can work without the Bundler runtime"
-    method_option "system", :type => :boolean, :banner =>
-      "Install to the system location ($BUNDLE_PATH or $GEM_HOME) even if the bundle was previously installed somewhere else for this application"
     method_option "trust-policy", :alias => "P", :type => :string, :banner =>
       "Gem trust policy (like gem install -P). Must be one of " +
         Bundler.rubygems.security_policy_keys.join("|")

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -99,7 +99,7 @@ module Bundler
     method_option "gemfile", :type => :string, :banner =>
       "Use the specified gemfile instead of Gemfile"
     method_option "path", :type => :string, :banner =>
-      "Specify a different path than the system default ($BUNDLE_PATH or $GEM_HOME). Bundler will remember this value for future installs on this machine"
+      "Specify a different path than the system default ($BUNDLE_PATH or $GEM_HOME)."
     map "c" => "check"
     def check
       require "bundler/cli/check"
@@ -138,7 +138,7 @@ module Bundler
     method_option "no-prune", :type => :boolean, :banner =>
       "Don't remove stale gems from the cache."
     method_option "path", :type => :string, :banner =>
-      "Specify a different path than the system default ($BUNDLE_PATH or $GEM_HOME). Bundler will remember this value for future installs on this machine"
+      "Specify a different path than the system default ($BUNDLE_PATH or $GEM_HOME)."
     method_option "quiet", :type => :boolean, :banner =>
       "Only output warnings and errors."
     method_option "shebang", :type => :string, :banner =>
@@ -250,7 +250,7 @@ module Bundler
     method_option "no-install",  :type => :boolean, :banner => "Don't actually install the gems, just package."
     method_option "no-prune",  :type => :boolean, :banner => "Don't remove stale gems from the cache."
     method_option "path", :type => :string, :banner =>
-      "Specify a different path than the system default ($BUNDLE_PATH or $GEM_HOME). Bundler will remember this value for future installs on this machine"
+      "Specify a different path than the system default ($BUNDLE_PATH or $GEM_HOME)."
     method_option "quiet", :type => :boolean, :banner => "Only output warnings and errors."
     long_desc <<-D
       The package command will copy the .gem files for every gem in the bundle into the

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -146,10 +146,6 @@ module Bundler
     method_option "trust-policy", :alias => "P", :type => :string, :banner =>
       "Gem trust policy (like gem install -P). Must be one of " +
         Bundler.rubygems.security_policy_keys.join("|")
-    method_option "without", :type => :array, :banner =>
-      "Exclude gems that are part of the specified named group."
-    method_option "with", :type => :array, :banner =>
-      "Include gems that are part of the specified named group."
     map "i" => "install"
     def install
       require "bundler/cli/install"

--- a/lib/bundler/cli/config.rb
+++ b/lib/bundler/cli/config.rb
@@ -57,6 +57,8 @@ module Bundler
           Bundler.ui.warn "`path.system` is already configured, so it will be unset."
           Bundler.settings.set_local("path.system", nil)
           Bundler.settings.set_global("path.system", nil)
+        elsif (name == "with" || name == "without")
+          new_value.gsub!(/\s+/, ":")
         end
 
         if scope == "global"

--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -10,35 +10,6 @@ module Bundler
 
       warn_if_root
 
-      [:with, :without].each do |option|
-        if options[option]
-          options[option] = options[option].join(":").tr(" ", ":").split(":")
-        end
-      end
-
-      if options[:without] && options[:with]
-        conflicting_groups = options[:without] & options[:with]
-        unless conflicting_groups.empty?
-          Bundler.ui.error "You can't list a group in both, --with and --without." \
-          "The offending groups are: #{conflicting_groups.join(", ")}."
-          exit 1
-        end
-      end
-
-      Bundler.settings.with    = [] if options[:with] && options[:with].empty?
-      Bundler.settings.without = [] if options[:without] && options[:without].empty?
-
-      with = options.fetch("with", [])
-      with |= Bundler.settings.with.map(&:to_s)
-      with -= options[:without] if options[:without]
-
-      without = options.fetch("without", [])
-      without |= Bundler.settings.without.map(&:to_s)
-      without -= options[:with] if options[:with]
-
-      options[:with]    = with
-      options[:without] = without
-
       ENV["RB_USER_INSTALL"] = "1" if Bundler::FREEBSD
 
       # Just disable color in deployment mode
@@ -91,8 +62,6 @@ module Bundler
       Bundler.settings[:no_prune] = true if options["no-prune"]
       Bundler.settings[:no_install] = true if options["no-install"]
       Bundler.settings[:clean]    = options["clean"] if options["clean"]
-      Bundler.settings.without    = options[:without]
-      Bundler.settings.with       = options[:with]
       Bundler::Fetcher.disable_endpoint = options["full-index"]
       Bundler.settings[:disable_shared_gems] = path ? "1" : nil
 

--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -95,7 +95,6 @@ module Bundler
       Bundler.settings.without    = options[:without]
       Bundler.settings.with       = options[:with]
       Bundler::Fetcher.disable_endpoint = options["full-index"]
-      Bundler.settings[:disable_shared_gems] = Bundler.settings[:path] ? "1" : nil
       Bundler.settings[:disable_shared_gems] = path ? "1" : nil
 
       # rubygems plugins sometimes hook into the gem install process

--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -54,7 +54,6 @@ module Bundler
       end
 
       path = Bundler.settings[:path]
-      path = Bundler.rubygems.gem_dir if options[:system]
       path = "#{Bundler.settings.path}/vendor/bundle" if options[:deployment]
 
       Bundler.settings[:shebang]  = options["shebang"] if options["shebang"]

--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -85,7 +85,6 @@ module Bundler
       path = Bundler.settings[:path]
       path = Bundler.rubygems.gem_dir if options[:system]
       path = "#{Bundler.settings.path}/vendor/bundle" if options[:deployment]
-      path ||= "bundle" if options["standalone"]
 
       Bundler.settings[:shebang]  = options["shebang"] if options["shebang"]
       Bundler.settings[:jobs]     = options["jobs"] if options["jobs"]

--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -82,10 +82,11 @@ module Bundler
         options[:system] = true
       end
 
-      path     = Bundler.settings[:path]
-      path     = Bundler.rubygems.gem_dir if options[:system]
-      path     = "#{Bundler.settings.path}/vendor/bundle" if options[:deployment]
-      path     ||= "bundle" if options["standalone"]
+      path = Bundler.settings[:path]
+      path = Bundler.rubygems.gem_dir if options[:system]
+      path = "#{Bundler.settings.path}/vendor/bundle" if options[:deployment]
+      path ||= "bundle" if options["standalone"]
+
       Bundler.settings[:shebang]  = options["shebang"] if options["shebang"]
       Bundler.settings[:jobs]     = options["jobs"] if options["jobs"]
       Bundler.settings[:no_prune] = true if options["no-prune"]

--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -214,7 +214,7 @@ module Bundler
     end
 
     def generate_standalone(groups)
-      standalone_path = Bundler.settings[:path]
+      standalone_path = Bundler.settings[:path] || "bundle"
       bundler_path = File.join(standalone_path, "bundler")
       FileUtils.mkdir_p(bundler_path)
 

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -148,6 +148,60 @@ You can set them globally either via environment variables or `bundle config`,
 whichever is preferable for your setup. If you use both, environment variables
 will take preference over global settings.
 
+## INSTALLING GROUPS
+
+By default, Bundler will install all gems in all groups
+in your Gemfile(5), except those declared for a different platform.
+
+However, you can explicitly tell Bundler to skip installing
+certain groups with the `without` option. This option takes
+a space-separated list of groups.
+
+While the `without` option will skip _installing_ the gems in the
+specified groups, it will still _download_ those gems and use them to
+resolve the dependencies of every gem in your Gemfile(5).
+
+This is so that installing a different set of groups on another
+ machine (such as a production server) will not change the
+gems and versions that you have already developed and tested against.
+
+`Bundler offers a rock-solid guarantee that the third-party
+code you are running in development and testing is also the
+third-party code you are running in production. You can choose
+to exclude some of that code in different environments, but you
+will never be caught flat-footed by different versions of
+third-party code being used in different environments.`
+
+For a simple illustration, consider the following Gemfile(5):
+
+    source 'https://rubygems.org'
+
+    gem 'sinatra'
+
+    group :production do
+      gem 'rack-perftools-profiler'
+    end
+
+In this case, `sinatra` depends on any version of Rack (`>= 1.0`), while
+`rack-perftools-profiler` depends on 1.x (`~> 1.0`).
+
+When you configure your bundle with `bundle config without production` and then
+run `bundle install` in development, we look at the dependencies of
+`rack-perftools-profiler` as well. That way, you do not spend all your time
+developing against Rack 2.0, using new APIs unavailable in Rack 1.x, only to
+have Bundler switch to Rack 1.2 when the `production` group _is_ used.
+
+This should not cause any problems in practice, because we do not
+attempt to `install` the gems in the excluded groups, and only evaluate
+as part of the dependency resolution process.
+
+This also means that you cannot include different versions of the same
+gem in different groups, because doing so would result in different
+sets of dependencies used in development and production. Because of
+the vagaries of the dependency resolution process, this usually
+affects more than just the gems you list in your Gemfile(5), and can
+(surprisingly) radically change the gems you are using.
+
 ## LOCAL GIT REPOS
 
 Bundler also allows you to work against a git repository locally

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -114,6 +114,11 @@ learn more about their operation in [bundle install(1)][bundle-install].
 * `frozen` (`BUNDLE_FROZEN`):
   Disallow changes to the `Gemfile`. Defaults to `true` when `--deployment`
   is used.
+* `with` (`BUNDLE_WITH`):
+  A `:`-separated list of groups whose gems bundler should install. If an
+  optional group is given it is installed. If a group is given that is
+  in the remembered list of groups given to `without`, it is removed
+  from that list.
 * `without` (`BUNDLE_WITHOUT`):
   A `:`-separated list of groups whose gems bundler should not install
 * `bin` (`BUNDLE_BIN`):

--- a/man/bundle-install.ronn
+++ b/man/bundle-install.ronn
@@ -81,7 +81,6 @@ time `bundle install` is run, use `bundle config` (see bundle-config(1)).
 
 * `--system`:
   Installs the gems specified in the bundle to the system's Rubygems location.
-  This overrides any previous configuration of `--path`.
 
 * `--cache`:
   Update the cache in `vendor/cache` with the newly bundled gems during the

--- a/man/bundle-install.ronn
+++ b/man/bundle-install.ronn
@@ -12,7 +12,6 @@ bundle-install(1) -- Install the dependencies specified in your Gemfile
                  [--force]
                  [--cache]
                  [--no-prune]
-                 [--path PATH]
                  [--system]
                  [--quiet]
                  [--retry=NUMBER]
@@ -89,13 +88,6 @@ time `bundle install` is run, use `bundle config` (see bundle-config(1)).
 * `--no-prune`:
   Don't remove stale gems from the cache when the installation finishes.
 
-* `--path=<path>`:
-  The location to install the specified gems to. This defaults to Rubygems'
-  setting. Bundler shares this location with Rubygems, `gem install ...` will
-  have gem installed there, too. Therefore, gems installed without a
-  `--path ...` setting will show up by calling `gem list`. Accodingly, gems
-  installed to other locations will not get listed.
-
 * `--quiet`:
   Do not print progress information to the standard output. Instead, Bundler
   will exit using a status code (`$?`).
@@ -168,8 +160,7 @@ will cause an error when the Gemfile(5) is modified.
    read them.
 
    As a result, `bundle install --deployment` installs gems to
-   the `vendor/bundle` directory in the application. This may be
-   overridden using the `--path` option.
+   the `vendor/bundle` directory in the application.
 
 ## SUDO USAGE
 

--- a/man/bundle-install.ronn
+++ b/man/bundle-install.ronn
@@ -191,60 +191,6 @@ As a result, you should run `bundle install` as the current user,
 and Bundler will ask for your password if it is needed to put the
 gems into their final location.
 
-## INSTALLING GROUPS
-
-By default, `bundle install` will install all gems in all groups
-in your Gemfile(5), except those declared for a different platform.
-
-However, you can explicitly tell Bundler to skip installing
-certain groups with the `--without` option. This option takes
-a space-separated list of groups.
-
-While the `--without` option will skip _installing_ the gems in the
-specified groups, it will still _download_ those gems and use them to
-resolve the dependencies of every gem in your Gemfile(5).
-
-This is so that installing a different set of groups on another
- machine (such as a production server) will not change the
-gems and versions that you have already developed and tested against.
-
-`Bundler offers a rock-solid guarantee that the third-party
-code you are running in development and testing is also the
-third-party code you are running in production. You can choose
-to exclude some of that code in different environments, but you
-will never be caught flat-footed by different versions of
-third-party code being used in different environments.`
-
-For a simple illustration, consider the following Gemfile(5):
-
-    source 'https://rubygems.org'
-
-    gem 'sinatra'
-
-    group :production do
-      gem 'rack-perftools-profiler'
-    end
-
-In this case, `sinatra` depends on any version of Rack (`>= 1.0`), while
-`rack-perftools-profiler` depends on 1.x (`~> 1.0`).
-
-When you run `bundle install --without production` in development, we
-look at the dependencies of `rack-perftools-profiler` as well. That way,
-you do not spend all your time developing against Rack 2.0, using new
-APIs unavailable in Rack 1.x, only to have Bundler switch to Rack 1.2
-when the `production` group _is_ used.
-
-This should not cause any problems in practice, because we do not
-attempt to `install` the gems in the excluded groups, and only evaluate
-as part of the dependency resolution process.
-
-This also means that you cannot include different versions of the same
-gem in different groups, because doing so would result in different
-sets of dependencies used in development and production. Because of
-the vagaries of the dependency resolution process, this usually
-affects more than just the gems you list in your Gemfile(5), and can
-(surprisingly) radically change the gems you are using.
-
 ## THE GEMFILE.LOCK
 
 When you run `bundle install`, Bundler will persist the full names

--- a/man/bundle-install.ronn
+++ b/man/bundle-install.ronn
@@ -114,15 +114,6 @@ time `bundle install` is run, use `bundle config` (see bundle-config(1)).
   `NoSecurity`. For more details, please see the Rubygems signing documentation
   linked below in [SEE ALSO][].
 
-* `--without=<list>`:
-  A space-separated list of groups referencing gems to skip during installation.
-
-* `--with=<list>`:
-  A space-separated list of groups referencing gems to install. If an
-  optional group is given it is installed. If a group is given that is
-  in the remembered list of groups given to --without, it is removed
-  from that list.
-
 ## DEPLOYMENT MODE
 
 Bundler's defaults are optimized for development. To switch to

--- a/spec/cache/git_spec.rb
+++ b/spec/cache/git_spec.rb
@@ -39,7 +39,8 @@ end
         gem "foo", :git => '#{lib_path("foo-1.0")}'
       G
 
-      bundle "install --path vendor/bundle"
+      config "BUNDLE_PATH" => "vendor/bundle"
+      bundle :install
       bundle "#{cmd} --all"
 
       expect(bundled_app("vendor/cache/foo-1.0-#{ref}")).to exist

--- a/spec/cache/git_spec.rb
+++ b/spec/cache/git_spec.rb
@@ -31,7 +31,7 @@ end
       should_be_installed "foo 1.0"
     end
 
-    it "copies repository to vendor cache and uses it even when installed with bundle --path" do
+    it "copies repository to vendor cache and uses it even when path configured" do
       git = build_git "foo"
       ref = git.ref_for("master", 11)
 

--- a/spec/commands/check_spec.rb
+++ b/spec/commands/check_spec.rb
@@ -112,7 +112,8 @@ describe "bundle check" do
       gem "rack", :group => :foo
     G
 
-    bundle "install --without foo"
+    config "BUNDLE_WITHOUT" => "foo"
+    bundle :install
 
     gemfile <<-G
       source "file://#{gem_repo1}"

--- a/spec/commands/check_spec.rb
+++ b/spec/commands/check_spec.rb
@@ -234,7 +234,8 @@ describe "bundle check" do
         source "file://#{gem_repo1}"
         gem "rails"
       G
-      bundle "install --path vendor/bundle"
+      config "BUNDLE_PATH" => "vendor/bundle"
+      bundle :install
 
       FileUtils.rm_rf(bundled_app(".bundle"))
     end

--- a/spec/commands/clean_spec.rb
+++ b/spec/commands/clean_spec.rb
@@ -119,7 +119,6 @@ describe "bundle clean" do
     ENV["BUNDLE_WITHOUT"] = "test_group"
     bundle :install
     bundle :clean
-    ENV["BUNDLE_WITHOUT"] = ""
 
     expect(out).to include("Removing rack (1.0.0)")
 
@@ -263,7 +262,6 @@ describe "bundle clean" do
     ENV["BUNDLE_WITHOUT"] = "test"
     bundle :install
     bundle :clean
-    ENV["BUNDLE_WITHOUT"] = ""
 
 
     expect(out).to include("")
@@ -287,7 +285,6 @@ describe "bundle clean" do
     ENV["BUNDLE_WITHOUT"] = "development"
     bundle :install
     bundle :clean
-    ENV["BUNDLE_WITHOUT"] = ""
 
     expect(exitstatus).to eq(0) if exitstatus
   end

--- a/spec/commands/clean_spec.rb
+++ b/spec/commands/clean_spec.rb
@@ -116,8 +116,10 @@ describe "bundle clean" do
 
     config "BUNDLE_PATH" => "vendor/bundle"
     bundle :install
-    bundle "install --without test_group"
+    ENV["BUNDLE_WITHOUT"] = "test_group"
+    bundle :install
     bundle :clean
+    ENV["BUNDLE_WITHOUT"] = ""
 
     expect(out).to include("Removing rack (1.0.0)")
 
@@ -258,8 +260,10 @@ describe "bundle clean" do
     G
 
     config "BUNDLE_PATH" => "vendor/bundle"
-    bundle "install --without test"
+    ENV["BUNDLE_WITHOUT"] = "test"
+    bundle :install
     bundle :clean
+    ENV["BUNDLE_WITHOUT"] = ""
 
 
     expect(out).to include("")
@@ -280,8 +284,10 @@ describe "bundle clean" do
     G
 
     config "BUNDLE_PATH" => "vendor/bundle"
-    bundle "install --without development"
+    ENV["BUNDLE_WITHOUT"] = "development"
+    bundle :install
     bundle :clean
+    ENV["BUNDLE_WITHOUT"] = ""
 
     expect(exitstatus).to eq(0) if exitstatus
   end

--- a/spec/commands/clean_spec.rb
+++ b/spec/commands/clean_spec.rb
@@ -114,11 +114,10 @@ describe "bundle clean" do
       end
     G
 
-    with_bundle_path_as('vendor/bundle') do
-      bundle :install
-      bundle "install --without test_group"
-      bundle :clean
-    end
+    config "BUNDLE_PATH" => "vendor/bundle"
+    bundle :install
+    bundle "install --without test_group"
+    bundle :clean
 
     expect(out).to include("Removing rack (1.0.0)")
 
@@ -142,9 +141,8 @@ describe "bundle clean" do
       end
     G
 
-    with_bundle_path_as('vendor/bundle') do
-      bundle :install
-    end
+    config "BUNDLE_PATH" => "vendor/bundle"
+    bundle :install
 
     bundle :clean
 
@@ -234,10 +232,9 @@ describe "bundle clean" do
       gem "activesupport", :git => "#{lib_path("rails")}", :ref => '#{revision}'
     G
 
-    with_bundle_path_as("vendor/bundle") do
-      bundle :install
-      bundle :clean
-    end
+    config "BUNDLE_PATH" => "vendor/bundle"
+    bundle :install
+    bundle :clean
 
     expect(out).to include("")
 
@@ -260,10 +257,9 @@ describe "bundle clean" do
       end
     G
 
-    with_bundle_path_as('vendor/bundle') do
-      bundle "install --without test"
-      bundle :clean
-    end
+    config "BUNDLE_PATH" => "vendor/bundle"
+    bundle "install --without test"
+    bundle :clean
 
 
     expect(out).to include("")
@@ -283,10 +279,9 @@ describe "bundle clean" do
       end
     G
 
-    with_bundle_path_as('vendor/bundle') do
-      bundle "install --without development"
-      bundle :clean
-    end
+    config "BUNDLE_PATH" => "vendor/bundle"
+    bundle "install --without development"
+    bundle :clean
 
     expect(exitstatus).to eq(0) if exitstatus
   end
@@ -313,22 +308,21 @@ describe "bundle clean" do
       gem "foo"
     G
 
-    with_bundle_path_as('vendor/bundle') do
-      bundle :install
+    config "BUNDLE_PATH" => "vendor/bundle"
+    bundle :install
 
-      gemfile <<-G
-        source "file://#{gem_repo1}"
+    gemfile <<-G
+      source "file://#{gem_repo1}"
 
-        gem "foo"
-      G
-      bundle :install
+      gem "foo"
+    G
+    bundle :install
 
-      FileUtils.rm(vendored_gems("bin/rackup"))
-      FileUtils.rm_rf(vendored_gems("gems/thin-1.0"))
-      FileUtils.rm_rf(vendored_gems("gems/rack-1.0.0"))
+    FileUtils.rm(vendored_gems("bin/rackup"))
+    FileUtils.rm_rf(vendored_gems("gems/thin-1.0"))
+    FileUtils.rm_rf(vendored_gems("gems/rack-1.0.0"))
 
-      bundle :clean
-    end
+    bundle :clean
 
 
     should_not_have_gems "thin-1.0", "rack-1.0"
@@ -556,10 +550,9 @@ describe "bundle clean" do
       gem "bar", "1.0", :path => "#{relative_path}"
     G
 
-    with_bundle_path_as('vendor/bundle') do
-      bundle :install
-      bundle :clean
-    end
+    config "BUNDLE_PATH" => "vendor/bundle"
+    bundle :install
+    bundle :clean
 
     expect(exitstatus).to eq(0) if exitstatus
   end

--- a/spec/commands/config_spec.rb
+++ b/spec/commands/config_spec.rb
@@ -11,7 +11,8 @@ describe ".bundle/config" do
   describe "BUNDLE_APP_CONFIG" do
     it "can be moved with an environment variable" do
       ENV["BUNDLE_APP_CONFIG"] = tmp("foo/bar").to_s
-      bundle "install --path vendor/bundle"
+      bundle "config --local path vendor/bundle"
+      bundle :install
 
       expect(bundled_app(".bundle")).not_to exist
       expect(tmp("foo/bar/config")).to exist
@@ -22,8 +23,9 @@ describe ".bundle/config" do
       FileUtils.mkdir_p bundled_app("omg")
       Dir.chdir bundled_app("omg")
 
-      ENV["BUNDLE_APP_CONFIG"] = "../foo"
-      bundle "install --path vendor/bundle"
+      ENV['BUNDLE_APP_CONFIG'] = "../foo"
+      bundle "config --local path vendor/bundle"
+      bundle :install
 
       expect(bundled_app(".bundle")).not_to exist
       expect(bundled_app("../foo/config")).to exist
@@ -56,7 +58,7 @@ describe ".bundle/config" do
     end
 
     it "has lower precedence than local" do
-      bundle "config --local  foo local"
+      bundle "config --local foo local"
 
       bundle "config --global foo global"
       expect(out).to match(/Your application has set foo to "local"/)

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -255,20 +255,6 @@ describe "bundle install with gem sources" do
         bundle :install
         should_be_installed "rack 1.0"
       end
-
-      it "allows running bundle install --system without deleting foo" do
-        bundle "install --path vendor"
-        bundle "install --system"
-        FileUtils.rm_rf(bundled_app("vendor"))
-        should_be_installed "rack 1.0"
-      end
-
-      it "allows running bundle install --system after deleting foo" do
-        bundle "install --path vendor"
-        FileUtils.rm_rf(bundled_app("vendor"))
-        bundle "install --system"
-        should_be_installed "rack 1.0"
-      end
     end
 
     it "finds gems in multiple sources" do

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -251,7 +251,8 @@ describe "bundle install with gem sources" do
       end
 
       it "works" do
-        bundle "install --path vendor"
+        config "BUNDLE_PATH" => "vendor"
+        bundle :install
         should_be_installed "rack 1.0"
       end
 

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -85,9 +85,8 @@ describe "bundle install with git sources" do
     end
 
     it "still works after moving the application directory" do
-      with_bundle_path_as('vendor/bundle') do
-        bundle :install
-      end
+      config "BUNDLE_PATH" => "vendor/bundle"
+      bundle :install
       FileUtils.mv bundled_app, tmp("bundled_app.bck")
 
       Dir.chdir tmp("bundled_app.bck")
@@ -95,9 +94,8 @@ describe "bundle install with git sources" do
     end
 
     it "can still install after moving the application directory" do
-      with_bundle_path_as("vendor/bundle") do
-        bundle :install
-      end
+      config "BUNDLE_PATH" => "vendor/bundle"
+      bundle :install
       FileUtils.mv bundled_app, tmp("bundled_app.bck")
 
       update_git "foo", "1.1", :path => lib_path("foo-1.0")

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -85,7 +85,9 @@ describe "bundle install with git sources" do
     end
 
     it "still works after moving the application directory" do
-      bundle "install --path vendor/bundle"
+      with_bundle_path_as('vendor/bundle') do
+        bundle :install
+      end
       FileUtils.mv bundled_app, tmp("bundled_app.bck")
 
       Dir.chdir tmp("bundled_app.bck")
@@ -93,7 +95,9 @@ describe "bundle install with git sources" do
     end
 
     it "can still install after moving the application directory" do
-      bundle "install --path vendor/bundle"
+      with_bundle_path_as("vendor/bundle") do
+        bundle :install
+      end
       FileUtils.mv bundled_app, tmp("bundled_app.bck")
 
       update_git "foo", "1.1", :path => lib_path("foo-1.0")

--- a/spec/install/gems/dependency_api_spec.rb
+++ b/spec/install/gems/dependency_api_spec.rb
@@ -410,9 +410,8 @@ describe "gemcutter's dependency API" do
       gem "rack"
     G
 
-    with_bundle_path_as('vendor/bundle') do
-      bundle :install, :artifice => "endpoint"
-    end
+    config "BUNDLE_PATH" => "vendor/bundle"
+    bundle :install, :artifice => "endpoint"
 
     expect(vendored_gems("bin/rackup")).to exist
   end
@@ -423,9 +422,8 @@ describe "gemcutter's dependency API" do
       gem "rack"
     G
 
-    with_bundle_path_as('vendor/bundle') do
-      bundle "install --no-clean", :artifice => "endpoint"
-    end
+    config "BUNDLE_PATH" => "vendor/bundle"
+    bundle "install --no-clean", :artifice => "endpoint"
 
     expect(vendored_gems("bin/rackup")).to exist
   end

--- a/spec/install/gems/dependency_api_spec.rb
+++ b/spec/install/gems/dependency_api_spec.rb
@@ -404,7 +404,7 @@ describe "gemcutter's dependency API" do
     should_be_installed "rails 2.3.2"
   end
 
-  it "installs the bins when using --path and uses autoclean" do
+  it "installs the bins when path configured and uses autoclean" do
     gemfile <<-G
       source "#{source_uri}"
       gem "rack"

--- a/spec/install/gems/dependency_api_spec.rb
+++ b/spec/install/gems/dependency_api_spec.rb
@@ -410,18 +410,22 @@ describe "gemcutter's dependency API" do
       gem "rack"
     G
 
-    bundle "install --path vendor/bundle", :artifice => "endpoint"
+    with_bundle_path_as('vendor/bundle') do
+      bundle :install, :artifice => "endpoint"
+    end
 
     expect(vendored_gems("bin/rackup")).to exist
   end
 
-  it "installs the bins when using --path and uses bundle clean" do
+  it "installs the bins when path configured and uses bundle clean" do
     gemfile <<-G
       source "#{source_uri}"
       gem "rack"
     G
 
-    bundle "install --path vendor/bundle --no-clean", :artifice => "endpoint"
+    with_bundle_path_as('vendor/bundle') do
+      bundle "install --no-clean", :artifice => "endpoint"
+    end
 
     expect(vendored_gems("bin/rackup")).to exist
   end

--- a/spec/install/gems/platform_spec.rb
+++ b/spec/install/gems/platform_spec.rb
@@ -94,12 +94,15 @@ describe "bundle install across platforms" do
       gem "rack", "1.0.0"
     G
 
-    bundle "install --path vendor/bundle"
+    with_bundle_path_as('vendor/bundle') do
+      bundle :install
 
-    new_version = Gem::ConfigMap[:ruby_version] == "1.8" ? "1.9.1" : "1.8"
-    FileUtils.mv(vendored_gems, bundled_app("vendor/bundle", Gem.ruby_engine, new_version))
+      new_version = Gem::ConfigMap[:ruby_version] == "1.8" ? "1.9.1" : "1.8"
+      FileUtils.mv(vendored_gems, bundled_app("vendor/bundle", Gem.ruby_engine, new_version))
 
-    bundle "install --path vendor/bundle"
+      bundle :install
+    end
+
     expect(vendored_gems("gems/rack-1.0.0")).to exist
   end
 end

--- a/spec/install/gems/platform_spec.rb
+++ b/spec/install/gems/platform_spec.rb
@@ -94,14 +94,13 @@ describe "bundle install across platforms" do
       gem "rack", "1.0.0"
     G
 
-    with_bundle_path_as('vendor/bundle') do
-      bundle :install
+    config "BUNDLE_PATH" => "vendor/bundle"
+    bundle :install
 
-      new_version = Gem::ConfigMap[:ruby_version] == "1.8" ? "1.9.1" : "1.8"
-      FileUtils.mv(vendored_gems, bundled_app("vendor/bundle", Gem.ruby_engine, new_version))
+    new_version = Gem::ConfigMap[:ruby_version] == "1.8" ? "1.9.1" : "1.8"
+    FileUtils.mv(vendored_gems, bundled_app("vendor/bundle", Gem.ruby_engine, new_version))
 
-      bundle :install
-    end
+    bundle :install
 
     expect(vendored_gems("gems/rack-1.0.0")).to exist
   end

--- a/spec/install/gems/sources_spec.rb
+++ b/spec/install/gems/sources_spec.rb
@@ -389,7 +389,9 @@ describe "bundle install with gems on multiple sources" do
           rack
       L
 
-      bundle "install --path ../gems/system"
+      with_bundle_path_as('../gems/system') do
+        bundle :install
+      end
 
       # 4. Then we add some new versions...
       update_repo4 do

--- a/spec/install/gems/sources_spec.rb
+++ b/spec/install/gems/sources_spec.rb
@@ -389,9 +389,8 @@ describe "bundle install with gems on multiple sources" do
           rack
       L
 
-      with_bundle_path_as('../gems/system') do
-        bundle :install
-      end
+      config "BUNDLE_PATH" => "../gems/system"
+      bundle :install
 
       # 4. Then we add some new versions...
       update_repo4 do

--- a/spec/install/gems/standalone_spec.rb
+++ b/spec/install/gems/standalone_spec.rb
@@ -158,7 +158,8 @@ describe "bundle install --standalone" do
     end
 
     it "allows remembered --without to limit the groups used in a standalone" do
-      bundle "install --without test"
+      config "BUNDLE_WITHOUT" => "test"
+      bundle "install"
       bundle "install --standalone"
 
       load_error_ruby <<-RUBY, "spec", :no_lib => true

--- a/spec/install/gems/standalone_spec.rb
+++ b/spec/install/gems/standalone_spec.rb
@@ -142,7 +142,7 @@ describe "bundle install --standalone" do
       expect(err).to eq("ZOMG LOAD ERROR")
     end
 
-    it "allows --path to change the location of the standalone bundle" do
+    it "allows the path option to change the location of the standalone bundle" do
       config "BUNDLE_PATH" => "path/to/bundle"
       bundle "install --standalone"
 

--- a/spec/install/gems/standalone_spec.rb
+++ b/spec/install/gems/standalone_spec.rb
@@ -143,9 +143,8 @@ describe "bundle install --standalone" do
     end
 
     it "allows --path to change the location of the standalone bundle" do
-      with_bundle_path_as('path/to/bundle') do
-        bundle "install --standalone"
-      end
+      config "BUNDLE_PATH" => "path/to/bundle"
+      bundle "install --standalone"
 
       ruby <<-RUBY, :no_lib => true, :expect_err => false
         $:.unshift File.expand_path("path/to/bundle")

--- a/spec/install/gems/standalone_spec.rb
+++ b/spec/install/gems/standalone_spec.rb
@@ -143,7 +143,9 @@ describe "bundle install --standalone" do
     end
 
     it "allows --path to change the location of the standalone bundle" do
-      bundle "install --standalone --path path/to/bundle"
+      with_bundle_path_as('path/to/bundle') do
+        bundle "install --standalone"
+      end
 
       ruby <<-RUBY, :no_lib => true, :expect_err => false
         $:.unshift File.expand_path("path/to/bundle")

--- a/spec/install/path_spec.rb
+++ b/spec/install/path_spec.rb
@@ -12,7 +12,7 @@ describe "bundle install" do
         gem "rack"
       G
 
-      bundle "config --local path vendor/bundle"
+      set_bundle_path('local', 'vendor/bundle')
     end
 
     it "does not use available system gems" do
@@ -50,18 +50,10 @@ describe "bundle install" do
       G
     end
 
-    def set_bundle_path(type, location)
-      if type == :env
-        ENV["BUNDLE_PATH"] = location
-      elsif type == :global
-        bundle "config path #{location}", "no-color" => nil
-      end
-    end
-
-    [:env, :global].each do |type|
+    %w/env global/.each do |type|
       it "gives precedence to the local path over #{type}" do
         set_bundle_path(type, bundled_app("vendor2").to_s)
-        bundle "config --local path vendor/bundle"
+        set_bundle_path('local', 'vendor/bundle')
         bundle :install
 
         expect(vendored_gems("gems/rack-1.0.0")).to be_directory
@@ -96,7 +88,7 @@ describe "bundle install" do
     end
 
     it "installs gems to BUNDLE_PATH from .bundle/config" do
-      bundle "config --local path vendor/bundle"
+      set_bundle_path('local', 'vendor/bundle')
 
       bundle :install
 
@@ -107,7 +99,7 @@ describe "bundle install" do
     it "disables system gems when passing a path to install" do
       # This is so that vendored gems can be distributed to others
       build_gem "rack", "1.1.0", :to_system => true
-      bundle "config --local path ./vendor/bundle"
+      set_bundle_path('local', 'vendor/bundle')
       bundle :install
 
       expect(vendored_gems("gems/rack-1.0.0")).to be_directory
@@ -128,9 +120,18 @@ describe "bundle install" do
         gem "rack"
       G
 
-      bundle "config --local path bundle"
+      set_bundle_path('local', 'bundle')
       bundle :install
       expect(out).to match(/invalid symlink/)
+    end
+  end
+
+  def set_bundle_path(type, location)
+    case type
+    when 'env'
+      ENV["BUNDLE_PATH"] = location
+    when 'global', 'local'
+      bundle "config --#{type} path #{location}", "no-color" => nil
     end
   end
 end

--- a/spec/install/post_bundle_message_spec.rb
+++ b/spec/install/post_bundle_message_spec.rb
@@ -52,30 +52,42 @@ describe "post bundle message" do
       expect(out).to include("4 Gemfile dependencies, 2 gems now installed.")
     end
 
-    describe "with --path and" do
+    describe "with configured path and" do
       it "without any options" do
-        bundle "install --path vendor"
+        with_bundle_path_as('vendor') do
+          bundle :install
+        end
+
         expect(out).to include(bundle_deployment_message)
         expect(out).to_not include("Gems in the group")
         expect(out).to include(bundle_complete_message)
       end
 
       it "with --without one group" do
-        bundle "install --without emo --path vendor"
+        with_bundle_path_as('vendor') do
+          bundle "install --without emo"
+        end
+
         expect(out).to include(bundle_deployment_message)
         expect(out).to include("Gems in the group emo were not installed")
         expect(out).to include(bundle_complete_message)
       end
 
       it "with --without two groups" do
-        bundle "install --without emo test --path vendor"
+        with_bundle_path_as('vendor') do
+          bundle "install --without emo test"
+        end
+
         expect(out).to include(bundle_deployment_message)
         expect(out).to include("Gems in the groups emo and test were not installed")
         expect(out).to include(bundle_complete_message)
       end
 
       it "with --without more groups" do
-        bundle "install --without emo obama test --path vendor"
+        with_bundle_path_as('vendor') do
+          bundle "install --without emo obama test"
+        end
+
         expect(out).to include(bundle_deployment_message)
         expect(out).to include("Gems in the groups emo, obama and test were not installed")
         expect(out).to include(bundle_complete_message)

--- a/spec/install/post_bundle_message_spec.rb
+++ b/spec/install/post_bundle_message_spec.rb
@@ -63,9 +63,8 @@ describe "post bundle message" do
       end
 
       it "with --without one group" do
-        with_bundle_path_as('vendor') do
-          bundle "install --without emo"
-        end
+        config "BUNDLE_PATH" => "vendor"
+        bundle "install --without emo"
 
         expect(out).to include(bundle_deployment_message)
         expect(out).to include("Gems in the group emo were not installed")
@@ -73,9 +72,8 @@ describe "post bundle message" do
       end
 
       it "with --without two groups" do
-        with_bundle_path_as('vendor') do
-          bundle "install --without emo test"
-        end
+        config "BUNDLE_PATH" => "vendor"
+        bundle "install --without emo test"
 
         expect(out).to include(bundle_deployment_message)
         expect(out).to include("Gems in the groups emo and test were not installed")
@@ -83,9 +81,8 @@ describe "post bundle message" do
       end
 
       it "with --without more groups" do
-        with_bundle_path_as('vendor') do
-          bundle "install --without emo obama test"
-        end
+        config "BUNDLE_PATH" => "vendor"
+        bundle "install --without emo obama test"
 
         expect(out).to include(bundle_deployment_message)
         expect(out).to include("Gems in the groups emo, obama and test were not installed")

--- a/spec/install/post_bundle_message_spec.rb
+++ b/spec/install/post_bundle_message_spec.rb
@@ -54,9 +54,8 @@ describe "post bundle message" do
 
     describe "with configured path and" do
       it "without any options" do
-        with_bundle_path_as('vendor') do
-          bundle :install
-        end
+        config "BUNDLE_PATH" => "vendor"
+        bundle :install
 
         expect(out).to include(bundle_deployment_message)
         expect(out).to_not include("Gems in the group")

--- a/spec/lock/lockfile_spec.rb
+++ b/spec/lock/lockfile_spec.rb
@@ -1139,7 +1139,8 @@ describe "the lockfile format" do
       gem "omg", :git => "#{lib_path("omg")}", :branch => 'master'
     G
 
-    bundle "install --path vendor"
+    config "BUNDLE_PATH" => 'vendor'
+    bundle :install
     should_be_installed "omg 1.0"
 
     # Create a Gemfile.lock that has duplicate GIT sections

--- a/spec/realworld/edgecases_spec.rb
+++ b/spec/realworld/edgecases_spec.rb
@@ -80,7 +80,8 @@ describe "real world edgecases", :realworld => true do
       gem 'rack', '1.0.1'
     G
 
-    bundle "install --path vendor/bundle", :expect_err => true
+    config "BUNDLE_PATH" => "vendor/bundle"
+    bundle :install, :expect_err => true
     expect(err).not_to include("Could not find rake")
     expect(err).to lack_errors
   end

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -377,13 +377,18 @@ describe "Bundler.setup" do
     end
 
     it "works even when the cache directory has been deleted" do
-      bundle "install --path vendor/bundle"
+      with_bundle_path_as("vendor/bundle") do
+        bundle :install
+      end
       FileUtils.rm_rf vendored_gems("cache")
+
       should_be_installed "rack 1.0.0"
     end
 
-    it "does not randomly change the path when specifying --path and the bundle directory becomes read only" do
-      bundle "install --path vendor/bundle"
+    it "does not randomly change the path when path is configured and the bundle directory becomes read only" do
+      with_bundle_path_as("vendor/bundle") do
+        bundle :install
+      end
 
       with_read_only("**/*") do
         should_be_installed "rack 1.0.0"

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -377,18 +377,17 @@ describe "Bundler.setup" do
     end
 
     it "works even when the cache directory has been deleted" do
-      with_bundle_path_as("vendor/bundle") do
-        bundle :install
-      end
+      config "BUNDLE_PATH" => "vendor/bundle"
+      bundle :install
+
       FileUtils.rm_rf vendored_gems("cache")
 
       should_be_installed "rack 1.0.0"
     end
 
     it "does not randomly change the path when path is configured and the bundle directory becomes read only" do
-      with_bundle_path_as("vendor/bundle") do
-        bundle :install
-      end
+      config "BUNDLE_PATH" => "vendor/bundle"
+      bundle :install
 
       with_read_only("**/*") do
         should_be_installed "rack 1.0.0"

--- a/spec/runtime/with_clean_env_spec.rb
+++ b/spec/runtime/with_clean_env_spec.rb
@@ -25,7 +25,9 @@ describe "Bundler.with_env helpers" do
 
     it "should keep the original GEM_PATH even in sub processes" do
       gemfile ""
-      bundle "install --path vendor/bundle"
+      with_bundle_path_as('vendor/bundle') do
+        bundle :install
+      end
 
       code = "Bundler.with_clean_env do;" +
              "  print ENV['GEM_PATH'] != '';" +

--- a/spec/runtime/with_clean_env_spec.rb
+++ b/spec/runtime/with_clean_env_spec.rb
@@ -25,9 +25,8 @@ describe "Bundler.with_env helpers" do
 
     it "should keep the original GEM_PATH even in sub processes" do
       gemfile ""
-      with_bundle_path_as('vendor/bundle') do
-        bundle :install
-      end
+      config "BUNDLE_PATH" => "vendor/bundle"
+      bundle :install
 
       code = "Bundler.with_clean_env do;" +
              "  print ENV['GEM_PATH'] != '';" +

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -107,6 +107,8 @@ RSpec.configure do |config|
     ENV["BUNDLE_PATH"]           = nil
     ENV["BUNDLE_GEMFILE"]        = nil
     ENV["BUNDLE_FROZEN"]         = nil
+    ENV["BUNDLE_WITH"]           = nil
+    ENV["BUNDLE_WITHOUT"]        = nil
     ENV["BUNDLE_APP_CONFIG"]     = nil
     ENV["BUNDLER_TEST"]          = nil
     ENV["BUNDLER_SPEC_PLATFORM"] = nil

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -192,6 +192,14 @@ module Spec
       ENV["PATH"] = old_path
     end
 
+    def with_env(key, value)
+      old_value = ENV[key]
+      ENV[key] = value
+      yield
+    ensure
+      ENV[key] = old_value
+    end
+
     def break_git!
       FileUtils.mkdir_p(tmp("broken_path"))
       File.open(tmp("broken_path/git"), "w", 0755) do |f|

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -192,6 +192,22 @@ module Spec
       ENV["PATH"] = old_path
     end
 
+    def with_bundle_path_as(path, local = true)
+      old_path = Bundler.settings.path
+
+      if local
+        config("BUNDLE_PATH" => path)
+      else
+        global_config("BUNDLE_PATH" => path)
+      end
+
+      yield
+    ensure
+      puts "back to #{old_path}"
+      Bundler.settings[:path] = old_path
+    end
+
+
     def break_git!
       FileUtils.mkdir_p(tmp("broken_path"))
       File.open(tmp("broken_path/git"), "w", 0755) do |f|

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -192,22 +192,6 @@ module Spec
       ENV["PATH"] = old_path
     end
 
-    def with_bundle_path_as(path, local = true)
-      old_path = Bundler.settings.path
-
-      if local
-        config("BUNDLE_PATH" => path)
-      else
-        global_config("BUNDLE_PATH" => path)
-      end
-
-      yield
-    ensure
-      puts "back to #{old_path}"
-      Bundler.settings[:path] = old_path
-    end
-
-
     def break_git!
       FileUtils.mkdir_p(tmp("broken_path"))
       File.open(tmp("broken_path/git"), "w", 0755) do |f|


### PR DESCRIPTION
Implements bundler/bundler-features#26.

Some specs are failing, but wanted to get  some early feedback.

* What do you think about resetting the `BUNDLE_WITH/WITHOUT` ENV variables after each spec?
* If that's OK, should setting `ENV` be the preferred method in most specs, compared to `bundle config`, `config`?  