### PR TITLE
Fix the path to the Gemfile during evaluation. 

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -28,10 +28,12 @@ module Bundler
       @env                  = nil
       @ruby_version         = nil
       @gemspecs             = []
+      @gemfile              = nil
       add_git_sources
     end
 
     def eval_gemfile(gemfile, contents = nil)
+      @gemfile = Pathname.new(gemfile)
       contents ||= Bundler.read_file(gemfile.to_s)
       instance_eval(contents, gemfile.to_s, 1)
     rescue Exception => e
@@ -47,7 +49,8 @@ module Bundler
       glob              = opts && opts[:glob]
       name              = opts && opts[:name] || "{,*}"
       development_group = opts && opts[:development_group] || :development
-      expanded_path     = File.expand_path(path, Bundler.default_gemfile.dirname)
+      gemfile           = @gemfile || Bundler.default_gemfile
+      expanded_path     = File.expand_path(path, gemfile.dirname)
 
       gemspecs = Dir[File.join(expanded_path, "#{name}.gemspec")]
 

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -49,8 +49,7 @@ module Bundler
       glob              = opts && opts[:glob]
       name              = opts && opts[:name] || "{,*}"
       development_group = opts && opts[:development_group] || :development
-      gemfile           = @gemfile || Bundler.default_gemfile
-      expanded_path     = File.expand_path(path, gemfile.dirname)
+      expanded_path     = path_relative_to_gemfile(path)
 
       gemspecs = Dir[File.join(expanded_path, "#{name}.gemspec")]
 
@@ -147,7 +146,7 @@ module Bundler
     end
 
     def path(path, options = {}, &blk)
-      with_source(@sources.add_path_source(normalize_hash(options).merge("path" => Pathname.new(path))), &blk)
+      with_source(@sources.add_path_source(normalize_hash(options).merge("path" => path_relative_to_gemfile(path))), &blk)
     end
 
     def git(uri, options = {}, &blk)
@@ -314,6 +313,10 @@ module Bundler
       git_name = (git_names & opts.keys).last
       if @git_sources[git_name]
         opts["git"] = @git_sources[git_name].call(opts[git_name])
+      end
+
+      if opts.key?("path")
+        opts["path"] = path_relative_to_gemfile(opts["path"])
       end
 
       %w(git path).each do |type|
@@ -489,6 +492,11 @@ module Bundler
         end
         [trace_line, description]
       end
+    end
+
+    def path_relative_to_gemfile(path)
+      @gemfile ||= Bundler.default_gemfile
+      @gemfile.dirname + path
     end
   end
 end

--- a/lib/bundler/source/path.rb
+++ b/lib/bundler/source/path.rb
@@ -3,7 +3,7 @@ module Bundler
     class Path < Source
       autoload :Installer, "bundler/source/path/installer"
 
-      attr_reader :path, :options
+      attr_reader :path, :options, :root_path
       attr_writer :name
       attr_accessor :version
 
@@ -15,6 +15,8 @@ module Bundler
 
         @allow_cached = false
         @allow_remote = false
+
+        @root_path = options["root_path"] || Bundler.root
 
         if options["path"]
           @path = Pathname.new(options["path"])
@@ -77,7 +79,7 @@ module Bundler
       def cache(spec, custom_path = nil)
         app_cache_path = app_cache_path(custom_path)
         return unless Bundler.settings[:cache_all]
-        return if expand(@original_path).to_s.index(Bundler.root.to_s + "/") == 0
+        return if expand(@original_path).to_s.index(root_path.to_s + "/") == 0
 
         unless @original_path.exist?
           raise GemNotFound, "Can't cache gem #{version_message(spec)} because #{self} is missing!"
@@ -111,7 +113,7 @@ module Bundler
       end
 
       def expand(somepath)
-        somepath.expand_path(Bundler.root)
+        somepath.expand_path(root_path)
       rescue ArgumentError => e
         Bundler.ui.debug(e)
         raise PathError, "There was an error while trying to use the path " \
@@ -164,8 +166,8 @@ module Bundler
       end
 
       def relative_path
-        if path.to_s.start_with?(Bundler.root.to_s)
-          return path.relative_path_from(Bundler.root)
+        if path.to_s.start_with?(root_path.to_s)
+          return path.relative_path_from(root_path)
         end
         path
       end

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -235,6 +235,7 @@ describe Bundler::Dsl do
       it "restores it after it's done" do
         other_source = double("other-source")
         allow(Bundler::Source::Rubygems).to receive(:new).and_return(other_source)
+        allow(Bundler).to receive(:default_gemfile).and_return(Pathname.new("./Gemfile"))
 
         subject.source("https://other-source.org") do
           subject.gem("dobry-pies", :path => "foo")


### PR DESCRIPTION
This is a continuation of https://github.com/bundler/bundler/pull/3349 Following up per: https://github.com/bundler/bundler/pull/3349#issuecomment-88307579

The issue here is that paths used with `Bundler::Dsl#gemspec` will only work when the Gemfile being evaluated is `Bundler.default_gemfile`. 

Passing a Gemfile other than `Bundler.default_gemfile` to `Bundler::Dsl.evaluate` will break uses of `path:` options in the Gemfile.

These changes update `Bundler::Dsl` to remember the Gemfile passed into `eval_gemfile` and use it to resolve relative paths.
