### PR TITLE
Disable Lint/UnusedMethodArgument

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,9 @@ Lint/AssignmentInCondition:
 Lint/EndAlignment:
   AlignWith: variable
 
+Lint/UnusedMethodArgument:
+  Enabled: false
+
 # Style
 
 Style/AccessModifierIndentation:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -25,11 +25,6 @@ Lint/NonLocalExitFromIterator:
 Lint/RescueException:
   Enabled: false
 
-# Offense count: 38
-# Cop supports --auto-correct.
-Lint/UnusedMethodArgument:
-  Enabled: false
-
 # Offense count: 7
 Lint/UselessAssignment:
   Enabled: false


### PR DESCRIPTION
We don't agree with this rule. See discussion in <https://github.com/bundler/bundler/pull/3922>.