### PR TITLE
expect positive case, instead of negative

### DIFF
--- a/spec/commands/clean_spec.rb
+++ b/spec/commands/clean_spec.rb
@@ -454,7 +454,7 @@ describe "bundle clean" do
     bundle :update
 
     sys_exec "gem list"
-    expect(out).not_to include("foo (1.0.1, 1.0)")
+    expect(out).to include("foo (1.0)")
   end
 
   it "cleans system gems when --force is used" do


### PR DESCRIPTION
The previous expectation didn't make it clear which version of the gem was supposed to be still there after the update.

**NOTE:** I'm not sure why, but it's version 1.0, whereas IMO it should be version 1.0.1.

This expectation also makes it easier to spot false positives, if any.

---
*SIDENOTE:* Why is either gem being cleaned? And where is the code that does this? The specs could be improved to make this clearer.