### PR TITLE
Make SSL Verify Mode a number setting

### DIFF
--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -3,7 +3,7 @@ require "uri"
 module Bundler
   class Settings
     BOOL_KEYS = %w(frozen cache_all no_prune disable_local_branch_check ignore_messages gem.mit gem.coc).freeze
-    NUMBER_KEYS = %w(retry timeout redirect).freeze
+    NUMBER_KEYS = %w(retry timeout redirect ssl_verify_mode).freeze
     DEFAULT_CONFIG = { :retry => 3, :timeout => 10, :redirect => 5 }
 
     def initialize(root = nil)

--- a/spec/bundler/settings_spec.rb
+++ b/spec/bundler/settings_spec.rb
@@ -41,6 +41,13 @@ describe Bundler::Settings do
       end
     end
 
+    context "when is number" do
+      it "returns a number" do
+        settings[:ssl_verify_mode] = "1"
+        expect(settings[:ssl_verify_mode]).to be 1
+      end
+    end
+
     context "when it's not possible to write to the file" do
       it "raises an PermissionError with explanation" do
         expect(FileUtils).to receive(:mkdir_p).with(settings.send(:local_config_file).dirname).


### PR DESCRIPTION
Needed to turn off SSL verify mode, most the code seemed to be there but the setting was being cast to a string which caused it to fail. Added it to NUMBER_KEYS and it's ok now