### PR TITLE
Remove --system flag from install

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -142,8 +142,6 @@ module Bundler
       "Specify a different shebang executable name than the default (usually 'ruby')"
     method_option "standalone", :type => :array, :lazy_default => [], :banner =>
       "Make a bundle that can work without the Bundler runtime"
-    method_option "system", :type => :boolean, :banner =>
-      "Install to the system location ($BUNDLE_PATH or $GEM_HOME) even if the bundle was previously installed somewhere else for this application"
     method_option "trust-policy", :alias => "P", :type => :string, :banner =>
       "Gem trust policy (like gem install -P). Must be one of " +
         Bundler.rubygems.security_policy_keys.join("|")

--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -80,7 +80,7 @@ module Bundler
       Bundler.settings[:no_install] = true if options["no-install"]
       Bundler.settings[:clean] = options["clean"] if options["clean"]
       Bundler::Fetcher.disable_endpoint = options["full-index"]
-      Bundler.settings[:disable_shared_gems] = (Bundler.settings[:path] || Bundler.settings["path.system"]) ? "1" : nil
+      Bundler.settings[:disable_shared_gems] = Bundler.settings[:path] ? "1" : nil
 
       # rubygems plugins sometimes hook into the gem install process
       Gem.load_env_plugins if Gem.respond_to?(:load_env_plugins)

--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -23,6 +23,10 @@ module Bundler
          "install --cache`."
         exit 1
       end
+      if options[:system]
+        Bundler.ui.error "Please use `bundle config path.system true` " \
+          "instead of `bundle install --system`"
+      end
 
       ENV["RB_USER_INSTALL"] = "1" if Bundler::FREEBSD
 

--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -35,12 +35,6 @@ module Bundler
         exit 1
       end
 
-      if (Bundler.settings[:path] || options[:deployment]) && options[:system]
-        Bundler.ui.error "You have configured a path to install your gems to, \n" \
-                         "and specified the --system path. Please use only one."
-        exit 1
-      end
-
       if options["trust-policy"]
         unless Bundler.rubygems.security_policies.keys.include?(options["trust-policy"])
           Bundler.ui.error "Rubygems doesn't know about trust policy '#{options["trust-policy"]}'. " \
@@ -73,7 +67,6 @@ module Bundler
         options[:system] = true
       end
 
-      Bundler.settings[:path]     = Bundler.rubygems.gem_dir if options[:system]
       Bundler.settings[:path]     = "#{Bundler.settings.path}/vendor/bundle" if options[:deployment]
 
       Bundler.settings[:path] ||= "bundle" if options["standalone"]

--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -76,7 +76,7 @@ module Bundler
       Bundler.settings[:no_install] = true if options["no-install"]
       Bundler.settings[:clean] = options["clean"] if options["clean"]
       Bundler::Fetcher.disable_endpoint = options["full-index"]
-      Bundler.settings[:disable_shared_gems] = Bundler.settings[:path] ? "1" : nil
+      Bundler.settings[:disable_shared_gems] = (Bundler.settings[:path] || Bundler.settings["path.system"]) ? "1" : nil
 
       # rubygems plugins sometimes hook into the gem install process
       Gem.load_env_plugins if Gem.respond_to?(:load_env_plugins)

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -111,6 +111,8 @@ learn more about their operation in [bundle install(1)][bundle-install].
   of `$GEM_HOME` or `$GEM_PATH` values. Bundle gems not found in this location
   will be installed by `bundle install`. Defaults to `Gem.dir`. When --deployment is
   used, defaults to vendor/bundle.
+* `path.system` (`BUNDLE_PATH__SYSTEM`):
+  Boolean, tells Bundler to install gems to the system path. Defaults to `false`.
 * `frozen` (`BUNDLE_FROZEN`):
   Disallow changes to `gems.rb`. Defaults to `true` when `--deployment`
   is used.

