### PR TITLE
give a better error message when a remote ref no longer exists

### DIFF
--- a/lib/bundler/source/git/git_proxy.rb
+++ b/lib/bundler/source/git/git_proxy.rb
@@ -27,7 +27,7 @@ module Bundler
         end
       end
 
-      class GitRevisionError < GitError
+      class MissingGitRevisionError < GitError
         def initialize(ref, repo)
           msg = "Revision #{ref} does not exist in the repository #{repo}. Maybe you misspelled it?"
           super msg
@@ -62,7 +62,7 @@ module Bundler
             begin
               @revision ||= find_local_revision
             rescue GitCommandError
-              raise GitRevisionError.new(ref, uri)
+              raise MissingGitRevisionError.new(ref, uri)
             end
           end
 

--- a/lib/bundler/source/git/git_proxy.rb
+++ b/lib/bundler/source/git/git_proxy.rb
@@ -56,14 +56,7 @@ module Bundler
           begin
             @revision ||= find_local_revision
           rescue GitCommandError
-            Bundler.ui.info "Error finding #{ref} in #{path}: clearing the cache and trying again"
-            remove_cache
-            checkout
-            begin
-              @revision ||= find_local_revision
-            rescue GitCommandError
-              raise MissingGitRevisionError.new(ref, uri)
-            end
+            raise MissingGitRevisionError.new(ref, uri)
           end
 
           @revision

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -761,6 +761,23 @@ describe "bundle install with git sources" do
 
       expect(out).to eq(old_revision)
     end
+
+    it "gives a helpful error message when the remote ref no longer exists" do
+      build_git "foo"
+      revision = revision_for(lib_path("foo-1.0"))
+
+      install_gemfile <<-G
+        gem "foo", :git => "file://#{lib_path("foo-1.0")}", :ref => "#{revision}"
+      G
+      bundle "install"
+      expect(out).to_not match(/Revision.*does not exist/)
+
+      install_gemfile <<-G
+        gem "foo", :git => "file://#{lib_path("foo-1.0")}", :ref => "deadbeef"
+      G
+      bundle "install"
+      expect(out).to include("Revision deadbeef does not exist in the repository")
+    end
   end
 
   describe "bundle install --deployment with git sources" do


### PR DESCRIPTION
if we can't find the given ref after fetching, try clearing the cache
ourselves and trying again. if we still can't find it, we know that it
actually just doesn't exist, so tell the user that.

Fixes #4140.
