### PR TITLE
Restrict gemspec platforms without breaking windows

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -635,7 +635,7 @@ module Bundler
         dep = Dependency.new(dep, ">= 0") unless dep.respond_to?(:name)
         next unless remote || dep.current_platform?
         dep.gem_platforms(@platforms).each do |p|
-          deps << DepProxy.new(dep, p) if remote || p == generic(Gem::Platform.local)
+          deps << DepProxy.new(dep, p) if remote || p == generic_local_platform
         end
       end
       deps

--- a/lib/bundler/dependency.rb
+++ b/lib/bundler/dependency.rb
@@ -54,6 +54,15 @@ module Bundler
       :x64_mingw_23 => Gem::Platform::X64_MINGW
     }.freeze
 
+    REVERSE_PLATFORM_MAP = {}.tap do |reverse_platform_map|
+      PLATFORM_MAP.each do |key, value|
+        reverse_platform_map[value] ||= []
+        reverse_platform_map[value] << key
+      end
+
+      reverse_platform_map.each {|_, platforms| platforms.freeze }
+    end.freeze
+
     def initialize(name, version, options = {}, &blk)
       type = options["type"] || :runtime
       super(name, version, type)

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -60,7 +60,7 @@ module Bundler
             "#{file}. Make sure you can build the gem, then try again"
         end
 
-        gem spec.name, :path => path, :glob => glob
+        gem spec.name, :path => path, :glob => glob, :platforms => Bundler::Dependency::REVERSE_PLATFORM_MAP[spec.platform]
 
         group(development_group) do
           spec.development_dependencies.each do |dep|

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -60,7 +60,8 @@ module Bundler
             "#{file}. Make sure you can build the gem, then try again"
         end
 
-        gem spec.name, :path => path, :glob => glob, :platforms => Bundler::Dependency::REVERSE_PLATFORM_MAP[spec.platform]
+        gem_platforms = Bundler::Dependency::REVERSE_PLATFORM_MAP[gem_helpers.generic(Gem::Platform.local)]
+        gem spec.name, :path => path, :glob => glob, :platforms => gem_platforms
 
         group(development_group) do
           spec.development_dependencies.each do |dep|
@@ -217,6 +218,14 @@ module Bundler
     end
 
   private
+
+    def gem_helpers
+      @gem_helpers ||= begin
+        helpers = Object.new
+        helpers.extend GemHelpers
+        helpers
+      end
+    end
 
     def add_git_sources
       git_source(:github) do |repo_name|

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -60,7 +60,7 @@ module Bundler
             "#{file}. Make sure you can build the gem, then try again"
         end
 
-        gem_platforms = Bundler::Dependency::REVERSE_PLATFORM_MAP[gem_helpers.generic(Gem::Platform.local)]
+        gem_platforms = Bundler::Dependency::REVERSE_PLATFORM_MAP[Bundler::GemHelpers.generic_local_platform]
         gem spec.name, :path => path, :glob => glob, :platforms => gem_platforms
 
         group(development_group) do
@@ -218,14 +218,6 @@ module Bundler
     end
 
   private
-
-    def gem_helpers
-      @gem_helpers ||= begin
-        helpers = Object.new
-        helpers.extend GemHelpers
-        helpers
-      end
-    end
 
     def add_git_sources
       git_source(:github) do |repo_name|

--- a/lib/bundler/gem_helpers.rb
+++ b/lib/bundler/gem_helpers.rb
@@ -21,5 +21,11 @@ module Bundler
         found || Gem::Platform::RUBY
       end
     end
+    module_function :generic
+
+    def generic_local_platform
+      generic(Gem::Platform.local)
+    end
+    module_function :generic_local_platform
   end
 end

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -172,6 +172,7 @@ describe Bundler::Dsl do
       let(:platform) { "java" }
 
       it "keeps track of the jruby platforms in the dependency" do
+        allow(Gem::Platform).to receive(:local).and_return(java)
         subject.gemspec
         expect(subject.dependencies.last.platforms).to eq(Bundler::Dependency::REVERSE_PLATFORM_MAP[Gem::Platform::JAVA])
       end

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -145,6 +145,39 @@ describe Bundler::Dsl do
     end
   end
 
