### PR TITLE
Create `TemporaryResourceError` that `SharedHelpers#filesystem_access` raises for `Errno::EAGAIN`

### DIFF
--- a/lib/bundler/errors.rb
+++ b/lib/bundler/errors.rb
@@ -58,19 +58,32 @@ module Bundler
       @permission_type = permission_type
     end
 
-    def message
-      action = case @permission_type
-               when :read then "read from"
-               when :write then "write to"
-               when :executable, :exec then "execute"
-               else @permission_type.to_s
+    def action
+      case @permission_type
+      when :read then "read from"
+      when :write then "write to"
+      when :executable, :exec then "execute"
+      else @permission_type.to_s
       end
+    end
+
+    def message
       "There was an error while trying to #{action} `#{@path}`. " \
       "It is likely that you need to grant #{@permission_type} permissions " \
       "for that path."
     end
 
     status_code(23)
+  end
+
+  class TemporaryResourceError < PermissionError
+    def message
+      "There was an error while trying to #{action} `#{@path}`. " \
+      "Some resource was temporarily unavailable. It's suggested that you try" \
+      "the operation again."
+    end
+
+    status_code(26)
   end
 
   class YamlSyntaxError < BundlerError

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -114,6 +114,8 @@ module Bundler
       yield path
     rescue Errno::EACCES
       raise PermissionError.new(path, action)
+    rescue Errno::EAGAIN
+      raise TemporaryResourceError.new(path, action)
     end
 
   private

--- a/spec/bundler/definition_spec.rb
+++ b/spec/bundler/definition_spec.rb
@@ -19,5 +19,15 @@ describe Bundler::Definition do
           to raise_error(Bundler::PermissionError, /Gemfile\.lock/)
       end
     end
+    context "when a temporary resource access issue occurs" do
+      subject { Bundler::Definition.new(nil, [], Bundler::SourceList.new, []) }
+
+      it "raises a TemporaryResourceError with explanation" do
+        expect(File).to receive(:open).with("Gemfile.lock", "wb").
+          and_raise(Errno::EAGAIN)
+        expect { subject.lock("Gemfile.lock") }.
+          to raise_error(Bundler::TemporaryResourceError, /temporarily unavailable/)
+      end
+    end
   end
 end


### PR DESCRIPTION
Addresses #4183

Creates a `TemporaryResourceError` that is raised when an `Errno::EAGAIN` occurs when trying to perform some file op. `Errno::EAGAIN`s can occur for a variety of scenarios when certain system resources (ex. memory, in which case a fork cannot occur) aren't available at a certain moment, so the error message suggests that the user rerun the operation, which worked in the case of #4183.
