### PR TITLE
Fix --no-coc and --no-mit flags

### DIFF
--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -148,7 +148,8 @@ module Bundler
     end
 
     def ask_and_set(key, header, message)
-      choice = options[key] || Bundler.settings["gem.#{key}"]
+      choice = options[key]
+      choice = Bundler.settings["gem.#{key}"] if choice.nil?
 
       if choice.nil?
         Bundler.ui.confirm header

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -15,6 +15,21 @@ describe "bundle gem" do
     end
   end
 
+  def execute_bundle_gem(gem_name, flag = "", to_remove_push_guard = true)
+    bundle "gem #{gem_name} #{flag}"
+    remove_push_guard(gem_name) if to_remove_push_guard
+    # reset gemspec cache for each test because of commit 3d4163a
+    Bundler.clear_gemspec_cache
+  end
+
+  def gem_skeleton_assertions(gem_name)
+    expect(bundled_app("#{gem_name}/#{gem_name}.gemspec")).to exist
+    expect(bundled_app("#{gem_name}/Gemfile")).to exist
+    expect(bundled_app("#{gem_name}/Rakefile")).to exist
+    expect(bundled_app("#{gem_name}/lib/test/gem.rb")).to exist
+    expect(bundled_app("#{gem_name}/lib/test/gem/version.rb")).to exist
+  end
+
   before do
     git_config_content = <<-EOF
     [user]
@@ -51,6 +66,48 @@ describe "bundle gem" do
 
     it "sets gemspec email to default message if git user.email is not set or empty" do
       expect(generated_gem.gemspec.email.first).to eq("TODO: Write your email address")
+    end
+  end
+
+  shared_examples_for "--mit flag" do
+    before do
+      execute_bundle_gem(gem_name, "--mit")
+    end
+    it "generates a gem skeleton with MIT license" do
+      gem_skeleton_assertions(gem_name)
+      expect(bundled_app("test-gem/LICENSE.txt")).to exist
+      skel = Bundler::GemHelper.new(bundled_app(gem_name).to_s)
+      expect(skel.gemspec.license).to eq("MIT")
+    end
+  end
+
+  shared_examples_for "--no-mit flag" do
+    before do
+      execute_bundle_gem(gem_name, "--no-mit")
+    end
+    it "generates a gem skeleton without MIT license" do
+      gem_skeleton_assertions(gem_name)
+      expect(bundled_app("test-gem/LICENSE.txt")).to_not exist
+    end
+  end
+
+  shared_examples_for "--coc flag" do
+    before do
+      execute_bundle_gem(gem_name, "--coc", false)
+    end
+    it "generates a gem skeleton with MIT license" do
+      gem_skeleton_assertions(gem_name)
+      expect(bundled_app("test-gem/CODE_OF_CONDUCT.md")).to exist
+    end
+  end
+
+  shared_examples_for "--no-coc flag" do
+    before do
+      execute_bundle_gem(gem_name, "--no-coc", false)
+    end
+    it "generates a gem skeleton without Code of Conduct" do
+      gem_skeleton_assertions(gem_name)
+      expect(bundled_app("test-gem/CODE_OF_CONDUCT.md")).to_not exist
     end
   end
 
@@ -126,10 +183,7 @@ describe "bundle gem" do
     let(:gem_name) { "test_gem" }
 
     before do
-      bundle "gem #{gem_name}"
-      remove_push_guard(gem_name)
-      # reset gemspec cache for each test because of commit 3d4163a
-      Bundler.clear_gemspec_cache
+      execute_bundle_gem(gem_name)
     end
 
     let(:generated_gem) { Bundler::GemHelper.new(bundled_app(gem_name).to_s) }
@@ -347,45 +401,35 @@ describe "bundle gem" do
     end
   end
 
-  context "with --mit option" do
+  context "testing --mit and --coc options against bundle config settings" do
     let(:gem_name) { "test-gem" }
 
