### PR TITLE
Extract kernel require, so we can extend it

### DIFF
--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -74,7 +74,7 @@ module Bundler
             file = dep.name if file == true
             required_file = file
             begin
-              Kernel.require file
+              kernel_require(file)
             rescue => e
               raise e if e.is_a?(LoadError) # we handle this a little later
               raise Bundler::GemRequireError.new e,
@@ -96,6 +96,10 @@ module Bundler
           end
         end
       end
+    end
+
+    def kernel_require(file)
+      Kernel.require(file)
     end
 
     def dependencies_for(*groups)


### PR DESCRIPTION
I find myself wanting to instrument this require calls, however to patch this code in bundler
is not super easy as Bundler.require is a big method. We can extract the Kernel.require to a method
and make it easier to extend it.

review @indirect 
Thoughts? Maybe you might have a better idea to accomplish what I need. let me know

thanks