### PR TITLE
Generate HTTPS URIs for github-targetted gems

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -220,7 +220,7 @@ module Bundler
     def add_git_sources
       git_source(:github) do |repo_name|
         repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
-        "git://github.com/#{repo_name}.git"
+        "https://github.com/#{repo_name}.git"
       end
 
       git_source(:gist) {|repo_name| "https://gist.github.com/#{repo_name}.git" }

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -28,7 +28,7 @@ describe Bundler::Dsl do
     context "default hosts (git, gist)" do
       it "converts :github to :git" do
         subject.gem("sparks", :github => "indirect/sparks")
-        github_uri = "git://github.com/indirect/sparks.git"
+        github_uri = "https://github.com/indirect/sparks.git"
         expect(subject.dependencies.first.source.uri).to eq(github_uri)
       end
 
@@ -46,7 +46,7 @@ describe Bundler::Dsl do
 
       it "converts 'rails' to 'rails/rails'" do
         subject.gem("rails", :github => "rails")
-        github_uri = "git://github.com/rails/rails.git"
+        github_uri = "https://github.com/rails/rails.git"
         expect(subject.dependencies.first.source.uri).to eq(github_uri)
       end
 
@@ -174,7 +174,7 @@ describe Bundler::Dsl do
         end
 
         subject.dependencies.each do |d|
-          expect(d.source.uri).to eq("git://github.com/spree/spree.git")
+          expect(d.source.uri).to eq("https://github.com/spree/spree.git")
         end
       end
     end


### PR DESCRIPTION
The [bundler-audit gem rightly raises an error](https://github.com/rubysec/bundler-audit/blob/96cc110974e2c26702fa99e22bc430a425696f4e/lib/bundler/audit/scanner.rb#L77-L116) when a Gemfile uses a `git://` or `http://` source, these being insecure protocols.

This patch sets an `https://` URI in the lockfile when you do something like
```
gem 'environmentor', github: 'madebymany/environmentor'
```