### PR TITLE
Friendly filesystem permission errors

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -100,8 +100,8 @@ module Bundler
   class MarshalError < StandardError; end
 
   class PermissionError < BundlerError
-    def initialize(file, permission_type = :write)
-      @file = file
+    def initialize(path, permission_type = :write)
+      @path = path
       @permission_type = permission_type
     end
 
@@ -109,12 +109,12 @@ module Bundler
       action = case @permission_type
                when :read then "read from"
                when :write then "write to"
-               when :executable then "execute"
+               when :executable, :exec then "execute"
                else @permission_type.to_s
                end
-      "There was an error while trying to #{action} `#{File.basename(@file)}`. " \
-      "It is likely that you need to grant #{@permission_type} permissions for " \
-      "the file at path: `#{File.expand_path(@file)}`."
+      "There was an error while trying to #{action} `#{@path}`. " \
+      "It is likely that you need to grant #{@permission_type} permissions " \
+      "for that path."
     end
 
     status_code(23)

--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -146,7 +146,7 @@ module Bundler
       @bin_path ||= begin
         path = settings[:bin] || "bin"
         path = Pathname.new(path).expand_path(root).expand_path
-        FileUtils.mkdir_p(path)
+        SharedHelpers.filesystem_access(path) {|p| FileUtils.mkdir_p(p) }
         path
       end
     end
@@ -349,7 +349,9 @@ module Bundler
       if requires_sudo?
         sudo "mkdir -p '#{path}'" unless File.exist?(path)
       else
-        FileUtils.mkdir_p(path)
+        SharedHelpers.filesystem_access(path, :write) do |p|
+          FileUtils.mkdir_p(p)
+        end
       end
     end
 

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -265,9 +265,9 @@ module Bundler
         return
       end
 
-      File.open(file, "wb") {|f| f.puts(contents) }
-    rescue Errno::EACCES
-      raise PermissionError.new(file)
+      SharedHelpers.filesystem_access(file) do |p|
+        File.open(p, "wb") {|f| f.puts(contents) }
+      end
     end
 
     # Returns the version of Bundler that is creating or has created

--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -74,7 +74,7 @@ module Bundler
       file_name = nil
       sh("gem build -V '#{spec_path}'") {
         file_name = File.basename(built_gem_path)
-        FileUtils.mkdir_p(File.join(base, "pkg"))
+        SharedHelpers.filesystem_access(File.join(base, "pkg")) {|p| FileUtils.mkdir_p(p) }
         FileUtils.mv(built_gem_path, "pkg")
         Bundler.ui.confirm "#{name} #{version} built to pkg/#{file_name}."
       }

--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -215,7 +215,9 @@ module Bundler
     def generate_standalone(groups)
       standalone_path = Bundler.settings[:path]
       bundler_path = File.join(standalone_path, "bundler")
-      FileUtils.mkdir_p(bundler_path)
+      SharedHelpers.filesystem_access(bundler_path) do |p|
+        FileUtils.mkdir_p(p)
+      end
 
       paths = []
 
@@ -262,7 +264,9 @@ module Bundler
     end
 
     def create_bundle_path
-      Bundler.mkdir_p(Bundler.bundle_path.to_s) unless Bundler.bundle_path.exist?
+      SharedHelpers.filesystem_access(Bundler.bundle_path.to_s) do |p|
+        Bundler.mkdir_p(p)
+      end unless Bundler.bundle_path.exist?
     rescue Errno::EEXIST
       raise PathError, "Could not install to path `#{Bundler.settings[:path]}` " \
         "because of an invalid symlink. Remove the symlink so the directory can be created."

--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -110,7 +110,9 @@ module Bundler
 
     def cache(custom_path = nil)
       cache_path = Bundler.app_cache(custom_path)
-      FileUtils.mkdir_p(cache_path) unless File.exist?(cache_path)
+      SharedHelpers.filesystem_access(cache_path) do |p|
+        FileUtils.mkdir_p(p)
+      end unless File.exist?(cache_path)
 
       Bundler.ui.info "Updating files in #{Bundler.settings.app_cache_path}"
       specs.each do |spec|
@@ -128,7 +130,9 @@ module Bundler
     end
 
     def prune_cache(cache_path)
-      FileUtils.mkdir_p(cache_path) unless File.exist?(cache_path)
+      SharedHelpers.filesystem_access(cache_path) do |p|
+        FileUtils.mkdir_p(p)
+      end unless File.exist?(cache_path)
       resolve = @definition.resolve
       prune_gem_cache(resolve, cache_path)
       prune_git_and_path_cache(resolve, cache_path)

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -208,14 +208,14 @@ module Bundler
       unless hash[key] == value
         hash[key] = value
         hash.delete(key) if value.nil?
-        FileUtils.mkdir_p(file.dirname)
-        require "bundler/psyched_yaml"
-        File.open(file, "w") {|f| f.puts YAML.dump(hash) }
+        SharedHelpers.filesystem_access(file) do |p|
+          FileUtils.mkdir_p(p.dirname)
+          require "bundler/psyched_yaml"
+          File.open(p, "w") {|f| f.puts YAML.dump(hash) }
+        end
       end
 
       value
-    rescue Errno::EACCES
-      raise PermissionError.new(file)
     end
 
     def global_config_file

--- a/lib/bundler/source/path/installer.rb
+++ b/lib/bundler/source/path/installer.rb
@@ -27,7 +27,9 @@ module Bundler
           super
 
           if Bundler.requires_sudo?
-            Bundler.mkdir_p @gem_bin_dir
+            SharedHelpers.filesystem_access(@gem_bin_dir) do |p|
+              Bundler.mkdir_p(p)
+            end
             spec.executables.each do |exe|
               Bundler.sudo "cp -R #{@bin_dir}/#{exe} #{@gem_bin_dir}"
             end

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -374,4 +374,22 @@ describe "bundle install with gem sources" do
       expect(out).to_not include("Your Gemfile has no gem server sources")
     end
   end
+
+  describe "when bundle path does not have write access" do
+    before do
+      FileUtils.mkdir_p(bundled_app("vendor"))
+      gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem 'rack'
+      G
+    end
+
+    it "should display a proper message to explain the problem" do
+      FileUtils.chmod(0500, bundled_app("vendor"))
+
+      bundle :install, :path => "vendor"
+      expect(out).to include(bundled_app("vendor").to_s)
+      expect(out).to include("grant write permissions")
+    end
+  end
 end


### PR DESCRIPTION
This introduces `SharedHelpers#filesystem_access` which can wrap any piece of code that makes a modification to the file system (eg. creating a directory). Doing so, results in user-friendly errors instead of the original ones (ie `Errno:EACCES`).

In the future we could (and probably should) handle more error types within `#filesystem_access`.

Closes #4009.
Closes #3988.

https://trello.com/c/OicgrmDd/102-improve-permissions-error-messages.