### PR TITLE
Add --shebang option to binstubs command

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -22,4 +22,4 @@ The `bundler/capistrano` and `bundler/vlad` deployment helper files have been re
 
 The `--binstubs` option has been removed from `bundle install` and replaced with the `bundle binstubs` command. This means that binstubs must be created and checked into version control individually.
 
-The `bundle binstubs [GEM]` command accepts two optional arguments: `--force`, which overwrites existing binstubs if they exist, and `--path=PATH`, which specifies the directory in which the binstubs will be installed (`./bin` by default).
+The `bundle binstubs [GEM]` command accepts three optional arguments: `--force`, which overwrites existing binstubs if they exist, `--path=PATH` which specifies the directory in which the binstubs will be installed (`./bin` by default) and `--shebang=RUBY_EXECUTABLE`, which sets the shebang executable name for the installed binstubs.

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -198,6 +198,8 @@ module Bundler
     D
     method_option "force", :type => :boolean, :default => false, :banner =>
       "Overwrite existing binstubs if they exist"
+    method_option "shebang", :type => :string, :banner =>
+      "Specify a different shebang executable name than the default (usually 'ruby')"
     def binstubs(*gems)
       require "bundler/cli/binstubs"
       Binstubs.new(options, gems).run

--- a/lib/bundler/cli/binstubs.rb
+++ b/lib/bundler/cli/binstubs.rb
@@ -12,6 +12,7 @@ module Bundler
       Bundler.definition.validate_ruby!
       Bundler.settings[:bin] = Bundler.settings["path.binstubs"] if Bundler.settings["path.binstubs"]
       Bundler.settings[:bin] = nil if Bundler.settings["path.binstubs"] && Bundler.settings["path.binstubs"].empty?
+      Bundler.settings[:shebang] = options["shebang"] if options["shebang"]
       installer = Installer.new(Bundler.root, Bundler.definition)
 
       if gems.empty?

--- a/spec/commands/binstubs_spec.rb
+++ b/spec/commands/binstubs_spec.rb
@@ -103,6 +103,19 @@ describe "bundle binstubs <gem>" do
         expect(File.stat(binary).mode.to_s(8)).to eq("100775")
       end
     end
+
+    context "when using --shebang" do
+      it "sets the specified shebang for the the binstub" do
+        install_gemfile <<-G
+          source "file://#{gem_repo1}"
+          gem "rack"
+        G
+
+        bundle "binstubs rack --shebang jruby"
+
+        expect(File.open("bin/rackup").gets).to eq("#!/usr/bin/env jruby\n")
+      end
+    end
   end
 
   context "when the gem doesn't exist" do


### PR DESCRIPTION
bundle install `--binstubs` option is to be removed from Bundler 2.0 and currently 
supports setting the shebang using the `--shebang` option.

See #1467 introducing the `--shebang` option, which with this commit
is ported to the binstubs command.