### PR TITLE
Ensure `bundle gem` default task matches framework

### DIFF
--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -27,7 +27,6 @@ module Bundler
       namespaced_path = name.tr("-", "/")
       constant_name = name.gsub(/-[_-]*(?![_-]|$)/) { "::" }.gsub(/([_-]+|(::)|^)(.|$)/) { $2.to_s + $3.upcase }
       constant_array = constant_name.split("::")
-      test_task = options[:test] == "minitest" ? "test" : "spec"
 
       git_user_name = `git config user.name`.chomp
       git_user_email = `git config user.email`.chomp
@@ -42,7 +41,6 @@ module Bundler
         :author           => git_user_name.empty? ? "TODO: Write your name" : git_user_name,
         :email            => git_user_email.empty? ? "TODO: Write your email address" : git_user_email,
         :test             => options[:test],
-        :test_task        => test_task,
         :ext              => options[:ext],
         :bin              => options[:bin],
         :bundler_version  => bundler_dependency_version
@@ -86,6 +84,8 @@ module Bundler
           )
         end
       end
+
+      config[:test_task] = config[:test] == "minitest" ? "test" : "spec"
 
       if ask_and_set(:mit, "Do you want to license your code permissively under the MIT license?",
         "This means that any other developer or company will be legally allowed to use your code " \

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -373,6 +373,32 @@ describe "bundle gem" do
       end
     end
 
+    context "gem.test setting set to minitest" do
+      before do
+        reset!
+        in_app_root
+        bundle "config gem.test minitest"
+        bundle "gem #{gem_name}"
+      end
+
+      it "creates a default rake task to run the test suite" do
+        rakefile = strip_whitespace <<-RAKEFILE
+          require "bundler/gem_tasks"
+          require "rake/testtask"
+
+          Rake::TestTask.new(:test) do |t|
+            t.libs << "test"
+            t.libs << "lib"
+            t.test_files = FileList['test/**/*_test.rb']
+          end
+
+          task :default => :test
+        RAKEFILE
+
+        expect(bundled_app("test_gem/Rakefile").read).to eq(rakefile)
+      end
+    end
+
     context "--test with no arguments" do
       before do
         reset!


### PR DESCRIPTION
Previously running `bundle gem` with a global config containing

    BUNDLE_GEM__TEST: 'minitest'

would incorrectly set the default task in the generated Rakefile to

    task :default => :spec

whereas `bundle gem --test=minitest` worked as expected.  This happened because the test task was determined before checking the global config or asking for user input, making the test task and default task inconsistent.

This fix moves the decision to after the test framework has been properly determined.