### PR TITLE
Restrict platforms when using gemspec in DSL

### DIFF
--- a/lib/bundler/dependency.rb
+++ b/lib/bundler/dependency.rb
@@ -54,6 +54,15 @@ module Bundler
       :x64_mingw_23 => Gem::Platform::X64_MINGW
     }.freeze
 
+    REVERSE_PLATFORM_MAP = {}.tap do |reverse_platform_map|
+      PLATFORM_MAP.each do |key, value|
+        reverse_platform_map[value] ||= []
+        reverse_platform_map[value] << key
+      end
+
+      reverse_platform_map.each {|_, platforms| platforms.freeze }
+    end.freeze
+
     def initialize(name, version, options = {}, &blk)
       type = options["type"] || :runtime
       super(name, version, type)

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -60,7 +60,7 @@ module Bundler
             "#{file}. Make sure you can build the gem, then try again"
         end
 
-        gem spec.name, :path => path, :glob => glob
+        gem spec.name, :path => path, :glob => glob, :platforms => Bundler::Dependency::REVERSE_PLATFORM_MAP[spec.platform]
 
         group(development_group) do
           spec.development_dependencies.each do |dep|

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -145,6 +145,39 @@ describe Bundler::Dsl do
     end
   end
 
+  describe "#gemspec" do
+    let(:spec) do
+      Gem::Specification.new do |gem|
+        gem.name = "example"
+        gem.platform = platform
+      end
+    end
+
+    before do
+      allow(Dir).to receive(:[]).and_return(["spec_path"])
+      allow(Bundler).to receive(:load_gemspec).with("spec_path").and_return(spec)
+      allow(Bundler).to receive(:default_gemfile).and_return(Pathname.new("./Gemfile"))
+    end
+
+    context "with a ruby platform" do
+      let(:platform) { "ruby" }
+
+      it "keeps track of the ruby platforms in the dependency" do
+        subject.gemspec
+        expect(subject.dependencies.last.platforms).to eq(Bundler::Dependency::REVERSE_PLATFORM_MAP[Gem::Platform::RUBY])
+      end
+    end
+
+    context "with a jruby platform" do
+      let(:platform) { "java" }
+
+      it "keeps track of the jruby platforms in the dependency" do
+        subject.gemspec
+        expect(subject.dependencies.last.platforms).to eq(Bundler::Dependency::REVERSE_PLATFORM_MAP[Gem::Platform::JAVA])
+      end
+    end
+  end
+
   context "can bundle groups of gems with" do
     # git "https://github.com/rails/rails.git" do
     #   gem "railties"


### PR DESCRIPTION
When referencing a `gemspec` in the `Gemfile`, restrict what platforms to check against to just those defined by the `gemspec` itself.

This fixes #4102