### PR TITLE
Extracting a new "GemInstaller" from installer.rb

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -27,7 +27,7 @@ module Bundler
   autoload :Fetcher,               "bundler/fetcher"
   autoload :GemHelper,             "bundler/gem_helper"
   autoload :GemHelpers,            "bundler/gem_helpers"
-  autoload :GemInstaller,          "bundler/gem_installer"
+  autoload :RubyGemsGemInstaller,  "bundler/rubygems_gem_installer"
   autoload :Graph,                 "bundler/graph"
   autoload :Index,                 "bundler/index"
   autoload :Installer,             "bundler/installer"

--- a/lib/bundler/gem_remote_fetcher.rb
+++ b/lib/bundler/gem_remote_fetcher.rb
@@ -4,7 +4,7 @@ module Bundler
   # Adds support for setting custom HTTP headers when fetching gems from the
   # server.
   #
-  # TODO Get rid of this when and if gemstash only supports RubyGems versions
+  # TODO: Get rid of this when and if gemstash only supports RubyGems versions
   # that contain https://github.com/rubygems/rubygems/commit/3db265cc20b2f813.
   class GemRemoteFetcher < Gem::RemoteFetcher
     attr_accessor :headers

--- a/lib/bundler/installer/gem_installer.rb
+++ b/lib/bundler/installer/gem_installer.rb
@@ -1,0 +1,76 @@
+module Bundler
+  class GemInstaller
+    attr_reader :spec, :standalone, :worker, :force, :installer
+
+    def initialize(spec, installer, standalone = false, worker = 0, force = false)
+      @spec = spec
+      @installer = installer
+      @standalone = standalone
+      @worker = worker
+      @force = force
+    end
+
+    def install_from_spec
+      post_install_message = spec_settings ? install_with_settings : install
+      Bundler.ui.debug "#{worker}:  #{spec.name} (#{spec.version}) from #{spec.loaded_from}"
+      generate_executable_stubs
+      post_install_message
+
+    rescue Errno::ENOSPC
+      raise Bundler::InstallError, out_of_space_message
+    rescue => e
+      handle_exception(e)
+    end
+
+  private
+
+    def failure_message
+      return install_error_message if spec.source.options["git"]
+      "#{install_error_message}\n#{gem_install_message}"
+    end
+
+    def install_error_message
+      "An error occurred while installing #{spec.name} (#{spec.version}), and Bundler cannot continue."
+    end
+
+    def gem_install_message
+      "Make sure that `gem install #{spec.name} -v '#{spec.version}'` succeeds before bundling."
+    end
+
+    def handle_exception(e)
+      # if install hook failed or gem signature is bad, just die
+      raise e if e.is_a?(Bundler::InstallHookError) || e.is_a?(Bundler::SecurityError)
+      # other failure, likely a native extension build failure
+      Bundler.ui.info ""
+      Bundler.ui.warn "#{e.class}: #{e.message}"
+      Bundler.ui.debug e.backtrace.join("\n")
+      raise Bundler::InstallError, failure_message
+    end
+
+    def spec_settings
+      # Fetch the build settings, if there are any
+      Bundler.settings["build.#{spec.name}"]
+    end
+
+    def install
+      spec.source.install(spec, :force => force, :ensure_builtin_gems_cached => standalone)
+    end
+
+    def install_with_settings
+      # Build arguments are global, so this is mutexed
+      Bundler.rubygems.with_build_args([spec_settings]) { install }
+    end
+
+    def out_of_space_message
+      "Your disk is out of space. Free some space to be able to install your bundle."
+    end
+
+    def generate_executable_stubs
+      if Bundler.settings[:bin] && standalone
+        installer.generate_standalone_bundler_executable_stubs(spec)
+      elsif Bundler.settings[:bin]
+        installer.generate_bundler_executable_stubs(spec, :force => true)
+      end
+    end
+  end
+end

--- a/lib/bundler/installer/parallel_installer.rb
+++ b/lib/bundler/installer/parallel_installer.rb
@@ -1,4 +1,5 @@
 require "bundler/worker"
+require "bundler/installer/gem_installer"
 
 class ParallelInstaller
   class SpecInstallation
@@ -84,7 +85,9 @@ class ParallelInstaller
 
   def worker_pool
     @worker_pool ||= Bundler::Worker.new @size, lambda { |spec_install, worker_num|
-      message = @installer.install_gem_from_spec spec_install.spec, @standalone, worker_num, @force
+      message = Bundler::GemInstaller.new(
+        spec_install.spec, @installer, @standalone, worker_num, @force
+      ).install_from_spec
       spec_install.post_install_message = message unless message.nil?
       spec_install
     }

--- a/lib/bundler/rubygems_gem_installer.rb
+++ b/lib/bundler/rubygems_gem_installer.rb
@@ -1,7 +1,7 @@
 require "rubygems/installer"
 
 module Bundler
-  class GemInstaller < Gem::Installer
+  class RubyGemsGemInstaller < Gem::Installer
     def check_executable_overwrite(filename)
       # Bundler needs to install gems regardless of binstub overwriting
     end

--- a/lib/bundler/source/path/installer.rb
+++ b/lib/bundler/source/path/installer.rb
@@ -1,7 +1,7 @@
 module Bundler
   class Source
     class Path
-      class Installer < Bundler::GemInstaller
+      class Installer < Bundler::RubyGemsGemInstaller
         attr_reader :spec
 
         def initialize(spec, options = {})

--- a/lib/bundler/source/rubygems.rb
+++ b/lib/bundler/source/rubygems.rb
@@ -132,7 +132,7 @@ module Bundler
 
           installed_spec = nil
           Bundler.rubygems.preserve_paths do
-            installed_spec = Bundler::GemInstaller.new(
+            installed_spec = Bundler::RubyGemsGemInstaller.new(
               path,
               :install_dir         => install_path.to_s,
               :bin_dir             => bin_path.to_s,


### PR DESCRIPTION
My goal was to reveal the main part of install_gem_from_spec. From my
perspective the main part is:
1. Install
2. Generate stubs
3. Print message to the user
(4. handle exceptions)

While working on it I found that Bundler::Installer's run method and
instance variables weren't used when installing gems with
install_gem_from_spec. The installer was (and still is) only used to
generate executable stubs.
So I inserted the new GemInstaller in ParallelInstaller; passing the
instantiated Bundler::Installer to the GemInstaller only to generate
the executable stubs.

Based on this I would continue by extracting two BinstubGenerator
classes and removing GemInstaller's dependency on Bundler::Installer,
possibly allowing for a more concise way to generate binstubs in other
parts of bundler.

I was a bit intimidated by the amount of installers and weary to add
another one to this contested namespace. So I checked in with
@indirect who approved of the general direction of the refactoring and
suggested to rename the old GemInstaller to RubyGemsGemInstaller.