### PR TITLE
Handle LazySpecifications and Ruby versions

### DIFF
--- a/lib/bundler/lazy_specification.rb
+++ b/lib/bundler/lazy_specification.rb
@@ -54,7 +54,7 @@ module Bundler
     end
 
     def respond_to?(*args)
-      super || @specification.respond_to?(*args)
+      super || @specification ? @specification.respond_to?(*args) : nil
     end
 
     def to_s


### PR DESCRIPTION
This is a fix for #4147, as well as a change in which Ruby version we use to resolve gems against.