-    before do
-      bundle "gem #{gem_name} --mit"
-      remove_push_guard(gem_name)
-      # reset gemspec cache for each test because of commit 3d4163a
-      Bundler.clear_gemspec_cache
+    context "with mit option in bundle config settings set to true" do
+      before do
+        global_config "BUNDLE_GEM__MIT" => "true", "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__COC" => "false"
+      end
+      after { reset! }
+      it_behaves_like "--mit flag"
+      it_behaves_like "--no-mit flag"
     end
 
-    it "generates a gem skeleton with MIT license" do
-      expect(bundled_app("test-gem/test-gem.gemspec")).to exist
-      expect(bundled_app("test-gem/LICENSE.txt")).to exist
-      expect(bundled_app("test-gem/Gemfile")).to exist
-      expect(bundled_app("test-gem/Rakefile")).to exist
-      expect(bundled_app("test-gem/lib/test/gem.rb")).to exist
-      expect(bundled_app("test-gem/lib/test/gem/version.rb")).to exist
-
-      skel = Bundler::GemHelper.new(bundled_app(gem_name).to_s)
-      expect(skel.gemspec.license).to eq("MIT")
-    end
-  end
-
-  context "with --coc option" do
-    let(:gem_name) { "test-gem" }
-
-    before do
-      bundle "gem #{gem_name} --coc"
-      # reset gemspec cache for each test because of commit 3d4163a
-      Bundler.clear_gemspec_cache
+    context "with mit option in bundle config settings set to false" do
+      it_behaves_like "--mit flag"
+      it_behaves_like "--no-mit flag"
     end
 
-    it "generates a gem skeleton with Code of Conduct" do
-      expect(bundled_app("test-gem/test-gem.gemspec")).to exist
-      expect(bundled_app("test-gem/CODE_OF_CONDUCT.md")).to exist
-      expect(bundled_app("test-gem/Gemfile")).to exist
-      expect(bundled_app("test-gem/Rakefile")).to exist
-      expect(bundled_app("test-gem/lib/test/gem.rb")).to exist
-      expect(bundled_app("test-gem/lib/test/gem/version.rb")).to exist
+    context "with coc option in bundle config settings set to true" do
+      before do
+        global_config "BUNDLE_GEM__MIT" => "false", "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__COC" => "true"
+      end
+      after { reset! }
+      it_behaves_like "--coc flag"
+      it_behaves_like "--no-coc flag"
+    end
+
+    context "with coc option in bundle config settings set to false" do
+      it_behaves_like "--coc flag"
+      it_behaves_like "--no-coc flag"
     end
   end
 
@@ -393,17 +437,13 @@ describe "bundle gem" do
     let(:gem_name) { "test-gem" }
 
     before do
-      bundle "gem #{gem_name}"
-      remove_push_guard(gem_name)
-      # reset gemspec cache for each test because of commit 3d4163a
-      Bundler.clear_gemspec_cache
+      execute_bundle_gem(gem_name)
     end
 
     let(:generated_gem) { Bundler::GemHelper.new(bundled_app(gem_name).to_s) }
 
     it "generates a gem skeleton" do
       expect(bundled_app("test-gem/test-gem.gemspec")).to exist
-      # expect(bundled_app("test-gem/LICENSE.txt")).to exist
       expect(bundled_app("test-gem/Gemfile")).to exist
       expect(bundled_app("test-gem/Rakefile")).to exist
       expect(bundled_app("test-gem/lib/test/gem.rb")).to exist


### PR DESCRIPTION
- Behavior for the `gem` command should be that utilizing these flags (or
  the `--coc` and `--mit` flags) overrides the defaults you have set in your
  bundler config settings for that one-off execution of the gem command
- Added test coverage for testing `--coc`, `--mit`, `--no-coc`, `--no-mit` flags
  against bundle config settings
- Refactored and DRYed up `newgem_spec`

Addresses #4094