### PR TITLE
Now won't wait for dependencies that will never install. Partial fix for #3692

### DIFF
--- a/lib/bundler/installer/parallel_installer.rb
+++ b/lib/bundler/installer/parallel_installer.rb
@@ -41,8 +41,8 @@ class ParallelInstaller
     # Represents only the non-development dependencies, the ones that are
     # itself and are in the total list.
     def dependencies(all_spec_names)
-      @dependencies ||= all_dependencies.reject {|dep| ignorable_dependency? dep }
-                                        .select {|dep| all_spec_names.include? dep.name }
+      @dependencies ||= all_dependencies.reject {|dep| ignorable_dependency? dep }.
+                                         select {|dep| all_spec_names.include? dep.name }
     end
 
     # Represents all dependencies

--- a/lib/bundler/installer/parallel_installer.rb
+++ b/lib/bundler/installer/parallel_installer.rb
@@ -35,13 +35,14 @@ class ParallelInstaller
     # sure needed dependencies have been installed.
     def dependencies_installed?(all_specs)
       installed_specs = all_specs.select(&:installed?).map(&:name)
-      dependencies.all? {|d| installed_specs.include? d.name }
+      dependencies(all_specs.map(&:name)).all? {|d| installed_specs.include? d.name }
     end
 
-    # Represents only the non-development dependencies and the ones that
-    # are itself.
-    def dependencies
+    # Represents only the non-development dependencies, the ones that are
+    # itself and are in the total list.
+    def dependencies(all_spec_names)
       @dependencies ||= all_dependencies.reject {|dep| ignorable_dependency? dep }
+                                        .select {|dep| all_spec_names.include? dep.name }
     end
 
     # Represents all dependencies

--- a/spec/install/parallel/spec_installation_spec.rb
+++ b/spec/install/parallel/spec_installation_spec.rb
@@ -57,5 +57,18 @@ describe ParallelInstaller::SpecInstallation do
         expect(spec.dependencies_installed?(all_specs)).to be_falsey
       end
     end
+
+    context "when dependencies that are not on the overall installation list are the only ones not installed" do
+      it "returns true" do
+        dependencies = []
+        dependencies << instance_double("SpecInstallation", :spec => "alpha", :name => "alpha", :installed? => true, :all_dependencies => [], :type => :production)
+        all_specs = dependencies + [instance_double("SpecInstallation", :spec => "gamma", :name => "gamma", :installed? => false, :all_dependencies => [], :type => :production)]
+        # Add dependency which is not in all_specs
+        dependencies << instance_double("SpecInstallation", :spec => "beta", :name => "beta", :installed? => false, :all_dependencies => [], :type => :production)
+        spec = ParallelInstaller::SpecInstallation.new(dep)
+        allow(spec).to receive(:all_dependencies).and_return(dependencies)
+        expect(spec.dependencies_installed?(all_specs)).to be_truthy
+      end
+    end
   end
 end


### PR DESCRIPTION
Before this fix, if for any reason a dependency is not on the install list
it will cause a deadlock. This now means the bundle will no longer fail
in that instance, which matches the behavior of the sequential installer.
It isn't clear why the gem is not making it onto the list however, which
appears to be a separate bug.

This fixes my instance of #3692 which was still occurring despite the issue being closed.