### PR TITLE
Use HTTPS protocol for :github shortcut

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -152,7 +152,7 @@ module Bundler
               "either use the :git option on a gem, or specify the gems that \n" \
               "bundler should find in the git source by passing a block to \n" \
               "the git method, like: \n\n" \
-              "  git 'git://github.com/rails/rails.git' do\n" \
+              "  git 'https://github.com/rails/rails.git' do\n" \
               "    gem 'rails'\n" \
               "  end"
         raise DeprecatedError, msg
@@ -220,7 +220,7 @@ module Bundler
     def add_git_sources
       git_source(:github) do |repo_name|
         repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
-        "git://github.com/#{repo_name}.git"
+        "https://github.com/#{repo_name}.git"
       end
 
       git_source(:gist) {|repo_name| "https://gist.github.com/#{repo_name}.git" }

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -28,7 +28,7 @@ describe Bundler::Dsl do
     context "default hosts (git, gist)" do
       it "converts :github to :git" do
         subject.gem("sparks", :github => "indirect/sparks")
-        github_uri = "git://github.com/indirect/sparks.git"
+        github_uri = "https://github.com/indirect/sparks.git"
         expect(subject.dependencies.first.source.uri).to eq(github_uri)
       end
 
@@ -46,7 +46,7 @@ describe Bundler::Dsl do
 
       it "converts 'rails' to 'rails/rails'" do
         subject.gem("rails", :github => "rails")
-        github_uri = "git://github.com/rails/rails.git"
+        github_uri = "https://github.com/rails/rails.git"
         expect(subject.dependencies.first.source.uri).to eq(github_uri)
       end
 
@@ -174,7 +174,7 @@ describe Bundler::Dsl do
         end
 
         subject.dependencies.each do |d|
-          expect(d.source.uri).to eq("git://github.com/spree/spree.git")
+          expect(d.source.uri).to eq("https://github.com/spree/spree.git")
         end
       end
     end


### PR DESCRIPTION
This improves security of cloning a Git repository using `:github` directive, as the clone process would go through a secured HTTPS protocol instead of insecure `git://` protocol.

Note that GitHub already starting to retire usage of `git://` protocol as you can notice by the clone URL on every project page. Also, given both `:gist` and `:bitbucket` already uses HTTPS protocol, I don't think
this will follow the good convention of choosing the best protocol for the users.