### PR TITLE
Add `Net#HTTP--` errors safely (only if in version of ruby stdlib)

### DIFF
--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -52,10 +52,16 @@ module Bundler
 
     # Exceptions classes that should bypass retry attempts. If your password didn't work the
     # first time, it's not going to the third time.
-    AUTH_ERRORS = [AuthenticationRequiredError, BadAuthenticationError, Net::HTTPBadGateway,
-                   Net::HTTPBadRequest, Net::HTTPForbidden, Net::HTTPMethodNotAllowed,
-                   Net::HTTPMovedPermanently, Net::HTTPNotImplemented, Net::HTTPNotFound,
-                   Net::HTTPRequestEntityTooLarge, Net::HTTPNoContent]
+    AUTH_ERRORS = [AuthenticationRequiredError, BadAuthenticationError]
+    NET_ERRORS_TO_ADD_SAFELY = [:HTTPBadGateway, :HTTPBadRequest, :HTTPFailedDependency,
+                                :HTTPForbidden, :HTTPInsufficientStorage, :HTTPMethodNotAllowed,
+                                :HTTPMovedPermanently, :HTTPNoContent, :HTTPNotFound,
+                                :HTTPNotImplemented, :HTTPPreconditionFailed, :HTTPRequestEntityTooLarge,
+                                :HTTPRequestURITooLong, :HTTPUnauthorized, :HTTPUnprocessableEntity,
+                                :HTTPUnsupportedMediaType, :HTTPVersionNotSupported]
+    NET_ERRORS_TO_ADD_SAFELY.each do |net_error|
+      AUTH_ERRORS << Net.const_get(net_error) if Net.constants.include? net_error
+    end
 
     class << self
       attr_accessor :disable_endpoint, :api_timeout, :redirect_limit, :max_retries

--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -53,15 +53,13 @@ module Bundler
     # Exceptions classes that should bypass retry attempts. If your password didn't work the
     # first time, it's not going to the third time.
     AUTH_ERRORS = [AuthenticationRequiredError, BadAuthenticationError]
-    NET_ERRORS_TO_ADD_SAFELY = [:HTTPBadGateway, :HTTPBadRequest, :HTTPFailedDependency,
-                                :HTTPForbidden, :HTTPInsufficientStorage, :HTTPMethodNotAllowed,
-                                :HTTPMovedPermanently, :HTTPNoContent, :HTTPNotFound,
-                                :HTTPNotImplemented, :HTTPPreconditionFailed, :HTTPRequestEntityTooLarge,
-                                :HTTPRequestURITooLong, :HTTPUnauthorized, :HTTPUnprocessableEntity,
-                                :HTTPUnsupportedMediaType, :HTTPVersionNotSupported]
-    NET_ERRORS_TO_ADD_SAFELY.each do |net_error|
-      AUTH_ERRORS << Net.const_get(net_error) if Net.constants.include? net_error
-    end
+    NET_ERRORS = [:HTTPBadGateway, :HTTPBadRequest, :HTTPFailedDependency,
+                  :HTTPForbidden, :HTTPInsufficientStorage, :HTTPMethodNotAllowed,
+                  :HTTPMovedPermanently, :HTTPNoContent, :HTTPNotFound,
+                  :HTTPNotImplemented, :HTTPPreconditionFailed, :HTTPRequestEntityTooLarge,
+                  :HTTPRequestURITooLong, :HTTPUnauthorized, :HTTPUnprocessableEntity,
+                  :HTTPUnsupportedMediaType, :HTTPVersionNotSupported]
+    AUTH_ERRORS.push(*NET_ERRORS.map {|e| SharedHelpers.const_get_safely(e, Net) }.compact)
 
     class << self
       attr_accessor :disable_endpoint, :api_timeout, :redirect_limit, :max_retries

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -119,9 +119,10 @@ module Bundler
     end
 
     def const_get_safely(constant_name, namespace)
-      constant_sym = constant_name.to_sym
-      return nil unless namespace.constants.include? constant_sym
-      namespace.const_get(constant_sym)
+      const_in_namespace = namespace.constants.include?(constant_name.to_s) ||
+        namespace.constants.include?(constant_name.to_sym)
+      return nil unless const_in_namespace
+      namespace.const_get(constant_name)
     end
 
   private

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -118,6 +118,12 @@ module Bundler
       raise TemporaryResourceError.new(path, action)
     end
 
+    def const_get_safely(constant_name, namespace)
+      constant_sym = constant_name.to_sym
+      return nil unless namespace.constants.include? constant_sym
+      namespace.const_get(constant_sym)
+    end
+
   private
 
     def find_gemfile

--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+require "bundler/shared_helpers"
+
+module TargetNamespace
+  VALID_CONSTANT = 1
+end
+
+describe Bundler::SharedHelpers do
+  describe "#const_get_safely" do
+    context "when the namespace does have the requested constant" do
+      subject { Bundler::SharedHelpers.const_get_safely(:VALID_CONSTANT, TargetNamespace) }
+      it "returns the value of the requested constant" do
+        expect(subject).to eq(1)
+      end
+    end
+    context "when the requested constant is passed as a string" do
+      subject { Bundler::SharedHelpers.const_get_safely("VALID_CONSTANT", TargetNamespace) }
+      it "returns the value of the requested constant" do
+        expect(subject).to eq(1)
+      end
+    end
+    context "when the namespace does not have the requested constant" do
+      subject { Bundler::SharedHelpers.const_get_safely("INVALID_CONSTANT", TargetNamespace) }
+      it "returns nil" do
+        expect(subject).to eq(nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Continuation of #4154. Some errors in the ruby `Net` module that we might not want to retry on were added in later Ruby versions of the stdlib. This PR allows us to preserve backwards compatibility while adding new  errors.