### PR TITLE
Add comment describing Bundler.settings.path

### DIFF
--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -153,7 +153,7 @@ module Bundler
       end
 
       if set_path == File.join(Bundler.settings.root, Bundler.ruby_scope)
-        # ?
+        # root bundler (gems.rb) path
         install_path = set_path
       elsif set_path == Bundler.rubygems.gem_dir
         # system gems path


### PR DESCRIPTION
An improvement over https://github.com/smlance/bundler/commit/426c36551823594f381b1fd136e9836a12f82d8e#diff-75219bd6bc0defc0e7f4ba322d92f950R157.

* The `install_path` variable isn't necessary, but I left it in for the sake of clarity
* The `if` branches at L155-167 can be shortened since three return values are the same, but I left it lengthened for clarity via the comments

Thoughts?