### PR TITLE
Failing spec for BUNDLE_NO_INSTALL breaking `bundle install`

### DIFF
--- a/spec/commands/package_spec.rb
+++ b/spec/commands/package_spec.rb
@@ -41,6 +41,18 @@ describe "bundle package" do
       should_not_be_installed "rack 1.0.0"
       expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
     end
+
+    it "does not prevent installing gems with bundle install" do
+      gemfile <<-D
+        source "file://#{gem_repo1}"
+        gem 'rack'
+      D
+
+      bundle "package --no-install"
+      bundle "install"
+
+      should_be_installed "rack 1.0.0"
+    end
   end
 
   context "with --all-platforms" do


### PR DESCRIPTION
Problem:

1. Run `bundle package --all --no-installl` on build machine during build
2. Run `bundle install --deployment` on target machine
3. It does not install any gems because `BUNDLE_NO_INSTALL` is set at `.bundle/config`.

A possible workaround is to remove the line from the config, but I believe `bundle install` should ignore `BUNDLE_NO_INSTALL`.

Another way to solve it is adding a new option to `bundle install` to force install `--force-install`. If we really need to keep the current behavior, we should do that. Otherwise, this PR would work.
