### PR TITLE
Dsl#with_source should restore the previous source

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -226,13 +226,14 @@ module Bundler
     end
 
     def with_source(source)
+      old_source = @source
       if block_given?
         @source = source
         yield
       end
       source
     ensure
-      @source = nil
+      @source = old_source
     end
 
     def normalize_hash(opts)

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -188,4 +188,20 @@ describe Bundler::Dsl do
     end
   end
 
+  describe "#with_source" do
+    context "if there was a rubygem source already defined" do
+      it "restores it after it's done" do
+        other_source = double("other-source")
+        allow(Bundler::Source::Rubygems).to receive(:new).and_return(other_source)
+
+        subject.source("https://other-source.org") do
+          subject.gem("dobry-pies", :path => "foo")
+          subject.gem("foo")
+        end
+
+        expect(subject.dependencies.last.source).to eq(other_source)
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Before this change, a gem inside a rubygems source block that also
defined a custom source, would cause subsequent gems inside that same
block to be fetched from rubygems.org.

For example:

    source "https://rubygems.org"

    source "https://foo.bar" do
      gem "rails", git: "git@github.com/rails/rails.git"
      gem "i18n"
    end

In that case, i18n would be fetched from rubygems.org instead of
foo.bar.

Fixes #3974.

Backport of #3978