### PR TITLE
Use travis container-based infrastructure

### DIFF
--- a/lib/bundler/templates/newgem/.travis.yml.tt
+++ b/lib/bundler/templates/newgem/.travis.yml.tt
@@ -1,3 +1,4 @@
+sudo: false
 language: ruby
 rvm:
   - <%= RUBY_VERSION %>


### PR DESCRIPTION
Jobs running on container-based infrastructure start up faster and permit the
use of caches for public repositories. As a default it makes sense to enable
this setting for generated gems.