### PR TITLE
[Resolver] Resolve for a given ruby version

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -196,7 +196,8 @@ module Bundler
           last_resolve
         else
           # Run a resolve against the locally available gems
-          last_resolve.merge Resolver.resolve(expanded_dependencies, index, source_requirements, last_resolve, ruby_version.version)
+          requested_ruby_version = ruby_version.version if ruby_version
+          last_resolve.merge Resolver.resolve(expanded_dependencies, index, source_requirements, last_resolve, requested_ruby_version)
         end
       end
     end

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -196,7 +196,7 @@ module Bundler
           last_resolve
         else
           # Run a resolve against the locally available gems
-          last_resolve.merge Resolver.resolve(expanded_dependencies, index, source_requirements, last_resolve)
+          last_resolve.merge Resolver.resolve(expanded_dependencies, index, source_requirements, last_resolve, ruby_version.version)
         end
       end
     end

--- a/lib/bundler/index.rb
+++ b/lib/bundler/index.rb
@@ -79,6 +79,7 @@ module Bundler
       when Gem::Specification, RemoteSpecification, LazySpecification, EndpointSpecification then search_by_spec(query)
       when String then specs_by_name(query)
       when Gem::Dependency then search_by_dependency(query, base)
+      when DepProxy then search_by_dependency(query.dep, base)
       else
         raise "You can't search for a #{query.inspect}."
       end

--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -194,7 +194,7 @@ module Bundler
       @search_for = {}
       @base_dg = Molinillo::DependencyGraph.new
       @base.each {|ls| @base_dg.add_vertex(ls.name, Dependency.new(ls.name, ls.version), true) }
-      @ruby_version = Gem::Version.create(ruby_version) if ruby_version
+      @ruby_version = ruby_version ? Gem::Version.create(ruby_version) : nil
     end
 
     def start(requirements)

--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -108,7 +108,7 @@ module Bundler
 
       def activate_platform(platform)
         unless @activated.include?(platform)
-          if for?(platform)
+          if for?(platform, nil)
             @activated << platform
             return __dependencies[platform] || []
           end
@@ -128,8 +128,14 @@ module Bundler
         @source ||= first.source
       end
 
-      def for?(platform)
-        @specs[platform]
+      def for?(platform, required_ruby_version)
+        if spec = @specs[platform]
+          if required_ruby_version && spec_required_ruby_version = spec.required_ruby_version
+            spec_required_ruby_version.satisfied_by?(required_ruby_version)
+          else
+            true
+          end
+        end
       end
 
       def to_s
@@ -173,14 +179,14 @@ module Bundler
     # ==== Returns
     # <GemBundle>,nil:: If the list of dependencies can be resolved, a
     #   collection of gemspecs is returned. Otherwise, nil is returned.
-    def self.resolve(requirements, index, source_requirements = {}, base = [])
+    def self.resolve(requirements, index, source_requirements = {}, base = [], ruby_version = nil)
       base = SpecSet.new(base) unless base.is_a?(SpecSet)
-      resolver = new(index, source_requirements, base)
+      resolver = new(index, source_requirements, base, ruby_version)
       result = resolver.start(requirements)
       SpecSet.new(result)
     end
 
-    def initialize(index, source_requirements, base)
+    def initialize(index, source_requirements, base, ruby_version)
       @index = index
       @source_requirements = source_requirements
       @base = base
@@ -188,6 +194,7 @@ module Bundler
       @search_for = {}
       @base_dg = Molinillo::DependencyGraph.new
       @base.each {|ls| @base_dg.add_vertex(ls.name, Dependency.new(ls.name, ls.version), true) }
+      @ruby_version = Gem::Version.create(ruby_version) if ruby_version
     end
 
     def start(requirements)
@@ -267,7 +274,7 @@ module Bundler
           []
         end
       end
-      search.select {|sg| sg.for?(platform) }.each {|sg| sg.activate_platform(platform) }
+      search.select {|sg| sg.for?(platform, @ruby_version) }.each {|sg| sg.activate_platform(platform) }
     end
 
     def name_for(dependency)

--- a/lib/bundler/source/path.rb
+++ b/lib/bundler/source/path.rb
@@ -49,7 +49,7 @@ module Bundler
       end
 
       def to_s
-        "source at #{@path}"
+        "source at `#{@path}`"
       end
 
       def hash

--- a/spec/resolver/basic_spec.rb
+++ b/spec/resolver/basic_spec.rb
@@ -74,4 +74,33 @@ describe "Resolving" do
     dep "foo", ">= 3.0.0"
     should_resolve_and_include %w(foo-3.0.5)
   end
+
+  it "takes into account required_ruby_version" do
+    @index = build_index do
+      gem "foo", "1.0.0" do
+        dep "bar", ">= 0"
+      end
+
+      gem "foo", "2.0.0" do |s|
+        dep "bar", ">= 0"
+        s.required_ruby_version = '~> 2.0.0'
+      end
+
+      gem "bar", "1.0.0"
+
+      gem "bar", "2.0.0" do |s|
+        s.required_ruby_version = '~> 2.0.0'
+      end
+    end
+    dep "foo"
+
+    deps = []
+    @deps.each do |d|
+      deps << Bundler::DepProxy.new(d, "ruby")
+    end
+
+    got = Bundler::Resolver.resolve(deps, @index, {}, [], "1.8.7")
+    got = got.map(&:full_name).sort
+    expect(got).to eq(%w(foo-1.0.0 bar-1.0.0).sort)
+  end
 end

--- a/spec/resolver/basic_spec.rb
+++ b/spec/resolver/basic_spec.rb
@@ -83,13 +83,13 @@ describe "Resolving" do
 
       gem "foo", "2.0.0" do |s|
         dep "bar", ">= 0"
-        s.required_ruby_version = '~> 2.0.0'
+        s.required_ruby_version = "~> 2.0.0"
       end
 
       gem "bar", "1.0.0"
 
       gem "bar", "2.0.0" do |s|
-        s.required_ruby_version = '~> 2.0.0'
+        s.required_ruby_version = "~> 2.0.0"
       end
     end
     dep "foo"

--- a/spec/support/builders.rb
+++ b/spec/support/builders.rb
@@ -439,6 +439,10 @@ module Spec
         @spec.add_runtime_dependency(name, requirements)
       end
 
+      def required_ruby_version=(*reqs)
+        @spec.required_ruby_version = *reqs
+      end
+
       alias_method :dep, :runtime
     end
 

--- a/spec/update/path_spec.rb
+++ b/spec/update/path_spec.rb
@@ -12,7 +12,7 @@ describe "path sources" do
       build_lib "activesupport", "3.0", :path => lib_path("rails/activesupport")
 
       bundle "update --source activesupport"
-      expect(out).to include("Using activesupport 3.0 (was 2.3.5) from source at #{lib_path("rails/activesupport")}")
+      expect(out).to include("Using activesupport 3.0 (was 2.3.5) from source at `#{lib_path("rails/activesupport")}`")
     end
   end
 end


### PR DESCRIPTION
Take the definition's ruby version into account when resolving, to try and avoid conflicts with incompatible `required_ruby_version`s. This will mostly help once the compact index is in use.