### PR TITLE
Don't rebuild git extensions

### DIFF
--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -170,7 +170,11 @@ module Bundler
           @copied = true
         end
 
-        return nil if gem_build_complete?(spec.extensions_dir)
+        if spec.respond_to?(:missing_extensions?)
+          return nil unless spec.missing_extensions?
+        else
+          return nil if gem_build_complete?(spec.extensions_dir)
+        end
 
         generate_bin(spec)
 

--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -169,6 +169,9 @@ module Bundler
           serialize_gemspecs_in(install_path)
           @copied = true
         end
+
+        return nil if gem_build_complete?(spec.extensions_dir)
+
         generate_bin(spec)
 
         requires_checkout? ? spec.post_install_message : nil
@@ -221,6 +224,14 @@ module Bundler
       end
 
     private
+
+      def gem_complete_path(extensions_dir)
+        File.join(extensions_dir, extension_dir_name, "gem.build_complete")
+      end
+
+      def gem_build_complete?(extensions_dir)
+        File.exists? gem_complete_path(extensions_dir)
+      end
 
       def serialize_gemspecs_in(destination)
         expanded_path = destination.expand_path(Bundler.root)

--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -172,8 +172,8 @@ module Bundler
 
         if spec.respond_to?(:missing_extensions?)
           return nil unless spec.missing_extensions?
-        else
-          return nil if gem_build_complete?(spec.extensions_dir)
+        elsif gem_build_complete?(spec.extensions_dir)
+          return nil
         end
 
         generate_bin(spec)

--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -230,7 +230,7 @@ module Bundler
       end
 
       def gem_build_complete?(extensions_dir)
-        File.exists? gem_complete_path(extensions_dir)
+        File.exist? gem_complete_path(extensions_dir)
       end
 
       def serialize_gemspecs_in(destination)

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -962,7 +962,7 @@ describe "bundle install with git sources" do
 
       install_gemfile <<-G
         source "file://#{gem_repo1}"
-        gem "foo", :git => "#{lib_path('foo-1.0')}"
+        gem "foo", :git => "#{lib_path("foo-1.0")}"
       G
 
       run <<-R
@@ -975,7 +975,7 @@ describe "bundle install with git sources" do
 
       install_gemfile <<-G
         source "file://#{gem_repo1}"
-        gem "foo", :git => "#{lib_path('foo-1.0')}"
+        gem "foo", :git => "#{lib_path("foo-1.0")}"
       G
 
       run <<-R


### PR DESCRIPTION
@andremedeiros /cc @Sirupsen

This is somewhat related to https://github.com/bundler/bundler/pull/4030 (and requires it to work). Bundler is not checking the `gem.build_complete` for git extensions, and as a result is recompiling extensions when performing a `bundle install`, for example.

This PR simply checks if `gem.build_complete` exists and bypasses the build step. This is a similar approach to what is done in [Rubygems](https://github.com/ruby/ruby/blob/v2_1_7/lib/rubygems/specification.rb#L1420).

In my Shopify development environment this brings `bundle install` time (when there are no Gemfile changes) from nearly 20 seconds to 3 seconds.