--- a/man/bundle-install.ronn
+++ b/man/bundle-install.ronn
@@ -11,7 +11,6 @@ bundle-install(1) -- Install the dependencies specified in your gems.rb
                  [--deployment]
                  [--force]
                  [--no-prune]
-                 [--system]
                  [--quiet]
                  [--retry=NUMBER]
                  [--shebang]
@@ -74,9 +73,6 @@ use `bundle config` (see bundle-config(1)).
 * `--force`:
   Force download every gem, even if the required versions are already available
   locally.
-
-* `--system`:
-  Installs the gems specified in the bundle to the system's Rubygems location.
 
 * `--no-prune`:
   Don't remove stale gems from the cache when the installation finishes.

--- a/spec/bundler/settings_spec.rb
+++ b/spec/bundler/settings_spec.rb
@@ -135,26 +135,6 @@ describe Bundler::Settings do
   end
 
   describe "a flag passed to a command" do
-    it "is not automatically remembered" do
-      install_gemfile <<-G, :system => true
-        source "file://#{gem_repo1}"
-        gem "rack"
-      G
-
-      expect(system_gem_path).to exist
-      FileUtils.rm_r(system_gem_path)
-      expect(system_gem_path).not_to exist
-
-      install_gemfile <<-G
-        source "file://#{gem_repo1}"
-        gem "rack"
-      G
-
-      expect(bundled_app("some/path")).not_to exist
-      expect(default_bundle_path("gems/rack-1.0.0")).to exist
-      should_be_installed("rack 1.0.0")
-    end
-
     it "is remembered if set with config" do
       bundle "config path another/directory"
       expect(bundled_app("another/directory")).not_to exist

--- a/spec/bundler/settings_spec.rb
+++ b/spec/bundler/settings_spec.rb
@@ -137,7 +137,6 @@ describe Bundler::Settings do
   describe "a flag passed to a command" do
     it "is remembered if set with config" do
       bundle "config path another/directory"
-      expect(bundled_app("another/directory")).not_to exist
 
       install_gemfile <<-G
         source "file://#{gem_repo1}"

--- a/spec/commands/clean_spec.rb
+++ b/spec/commands/clean_spec.rb
@@ -339,7 +339,8 @@ describe "bundle clean" do
       gem "thin"
       gem "rack"
     G
-    bundle "install --system"
+    bundle "config path.system true"
+    bundle :install
     sys_exec "gem list"
     expect(out).to include("rack (1.0.0)")
     expect(out).to include("thin (1.0)")
@@ -349,7 +350,8 @@ describe "bundle clean" do
 
       gem "rack"
     G
-    bundle "install --system"
+    bundle "config path.system true"
+    bundle :install
     sys_exec "gem list"
     expect(out).to include("rack (1.0.0)")
     expect(out).to include("thin (1.0)")
@@ -529,7 +531,8 @@ describe "bundle clean" do
 
       gem "bindir"
     G
-    bundle "install --system"
+    bundle "config path.system true"
+    bundle :install
 
     bundle "clean --force"
 

--- a/spec/commands/clean_spec.rb
+++ b/spec/commands/clean_spec.rb
@@ -350,7 +350,6 @@ describe "bundle clean" do
 
       gem "rack"
     G
-    bundle "config path.system true"
     bundle :install
     sys_exec "gem list"
     expect(out).to include("rack (1.0.0)")

--- a/spec/commands/clean_spec.rb
+++ b/spec/commands/clean_spec.rb
@@ -333,24 +333,25 @@ describe "bundle clean" do
   end
 
   it "does not call clean automatically when using system gems" do
-    gemfile <<-G
+    bundle "config path.system true"
+
+    install_gemfile <<-G
       source "file://#{gem_repo1}"
 
       gem "thin"
       gem "rack"
     G
-    bundle "config path.system true"
-    bundle :install
+
     sys_exec "gem list"
     expect(out).to include("rack (1.0.0)")
     expect(out).to include("thin (1.0)")
 