+  describe "#gemspec" do
+    let(:spec) do
+      Gem::Specification.new do |gem|
+        gem.name = "example"
+        gem.platform = platform
+      end
+    end
+
+    before do
+      allow(Dir).to receive(:[]).and_return(["spec_path"])
+      allow(Bundler).to receive(:load_gemspec).with("spec_path").and_return(spec)
+      allow(Bundler).to receive(:default_gemfile).and_return(Pathname.new("./Gemfile"))
+    end
+
+    context "with a ruby platform" do
+      let(:platform) { "ruby" }
+
+      it "keeps track of the ruby platforms in the dependency" do
+        subject.gemspec
+        expect(subject.dependencies.last.platforms).to eq(Bundler::Dependency::REVERSE_PLATFORM_MAP[Gem::Platform::RUBY])
+      end
+    end
+
+    context "with a jruby platform" do
+      let(:platform) { "java" }
+
+      it "keeps track of the jruby platforms in the dependency" do
+        subject.gemspec
+        expect(subject.dependencies.last.platforms).to eq(Bundler::Dependency::REVERSE_PLATFORM_MAP[Gem::Platform::JAVA])
+      end
+    end
+  end
+
   context "can bundle groups of gems with" do
     # git "https://github.com/rails/rails.git" do
     #   gem "railties"

--- a/spec/commands/check_spec.rb
+++ b/spec/commands/check_spec.rb
@@ -298,7 +298,7 @@ describe "bundle check" do
             rack (1.0.0)
 
         PLATFORMS
-          #{generic(Gem::Platform.local)}
+          #{generic_local_platform}
 
         DEPENDENCIES
           rack

--- a/spec/install/gemfile/gemspec_spec.rb
+++ b/spec/install/gemfile/gemspec_spec.rb
@@ -171,11 +171,12 @@ describe "bundle install from an existing gemspec" do
 
     context "previously bundled for Ruby" do
       let(:platform) { "ruby" }
+      let(:explicit_platform) { false }
 
       before do
         build_lib("foo", :path => tmp.join("foo")) do |s|
           s.add_dependency "rack", "=1.0.0"
-          s.platform = "java" if platform == "java"
+          s.platform = platform if explicit_platform
         end
 
         gemfile <<-G
@@ -204,6 +205,21 @@ describe "bundle install from an existing gemspec" do
           BUNDLED WITH
              #{Bundler::VERSION}
         L
+      end
+
+      context "using JRuby with explicit platform" do
+        let(:platform) { "java" }
+        let(:explicit_platform) { true }
+
+        it "should install" do
+          simulate_ruby_engine "jruby" do
+            simulate_platform "java" do
+              results = bundle "install", :artifice => "endpoint"
+              expect(results).to include("Installing rack 1.0.0")
+              should_be_installed "rack 1.0.0"
+            end
+          end
+        end
       end
 
       context "using JRuby" do

--- a/spec/install/gemfile/gemspec_spec.rb
+++ b/spec/install/gemfile/gemspec_spec.rb
@@ -197,7 +197,7 @@ describe "bundle install from an existing gemspec" do
               rack (1.0.0)
 
           PLATFORMS
-            #{generic(Gem::Platform.local)}
+            #{generic_local_platform}
 
           DEPENDENCIES
             foo!

--- a/spec/lock/lockfile_spec.rb
+++ b/spec/lock/lockfile_spec.rb
@@ -17,7 +17,7 @@ describe "the lockfile format" do
           rack (1.0.0)
 
       PLATFORMS
-        #{generic(Gem::Platform.local)}
+        #{generic_local_platform}
 
       DEPENDENCIES
         rack
@@ -40,7 +40,7 @@ describe "the lockfile format" do
           rack (1.0.0)
 
       PLATFORMS
-        #{generic(Gem::Platform.local)}
+        #{generic_local_platform}
 
       DEPENDENCIES
         omg!
@@ -63,7 +63,7 @@ describe "the lockfile format" do
           rack (1.0.0)
 
       PLATFORMS
-        #{generic(Gem::Platform.local)}
+        #{generic_local_platform}
 
       DEPENDENCIES
         rack
@@ -81,7 +81,7 @@ describe "the lockfile format" do
           rack (1.0.0)
 
       PLATFORMS
-        #{generic(Gem::Platform.local)}
+        #{generic_local_platform}
 
       DEPENDENCIES
         rack
@@ -103,7 +103,7 @@ describe "the lockfile format" do
           rack (1.0.0)
 
       PLATFORMS
-        #{generic(Gem::Platform.local)}
+        #{generic_local_platform}
 
       DEPENDENCIES
         rack
@@ -121,7 +121,7 @@ describe "the lockfile format" do
           rack (1.0.0)
 
       PLATFORMS
