### PR TITLE
Persist path to configuration when there are conflicts

### DIFF
--- a/lib/bundler/cli/config.rb
+++ b/lib/bundler/cli/config.rb
@@ -105,10 +105,6 @@ module Bundler
     # @param  [String] scope
     #         the scope of the option being set by the user (either `"local"` or
     #         `"global"`).
-    #
-    # @return [Symbol] Either `:conflict` or `:no_conflict`, depending on whether
-    #         the options conflict.
-    #
     def resolve_system_path_conflicts(name, new_value, scope = "global")
       if name == "path.system" and Bundler.settings[:path] and new_value == "true"
         Bundler.ui.warn "`path` is already configured, so it will be unset."

--- a/lib/bundler/cli/config.rb
+++ b/lib/bundler/cli/config.rb
@@ -75,7 +75,7 @@ module Bundler
             "#{locations[:local].inspect}"
         end
 
-        return if resolve_system_path_conflicts(name, new_value, scope) == :conflict
+        resolve_system_path_conflicts(name, new_value, scope)
         resolve_group_conflicts(name, new_value, scope)
         delete_config(name, nil) if new_value == "" and (name == "with" or name == "without")
 
@@ -113,13 +113,9 @@ module Bundler
       if name == "path.system" and Bundler.settings[:path] and new_value == "true"
         Bundler.ui.warn "`path` is already configured, so it will be unset."
         delete_config("path")
-        :conflict
       elsif name == "path" and Bundler.settings["path.system"]
         Bundler.ui.warn "`path.system` is already configured, so it will be unset."
         delete_config("path.system")
-        :conflict
-      else
-        :no_conflict
       end
     end
 

--- a/spec/commands/config_spec.rb
+++ b/spec/commands/config_spec.rb
@@ -309,6 +309,12 @@ E
         expect(out).to include("`path.system` is already configured")
 
         expect(Bundler.settings['path.system']).to be_nil
+      end
+
+      it "should persist `path`" do
+        bundle "config path.system true"
+        bundle "config path #{bundled_app(".bundle")}"
+
         expect(Bundler.settings[:path]).to eq(bundled_app('.bundle').to_s)
       end
     end
@@ -322,6 +328,12 @@ E
 
         expect(out).to include("`path` is already configured")
         expect(Bundler.settings[:path]).to be_nil
+      end
+
+      it "should persist `path.system`" do
+        bundle "config path #{default_bundle_path}"
+        bundle "config path.system true"
+
         expect(Bundler.settings['path.system']).to eq("true")
       end
     end

--- a/spec/commands/config_spec.rb
+++ b/spec/commands/config_spec.rb
@@ -307,8 +307,9 @@ E
         bundle "config path #{bundled_app(".bundle")}"
 
         expect(out).to include("`path.system` is already configured")
-        run "puts Bundler.settings['path.system'] == nil"
-        expect(out).to eq("true")
+
+        expect(Bundler.settings['path.system']).to be_nil
+        expect(Bundler.settings[:path]).to eq(bundled_app('.bundle').to_s)
       end
     end
 
@@ -320,8 +321,8 @@ E
         bundle "config path.system true"
 
         expect(out).to include("`path` is already configured")
-        run "puts Bundler.settings[:path] == nil"
-        expect(out).to eq("true")
+        expect(Bundler.settings[:path]).to be_nil
+        expect(Bundler.settings['path.system']).to eq("true")
       end
     end
   end

--- a/spec/commands/config_spec.rb
+++ b/spec/commands/config_spec.rb
@@ -308,14 +308,14 @@ E
 
         expect(out).to include("`path.system` is already configured")
 
-        expect(Bundler.settings['path.system']).to be_nil
+        expect(Bundler.settings["path.system"]).to be_nil
       end
 
       it "should persist `path`" do
         bundle "config path.system true"
         bundle "config path #{bundled_app(".bundle")}"
 
-        expect(Bundler.settings[:path]).to eq(bundled_app('.bundle').to_s)
+        expect(Bundler.settings[:path]).to eq(bundled_app(".bundle").to_s)
       end
     end
 
@@ -334,7 +334,7 @@ E
         bundle "config path #{default_bundle_path}"
         bundle "config path.system true"
 
-        expect(Bundler.settings['path.system']).to eq("true")
+        expect(Bundler.settings["path.system"]).to eq("true")
       end
     end
   end


### PR DESCRIPTION
Previously, if the user tried to set `path` when `system` was set (and viceversa), the conflicting option would be removed, but the passed option would not be saved.