### PR TITLE
[Lock] Add support for specify gems to `bundle lock` command

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -399,8 +399,8 @@ module Bundler
     end
 
     desc "lock", "Creates a lockfile without installing"
-    method_option "update", :type => :boolean, :default => false, :banner =>
-      "ignore the existing lockfile"
+    method_option "update", :type => :array, :lazy_default => [], :banner =>
+      "ignore the existing lockfile, update all gems by default, or update list of given gems"
     method_option "local", :type => :boolean, :default => false, :banner =>
       "do not attempt to fetch remote gemspecs and use the local gem cache only"
     method_option "print", :type => :boolean, :default => false, :banner =>

--- a/lib/bundler/cli/lock.rb
+++ b/lib/bundler/cli/lock.rb
@@ -16,8 +16,14 @@ module Bundler
       ui = Bundler.ui
       Bundler.ui = UI::Silent.new if print
 
-      unlock = options[:update]
-      definition = Bundler.definition(unlock)
+      gems = options[:update]
+
+      if gems && !gems.empty?
+        definition = Bundler.definition(:gems => gems)
+      else
+        definition = Bundler.definition(true)
+      end
+
       definition.resolve_remotely! unless options[:local]
 
       if print

--- a/spec/commands/lock_spec.rb
+++ b/spec/commands/lock_spec.rb
@@ -94,4 +94,12 @@ describe "bundle lock" do
     expect(read_lockfile "lock").to eq(@lockfile)
     expect { read_lockfile }.to raise_error(Errno::ENOENT)
   end
+
+  it "update specific gems using --update" do
+    lockfile @lockfile.gsub("2.3.2", "2.3.1").gsub("10.0.2", "10.0.1")
+
+    bundle "lock --update rails rake"
+
+    expect(read_lockfile).to eq(@lockfile)
+  end
 end


### PR DESCRIPTION
This Pull Request adds the ability to specify gems in bundle lock command via command-line option,
so that this is allowed:

```
bundle lock --gems devise
```

or

```
bundle lock --gems devise ominiauth
```

In this way, we can use lock command for specific gems without downloading any gem.

Thanks!