### PR TITLE
Resolve gems against the running Ruby version

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -194,8 +194,7 @@ module Bundler
           last_resolve
         else
           # Run a resolve against the locally available gems
-          requested_ruby_version = ruby_version.version if ruby_version
-          last_resolve.merge Resolver.resolve(expanded_dependencies, index, source_requirements, last_resolve, requested_ruby_version)
+          last_resolve.merge Resolver.resolve(expanded_dependencies, index, source_requirements, last_resolve, Bundler.ruby_version)
         end
       end
     end

--- a/lib/bundler/lazy_specification.rb
+++ b/lib/bundler/lazy_specification.rb
@@ -54,7 +54,7 @@ module Bundler
     end
 
     def respond_to?(*args)
-      super || @specification.respond_to?(*args)
+      super || @specification ? @specification.respond_to?(*args) : nil
     end
 
     def to_s


### PR DESCRIPTION
The initial implementation of respecting a gem's required_ruby_version used the Gemfile `ruby` requirement. I believe that what we actually want to do (and what users will expect) is to resolve the required_ruby_version against the currently running version of Ruby, even if the Gemfile does not contain a `ruby` call.

/cc @segiddins
