### PR TITLE
Modified newgem generator to exclude Gemfile from the gemspec spec.files.

### DIFF
--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
     raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
   end
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) || f.start_with?('Gemfile') }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]


### PR DESCRIPTION
This PR modifies the `bundle gem` generator to exclude Gemfile from the gemspec spec.files (the list of files that will be copied in the generated gem).

The reason is that:
 - the `Gemfile` file is not used by rubygems (as far as I know)
 - the `Gemfile` file may contain private sources (possibly with credentials) that we do not want to leak into a packaged gem.