### PR TITLE
Update `SharedHelpers#filesystem_access` inline comment documentation with `Errno::EAGAIN` rescuing [ci skip]

### DIFF
--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -93,7 +93,7 @@ module Bundler
     end
 
     # Rescues permissions errors raised by file system operations
-    # (ie. Errno:EACCESS) and raises more friendly errors instead.
+    # (ie. Errno:EACCESS, Errno::EAGAIN) and raises more friendly errors instead.
     #
     # @param path [String] the path that the action will be attempted to
     # @param action [Symbol, #to_s] the type of operation that will be
@@ -102,6 +102,8 @@ module Bundler
     # @yield path
     #
     # @raise [Bundler::PermissionError] if Errno:EACCES is raised in the
+    #   given block
+    # @raise [Bundler::TemporaryResourceError] if Errno:EAGAIN is raised in the
     #   given block
     #
     # @example


### PR DESCRIPTION
Method was updated by #4189