### PR TITLE
Clean up various test suite warnings

### DIFF
--- a/spec/cache/git_spec.rb
+++ b/spec/cache/git_spec.rb
@@ -123,18 +123,18 @@ end
       end
 
       Dir.chdir(lib_path("has_submodule-1.0")) do
-        `git submodule add #{lib_path("submodule-1.0")} submodule-1.0`
+        sys_exec "git submodule add #{lib_path("submodule-1.0")} submodule-1.0", :expect_err => true
         `git commit -m "submodulator"`
       end
 
-      install_gemfile <<-G
+      install_gemfile <<-G, :expect_err => true
         git "#{lib_path("has_submodule-1.0")}", :submodules => true do
           gem "has_submodule"
         end
       G
 
       ref = git.ref_for("master", 11)
-      bundle "#{cmd} --all"
+      bundle "#{cmd} --all", :expect_err => true
 
       expect(bundled_app("vendor/cache/has_submodule-1.0-#{ref}")).to exist
       expect(bundled_app("vendor/cache/has_submodule-1.0-#{ref}/submodule-1.0")).to exist

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -126,7 +126,7 @@ describe "bundle exec" do
       G
     end
 
-    bundle "exec rackup"
+    bundle "exec rackup", :expect_err => true
 
     expect(out).to eq("0.9.1")
     expect(err).to match("deprecated")

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -345,7 +345,7 @@ describe "bundle install with gem sources" do
 
     context "and using an unsupported Ruby version" do
       it "prints an error" do
-        install_gemfile <<-G
+        install_gemfile <<-G, :expect_err => true
           ::RUBY_VERSION = '1.8.7'
           ruby '~> 2.1'
         G
@@ -355,7 +355,7 @@ describe "bundle install with gem sources" do
 
     context "and using a supported Ruby version" do
       before do
-        install_gemfile <<-G
+        install_gemfile <<-G, :expect_err => true
           ::RUBY_VERSION = '2.1.3'
           ::RUBY_PATCHLEVEL = 100
           ruby '~> 2.1.0'
@@ -381,7 +381,7 @@ describe "bundle install with gem sources" do
       end
 
       it "does not update Gemfile.lock with updated ruby versions" do
-        install_gemfile <<-G
+        install_gemfile <<-G, :expect_err => true
           ::RUBY_VERSION = '2.2.3'
           ::RUBY_PATCHLEVEL = 100
           ruby '~> 2.2.0'

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -338,7 +338,7 @@ describe "bundle update --ruby" do
       G
     end
     it "removes the Ruby from the Gemfile.lock" do
-      bundle "update --ruby"
+      bundle "update --ruby", :expect_err => true
 
       lockfile_should_be <<-L
        GEM

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -575,7 +575,7 @@ describe "bundle install with git sources" do
       s.add_dependency "submodule"
     end
     Dir.chdir(lib_path("has_submodule-1.0")) do
-      `git submodule add #{lib_path("submodule-1.0")} submodule-1.0`
+      sys_exec "git submodule add #{lib_path("submodule-1.0")} submodule-1.0", :expect_err => true
       `git commit -m "submodulator"`
     end
 
@@ -595,11 +595,11 @@ describe "bundle install with git sources" do
       s.add_dependency "submodule"
     end
     Dir.chdir(lib_path("has_submodule-1.0")) do
-      `git submodule add #{lib_path("submodule-1.0")} submodule-1.0`
+      sys_exec "git submodule add #{lib_path("submodule-1.0")} submodule-1.0", :expect_err => true
       `git commit -m "submodulator"`
     end
 
-    install_gemfile <<-G
+    install_gemfile <<-G, :expect_err => true
       git "#{lib_path("has_submodule-1.0")}", :submodules => true do
         gem "has_submodule"
       end

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -772,10 +772,10 @@ describe "bundle install with git sources" do
       bundle "install"
       expect(out).to_not match(/Revision.*does not exist/)
 
-      install_gemfile <<-G
+      install_gemfile <<-G, :expect_err => true
         gem "foo", :git => "file://#{lib_path("foo-1.0")}", :ref => "deadbeef"
       G
-      bundle "install"
+      bundle "install", :expect_err => true
       expect(out).to include("Revision deadbeef does not exist in the repository")
     end
   end

--- a/spec/other/bundle_ruby_spec.rb
+++ b/spec/other/bundle_ruby_spec.rb
@@ -10,7 +10,7 @@ describe "bundle_ruby" do
         gem "foo"
       G
 
-      bundle_ruby
+      bundle_ruby :expect_err => true
 
       expect(err).to eq("Warning: bundle_ruby will be deprecated in " \
                         "Bundler 2.0.0.")
@@ -26,7 +26,7 @@ describe "bundle_ruby" do
         gem "foo"
       G
 
-      bundle_ruby
+      bundle_ruby :expect_err => true
 
       expect(out).to include("ruby 1.9.3")
     end
@@ -39,7 +39,7 @@ describe "bundle_ruby" do
         gem "foo"
       G
 
