### PR TITLE
Fix bitbucket source deprecation warning

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -230,8 +230,8 @@ module Bundler
 
       # TODO 2.0 remove this deprecated git source
       git_source(:bitbucket) do |repo_name|
-        warn_deprecated_git_source(:bitbucket, "https://#{user_name}@bitbucket.org/#{user_name}/#{repo_name}.git")
         user_name, repo_name = repo_name.split "/"
+        warn_deprecated_git_source(:bitbucket, "https://#{user_name}@bitbucket.org/#{user_name}/#{repo_name}.git")
         repo_name ||= user_name
         "https://#{user_name}@bitbucket.org/#{user_name}/#{repo_name}.git"
       end


### PR DESCRIPTION
The deprecation warning tries to access `user_name` which is not yet
assigned and falls back to `method_missing` which raises an error.