### PR TITLE
Missing locked specs should not block installation.

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -455,7 +455,13 @@ module Bundler
         end
       end
 
-      !locked || unlocking || dependencies_for_source_changed?(locked) || source.specs != locked.specs
+      begin
+        locked_specs = locked.specs
+      rescue GitError
+        locked_specs = Bundler::Index.new
+      end
+
+      !locked || unlocking || dependencies_for_source_changed?(locked) || source.specs != locked_specs
     end
 
     def dependencies_for_source_changed?(source)


### PR DESCRIPTION
Hey all,

Not sure if this is the appropriate way to solve the issue I was running into, but the TLDR is that when a Gemfile.lock is pointing to a private remote locked to a given sha, when I attempt to set a local override and run `bundle install --path=vendor/bundle`, bundler blows up with the following backtrace.

```
bundle install --path=vendor/bundle --verbose
Bundler::PathError: The path `/Users/darrencheng/dependents/mobile/vendor/bundle/ruby/2.1.0/bundler/gems/[redacted]-c48c8b0f95ad` does not exist.
/Users/darrencheng/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/bundler-1.11.2/lib/bundler/source/path.rb:160:in `load_spec_files'
  /Users/darrencheng/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/bundler-1.11.2/lib/bundler/source/git.rb:188:in `load_spec_files'
  /Users/darrencheng/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/bundler-1.11.2/lib/bundler/source/path.rb:92:in `local_specs'
  /Users/darrencheng/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/bundler-1.11.2/lib/bundler/source/git.rb:159:in `specs'
  /Users/darrencheng/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/bundler-1.11.2/lib/bundler/definition.rb:437:in `specs_changed?'
  /Users/darrencheng/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/bundler-1.11.2/lib/bundler/definition.rb:463:in `block in converge_locals'
  /Users/darrencheng/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/bundler-1.11.2/lib/bundler/definition.rb:462:in `each'
  /Users/darrencheng/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/bundler-1.11.2/lib/bundler/definition.rb:462:in `any?'
  /Users/darrencheng/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/bundler-1.11.2/lib/bundler/definition.rb:462:in `converge_locals'
  /Users/darrencheng/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/bundler-1.11.2/lib/bundler/definition.rb:96:in `initialize'
  /Users/darrencheng/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/bundler-1.11.2/lib/bundler/dsl.rb:173:in `new'
  /Users/darrencheng/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/bundler-1.11.2/lib/bundler/dsl.rb:173:in `to_definition'
  /Users/darrencheng/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/bundler-1.11.2/lib/bundler/dsl.rb:11:in `evaluate'
  /Users/darrencheng/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/bundler-1.11.2/lib/bundler/definition.rb:24:in `build'
  /Users/darrencheng/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/bundler-1.11.2/lib/bundler.rb:120:in `definition'
  /Users/darrencheng/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/bundler-1.11.2/lib/bundler/cli/install.rb:102:in `run'
  /Users/darrencheng/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/bundler-1.11.2/lib/bundler/cli.rb:172:in `install'
  /Users/darrencheng/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/bundler-1.11.2/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
  /Users/darrencheng/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/bundler-1.11.2/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
  /Users/darrencheng/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/bundler-1.11.2/lib/bundler/vendor/thor/lib/thor.rb:359:in `dispatch'
  /Users/darrencheng/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/bundler-1.11.2/lib/bundler/vendor/thor/lib/thor/base.rb:440:in `start'
  /Users/darrencheng/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/bundler-1.11.2/lib/bundler/cli.rb:10:in `start'
  /Users/darrencheng/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/bundler-1.11.2/exe/bundle:19:in `block in <top (required)>'
  /Users/darrencheng/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/bundler-1.11.2/lib/bundler/friendly_errors.rb:7:in `with_friendly_errors'
  /Users/darrencheng/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/bundler-1.11.2/exe/bundle:17:in `<top (required)>'
  /Users/darrencheng/.rbenv/versions/2.1.7/bin/bundle:23:in `load'
  /Users/darrencheng/.rbenv/versions/2.1.7/bin/bundle:23:in `<main>'
https://[redacted]@github.com/[redacted]/[redacted].git (at
[redacted]@c48c8b0) is not yet checked out. Run `bundle install` first.
```

I took a peak at the bundler source code and it looks like there is a GitError raised if the locked spec is missing from `vendor/bundle`. The change I made patches the exception and allows usage of the local override.

I'm happy to spend some time setting up a public example that replicates this issue, but here are the basic steps that I think will reproduce the above backtrace (untested):
* set up a simple ruby projects with a `Gemfile` loading a gem (let's call it `the-gem`) via `git:` and `path:` options
* let bundler create a `Gemfile.lock` by running `bundle`
* clone the gem locally and add a commit
* override local bundler config for that gem (`bundler config local.the_gem ~/path/to/the-gem`)
* attempt to run `bundle install --path=vendor/bundle`

Here's a more in depth description of the problem / my use case. My team maintains an internal rails engine that we use to share our core models between a number of rails applications. Normally, our Gemfile looks something like this (with relevant names replaced):
```
gem 'engine',
  git: "https://ENV['GITHUB_API_TOKEN']@github.com/organization/engine.git",
  branch: (ENV['ENGINE_BRANCH'] || master)
```
This works well for the most part - when we make a change to the engine, we just run `bundle update engine` in the dependent application and the commit sha in the Gemfile.lock updates.

Right now, I'm working on a relatively complex CI setup for the engine that clones the dependent apps' codebases, resets hard to a branch that matches the one that kicked off CI, sets up local bundle override for the engine, runs `bundle install --path=vendor/bundle`, then kicks off specs. This all works well when the sha captured in the dependent app's Gemfile.lock matches the local engine's sha. However, I'm getting the exception listed above when that's not the case.

Let me know if you need any more info or if there is another way around the exception.

Cheers,
Darren