### PR TITLE
Catch NoMethodError for `use_ssl=` and raise appropriate FriendlyErrors warning

### DIFF
--- a/lib/bundler/fetcher/downloader.rb
+++ b/lib/bundler/fetcher/downloader.rb
@@ -43,6 +43,12 @@ module Bundler
           req.basic_auth(user, password)
         end
         connection.request(uri, req)
+      rescue NoMethodError => e
+        if ["undefined method", "use_ssl="].all? {|snippet| e.message.include? snippet }
+          raise LoadError.new("cannot load such file -- openssl")
+        else
+          raise e
+        end
       rescue OpenSSL::SSL::SSLError
         raise CertificateFailureError.new(uri)
       rescue *HTTP_ERRORS => e


### PR DESCRIPTION
Addresses #4054. 

- `NoMethodError` for `use_ssl=` in the downloader should now throw a `LoadError` with `cannot load such file -- openssl` as the message which will be caught and logged by the `FriendlyErrors` module as an OpenSSL Ruby error.