### PR TITLE
Send X-Gemfile-Source when bundling with --full-index

### DIFF
--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -169,7 +169,7 @@ module Bundler
     end
 
     def fetchers
-      @fetchers ||= FETCHERS.map {|f| f.new(downloader, remote_uri, fetch_uri, uri) }
+      @fetchers ||= FETCHERS.map {|f| f.new(downloader, @remote, uri) }
     end
 
     def http_proxy
@@ -265,18 +265,6 @@ module Bundler
     end
 
   private
-
-    def fetch_uri
-      @fetch_uri ||= begin
-        if remote_uri.host == "rubygems.org"
-          uri = remote_uri.dup
-          uri.host = "bundler.rubygems.org"
-          uri
-        else
-          remote_uri
-        end
-      end
-    end
 
     def remote_uri
       @remote.uri

--- a/lib/bundler/fetcher/base.rb
+++ b/lib/bundler/fetcher/base.rb
@@ -2,16 +2,30 @@ module Bundler
   class Fetcher
     class Base
       attr_reader :downloader
-      attr_reader :remote_uri
-      attr_reader :fetch_uri
       attr_reader :display_uri
+      attr_reader :remote
 
-      def initialize(downloader, remote_uri, fetch_uri, display_uri)
+      def initialize(downloader, remote, display_uri)
         raise "Abstract class" if self.class == Base
         @downloader = downloader
-        @remote_uri = remote_uri
-        @fetch_uri = fetch_uri
+        @remote = remote
         @display_uri = display_uri
+      end
+
+      def remote_uri
+        @remote.uri
+      end
+
+      def fetch_uri
+        @fetch_uri ||= begin
+          if remote_uri.host == "rubygems.org"
+            uri = remote_uri.dup
+            uri.host = "bundler.rubygems.org"
+            uri
+          else
+            remote_uri
+          end
+        end
       end
 
       def api_available?

--- a/lib/bundler/fetcher/index.rb
+++ b/lib/bundler/fetcher/index.rb
@@ -5,9 +5,7 @@ module Bundler
   class Fetcher
     class Index < Base
       def specs(_gem_names)
-        old_sources = Bundler.rubygems.sources
-        Bundler.rubygems.sources = [remote_uri.to_s]
-        Bundler.rubygems.fetch_all_remote_specs
+        Bundler.rubygems.fetch_all_remote_specs(remote)
       rescue Gem::RemoteFetcher::FetchError, OpenSSL::SSL::SSLError, Net::HTTPFatalError => e
         case e.message
         when /certificate verify failed/
@@ -24,8 +22,6 @@ module Bundler
           Bundler.ui.trace e
           raise HTTPError, "Could not fetch specs from #{display_uri}"
         end
-      ensure
-        Bundler.rubygems.sources = old_sources
       end
     end
   end

--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -184,13 +184,21 @@ module Bundler
       [] # if we can't download them, there aren't any
     end
 
-    def fetch_all_remote_specs
+    # TODO: This is for older versions of Rubygems... should we support the
+    # X-Gemfile-Source header on these old versions?
+    # Maybe the newer implementation will work on older Rubygems?
+    # It seems difficult to keep this implementation and still send the header.
+    def fetch_all_remote_specs(remote)
+      old_sources = Bundler.rubygems.sources
+      Bundler.rubygems.sources = [remote.uri.to_s]
       # Fetch all specs, minus prerelease specs
       spec_list = fetch_specs(true, false)
       # Then fetch the prerelease specs
       fetch_prerelease_specs.each {|k, v| spec_list[k] += v }
 
       spec_list
+    ensure
+      Bundler.rubygems.sources = old_sources
     end
 
     def with_build_args(args)
@@ -560,27 +568,28 @@ module Bundler
         Gem::Specification.find_all_by_name name
       end
 
-      def fetch_specs(source, name)
+      def fetch_specs(source, remote, name)
         path = source + "#{name}.#{Gem.marshal_version}.gz"
-        string = Gem::RemoteFetcher.fetcher.fetch_path(path)
+        fetcher = Bundler::GemRemoteFetcher.fetcher
+        fetcher.headers = { "X-Gemfile-Source" => remote.original_uri.to_s } if remote.original_uri
+        string = fetcher.fetch_path(path)
         Bundler.load_marshal(string)
       rescue Gem::RemoteFetcher::FetchError => e
         # it's okay for prerelease to fail
         raise e unless name == "prerelease_specs"
       end
 
-      def fetch_all_remote_specs
+      def fetch_all_remote_specs(remote)
         # Since SpecFetcher now returns NameTuples, we just fetch directly
         # and unmarshal the array ourselves.
         hash = {}
 
-        Gem.sources.each do |source|
-          source = URI.parse(source.to_s) unless source.is_a?(URI)
-          hash[source] = fetch_specs(source, "specs")
+        source = remote.uri
+        source = URI.parse(source.to_s) unless source.is_a?(URI)
+        hash[source] = fetch_specs(source, remote, "specs")
 
-          pres = fetch_specs(source, "prerelease_specs")
-          hash[source].push(*pres) if pres && !pres.empty?
-        end
+        pres = fetch_specs(source, remote, "prerelease_specs")
+        hash[source].push(*pres) if pres && !pres.empty?
 
         hash
       end

