### PR TITLE
Allocate the "ruby" and "\0" Strings once.

### DIFF
--- a/lib/bundler/index.rb
+++ b/lib/bundler/index.rb
@@ -13,6 +13,9 @@ module Bundler
     attr_reader :specs, :all_specs, :sources
     protected :specs, :all_specs
 
+    RUBY = "ruby".freeze
+    NULL = "\0".freeze
+
     def initialize
       @sources = []
       @cache = {}
@@ -68,7 +71,7 @@ module Bundler
         end
       end
 
-      results.sort_by {|s| [s.version, s.platform.to_s == "ruby" ? "\0" : s.platform.to_s] }
+      results.sort_by {|s| [s.version, s.platform.to_s == RUBY ? NULL : s.platform.to_s] }
     end
 
     def local_search(query, base = nil)


### PR DESCRIPTION
Index#search is called many times so this change is worth it.

With a single gem in your Gemfile, this change drops the string
allocations by nearly 30,000.

Script:

```ruby
require 'allocation_tracer'

ObjectSpace::AllocationTracer.setup(%i{path line type})

result = ObjectSpace::AllocationTracer.trace do
  begin
    require 'bundler/inline'
  rescue LoadError => e
    $stderr.puts 'Bundler version 1.10 or later is required. Please update your Bundler'
    raise e
  end

  gemfile(true) do
    source 'https://rubygems.org'
    gem 'benchmark-ips'
  end
end

result.sort_by{|k, v| k}.each{|k, v|
  puts ([v[0]]+k).join("\t")
}
```

**String allocations before**:

```
$ruby benchmark_allocations.rb | grep T_STRING | sort -nr | head -n 10
65461 /Users/joerafaniello/.rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb  54  T_STRING
64982 /Users/joerafaniello/.rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/version.rb  163 T_STRING
29986 /Users/joerafaniello/.gem/ruby/2.2.3/gems/bundler-1.10.6/lib/bundler/index.rb 71  T_STRING
22142 /Users/joerafaniello/.gem/ruby/2.2.3/gems/bundler-1.10.6/lib/bundler/spec_set.rb  111 T_STRING
20457 /Users/joerafaniello/.rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/version.rb  225 T_STRING
5280  /Users/joerafaniello/.gem/ruby/2.2.3/gems/bundler-1.10.6/lib/bundler/index.rb 87  T_STRING
4848  /Users/joerafaniello/.rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/requirement.rb  92  T_STRING
4708  /Users/joerafaniello/.gem/ruby/2.2.3/gems/bundler-1.10.6/lib/bundler/lockfile_parser.rb 54  T_STRING
4608  /Users/joerafaniello/.rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/version.rb  282 T_STRING
4561  /Users/joerafaniello/.gem/ruby/2.2.3/gems/bundler-1.10.6/lib/bundler/index.rb 19  T_STRING
```

**String allocations after**:

```
$ ruby benchmark_allocations.rb | grep T_STRING | sort -nr | head -n 10
65479 /Users/joerafaniello/.rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb  54  T_STRING
64143 /Users/joerafaniello/.rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/version.rb  163 T_STRING
22142 /Users/joerafaniello/.gem/ruby/2.2.3/gems/bundler-1.10.6/lib/bundler/spec_set.rb  111 T_STRING
20407 /Users/joerafaniello/.rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/version.rb  225 T_STRING
5280  /Users/joerafaniello/.gem/ruby/2.2.3/gems/bundler-1.10.6/lib/bundler/index.rb 90  T_STRING
4916  /Users/joerafaniello/.rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/requirement.rb  92  T_STRING
4730  /Users/joerafaniello/.gem/ruby/2.2.3/gems/bundler-1.10.6/lib/bundler/lockfile_parser.rb 54  T_STRING
4608  /Users/joerafaniello/.rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/version.rb  282 T_STRING
4561  /Users/joerafaniello/.gem/ruby/2.2.3/gems/bundler-1.10.6/lib/bundler/index.rb 22  T_STRING
3334  /Users/joerafaniello/.gem/ruby/2.2.3/gems/bundler-1.10.6/lib/bundler/spec_set.rb  134 T_STRING
```