-    gemfile <<-G
+    install_gemfile <<-G
       source "file://#{gem_repo1}"
 
       gem "rack"
     G
-    bundle :install
+
     sys_exec "gem list"
     expect(out).to include("rack (1.0.0)")
     expect(out).to include("thin (1.0)")
@@ -460,22 +461,21 @@ describe "bundle clean" do
   end
 
   it "cleans system gems when --force is used" do
-    gemfile <<-G
+    bundle "config path.system true"
+
+    install_gemfile <<-G
       source "file://#{gem_repo1}"
 
       gem "foo"
       gem "rack"
     G
 
-    bundle "config path.system true"
-    bundle "install"
-
-    gemfile <<-G
+    install_gemfile <<-G
       source "file://#{gem_repo1}"
 
       gem "rack"
     G
-    bundle "install"
+
     bundle "clean --force"
 
     expect(out).to include("Removing foo (1.0)")
@@ -525,13 +525,13 @@ describe "bundle clean" do
       end
     end
 
-    gemfile <<-G
+    bundle "config path.system true"
+
+    install_gemfile <<-G
       source "file://#{gem_repo2}"
 
       gem "bindir"
     G
-    bundle "config path.system true"
-    bundle :install
 
     bundle "clean --force"
 

--- a/spec/commands/clean_spec.rb
+++ b/spec/commands/clean_spec.rb
@@ -440,7 +440,7 @@ describe "bundle clean" do
     should_have_gems "foo-1.0", "foo-1.0.1"
   end
 
-  it "does not clean on bundle update when using --system" do
+  it "does not clean on bundle update when installing to system path" do
     bundle "config path.system true"
 
     build_repo2

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -114,16 +114,18 @@ describe "bundle exec" do
       end
     end
 
-    # We added :system => true here and in the block below, since the
+    # We added `config path.system true` here, since the
     # (old default) system gem directory was implicitly used in previous
     # versions of Bundler.
-    install_gemfile <<-G, :system => true
+    bundle "config path.system true"
+
+    install_gemfile <<-G
       source "file://#{gem_repo1}"
       gem "rack", "0.9.1"
     G
 
     Dir.chdir bundled_app2 do
-      install_gemfile bundled_app2("gems.rb"), <<-G, :system => true
+      install_gemfile bundled_app2("gems.rb"), <<-G
         source "file://#{gem_repo2}"
         gem "rack_two", "1.0.0"
       G

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -256,22 +256,19 @@ describe "bundle install with gem sources" do
         should_be_installed "rack 1.0"
       end
 
-      # NOTE: This interface (`install; config --delete path; install --system`)
-      # is a bit clunky.
-      # (Just using `install; install --system` produces an error.)
-      it "allows running bundle install --system without deleting foo" do
-        bundle "install"
-        bundle "config --delete path"
-        bundle "install --system"
+      it "allows installing gems to system path without deleting foo" do
+        bundle :install
+        bundle "config path.system true"
+        bundle :install
         FileUtils.rm_rf(bundled_app("vendor"))
         should_be_installed "rack 1.0"
       end
 
-      it "allows running bundle install --system after deleting foo" do
-        bundle "install"
+      it "allows installing gems to system path after deleting foo" do
+        bundle :install
         FileUtils.rm_rf(bundled_app("vendor"))
-        bundle "config --delete path"
-        bundle "install --system"
+        bundle "config path.system true"
+        bundle :install
         should_be_installed "rack 1.0"
       end
     end

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -393,7 +393,7 @@ describe "bundle install with gem sources" do
   end
 
   describe "when using the --path flag" do
-    it "print an error and exit" do
+    it "prints an error and exits" do
       gemfile <<-G
         gem 'rack'
       G
@@ -401,6 +401,18 @@ describe "bundle install with gem sources" do
       bundle "install --path vendor/bundle"
 
       expect(err).to include("Unknown switches '--path'")