--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -570,7 +570,7 @@ module Bundler
 
       def fetch_specs(source, remote, name)
         path = source + "#{name}.#{Gem.marshal_version}.gz"
-        fetcher = Bundler::GemRemoteFetcher.fetcher
+        fetcher = gem_remote_fetcher
         fetcher.headers = { "X-Gemfile-Source" => remote.original_uri.to_s } if remote.original_uri
         string = fetcher.fetch_path(path)
         Bundler.load_marshal(string)
@@ -595,13 +595,17 @@ module Bundler
       end
 
       def download_gem(spec, uri, path)
-        require "resolv"
         uri = Bundler.settings.mirror_for(uri)
-        proxy = configuration[:http_proxy]
-        dns = Resolv::DNS.new
-        fetcher = Bundler::GemRemoteFetcher.new(proxy, dns)
+        fetcher = gem_remote_fetcher
         fetcher.headers = { "X-Gemfile-Source" => spec.remote.original_uri.to_s } if spec.remote.original_uri
         fetcher.download(spec, uri, path)
+      end
+
+      def gem_remote_fetcher
+        require "resolv"
+        proxy = configuration[:http_proxy]
+        dns = Resolv::DNS.new
+        Bundler::GemRemoteFetcher.new(proxy, dns)
       end
 
       def gem_from_path(path, policy = nil)

--- a/spec/bundler/fetcher/index_spec.rb
+++ b/spec/bundler/fetcher/index_spec.rb
@@ -10,7 +10,7 @@ describe Bundler::Fetcher::Index do
     allow(Bundler).to receive(:ui).and_return(double(:trace => nil))
 
     expect {
-      Bundler::Fetcher::Index.new(nil, nil, nil, nil).specs(%w[foo bar])
+      Bundler::Fetcher::Index.new(nil, nil, nil).specs(%w[foo bar])
     }.to raise_error(Bundler::HTTPError)
   end
 end

--- a/spec/bundler/rubygems_integration_spec.rb
+++ b/spec/bundler/rubygems_integration_spec.rb
@@ -25,4 +25,38 @@ describe Bundler::RubygemsIntegration do
       expect { Bundler.rubygems.configuration }.to raise_error(Gem::SystemExitException)
     end
   end
+
+  describe "#fetch_all_remote_specs", :rubygems => ">= 2.0" do
+    let(:uri) { URI("https://example.com") }
+    let(:fetcher) { double("gem_remote_fetcher") }
+    let(:specs_response) { Marshal.dump(["specs"]) }
+    let(:prerelease_specs_response) { Marshal.dump(["prerelease_specs"]) }
+
+    context "when a rubygems source mirror is set" do
+      let(:orig_uri) { URI("http://zombo.com") }
+      let(:remote_with_mirror) { double("remote", :uri => uri, :original_uri => orig_uri) }
+
+      it "sets the 'X-Gemfile-Source' header containing the original source" do
+        expect(Bundler.rubygems).to receive(:gem_remote_fetcher).twice.and_return(fetcher)
+        expect(fetcher).to receive(:headers=).with("X-Gemfile-Source" => "http://zombo.com").twice
+        expect(fetcher).to receive(:fetch_path).with(uri + "specs.4.8.gz").and_return(specs_response)
+        expect(fetcher).to receive(:fetch_path).with(uri + "prerelease_specs.4.8.gz").and_return(prerelease_specs_response)
+        result = Bundler.rubygems.fetch_all_remote_specs(remote_with_mirror)
+        expect(result).to eq(uri => %w(specs prerelease_specs))
+      end
+    end
+
+    context "when there is no rubygems source mirror set" do
+      let(:remote_no_mirror) { double("remote", :uri => uri, :original_uri => nil) }
+
+      it "does not set the 'X-Gemfile-Source' header" do
+        expect(Bundler.rubygems).to receive(:gem_remote_fetcher).twice.and_return(fetcher)
+        expect(fetcher).to_not receive(:headers=)
+        expect(fetcher).to receive(:fetch_path).with(uri + "specs.4.8.gz").and_return(specs_response)
+        expect(fetcher).to receive(:fetch_path).with(uri + "prerelease_specs.4.8.gz").and_return(prerelease_specs_response)
+        result = Bundler.rubygems.fetch_all_remote_specs(remote_no_mirror)
+        expect(result).to eq(uri => %w(specs prerelease_specs))
+      end
+    end
+  end
 end


### PR DESCRIPTION
This fixes #4090

I did a little refactoring that made sense to me along the way, but if I went too far or might be breaking something I'm not aware of, please let me know.

**Existing issue:** This doesn't fix bundling with full index when using Rubygems < 2.0, as that code path seemed a bit trickier to fix. I added a *TODO* comment at the relevant method. I thought of a couple possibilities:
* Subclass `Gem::SpecFetcher` like `Bundler::GemRemoteFetcher`, it seems like it might be as simple as calling the super constructor and then replace `@fetcher` with a `Bundler::GemRemoteFetcher` with the headers added ahead of time (see https://github.com/rubygems/rubygems/blob/v1.8.30/lib/rubygems/spec_fetcher.rb#L66). This may involve different solutions the further back in Rubygems you go.
* Use the newer implementation of `fetch_all_remote_specs` for older Rubygems as well (I don't know if that would work though, but it might be worth a try).

I haven't yet added additional specs for this, but I wanted to get this out there first to get some feedback if possible.