-      bundle_ruby
+      bundle_ruby :expect_err => true
 
       expect(out).to include("ruby 1.9.3")
     end
@@ -52,7 +52,7 @@ describe "bundle_ruby" do
         gem "foo"
       G
 
-      bundle_ruby
+      bundle_ruby :expect_err => true
 
       expect(out).to include("ruby 1.8.7 (jruby 1.6.5)")
     end
@@ -65,7 +65,7 @@ describe "bundle_ruby" do
         gem "foo"
       G
 
-      bundle_ruby
+      bundle_ruby :expect_err => true
 
       expect(out).to include("ruby 1.8.7 (rbx 1.2.4)")
     end
@@ -78,10 +78,10 @@ describe "bundle_ruby" do
         gem "foo"
       G
 
-      bundle_ruby :exitstatus => true
+      bundle_ruby :expect_err => true, :exitstatus => true
       expect(exitstatus).not_to eq(0) if exitstatus
 
-      bundle_ruby
+      bundle_ruby :expect_err => true
       expect(out).to include("Please define :engine_version")
     end
 
@@ -93,10 +93,10 @@ describe "bundle_ruby" do
         gem "foo"
       G
 
-      bundle_ruby :exitstatus => true
+      bundle_ruby :expect_err => true, :exitstatus => true
       expect(exitstatus).not_to eq(0) if exitstatus
 
-      bundle_ruby
+      bundle_ruby :expect_err => true
       expect(out).to include("Please define :engine")
     end
 
@@ -108,10 +108,10 @@ describe "bundle_ruby" do
         gem "foo"
       G
 
-      bundle_ruby :exitstatus => true
+      bundle_ruby :expect_err => true, :exitstatus => true
       expect(exitstatus).not_to eq(0) if exitstatus
 
-      bundle_ruby
+      bundle_ruby :expect_err => true
       expect(out).to include("ruby_version must match the :engine_version for MRI")
     end
 
@@ -122,7 +122,7 @@ describe "bundle_ruby" do
         gem "foo"
       G
 
-      bundle_ruby
+      bundle_ruby :expect_err => true
 
       expect(out).to include("No ruby version specified")
     end
@@ -137,7 +137,7 @@ describe "bundle_ruby" do
         gem "foo"
       G
 
-      bundle_ruby
+      bundle_ruby :expect_err => true
 
       expect(out).to include("ruby 1.9.3p429")
     end
@@ -150,7 +150,7 @@ describe "bundle_ruby" do
         gem "foo"
       G
 
-      bundle_ruby
+      bundle_ruby :expect_err => true
 
       expect(out).to include("ruby 1.9.3p392 (jruby 1.7.4)")
     end

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -92,7 +92,7 @@ describe "Bundler.setup" do
     end
 
     it "handles multiple non-additive invocations" do
-      ruby <<-RUBY
+      ruby <<-RUBY, :expect_err => true
         require 'bundler'
         Bundler.setup(:default, :test)
         Bundler.setup(:default)

--- a/spec/update/git_spec.rb
+++ b/spec/update/git_spec.rb
@@ -131,7 +131,7 @@ describe "bundle update" do
         end
 
         Dir.chdir(lib_path("has_submodule-1.0")) do
-          `git submodule add #{lib_path("submodule-1.0")} submodule-1.0`
+          sys_exec "git submodule add #{lib_path("submodule-1.0")} submodule-1.0", :expect_err => true
           `git commit -m "submodulator"`
         end
       end
@@ -146,7 +146,7 @@ describe "bundle update" do
         run "require 'submodule'"
         expect(out).to eq("GEM")
 
-        install_gemfile <<-G
+        install_gemfile <<-G, :expect_err => true
           git "#{lib_path("has_submodule-1.0")}", :submodules => true do
             gem "has_submodule"
           end
@@ -158,7 +158,7 @@ describe "bundle update" do
 
       it "it unlocks the source when submodules are removed from git source" do
         pending "This would require actually removing the submodule from the clone"
-        install_gemfile <<-G
+        install_gemfile <<-G, :expect_err => true
           git "#{lib_path("has_submodule-1.0")}", :submodules => true do
             gem "has_submodule"
           end


### PR DESCRIPTION
These commits remove a series of extraneous warnings and output messages from the test suite.

These include:
```
/path/bundler/tmp/bundled_app/Gemfile:1: warning: already initialized constant RUBY_VERSION

/path/bundler/tmp/bundled_app/Gemfile:2: warning: already initialized constant RUBY_PATCHLEVEL

Warning: bundle_ruby will be deprecated in Bundler 2.0.0.

Bundler is using a binstub that was created for a different gem.
    This is deprecated, in future versions you may need to `bundle binstub
    rack_two` to work around a system/bundle conflict.

-e:4:in `require': cannot load such file -- rack (LoadError)
    from -e:4:in `<main>'

fatal: Needed a single revision

Cloning into 'submodule-1.0'...
    done.
```
None of these messages indicate a failure in the correlated specs.