### PR TITLE
Improve hint on conflict error message

### DIFF
--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -326,7 +326,9 @@ module Bundler
             message = "You have requested:\n" \
               "  #{requirement.name} #{requirement.requirement}\n\n" \
               "The bundle currently has #{requirement.name} locked at #{version}.\n" \
-              "Try running `bundle update #{requirement.name}`"
+              "Try running `bundle update #{requirement.name}`\n\n" \
+              "If you are updating multiple gems in your Gemfile at once,\n" \
+              "try passing them all to `bundle update`"
           elsif requirement.source
             name = requirement.name
             versions = @source_requirements[name][name].map(&:version)


### PR DESCRIPTION
Given this previous configuration:
```ruby
gem 'rails',      '~> 4.1.11'
gem 'sass-rails', '~> 4.0.3'
```

When changing both gem versions:
```ruby
gem 'rails',      '~> 4.2.4'
gem 'sass-rails', '~> 5.0.0'
```

And running `bundle update rails`, you see this error message:
```
You have requested:
  sass-rails ~> 5.0.0

The bundle currently has sass-rails locked at 4.0.3.
Try running `bundle update sass-rails`
```

This commit adds a hint to run `bundle update rails sass-rails`:
```
You have requested:
  sass-rails ~> 5.0.0

The bundle currently has sass-rails locked at 4.0.3.
Try running `bundle update sass-rails`

If you are updating multiple gems in your Gemfile at once,
try passing them all to `bundle update`
```