### PR TITLE
Update config man for 2.0

### DIFF
--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -146,8 +146,8 @@ learn more about their operation in [bundle install(1)][bundle-install].
   messages will be printed. To silence a single gem, use dot notation like
   `ignore_messages.httparty true`.
 
-In general, you should set these settings per-application by using the applicable
-flag to the [bundle install(1)][bundle-install] or [bundle cache(1)][bundle-cache] command.
+In general, you should set these settings per-application by passing the
+applicable flag to the `bundle config --local` command.
 
 You can set them globally either via environment variables or `bundle config`,
 whichever is preferable for your setup. If you use both, environment variables

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -38,8 +38,8 @@ cause it to ignore all configuration.
 ## REMEMBERING OPTIONS
 
 Flags passed to `bundle install` or the Bundler runtime,
-such as `--path foo` or `--without production`, are not remembered between commands.
-If these options must be remembered, they must be set using `bundle config`
+such as `--deployment` or `--local`, are not remembered between commands.
+If an option must be remembered, it must be set using `bundle config`
 (e.g., `bundle config path foo`).
 
 The options that can be configured are:


### PR DESCRIPTION
Fixes some outdated information in `bundle config`'s man page:

* Avoids using invalid flags
* Tells users to pass options to `bundle config` instead of `bundle install`