-        #{generic(Gem::Platform.local)}
+        #{generic_local_platform}
 
       DEPENDENCIES
         rack
@@ -140,7 +140,7 @@ describe "the lockfile format" do
           rack (1.0.0)
 
       PLATFORMS
-        #{generic(Gem::Platform.local)}
+        #{generic_local_platform}
 
       DEPENDENCIES
         rack (> 0)
@@ -158,7 +158,7 @@ describe "the lockfile format" do
           rack (1.0.0)
 
       PLATFORMS
-        #{generic(Gem::Platform.local)}
+        #{generic_local_platform}
 
       DEPENDENCIES
         rack
@@ -186,7 +186,7 @@ describe "the lockfile format" do
           rack (1.0.0)
 
       PLATFORMS
-        #{generic(Gem::Platform.local)}
+        #{generic_local_platform}
 
       DEPENDENCIES
         rack
@@ -204,7 +204,7 @@ describe "the lockfile format" do
           rack (1.0.0)
 
       PLATFORMS
-        #{generic(Gem::Platform.local)}
+        #{generic_local_platform}
 
       DEPENDENCIES
         rack
@@ -269,7 +269,7 @@ describe "the lockfile format" do
           rack (1.0.0)
 
       PLATFORMS
-        #{generic(Gem::Platform.local)}
+        #{generic_local_platform}
 
       DEPENDENCIES
         rack
@@ -296,7 +296,7 @@ describe "the lockfile format" do
           rack (1.0.0)
 
       PLATFORMS
-        #{generic(Gem::Platform.local)}
+        #{generic_local_platform}
 
       DEPENDENCIES
         rack
@@ -322,7 +322,7 @@ describe "the lockfile format" do
             rack
 
       PLATFORMS
-        #{generic(Gem::Platform.local)}
+        #{generic_local_platform}
 
       DEPENDENCIES
         rack-obama
@@ -348,7 +348,7 @@ describe "the lockfile format" do
             rack
 
       PLATFORMS
-        #{generic(Gem::Platform.local)}
+        #{generic_local_platform}
 
       DEPENDENCIES
         rack-obama (>= 1.0)
@@ -378,7 +378,7 @@ describe "the lockfile format" do
             rack
 
       PLATFORMS
-        #{generic(Gem::Platform.local)}
+        #{generic_local_platform}
 
       DEPENDENCIES
         rack-obama (>= 1.0)
@@ -433,7 +433,7 @@ describe "the lockfile format" do
         specs:
 
       PLATFORMS
-        #{generic(Gem::Platform.local)}
+        #{generic_local_platform}
 
       DEPENDENCIES
         foo!
@@ -502,7 +502,7 @@ describe "the lockfile format" do
         specs:
 
       PLATFORMS
-        #{generic(Gem::Platform.local)}
+        #{generic_local_platform}
 
       DEPENDENCIES
         foo!
@@ -532,7 +532,7 @@ describe "the lockfile format" do
         specs:
 
       PLATFORMS
-        #{generic(Gem::Platform.local)}
+        #{generic_local_platform}
 
       DEPENDENCIES
         foo!
@@ -562,7 +562,7 @@ describe "the lockfile format" do
         specs:
 
       PLATFORMS
-        #{generic(Gem::Platform.local)}
+        #{generic_local_platform}
 
       DEPENDENCIES
         foo!
@@ -589,7 +589,7 @@ describe "the lockfile format" do
         specs:
 
       PLATFORMS
-        #{generic(Gem::Platform.local)}
+        #{generic_local_platform}
 
       DEPENDENCIES
         foo!
@@ -629,7 +629,7 @@ describe "the lockfile format" do
           rack (1.0.0)
 
       PLATFORMS
-        #{generic(Gem::Platform.local)}
+        #{generic_local_platform}
 
       DEPENDENCIES
         bar!
@@ -664,7 +664,7 @@ describe "the lockfile format" do
             rack
 
       PLATFORMS
-        #{generic(Gem::Platform.local)}
+        #{generic_local_platform}
 
       DEPENDENCIES
         actionpack
@@ -705,7 +705,7 @@ describe "the lockfile format" do
           rake (10.0.2)
 
       PLATFORMS
-        #{generic(Gem::Platform.local)}
+        #{generic_local_platform}
 
       DEPENDENCIES
         rails
@@ -731,7 +731,7 @@ describe "the lockfile format" do
           net-ssh (1.0)
 
       PLATFORMS
