### PR TITLE
Make `bundle env` output consistent

### DIFF
--- a/lib/bundler/env.rb
+++ b/lib/bundler/env.rb
@@ -43,7 +43,7 @@ module Bundler
       if print_gemspecs
         dsl = Dsl.new.tap {|d| d.eval_gemfile(Bundler.default_gemfile) }
         dsl.gemspecs.each do |gs|
-          out << "\n#{Pathname.new(gs).basename}:"
+          out << "\n#{Pathname.new(gs).basename}"
           out << "\n\n    " << read_file(gs).gsub(/\n/, "\n    ") << "\n"
         end
       end

--- a/spec/bundler/env_spec.rb
+++ b/spec/bundler/env_spec.rb
@@ -67,7 +67,7 @@ describe Bundler::Env do
       it "prints the gemspec" do
         output = env.report(:print_gemspecs => true).gsub(/^\s+/, "")
 
-        expect(output).to include("foo.gemspec:")
+        expect(output).to include("foo.gemspec")
         expect(output).to include(gemspec)
       end
     end


### PR DESCRIPTION
We don't use ":" anywhere else on `bundle env` output.