### PR TITLE
Configure Code Climate exclusions

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,24 @@
+---
+engines:
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - ruby
+  fixme:
+    enabled: true
+  rubocop:
+    enabled: false
+ratings:
+  paths:
+  - "**.rb"
+  - "bin/*"
+  - "exe/*"
+exclude_paths:
+- bundler.gemspec
+- "*.md"
+- lib/bundler/ssl_certs/*.pem
+- lib/bundler/vendor/**/*
+- lib/bundler/templates/**/*.tt
+- man/*
+- spec/**/*

--- a/spec/support/code_climate.rb
+++ b/spec/support/code_climate.rb
@@ -3,9 +3,22 @@ module Spec
     def self.setup
       require "codeclimate-test-reporter"
       ::CodeClimate::TestReporter.start
+      configure_exclusions
     rescue LoadError
       # it's fine if CodeClimate isn't set up
       nil
+    end
+
+    def self.configure_exclusions
+      SimpleCov.start do
+        add_filter "/bin/"
+        add_filter "/lib/bundler/man/"
+        add_filter "/lib/bundler/vendor/"
+        add_filter "/man/"
+        add_filter "/pkg/"
+        add_filter "/spec/"
+        add_filter "/tmp/"
+      end
     end
   end
 end


### PR DESCRIPTION
This PR configures file exclusions for Code Climate test coverage analysis (which files we don't care about "coverage" on) and code analysis.