### PR TITLE
Remove -I option from alias in DEVELOPMENT.md.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -29,7 +29,7 @@ Bundler doesn't use a Gemfile to list development dependencies, because when we 
 
   3. Set up a shell alias to run Bundler from your clone, e.g. a Bash alias:
 
-        $ alias dbundle='ruby -I /path/to/bundler/lib /path/to/bundler/exe/bundle'
+        $ alias dbundle='ruby /path/to/bundler/exe/bundle'
 
      With that set up, you can test changes you've made to Bundler by running `dbundle`, without interfering with the regular `bundle` command.
 


### PR DESCRIPTION
Loading lib/ into `$LOAD_PATH` causes the following:

[03:46 PM][~/src/clio/themis][b3bbbeb:master $] $ ruby -I ~/src/bundler/lib ~/src/bundler/exe/bundle
--- ERROR REPORT TEMPLATE -------------------------------------------------------
- What did you do?

  I ran the command `/home/adam/src/bundler/exe/bundle `

- What did you expect to happen?

  I expected Bundler to...

- What happened instead?

  Instead, what actually happened was...


Error details

    RuntimeError: LazySpecification has not been materialized yet (calling :required_ruby_version [])
      /home/adam/src/bundler/lib/bundler/lazy_specification.rb:75:in `method_missing'
      /home/adam/src/bundler/lib/bundler/resolver.rb:133:in `for?'
      /home/adam/src/bundler/lib/bundler/resolver.rb:277:in `block in search_for'
      /home/adam/src/bundler/lib/bundler/resolver.rb:277:in `select'
      /home/adam/src/bundler/lib/bundler/resolver.rb:277:in `search_for'
      /home/adam/src/bundler/lib/bundler/resolver.rb:330:in `block in verify_gemfile_dependencies_are_found!'
      /home/adam/src/bundler/lib/bundler/resolver.rb:328:in `each'
      /home/adam/src/bundler/lib/bundler/resolver.rb:328:in `verify_gemfile_dependencies_are_found!'
      /home/adam/src/bundler/lib/bundler/resolver.rb:201:in `start'
      /home/adam/src/bundler/lib/bundler/resolver.rb:185:in `resolve'
      /home/adam/src/bundler/lib/bundler/definition.rb:200:in `resolve'
      /home/adam/src/bundler/lib/bundler/definition.rb:165:in `missing_specs'
      /home/adam/src/bundler/lib/bundler/installer.rb:231:in `block in resolve_if_need'
      /home/adam/src/bundler/lib/bundler/ui/shell.rb:79:in `silence'
      /home/adam/src/bundler/lib/bundler/installer.rb:228:in `resolve_if_need'
      /home/adam/src/bundler/lib/bundler/installer.rb:68:in `run'
      /home/adam/src/bundler/lib/bundler/installer.rb:20:in `install'
      /home/adam/src/bundler/lib/bundler/cli/install.rb:107:in `run'
      /home/adam/src/bundler/lib/bundler/cli.rb:172:in `install'
      /home/adam/src/bundler/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
      /home/adam/src/bundler/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
      /home/adam/src/bundler/lib/bundler/vendor/thor/lib/thor.rb:359:in `dispatch'
      /home/adam/src/bundler/lib/bundler/vendor/thor/lib/thor/base.rb:440:in `start'
      /home/adam/src/bundler/lib/bundler/cli.rb:10:in `start'
      /home/adam/src/bundler/exe/bundle:20:in `block in <main>'
      /home/adam/src/bundler/lib/bundler/friendly_errors.rb:7:in `with_friendly_errors'
      /home/adam/src/bundler/exe/bundle:18:in `<main>'

Environment

    Bundler   1.10.6
    Rubygems  2.2.2
    Ruby      2.1.4p265 (2014-10-27 revision 48166) [x86_64-linux]
    GEM_HOME  /home/adam/.gem/ruby/2.1.4
    GEM_PATH  /home/adam/.gem/ruby/2.1.4:/home/adam/.rubies/ruby-2.1.4/lib/ruby/gems/2.1.0
    Git       1.9.1
--- TEMPLATE END ----------------------------------------------------------------

* This seem to have been introduced in 1.10.6 when the bundle script was moved from
  bin/ to exe/.
* Removing the option allows the alias to work as expected.