### PR TITLE
Remove `Bundler::SharedHelpers#in_bundle?` and make `Bundler::SharedHelpers#find_gemfile` public

### DIFF
--- a/lib/bundler/setup.rb
+++ b/lib/bundler/setup.rb
@@ -1,6 +1,6 @@
 require "bundler/shared_helpers"
 
-if Bundler::SharedHelpers.in_bundle?
+if Bundler::SharedHelpers.find_gemfile
   require "bundler"
 
   if STDOUT.tty? || ENV["BUNDLER_FORCE_TTY"]

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -44,8 +44,11 @@ module Bundler
       Pathname.new(bundle_dir)
     end
 
-    def in_bundle?
-      find_gemfile
+    def find_gemfile
+      given = ENV["BUNDLE_GEMFILE"]
+      return given if given && !given.empty?
+
+      find_file("Gemfile", "gems.rb")
     end
 
     def chdir(dir, &blk)
@@ -128,13 +131,6 @@ module Bundler
     end
 
   private
-
-    def find_gemfile
-      given = ENV["BUNDLE_GEMFILE"]
-      return given if given && !given.empty?
-
-      find_file("Gemfile", "gems.rb")
-    end
 
     def find_file(*names)
       search_up(*names) do |filename|

--- a/lib/bundler/source/path.rb
+++ b/lib/bundler/source/path.rb
@@ -123,7 +123,7 @@ module Bundler
       end
 
       def has_app_cache?
-        SharedHelpers.in_bundle? && app_cache_path.exist?
+        SharedHelpers.find_gemfile && app_cache_path.exist?
       end
 
       def load_spec_files


### PR DESCRIPTION
- `Bundler::SharedHelpers#in_bundle?` is currently just a wrapper around solely `Bundler::SharedHelpers#find_gemfile`
  so the two are functionally equivalent
- Modify `Bundler::SharedHelpers#default_gemfile` unit tests to use
  mocking for `find_gemfile`