### PR TITLE
Fix returning case-sensitive mirror URIs in Ruby 2.3

### DIFF
--- a/lib/bundler/mirror.rb
+++ b/lib/bundler/mirror.rb
@@ -42,7 +42,7 @@ module Bundler
     private
 
       def fetch_valid_mirror_for(uri)
-        mirror = (@mirrors[uri] || Mirror.new(uri)).validate!(@prober)
+        mirror = (@mirrors[URI(uri.to_s.downcase)] || Mirror.new(uri)).validate!(@prober)
         mirror = Mirror.new(uri) unless mirror.valid?
         mirror
       end

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -63,8 +63,7 @@ module Bundler
 
     def mirror_for(uri)
       uri = URI(uri.to_s) unless uri.is_a?(URI)
-      # Settings keys are all downcased
-      gem_mirrors.for(uri.to_s.downcase).uri
+      gem_mirrors.for(uri.to_s).uri
     end
 
     def credentials_for(uri)


### PR DESCRIPTION
I have no idea why this fixes things locally, but it does. ¯\\_(ツ)_/¯