### PR TITLE
add option in dsl "ca_cert" to specify ssl ca_certificate to verify server connection with

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -124,6 +124,10 @@ module Bundler
         @sources.add_rubygems_remote(source)
       end
     end
+    
+    def ca_cert(source)
+      ENV['SSL_CERT_FILE'] = source
+    end
 
     def git_source(name, &block)
       unless block_given?

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -124,9 +124,9 @@ module Bundler
         @sources.add_rubygems_remote(source)
       end
     end
-    
+
     def ca_cert(source)
-      ENV['SSL_CERT_FILE'] = source
+      ENV["SSL_CERT_FILE"] = source
     end
 
     def git_source(name, &block)


### PR DESCRIPTION
It's common to use self-signed ca certificates inside local work environment.

This PR add option to bundler to allow easier use of custom CA certificates - by allowing to specify `ca_cert` option inside Gemfile itself - which makes it simpler for users.

Example usage inside Gemfile: `ca_cert 'test.pem'`