### PR TITLE
Add "source :default" support.

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -121,11 +121,17 @@ module Bundler
 
     def source(source, &blk)
       source = normalize_source(source)
+
+      if source == :default
+        Bundler.rubygems.configuration
+        source = Bundler.rubygems.sources
+      end
+
       if block_given?
         with_source(@sources.add_rubygems_source("remotes" => source), &blk)
       else
         check_primary_source_safety(@sources)
-        @sources.add_rubygems_remote(source)
+        Array(source || []).reverse_each {|r| @sources.add_rubygems_remote(r) }
       end
     end
 
@@ -348,7 +354,7 @@ module Bundler
           "requests are insecure.\nPlease change your source to 'https://" \
           "rubygems.org' if possible, or 'http://rubygems.org' if not."
         "http://rubygems.org"
-      when String
+      when String, :default
         source
       else
         raise GemfileError, "Unknown source '#{source}'"

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -211,4 +211,16 @@ describe Bundler::Dsl do
       end
     end
   end
+
+  describe "#source" do
+    it ":default is using sources specified by RubyGems" do
+      other_source = double("default-source")
+      allow(Bundler::Source::Rubygems).to receive(:new).and_return(other_source)
+      allow(other_source).to receive(:remotes).and_return([])
+
+      expect(other_source).to receive(:add_remote).with(Gem.default_sources.last)
+
+      subject.source :default
+    end
+  end
 end


### PR DESCRIPTION
I'd love to configure my sources once for RubyGems and later share this setting by all my projects. As far as I understand, there is no way how to achieve this at the moment, it is always necessary to specify the "source" in my Gemfile. Hence I am proposing to use "source :default" to inherit my RubyGems settings.

Please note that that although this is in principle request similar to #118, #2051 of #3528, the main difference is that this has to be explicitly enabled and hence any possible issues are user responsibility.