### PR TITLE
Also print gemspecs in `bundle env`

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -13,6 +13,7 @@ module Bundler
 
     VALID_PLATFORMS = Bundler::Dependency::PLATFORM_MAP.keys.freeze
 
+    attr_reader :gemspecs
     attr_accessor :dependencies
 
     def initialize
@@ -26,6 +27,7 @@ module Bundler
       @platforms            = []
       @env                  = nil
       @ruby_version         = nil
+      @gemspecs             = []
       add_git_sources
     end
 
@@ -65,6 +67,8 @@ module Bundler
             gem dep.name, *(dep.requirement.as_list + [:type => :development])
           end
         end
+
+        @gemspecs << gemspecs.first
       when 0
         raise InvalidOption, "There are no gemspecs at #{expanded_path}."
       else

--- a/lib/bundler/env.rb
+++ b/lib/bundler/env.rb
@@ -4,11 +4,12 @@ require "bundler/source/git/git_proxy"
 module Bundler
   class Env
     def write(io)
-      io.write report(:print_gemfile => true)
+      io.write report(:print_gemfile => true, :print_gemspecs => true)
     end
 
     def report(options = {})
       print_gemfile = options.delete(:print_gemfile)
+      print_gemspecs = options.delete(:print_gemspecs)
 
       out = "Environment\n\n"
       out << "    Bundler   #{Bundler::VERSION}\n"
@@ -37,6 +38,14 @@ module Bundler
 
         out << "\n#{Bundler.default_lockfile.relative_path_from(SharedHelpers.pwd)}\n\n"
         out << "    " << read_file(Bundler.default_lockfile).gsub(/\n/, "\n    ") << "\n"
+      end
+
+      if print_gemspecs
+        dsl = Dsl.new.tap {|d| d.eval_gemfile(Bundler.default_gemfile) }
+        dsl.gemspecs.each do |gs|
+          out << "\n#{Pathname.new(gs).basename}:"
+          out << "\n\n    " << read_file(gs).gsub(/\n/, "\n    ") << "\n"
+        end
       end
 
       out

--- a/lib/bundler/friendly_errors.rb
+++ b/lib/bundler/friendly_errors.rb
@@ -67,7 +67,7 @@ module Bundler
           #{e.class}: #{e.message}
             #{e.backtrace.join("\n            ")}
 
-      #{Bundler::Env.new.report(:print_gemfile => false).gsub(/\n/, "\n      ").strip}
+      #{Bundler::Env.new.report(:print_gemfile => false, :print_gemspecs => false).gsub(/\n/, "\n      ").strip}
       --- TEMPLATE END ----------------------------------------------------------------
 
     EOS

--- a/spec/bundler/env_spec.rb
+++ b/spec/bundler/env_spec.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+require "bundler/settings"
+
+describe Bundler::Env do
+  let(:env) { described_class.new }
+
+  describe "#report" do
+    context "when Gemfile contains a gemspec and print_gemspecs is true" do
+      let(:gemspec) do
+        <<-GEMSPEC.gsub(/^\s+/, "")
+          Gem::Specification.new do |gem|
+            gem.name = "foo"
+            gem.author = "Fumofu"
+          end
+        GEMSPEC
+      end
+
+      before do
+        gemfile("gemspec")
+
+        File.open(bundled_app.join("foo.gemspec"), "wb") do |f|
+          f.write(gemspec)
+        end
+      end
+
+      it "prints the contents of that gemspec" do
+        output = env.report(:print_gemspecs => true)
+        expect(output.gsub(/^\s+/, "")).to include(gemspec)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change has the nice side-effect that `bundle env` will throw an error for Gemfiles with invalid DSLs.

Closes https://trello.com/c/QOX9jyYN.