### PR TITLE
Fixed quotes in newgem.gemspec.tt

### DIFF
--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -13,31 +13,31 @@ Gem::Specification.new do |spec|
   spec.description   = %q{TODO: Write a longer description or delete this line.}
   spec.homepage      = "TODO: Put your gem's website or public repo URL here."
 <%- if config[:mit] -%>
-  spec.license       = "MIT"
+  spec.license       = 'MIT'
 <%- end -%>
 
   # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
   # delete this section to allow pushing this gem to any host.
   if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
+    spec.metadata['allowed_push_host'] = 'TODO: Set to http://mygemserver.com'
   else
-    raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
+    raise 'RubyGems 2.0 or newer is required to protect against public gem pushes.'
   end
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = `git ls-files -z`.split('\x0').reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 <%- if config[:ext] -%>
-  spec.extensions    = ["ext/<%=config[:underscored_name]%>/extconf.rb"]
+  spec.extensions    = ['ext/<%=config[:underscored_name]%>/extconf.rb']
 <%- end -%>
 
-  spec.add_development_dependency "bundler", "~> <%= config[:bundler_version] %>"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency 'bundler', '~> <%= config[:bundler_version] %>'
+  spec.add_development_dependency 'rake', '~> 10.0'
 <%- if config[:ext] -%>
-  spec.add_development_dependency "rake-compiler"
+  spec.add_development_dependency 'rake-compiler'
 <%- end -%>
 <%- if config[:test] -%>
-  spec.add_development_dependency "<%=config[:test]%>", "~> <%=config[:test_framework_version]%>"
+  spec.add_development_dependency '<%=config[:test]%>', '~> <%=config[:test_framework_version]%>'
 <%- end -%>
 end

--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
     raise 'RubyGems 2.0 or newer is required to protect against public gem pushes.'
   end
 
-  spec.files         = `git ls-files -z`.split('\x0').reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']


### PR DESCRIPTION
I always end up fixing quotes manually. Should it be like that by default, or is it not convenient?