+    end
+  end
+
+  describe "when using the --system flag" do
+    it "prints an error and exit" do
+      gemfile <<-G
+        gem 'rack'
+      G
+
+      bundle "install --system"
+
+      expect(err).to include("Unknown switches '--system'")
     end
   end
 

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -380,39 +380,20 @@ describe "bundle install with gem sources" do
     end
   end
 
-  describe "when using the --cache flag" do
+  describe "when using deprecated flags" do
     it "prints an error and exits" do
-      gemfile <<-G
-        gem 'rack'
-      G
+      ["--cache",
+       "--path vendor/bundle",
+       "--system"
+      ].each do |flag|
+        gemfile <<-G
+          gem 'rack'
+        G
 
-      bundle "install --cache"
+        bundle "install #{flag}"
 
-      expect(err).to include("Unknown switches '--cache'")
-    end
-  end
-
-  describe "when using the --path flag" do
-    it "prints an error and exits" do
-      gemfile <<-G
-        gem 'rack'
-      G
-
-      bundle "install --path vendor/bundle"
-
-      expect(err).to include("Unknown switches '--path'")
-    end
-  end
-
-  describe "when using the --system flag" do
-    it "prints an error and exit" do
-      gemfile <<-G
-        gem 'rack'
-      G
-
-      bundle "install --system"
-
-      expect(err).to include("Unknown switches '--system'")
+        expect(err).to include("Unknown switches '#{flag.split.first}'")
+      end
     end
   end
 

--- a/spec/install/gems/sudo_spec.rb
+++ b/spec/install/gems/sudo_spec.rb
@@ -10,7 +10,8 @@ describe "when using sudo", :sudo => true do
       end
 
       it "installs" do
-        install_gemfile <<-G, :system => true
+        bundler "config path.system true"
+        install_gemfile <<-G
           source "file://#{gem_repo1}"
           gem "rack"
         G
@@ -28,7 +29,8 @@ describe "when using sudo", :sudo => true do
     end
 
     it "installs" do
-      install_gemfile <<-G, :system => true
+      bundler "config path.system true"
+      install_gemfile <<-G
         source "file://#{gem_repo1}"
         gem "rack", '1.0'
         gem "thin"
@@ -86,7 +88,8 @@ describe "when using sudo", :sudo => true do
     end
 
     it "installs extensions/ compiled by Rubygems 2.2", :rubygems => "2.2" do
-      install_gemfile <<-G, :system => true
+      bundler "config path.system true"
+      install_gemfile <<-G
         source "file://#{gem_repo1}"
         gem "very_simple_binary"
       G
@@ -139,7 +142,8 @@ describe "when using sudo", :sudo => true do
         gem "rack", '1.0'
       G
 
-      bundle :install, :env => { "GEM_HOME" => gem_home.to_s, "GEM_PATH" => nil }, :system => true
+      bundler "config path.system true"
+      bundle :install, :env => { "GEM_HOME" => gem_home.to_s, "GEM_PATH" => nil }
       expect(gem_home.join("bin/rackup")).to exist
       should_be_installed "rack 1.0", :env => { "GEM_HOME" => gem_home.to_s, "GEM_PATH" => nil }
     end

--- a/spec/install/gems/sudo_spec.rb
+++ b/spec/install/gems/sudo_spec.rb
@@ -45,7 +45,8 @@ describe "when using sudo", :sudo => true do
           gem "rake"
           gem "another_implicit_rake_dep"
       G
-      bundle "install --system"
+      bundle "config path.system true"
+      bundle :install
       expect(system_gem_path("gems/another_implicit_rake_dep-1.0")).to exist
     end
 

--- a/spec/install/gems/sudo_spec.rb
+++ b/spec/install/gems/sudo_spec.rb
@@ -10,7 +10,7 @@ describe "when using sudo", :sudo => true do
       end
 
       it "installs" do
-        bundler "config path.system true"
+        bundle "config path.system true"
         install_gemfile <<-G
           source "file://#{gem_repo1}"
           gem "rack"
