### PR TITLE
Separate concerns of `Bundler::SharedHelpers#set_bundle_environment`

### DIFF
--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -74,22 +74,9 @@ module Bundler
     end
 
     def set_bundle_environment
-      # Set PATH
-      paths = (ENV["PATH"] || "").split(File::PATH_SEPARATOR)
-      paths.unshift "#{Bundler.bundle_path}/bin"
-      ENV["PATH"] = paths.uniq.join(File::PATH_SEPARATOR)
-
-      # Set RUBYOPT
-      rubyopt = [ENV["RUBYOPT"]].compact
-      if rubyopt.empty? || rubyopt.first !~ %r{-rbundler/setup}
-        rubyopt.unshift %(-rbundler/setup)
-        ENV["RUBYOPT"] = rubyopt.join(" ")
-      end
-
-      # Set RUBYLIB
-      rubylib = (ENV["RUBYLIB"] || "").split(File::PATH_SEPARATOR)
-      rubylib.unshift File.expand_path("../..", __FILE__)
-      ENV["RUBYLIB"] = rubylib.uniq.join(File::PATH_SEPARATOR)
+      set_path
+      set_rubyopt
+      set_rubylib
     end
 
     # Rescues permissions errors raised by file system operations
@@ -165,6 +152,26 @@ module Bundler
         previous = current
         current = File.expand_path("..", current)
       end
+    end
+
+    def set_path
+      paths = (ENV["PATH"] || "").split(File::PATH_SEPARATOR)
+      paths.unshift "#{Bundler.bundle_path}/bin"
+      ENV["PATH"] = paths.uniq.join(File::PATH_SEPARATOR)
+    end
+
+    def set_rubyopt
+      rubyopt = [ENV["RUBYOPT"]].compact
+      if rubyopt.empty? || rubyopt.first !~ %r{-rbundler/setup}
+        rubyopt.unshift %(-rbundler/setup)
+        ENV["RUBYOPT"] = rubyopt.join(" ")
+      end
+    end
+
+    def set_rubylib
+      rubylib = (ENV["RUBYLIB"] || "").split(File::PATH_SEPARATOR)
+      rubylib.unshift File.expand_path("../..", __FILE__)
+      ENV["RUBYLIB"] = rubylib.uniq.join(File::PATH_SEPARATOR)
     end
 
     def clean_load_path

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -77,6 +77,8 @@ RSpec.configure do |config|
   original_wd       = Dir.pwd
   original_path     = ENV["PATH"]
   original_gem_home = ENV["GEM_HOME"]
+  original_ruby_opt = ENV["RUBYOPT"]
+  original_ruby_lib = ENV["RUBYLIB"]
 
   def pending_jruby_shebang_fix
     pending "JRuby executables do not have a proper shebang" if RUBY_PLATFORM == "java"
@@ -104,6 +106,8 @@ RSpec.configure do |config|
     ENV["PATH"]                  = original_path
     ENV["GEM_HOME"]              = original_gem_home
     ENV["GEM_PATH"]              = original_gem_home
+    ENV["RUBYOPT"]               = original_ruby_opt
+    ENV["RUBYLIB"]               = original_ruby_lib
     ENV["BUNDLE_PATH"]           = nil
     ENV["BUNDLE_GEMFILE"]        = nil
     ENV["BUNDLE_FROZEN"]         = nil


### PR DESCRIPTION
- Splits the implementation details/sections of `Bundler::SharedHelpers#set_bundle_environment` into three more modular, singularly responsible methods: `set_path`, `set_rubyopt`, `set_rubylib`
- Adds unit tests for `set_bundle_environment` and the new methods