### PR TITLE
Add missing backtick in Bundler::GemHelper#sh

### DIFF
--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -167,7 +167,7 @@ module Bundler
       if code == 0
         out
       else
-        raise(out.empty? ? "Running `#{cmd}' failed. Run this command directly for more detailed output." : out)
+        raise(out.empty? ? "Running `#{cmd}` failed. Run this command directly for more detailed output." : out)
       end
     end
 


### PR DESCRIPTION
Since across the codebase and documentation shell commands are displayed
wrapped in backticks, the command included in the error output of
Bundler::GemHelper#sh should also be displayed in the same format.