-        #{generic(Gem::Platform.local)}
+        #{generic_local_platform}
 
       DEPENDENCIES
         double_deps
@@ -757,7 +757,7 @@ describe "the lockfile format" do
             rack
 
       PLATFORMS
-        #{generic(Gem::Platform.local)}
+        #{generic_local_platform}
 
       DEPENDENCIES
         rack-obama (>= 1.0)
@@ -783,7 +783,7 @@ describe "the lockfile format" do
             rack
 
       PLATFORMS
-        #{generic(Gem::Platform.local)}
+        #{generic_local_platform}
 
       DEPENDENCIES
         rack-obama (>= 1.0)
@@ -811,7 +811,7 @@ describe "the lockfile format" do
         specs:
 
       PLATFORMS
-        #{generic(Gem::Platform.local)}
+        #{generic_local_platform}
 
       DEPENDENCIES
         foo
@@ -839,7 +839,7 @@ describe "the lockfile format" do
         specs:
 
       PLATFORMS
-        #{generic(Gem::Platform.local)}
+        #{generic_local_platform}
 
       DEPENDENCIES
         foo
@@ -867,7 +867,7 @@ describe "the lockfile format" do
         specs:
 
       PLATFORMS
-        #{generic(Gem::Platform.local)}
+        #{generic_local_platform}
 
       DEPENDENCIES
         foo
@@ -894,7 +894,7 @@ describe "the lockfile format" do
         specs:
 
       PLATFORMS
-        #{generic(Gem::Platform.local)}
+        #{generic_local_platform}
 
       DEPENDENCIES
         foo!
@@ -927,7 +927,7 @@ describe "the lockfile format" do
       gem "rack"
     G
 
-    platforms = ["java", generic(Gem::Platform.local).to_s].sort
+    platforms = ["java", generic_local_platform.to_s].sort
 
     lockfile_should_be <<-G
       GEM

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -908,7 +908,7 @@ describe "Bundler.setup" do
             rack (1.0.0)
 
         PLATFORMS
-          #{generic(Gem::Platform.local)}
+          #{generic_local_platform}
 
         DEPENDENCIES
           rack

--- a/spec/support/hax.rb
+++ b/spec/support/hax.rb
@@ -10,6 +10,15 @@ if ENV["BUNDLER_SPEC_VERSION"]
   end
 end
 
+if ENV["BUNDLER_SPEC_WINDOWS"] == "true"
+  require "bundler/constants"
+
+  module Bundler
+    remove_const :WINDOWS if defined?(WINDOWS)
+    WINDOWS = true
+  end
+end
+
 class Object
   if ENV["BUNDLER_SPEC_RUBY_ENGINE"]
     remove_const :RUBY_ENGINE if defined?(RUBY_ENGINE)

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -353,6 +353,16 @@ module Spec
       ENV["BUNDLER_SPEC_VERSION"] = old if block_given?
     end
 
+    def simulate_windows
+      old = ENV["BUNDLER_SPEC_WINDOWS"]
+      ENV["BUNDLER_SPEC_WINDOWS"] = "true"
+      simulate_platform mswin do
+        yield
+      end
+    ensure
+      ENV["BUNDLER_SPEC_WINDOWS"] = old
+    end
+
     def revision_for(path)
       Dir.chdir(path) { `git rev-parse HEAD`.strip }
     end

--- a/spec/support/platforms.rb
+++ b/spec/support/platforms.rb
@@ -35,11 +35,11 @@ module Spec
     end
 
     def local
-      generic(Gem::Platform.local)
+      generic_local_platform
     end
 
     def not_local
-      all_platforms.find {|p| p != generic(Gem::Platform.local) }
+      all_platforms.find {|p| p != generic_local_platform }
     end
 
     def local_tag

--- a/spec/update/git_spec.rb
+++ b/spec/update/git_spec.rb
@@ -222,7 +222,7 @@ describe "bundle update" do
             rails (2.3.2)
 
         PLATFORMS
-          #{generic(Gem::Platform.local)}
+          #{generic_local_platform}
 
         DEPENDENCIES
           rails!


### PR DESCRIPTION
This keeps the fix for #4102 but also fixes #4150

I added a test which fails if #4102 is broken, but also fails if #4150 is broken.

I have run the specs in the following scenarios:
* With the original Bundler code: the JRuby spec breaks but the Windows one passes
* With my previous fix attempt: the JRuby spec passes but the Windows one breaks
* With this new fix: both pass