### PR TITLE
[Exec] Fix exec-ing with 0 args in a directory with spaces

### DIFF
--- a/lib/bundler/cli/exec.rb
+++ b/lib/bundler/cli/exec.rb
@@ -25,7 +25,7 @@ module Bundler
       bin_path = Bundler.which(@cmd)
       if bin_path
         Bundler.ui = nil
-        Kernel.exec(bin_path, *args)
+        Kernel.exec([bin_path, @cmd], *args)
       end
 
       # If that didn't work, set up the whole bundle


### PR DESCRIPTION
Closes #4230 by forcing `Kernel.exec` to never use a shell