### PR TITLE
Fix Gem::SystemExitException initialization

### DIFF
--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -66,7 +66,7 @@ module Bundler
     rescue Gem::SystemExitException => e
       Bundler.ui.error "#{e.class}: #{e.message}"
       Bundler.ui.trace e
-      raise Gem::SystemExitException
+      raise
     end
 
     def ruby_engine

--- a/spec/bundler/rubygems_integration_spec.rb
+++ b/spec/bundler/rubygems_integration_spec.rb
@@ -18,4 +18,11 @@ describe Bundler::RubygemsIntegration do
       Bundler.rubygems.validate(spec)
     end
   end
+
+  describe "#configuration" do
+    it "handles Gem::SystemExitException errors" do
+      allow(Gem).to receive(:configuration) { raise Gem::SystemExitException.new(1) }
+      expect { Bundler.rubygems.configuration }.to raise_error(Gem::SystemExitException)
+    end
+  end
 end


### PR DESCRIPTION
Previously, we would attempt to initialize `Gem::SystemExitException`
without an argument, which would result in an `ArgumentError` since the
argument is required (from Rubygems 1.3 all the way to 2.4).

I don't know how we missed this all this time. Maybe that path is not
even hit anymore.

Anyway, we don't even have to initialize a new exception, just re-raising the
one we've rescued is sufficient.