### PR TITLE
Documents lock command's `--update` option [ci skip].

### DIFF
--- a/man/bundle-lock.ronn
+++ b/man/bundle-lock.ronn
@@ -14,8 +14,9 @@ Lock the gems specified in Gemfile.
 
 ## OPTIONS
 
-* `--update`:
-  Ignores the existing lockfile. Resolve then updates lockfile.
+* `--update=<*gems>`:
+  Ignores the existing lockfile. Resolve then updates lockfile. Taking a list
+  of gems or updating all gems if no list is given.
 
 * `--local`:
   Do not attempt to connect to `rubygems.org`. Instead, Bundler will use the
@@ -28,3 +29,19 @@ Lock the gems specified in Gemfile.
 
 * `--lockfile=<path>`:
   The path where the lockfile should be written to.
+
+## UPDATING ALL GEMS
+
+If you run `bundle lock` with `--update` option without list of gems, bundler will
+ignore any previously installed gems and resolve all dependencies again based
+on the latest versions of all gems available in the sources.
+
+## UPDATING A LIST OF GEMS
+
+Sometimes, you want to update a single gem in the Gemfile(5), and leave the rest of
+the gems that you specified locked to the versions in the `Gemfile.lock`.
+
+For instance, you only want to update `nokogiri`, run `bundle lock --update nokogiri`.
+
+Bundler will update `nokogiri` and any of its dependencies, but leave the rest of the
+gems that you specified locked to the versions in the `Gemfile.lock`.


### PR DESCRIPTION
Follow up of #4105. `UPDATING ALL GEMS` and `UPDATING A LIST OF GEMS` sections are based on [bundle-update manual](https://github.com/bundler/bundler/blob/master/man/bundle-update.ronn).