### PR TITLE
Check silence_root_warning option to skip warning on root install cmds

### DIFF
--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -8,7 +8,7 @@ module Bundler
     def run
       Bundler.ui.level = "error" if options[:quiet]
 
-      warn_if_root unless ENV['SILENCE_ROOT_WARNING']
+      warn_if_root
 
       [:with, :without].each do |option|
         if options[option]
@@ -157,7 +157,7 @@ module Bundler
   private
 
     def warn_if_root
-      return if Bundler::WINDOWS || !Process.uid.zero?
+      return if Bundler.settings[:silence_root_warning] || Bundler::WINDOWS || !Process.uid.zero?
       Bundler.ui.warn "Don't run Bundler as root. Bundler can ask for sudo " \
         "if it is needed, and installing your bundle as root will break this " \
         "application for all non-root users on this machine.", :wrap => true

--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -8,7 +8,7 @@ module Bundler
     def run
       Bundler.ui.level = "error" if options[:quiet]
 
-      warn_if_root
+      warn_if_root unless ENV['SILENCE_ROOT_WARNING']
 
       [:with, :without].each do |option|
         if options[option]

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -2,7 +2,7 @@ require "uri"
 
 module Bundler
   class Settings
-    BOOL_KEYS = %w(frozen cache_all no_prune disable_local_branch_check ignore_messages gem.mit gem.coc).freeze
+    BOOL_KEYS = %w(frozen cache_all no_prune disable_local_branch_check ignore_messages gem.mit gem.coc silence_root_warning).freeze
     NUMBER_KEYS = %w(retry timeout redirect ssl_verify_mode).freeze
     DEFAULT_CONFIG = { :retry => 3, :timeout => 10, :redirect => 5 }
 

--- a/spec/install/gems/sudo_spec.rb
+++ b/spec/install/gems/sudo_spec.rb
@@ -154,10 +154,24 @@ describe "when using sudo", :sudo => true do
       expect(out).to include(warning)
     end
 
-    context "when ENV['SILENCE_ROOT_WARNING'] is set" do
-      it 'skips the warning' do
-        bundle :install, sudo: :preserve_env, :env => { 'SILENCE_ROOT_WARNING' => true}
+    context "when ENV['BUNDLE_SILENCE_ROOT_WARNING'] is set" do
+      it "skips the warning" do
+        bundle :install, :sudo => :preserve_env, :env => { "BUNDLE_SILENCE_ROOT_WARNING" => true }
         expect(out).to_not include(warning)
+      end
+    end
+
+    context "when silence_root_warning is passed as an option" do
+      it "skips the warning" do
+        bundle :install, :sudo => true, :silence_root_warning => true
+        expect(out).to_not include(warning)
+      end
+    end
+
+    context "when silence_root_warning = false" do
+      it "warns against that" do
+        bundle :install, :sudo => true, :silence_root_warning => false
+        expect(out).to include(warning)
       end
     end
   end

--- a/spec/install/gems/sudo_spec.rb
+++ b/spec/install/gems/sudo_spec.rb
@@ -143,10 +143,22 @@ describe "when using sudo", :sudo => true do
   end
 
   describe "and root runs install" do
-    it "warns against that" do
+    let(:warning) { "Don't run Bundler as root." }
+
+    before do
       gemfile %|source "file://#{gem_repo1}"|
+    end
+
+    it "warns against that" do
       bundle :install, :sudo => true
-      expect(out).to include("Don't run Bundler as root.")
+      expect(out).to include(warning)
+    end
+
+    context "when ENV['SILENCE_ROOT_WARNING'] is set" do
+      it 'skips the warning' do
+        bundle :install, sudo: :preserve_env, :env => { 'SILENCE_ROOT_WARNING' => true}
+        expect(out).to_not include(warning)
+      end
     end
   end
 end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -64,7 +64,10 @@ module Spec
 
     def bundle(cmd, options = {})
       expect_err = options.delete(:expect_err)
-      sudo       = "sudo" if options.delete(:sudo)
+      with_sudo = options.delete(:sudo)
+      if with_sudo
+        sudo = with_sudo == :preserve_env ? 'sudo -E' : 'sudo'
+      end
       options["no-color"] = true unless options.key?("no-color") || %w(exec conf).include?(cmd.to_s[0..3])
 
       bundle_bin = File.expand_path("../../../exe/bundle", __FILE__)

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -65,9 +65,8 @@ module Spec
     def bundle(cmd, options = {})
       expect_err = options.delete(:expect_err)
       with_sudo = options.delete(:sudo)
-      if with_sudo
-        sudo = with_sudo == :preserve_env ? 'sudo -E' : 'sudo'
-      end
+      sudo = with_sudo == :preserve_env ? "sudo -E" : "sudo" if with_sudo
+
       options["no-color"] = true unless options.key?("no-color") || %w(exec conf).include?(cmd.to_s[0..3])
 
       bundle_bin = File.expand_path("../../../exe/bundle", __FILE__)


### PR DESCRIPTION
Adds a new setting `silence_root_warning` (environment variable: `BUNDLE_SILENCE_ROOT_WARNING`) that skips the default warning when `install` is run as root.

The warning is useful but I think it should be able to be disabled if the user knows what he's doing, it's handy when run inside Docker containers (which by default run as root), or other environments where root is used.

Also adds a new `preserve_env` option to `bundle` helper in tests which allows running commands under sudo with the `-E` flag (preserve environment) as opposed to the default env_reset. Without this, the command would be run without our flag which makes it impossible to test. There might be cleaner ways to achieve this, though.