@@ -29,7 +29,7 @@ describe "when using sudo", :sudo => true do
     end
 
     it "installs" do
-      bundler "config path.system true"
+      bundle "config path.system true"
       install_gemfile <<-G
         source "file://#{gem_repo1}"
         gem "rack", '1.0'
@@ -88,7 +88,7 @@ describe "when using sudo", :sudo => true do
     end
 
     it "installs extensions/ compiled by Rubygems 2.2", :rubygems => "2.2" do
-      bundler "config path.system true"
+      bundle "config path.system true"
       install_gemfile <<-G
         source "file://#{gem_repo1}"
         gem "very_simple_binary"
@@ -142,7 +142,7 @@ describe "when using sudo", :sudo => true do
         gem "rack", '1.0'
       G
 
-      bundler "config path.system true"
+      bundle "config path.system true"
       bundle :install, :env => { "GEM_HOME" => gem_home.to_s, "GEM_PATH" => nil }
       expect(gem_home.join("bin/rackup")).to exist
       should_be_installed "rack 1.0", :env => { "GEM_HOME" => gem_home.to_s, "GEM_PATH" => nil }

--- a/spec/install/path_spec.rb
+++ b/spec/install/path_spec.rb
@@ -13,6 +13,16 @@ describe "bundle install" do
       G
     end
 
+    it "does not use available system gems with config path vendor/bundle" do
+      bundle "config path vendor/bundle"
+      bundle :install
+
+      # See CLI::Install#run.
+      with_config(:disable_shared_gems => "1") do
+        should_be_installed "rack 1.0.0"
+      end
+    end
+
     it "handles paths with regex characters in them" do
       dir = bundled_app("bun++dle")
       dir.mkpath

--- a/spec/install/path_spec.rb
+++ b/spec/install/path_spec.rb
@@ -13,16 +13,6 @@ describe "bundle install" do
       G
     end
 
-    it "does not use available system gems with config path vendor/bundle" do
-      bundle "config path vendor/bundle"
-      bundle "install"
-
-      # See CLI::Install#run.
-      with_config(:disable_shared_gems => "1") do
-        should_be_installed "rack 1.0.0"
-      end
-    end
-
     it "handles paths with regex characters in them" do
       dir = bundled_app("bun++dle")
       dir.mkpath

--- a/spec/install/path_spec.rb
+++ b/spec/install/path_spec.rb
@@ -42,12 +42,6 @@ describe "bundle install" do
       expect(out).to include("gems are installed into ./vendor")
     end
 
-    it "disallows config path vendor/bundle and install system" do
-      bundle "config path vendor/bundle"
-      bundle "install --system"
-      expect(err).to include("Please use only one.")
-    end
-
     it "remembers to disable system gems after config path vendor/bundle" do
       bundle "config path vendor/bundle"
       bundle "install"

--- a/spec/other/platform_spec.rb
+++ b/spec/other/platform_spec.rb
@@ -540,7 +540,9 @@ G
 
   context "bundle show" do
     before do
-      install_gemfile <<-G, :system => true
+      bundle "config path.system true"
+
+      install_gemfile <<-G
         source "file://#{gem_repo1}"
         gem "rails"
       G
@@ -874,7 +876,9 @@ G
 
   context "bundle console" do
     before do
-      install_gemfile <<-G, :system => true
+      bundle "config path.system true"
+
+      install_gemfile <<-G
         source "file://#{gem_repo1}"
         gem "rack"
         gem "activesupport", :group => :test


### PR DESCRIPTION
As [planned](https://github.com/bundler/bundler-features/issues/26#issuecomment-129487171), this PR removes the `--system` flag from `install`.

Users are expected to use `bundle config path.system true` instead.

Also fixes a bug introduced in ddafe06ab60c42943cc7c8d64973d4745d6a26ca where passing the `--system` option would set `Bundler.settings[:path]`, which in turn would be used to `disable_shared_gems` when doing a system install - which seems wrong.