### PR TITLE
Require 'irb/completion' in bin/console template

### DIFF
--- a/lib/bundler/templates/newgem/bin/console.tt
+++ b/lib/bundler/templates/newgem/bin/console.tt
@@ -11,4 +11,5 @@ require "<%= config[:namespaced_path] %>"
 # Pry.start
 
 require "irb"
+require "irb/completion"
 IRB.start


### PR DESCRIPTION
Effortlessly providing completion in the generated `bin/console` seems like a sane default.

Rails has followed this way, at least [since 2009](https://github.com/rails/rails/commit/f0dd77c#diff-cd8bfebc5a193c9a13a282e9be10e180R14) and 'irb/completion' is present in the standard library for all Ruby versions we support.

What do you think?