### PR TITLE
Handle odd encoding cases in bundler path setup.

### DIFF
--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -77,7 +77,11 @@ module Bundler
       # Set PATH
       paths = (ENV["PATH"] || "").split(File::PATH_SEPARATOR)
       paths.unshift "#{Bundler.bundle_path}/bin"
-      ENV["PATH"] = paths.uniq.join(File::PATH_SEPARATOR)
+      begin
+        ENV["PATH"] = paths.uniq.join(File::PATH_SEPARATOR)
+      rescue Encoding::CompatibilityError
+        ENV["PATH"] = paths.uniq.map {|x| x.encode("UTF-8") }.join(File::PATH_SEPARATOR)
+      end
 
       # Set RUBYOPT
       rubyopt = [ENV["RUBYOPT"]].compact

--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+require "bundler/shared_helpers"
+
+RSpec.describe Bundler::SharedHelpers do
+  describe "#set_bundle_environment" do
+    it "does not raise an exception when the filesystem prsents utf-8 paths and env is windows-1251 encoded" do
+      # cyrillic c encoded with windows-1251
+      allow(ENV).to receive(:[]).and_return([209].pack("c*").force_encoding("windows-1251"))
+
+      # unicode heart emoji
+      allow(Bundler).to receive(:bundle_path).and_return([240, 159, 146, 149].pack("c*").force_encoding("utf-8"))
+
+      foo = Class.new do
+        include Bundler::SharedHelpers
+      end
+
+      expect {
+        foo.new.set_bundle_environment
+      }.to_not raise_error
+    end
+  end
+end


### PR DESCRIPTION
This patch is motivated by [vagrant
5475](https://github.com/mitchellh/vagrant/issues/5475)

On some windows systems, the value of `ENV["PATH"]` is encoded with
`windows-1251`, while the filesystem returns `utf-8` encoded strings for
file paths. During bundler setup it manipulates the path, but
unfortunately this can potentially raise an
`Encoding::CompatabilityError`.

Consider a `windows-1251` encoded path:

```ruby
[209].pack("c*").force_encoding("windows-1251")
```

If the bundler path contains characters which are not valid in the
windows-1251 encoding:

```
"💕"
```

then this [code
fragment](https://github.com/bundler/bundler/blob/21b1e3b6ff0f4fc9ff7ffeaded1fefdd42bcf8eb/lib/bundler/shared_helpers.rb#L78-L80)
will raise the `Encoding::CompatabilityError`.

A reproduction example of this (which works on OS X and linux) can be
found in [this
gist](https://gist.github.com/samphippen/85ed7a568d7475d50fa4). It's
pretty weird, but to explain, it basically stubs `ENV["PATH"]` and
`Bundler.bundle_path` to reproduce the error.

With the patch contained in this commit we circumvent the problem by
mapping each string in `ENV["PATH"]` with the UTF-8 encoding. This only
happens if an exception is raised and seems to fix my reproduction case.