### PR TITLE
Fix bundle console IRB fallback

### DIFF
--- a/lib/bundler/cli/console.rb
+++ b/lib/bundler/cli/console.rb
@@ -18,7 +18,8 @@ module Bundler
       require name
       get_constant(name)
     rescue LoadError
-      Bundler.ui.error "Couldn't load console #{name}"
+      Bundler.ui.error "Couldn't load console #{name}, falling back to irb"
+      require "irb"
       get_constant("irb")
     end
 

--- a/spec/commands/console_spec.rb
+++ b/spec/commands/console_spec.rb
@@ -18,14 +18,26 @@ describe "bundle console" do
     expect(out).to include("0.9.1")
   end
 
+  it "uses IRB as default console" do
+    bundle "console" do |input|
+      input.puts("__method__")
+      input.puts("exit")
+    end
+    expect(out).to include(":irb_binding")
+  end
+
   it "starts another REPL if configured as such" do
+    install_gemfile <<-G
+      source "file://#{gem_repo1}"
+      gem "pry"
+    G
     bundle "config console pry"
 
     bundle "console" do |input|
-      input.puts("__callee__")
+      input.puts("__method__")
       input.puts("exit")
     end
-    expect(out).to include("pry")
+    expect(out).to include(":__pry__")
   end
 
   it "falls back to IRB if the other REPL isn't available" do
@@ -33,10 +45,10 @@ describe "bundle console" do
     # make sure pry isn't there
 
     bundle "console" do |input|
-      input.puts("__callee__")
+      input.puts("__method__")
       input.puts("exit")
     end
-    expect(out).to include("IRB")
+    expect(out).to include(":irb_binding")
   end
 
   it "doesn't load any other groups" do

--- a/spec/support/builders.rb
+++ b/spec/support/builders.rb
@@ -242,6 +242,39 @@ module Spec
         end
 
         build_gem "foo"
+
+        # A minimal fake pry console
+        build_gem "pry" do |s|
+          s.write "lib/pry.rb", <<-RUBY
+            class Pry
+              class << self
+                def toplevel_binding
+                  unless defined?(@toplevel_binding) && @toplevel_binding
+                    TOPLEVEL_BINDING.eval %{
+                      def self.__pry__; binding; end
+                      Pry.instance_variable_set(:@toplevel_binding, __pry__)
+                      class << self; undef __pry__; end
+                    }
+                  end
+                  @toplevel_binding.eval('private')
+                  @toplevel_binding
+                end
+
+                def __pry__
+                  while line = gets
+                    begin
+                      puts eval(line, toplevel_binding).inspect.sub(/^"(.*)"$/, '=> \\1')
+                    rescue Exception => e
+                      puts "\#{e.class}: \#{e.message}"
+                      puts e.backtrace.first
+                    end
+                  end
+                end
+                alias start __pry__
+              end
+            end
+          RUBY
+        end
       end
     end
 


### PR DESCRIPTION
The fallback to IRB for `bundle console` is currently broken, due to a missing `require 'irb'`:
```bash
bundle config console pry
bundle console
Couldn't load console pry
Could not find constant IRB
```

This fixes the fallback and also alters the error message to indicate the fallback to irb.

While investigating the fix I noticed that the `bundle console` specs were broken and only worked because the expected strings were both contained in the error message.

In order to test an alternate console and the fallback behavior, I added a fake pry gem that implements the minimum required api. I also replaced `__callee__` with `__method__` for ruby 1.8.7 compatibility.