### PR TITLE
Use exe instead of bin for BUNDLE_BIN_PATH fallback

### DIFF
--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -192,7 +192,7 @@ module Bundler
       begin
         ENV["BUNDLE_BIN_PATH"] = Bundler.rubygems.bin_path("bundler", "bundle", VERSION)
       rescue Gem::GemNotFoundException
-        ENV["BUNDLE_BIN_PATH"] = File.expand_path("../../../bin/bundle", __FILE__)
+        ENV["BUNDLE_BIN_PATH"] = File.expand_path("../../../exe/bundle", __FILE__)
       end
 
       # Set BUNDLE_GEMFILE

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -345,4 +345,20 @@ describe "bundle exec" do
       expect(out).to match('"TODO" is not a summary')
     end
   end
+
+  describe "with gems bundled for deployment" do
+    it "works when calling bundler from another script" do
+      gemfile <<-G
+      module Monkey
+        def bin_path(a,b,c)
+          raise Gem::GemNotFoundException.new('Fail')
+        end
+      end
+      Bundler.rubygems.extend(Monkey)
+      G
+      bundle "install --deployment"
+      bundle "exec ruby -e '`bundler -v`; puts $?.success?'"
+      expect(out).to match("true")
+    end
+  end
 end


### PR DESCRIPTION
Looks like these got moved.
I'm having a hard time getting this to actually fail in the tests. Here's a gist of something that fails:

Gemfile
----------
```ruby
source 'https://rubygems.org'
gem 'rake'
```

Rakefile
-----------
```ruby
desc "foo"
task :foo do
  sh 'bundle -v'
end
```

> bundle install
> bundle install --deployment
> bundle exec rake foo

```
bundle -v
/Users/jmundrawala/.rbenv/versions/2.1.2/bin/bundle:23:in `load': cannot load such file -- /Users/jmundrawala/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/bundler-1.10.6/bin/bundle (LoadError)
	from /Users/jmundrawala/.rbenv/versions/2.1.2/bin/bundle:23:in `<main>'
rake aborted!
Command failed with status (1): [bundle -v...]
/Users/jmundrawala/workspace/bundler/foo/Rakefile:4:in `block in <top (required)>'
Tasks: TOP => foo
(See full trace by running task with --trace)
```