### PR TITLE
Finish adding unit tests for `Bundler::SharedHelpers` module

### DIFF
--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -72,6 +72,47 @@ describe Bundler::SharedHelpers do
       end
     end
   end
+  describe "#in_bundle?" do
+    it "calls the find_gemfile method" do
+      expect(subject).to receive(:find_gemfile)
+      subject.in_bundle?
+    end
+    shared_examples_for "correctly determines whether to return a Gemfile path" do
+      context "currently in directory with a Gemfile" do
+        before do
+          File.new("Gemfile", "w")
+        end
+        it "returns path of the bundle gemfile" do
+          expect(subject.in_bundle?).to eq("#{bundled_app}/Gemfile")
+        end
+      end
+      context "currently in directory without a Gemfile" do
+        it "returns nil" do
+          expect(subject.in_bundle?).to eq(nil)
+        end
+      end
+    end
+    context "ENV['BUNDLE_GEMFILE'] set" do
+      before do
+        ENV["BUNDLE_GEMFILE"] = "/path/Gemfile"
+      end
+      it "returns ENV['BUNDLE_GEMFILE']" do
+        expect(subject.in_bundle?).to eq("/path/Gemfile")
+      end
+    end
+    context "ENV['BUNDLE_GEMFILE'] not set" do
+      before do
+        ENV["BUNDLE_GEMFILE"] = nil
+      end
+      it_behaves_like "correctly determines whether to return a Gemfile path"
+    end
+    context "ENV['BUNDLE_GEMFILE'] is blank" do
+      before do
+        ENV["BUNDLE_GEMFILE"] = ""
+      end
+      it_behaves_like "correctly determines whether to return a Gemfile path"
+    end
+  end
   describe "#set_bundle_environment" do
     shared_examples_for "ENV['PATH'] gets set correctly" do
       before do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -74,11 +74,13 @@ RSpec.configure do |config|
   config.filter_run :focused => true unless ENV["CI"]
   config.run_all_when_everything_filtered = true
 
-  original_wd       = Dir.pwd
-  original_path     = ENV["PATH"]
-  original_gem_home = ENV["GEM_HOME"]
-  original_ruby_opt = ENV["RUBYOPT"]
-  original_ruby_lib = ENV["RUBYLIB"]
+  original_wd            = Dir.pwd
+  original_path          = ENV["PATH"]
+  original_gem_home      = ENV["GEM_HOME"]
+  original_ruby_opt      = ENV["RUBYOPT"]
+  original_ruby_lib      = ENV["RUBYLIB"]
+  original_git_dir       = ENV["GIT_DIR"]
+  original_git_work_tree = ENV["GIT_WORK_TREE"]
 
   def pending_jruby_shebang_fix
     pending "JRuby executables do not have a proper shebang" if RUBY_PLATFORM == "java"
@@ -108,6 +110,8 @@ RSpec.configure do |config|
     ENV["GEM_PATH"]              = original_gem_home
     ENV["RUBYOPT"]               = original_ruby_opt
     ENV["RUBYLIB"]               = original_ruby_lib
+    ENV["GIT_DIR"]               = original_git_dir
+    ENV["GIT_WORK_TREE"]         = original_git_work_tree
     ENV["BUNDLE_PATH"]           = nil
     ENV["BUNDLE_GEMFILE"]        = nil
     ENV["BUNDLE_FROZEN"]         = nil


### PR DESCRIPTION
If this PR and #4207 are accepted/merged, then the `Bundler::SharedHelpers` module will have all its public methods unit tested. The only thing that's missing coverage in the spec file for `Bundler::SharedHelpers` is `clean_load_path`, which is used in the `Bundler::Runtime` class. This'll be hopefully addressed/covered as I look more into increasing reasonable unit test coverage to near 100%.