### PR TITLE
add spec verifying that #4147 is fixed

### DIFF
--- a/spec/install/gemfile/ruby_spec.rb
+++ b/spec/install/gemfile/ruby_spec.rb
@@ -1,0 +1,24 @@
+require "spec_helper"
+
+describe "ruby requirement" do
+  # As discovered by https://github.com/bundler/bundler/issues/4147, there is
+  # no test coverage to ensure that adding a gem is possible with a ruby
+  # requirement. This test verifies the fix, committed in bfbad5c5.
+  it "allows adding gems" do
+    install_gemfile <<-G
+      source "file://#{gem_repo1}"
+      ruby "#{RUBY_VERSION}"
+      gem "rack"
+    G
+
+    install_gemfile <<-G
+      source "file://#{gem_repo1}"
+      ruby "#{RUBY_VERSION}"
+      gem "rack"
+      gem "rack-obama"
+    G
+
+    expect(exitstatus).to eq(0) if exitstatus
+    should_be_installed "rack-obama 1.0"
+  end
+end


### PR DESCRIPTION
See #4147 
this test fails when run against the tag v1.11.0, and passes when run against v1.11.2.