### PR TITLE
Redirects any usage of --help flag for a command to that command's man page

### DIFF
--- a/exe/bundle
+++ b/exe/bundle
@@ -16,5 +16,11 @@ end
 require "bundler/friendly_errors"
 Bundler.with_friendly_errors do
   require "bundler/cli"
-  Bundler::CLI.start(ARGV, :debug => true)
+
+  # Allow any command to use --help flag to show help for that command
+  help_flags = %w(--help -h)
+  help_flag_used = ARGV.any? {|a| help_flags.include? a }
+  args = help_flag_used ? Bundler::CLI.reformatted_help_args(ARGV) : ARGV
+
+  Bundler::CLI.start(args, :debug => true)
 end

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -419,6 +419,19 @@ module Bundler
       Env.new.write($stdout)
     end
 
+    # Reformat the arguments passed to bundle that include a --help flag
+    # into the corresponding `bundle help #{command}` call
+    def self.reformatted_help_args(args)
+      bundler_commands = all_commands.keys
+      command = args.select {|a| bundler_commands.include? a }
+      if command.empty?
+        abort("Could not find command \"#{args.join(" ")}\".")
+      else
+        command = command.first
+      end
+      ["help", command]
+    end
+
   private
 
     # Automatically invoke `bundle install` and resume if

--- a/spec/commands/help_spec.rb
+++ b/spec/commands/help_spec.rb
@@ -49,4 +49,39 @@ describe "bundle help" do
     expect(exitstatus).to be_zero if exitstatus
     expect(out).to eq("--help")
   end
+
+  it "is called when the --help flag is used after the command" do
+    fake_man!
+
+    bundle "install --help"
+    expect(out).to eq(%(["#{root}/lib/bundler/man/bundle-install"]))
+  end
+
+  it "is called when the --help flag is used before the command" do
+    fake_man!
+
+    bundle "--help install"
+    expect(out).to eq(%(["#{root}/lib/bundler/man/bundle-install"]))
+  end
+
+  it "is called when the -h flag is used before the command" do
+    fake_man!
+
+    bundle "-h install"
+    expect(out).to eq(%(["#{root}/lib/bundler/man/bundle-install"]))
+  end
+
+  it "is called when the -h flag is used after the command" do
+    fake_man!
+
+    bundle "install -h"
+    expect(out).to eq(%(["#{root}/lib/bundler/man/bundle-install"]))
+  end
+
+  it "has helpful output when using --help flag for a non-existent command" do
+    fake_man!
+
+    bundle "instill -h", :expect_err => true
+    expect(err).to include('Could not find command "instill -h --no-color".')
+  end
 end


### PR DESCRIPTION
In response to: bundler/bundler-features#97