### PR TITLE
make it able to specify gem host with GEM_HOST env

### DIFF
--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -93,9 +93,10 @@ module Bundler
     def rubygem_push(path)
       if Pathname.new("~/.gem/credentials").expand_path.exist?
         gem_command = "gem push '#{path}'"
-        gem_command << " --host #{ENV['GEM_HOST']}" if ENV['GEM_HOST']
+        allowed_push_host = @gemspec.metadata["allowed_push_host"]
+        gem_command << " --host #{allowed_push_host}" if allowed_push_host
         sh(gem_command)
-        Bundler.ui.confirm "Pushed #{name} #{version} to rubygems.org."
+        Bundler.ui.confirm "Pushed #{name} #{version} to #{allowed_push_host ? allowed_push_host : "rubygems.org."}"
       else
         raise "Your rubygems.org credentials aren't set. Run `gem push` to set them."
       end

--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -92,9 +92,12 @@ module Bundler
 
     def rubygem_push(path)
       if Pathname.new("~/.gem/credentials").expand_path.exist?
+        allowed_push_host = nil
         gem_command = "gem push '#{path}'"
-        allowed_push_host = @gemspec.metadata["allowed_push_host"]
-        gem_command << " --host #{allowed_push_host}" if allowed_push_host
+        if spec.respond_to?(:metadata)
+          allowed_push_host = @gemspec.metadata["allowed_push_host"]
+          gem_command << " --host #{allowed_push_host}" if allowed_push_host
+        end
         sh(gem_command)
         Bundler.ui.confirm "Pushed #{name} #{version} to #{allowed_push_host ? allowed_push_host : "rubygems.org."}"
       else

--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -92,7 +92,9 @@ module Bundler
 
     def rubygem_push(path)
       if Pathname.new("~/.gem/credentials").expand_path.exist?
-        sh("gem push '#{path}'")
+        gem_command = "gem push '#{path}'"
+        gem_command << " --host #{ENV['GEM_HOST']}" if ENV['GEM_HOST']
+        sh(gem_command)
         Bundler.ui.confirm "Pushed #{name} #{version} to rubygems.org."
       else
         raise "Your rubygems.org credentials aren't set. Run `gem push` to set them."


### PR DESCRIPTION
when you in your `.gemspec` specify

```
  if spec.respond_to?(:metadata)
    spec.metadata['allowed_push_host'] = 'https://gems.example.com'
  end
```

you can't use the `bundler` rake tasks, as it can't specify the alternate host. This change picks up the `allowed_push_host` and uses it when pushing.