### PR TITLE
Include revision hash in Source::Git#to_s

### DIFF
--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -65,7 +65,14 @@ module Bundler
         else
           ref
         end
-        "#{uri} (at #{at})"
+
+        rev = begin
+                "@#{shortref_for_display(revision)}"
+              rescue GitError
+                nil
+              end
+
+        "#{uri} (at #{at}#{rev})"
       end
 
       def name

--- a/spec/install/deploy_spec.rb
+++ b/spec/install/deploy_spec.rb
@@ -207,7 +207,7 @@ describe "install with --deployment or --frozen" do
 
       bundle "install --deployment"
       expect(out).to include("deployment mode")
-      expect(out).to include("You have deleted from the Gemfile:\n* source: #{lib_path("rack-1.0")} (at master)")
+      expect(out).to include("You have deleted from the Gemfile:\n* source: #{lib_path("rack-1.0")} (at master@#{revision_for(lib_path("rack-1.0"))[0..6]}")
       expect(out).not_to include("You have added to the Gemfile")
       expect(out).not_to include("You have changed in the Gemfile")
     end
@@ -230,7 +230,7 @@ describe "install with --deployment or --frozen" do
 
       bundle "install --deployment"
       expect(out).to include("deployment mode")
-      expect(out).to include("You have changed in the Gemfile:\n* rack from `no specified source` to `#{lib_path("rack")} (at master)`")
+      expect(out).to include("You have changed in the Gemfile:\n* rack from `no specified source` to `#{lib_path("rack")} (at master@#{revision_for(lib_path("rack"))[0..6]})`")
       expect(out).not_to include("You have added to the Gemfile")
       expect(out).not_to include("You have deleted from the Gemfile")
     end

--- a/spec/install/git_spec.rb
+++ b/spec/install/git_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+
+describe "bundle install" do
+  context "git sources" do
+    it "displays the revision hash of the gem repository" do
+      build_git "foo", "1.0", :path => lib_path("foo")
+
+      install_gemfile <<-G
+        gem "foo", :git => "#{lib_path("foo")}"
+      G
+
+      bundle :install
+      expect(out).to include("Using foo 1.0 from #{lib_path("foo")} (at master@#{revision_for(lib_path("foo"))[0..6]})")
+      should_be_installed "foo 1.0"
+    end
+  end
+end

--- a/spec/update/git_spec.rb
+++ b/spec/update/git_spec.rb
@@ -32,7 +32,7 @@ describe "bundle update" do
       G
 
       bundle "update rails"
-      expect(out).to include("Using activesupport 3.0 from #{lib_path("rails")} (at master)")
+      expect(out).to include("Using activesupport 3.0 from #{lib_path("rails")} (at master@#{revision_for(lib_path("rails"))[0..6]})")
       should_be_installed "rails 3.0", "activesupport 3.0"
     end
 
@@ -229,7 +229,7 @@ describe "bundle update" do
       G
 
       bundle "update"
-      expect(out).to include("Using rails 3.0 (was 2.3.2) from #{lib_path("rails")} (at master)")
+      expect(out).to include("Using rails 3.0 (was 2.3.2) from #{lib_path("rails")} (at master@#{revision_for(lib_path("rails"))[0..6]})")
     end
   end
 


### PR DESCRIPTION
This effectively changes the output of commands that use Source::Git#to_s
(ie. `bundle install`). For example:

    Using rack 1.0.0 from git@github.com:rack/rack.git (at master@574b147)

Closes #3433.