### PR TITLE
Allow passing UI object into bundler/inline

### DIFF
--- a/lib/bundler/inline.rb
+++ b/lib/bundler/inline.rb
@@ -27,7 +27,9 @@
 #
 #          puts Pod::VERSION # => "0.34.4"
 #
-def gemfile(install = false, ui = nil, &gemfile)
+def gemfile(install = false, options = {}, &gemfile)
+  ui = options[:ui]
+
   require "bundler"
   old_root = Bundler.method(:root)
   def Bundler.root

--- a/lib/bundler/inline.rb
+++ b/lib/bundler/inline.rb
@@ -28,9 +28,12 @@
 #          puts Pod::VERSION # => "0.34.4"
 #
 def gemfile(install = false, options = {}, &gemfile)
-  ui = options[:ui]
-
   require "bundler"
+
+  opts = options.dup
+  ui = opts.delete(:ui) { Bundler::UI::Shell.new }
+  raise ArgumentError, "Unknown options: #{opts.keys.join(", ")}" unless opts.empty?
+
   old_root = Bundler.method(:root)
   def Bundler.root
     Bundler::SharedHelpers.pwd.expand_path
@@ -45,7 +48,7 @@ def gemfile(install = false, options = {}, &gemfile)
   definition.validate_ruby!
 
   if install
-    Bundler.ui = ui || Bundler::UI::Shell.new
+    Bundler.ui = ui
     Bundler::Installer.install(Bundler.root, definition, :system => true)
     Bundler::Installer.post_install_messages.each do |name, message|
       Bundler.ui.info "Post-install message from #{name}:\n#{message}"

--- a/lib/bundler/inline.rb
+++ b/lib/bundler/inline.rb
@@ -27,7 +27,7 @@
 #
 #          puts Pod::VERSION # => "0.34.4"
 #
-def gemfile(install = false, &gemfile)
+def gemfile(install = false, ui = nil, &gemfile)
   require "bundler"
   old_root = Bundler.method(:root)
   def Bundler.root
@@ -43,7 +43,7 @@ def gemfile(install = false, &gemfile)
   definition.validate_ruby!
 
   if install
-    Bundler.ui = Bundler::UI::Shell.new
+    Bundler.ui = ui || Bundler::UI::Shell.new
     Bundler::Installer.install(Bundler.root, definition, :system => true)
     Bundler::Installer.post_install_messages.each do |name, message|
       Bundler.ui.info "Post-install message from #{name}:\n#{message}"

--- a/spec/runtime/inline_spec.rb
+++ b/spec/runtime/inline_spec.rb
@@ -102,7 +102,7 @@ describe "bundler/inline#gemfile" do
           puts "CONFIRMED!"
         end
       end
-      gemfile(true, ui: MyBundlerUI.new) do
+      gemfile(true, :ui => MyBundlerUI.new) do
         source "https://rubygems.org"
         gem "activesupport", :require => true
       end

--- a/spec/runtime/inline_spec.rb
+++ b/spec/runtime/inline_spec.rb
@@ -93,4 +93,22 @@ describe "bundler/inline#gemfile" do
     expect(err).to eq("")
     expect(exitstatus).to be_zero if exitstatus
   end
+
+  it "lets me use my own ui object" do
+    script <<-RUBY, :artifice => "endpoint"
+      require 'bundler'
+      class MyBundlerUI < Bundler::UI::Silent
+        def confirm(msg, newline = nil)
+          puts "CONFIRMED!"
+        end
+      end
+      gemfile(true, MyBundlerUI.new) do
+        source "https://rubygems.org"
+        gem "activesupport", :require => true
+      end
+    RUBY
+
+    expect(out).to eq("CONFIRMED!")
+    expect(exitstatus).to be_zero if exitstatus
+  end
 end

--- a/spec/runtime/inline_spec.rb
+++ b/spec/runtime/inline_spec.rb
@@ -111,4 +111,32 @@ describe "bundler/inline#gemfile" do
     expect(out).to eq("CONFIRMED!")
     expect(exitstatus).to be_zero if exitstatus
   end
+
+  it "raises an exception if passed unknown arguments" do
+    script <<-RUBY, :expect_err => true
+      gemfile(true, arglebargle: true) do
+        path "#{lib_path}"
+        gem "two"
+      end
+
+      puts "success"
+    RUBY
+    expect(err).to include "Unknown options: arglebargle"
+    expect(out).not_to include "success"
+  end
+
+  it "does not mutate the option argument" do
+    script <<-RUBY
+      require 'bundler'
+      options = { ui: Bundler::UI::Shell.new }
+      gemfile(false, options) do
+        path "#{lib_path}"
+        gem "two"
+      end
+      puts "OKAY" if options.key?(:ui)
+    RUBY
+
+    expect(out).to match("OKAY")
+    expect(exitstatus).to be_zero if exitstatus
+  end
 end

--- a/spec/runtime/inline_spec.rb
+++ b/spec/runtime/inline_spec.rb
@@ -114,7 +114,7 @@ describe "bundler/inline#gemfile" do
 
   it "raises an exception if passed unknown arguments" do
     script <<-RUBY, :expect_err => true
-      gemfile(true, arglebargle: true) do
+      gemfile(true, :arglebargle => true) do
         path "#{lib_path}"
         gem "two"
       end
@@ -128,7 +128,7 @@ describe "bundler/inline#gemfile" do
   it "does not mutate the option argument" do
     script <<-RUBY
       require 'bundler'
-      options = { ui: Bundler::UI::Shell.new }
+      options = { :ui => Bundler::UI::Shell.new }
       gemfile(false, options) do
         path "#{lib_path}"
         gem "two"

--- a/spec/runtime/inline_spec.rb
+++ b/spec/runtime/inline_spec.rb
@@ -102,7 +102,7 @@ describe "bundler/inline#gemfile" do
           puts "CONFIRMED!"
         end
       end
-      gemfile(true, MyBundlerUI.new) do
+      gemfile(true, ui: MyBundlerUI.new) do
         source "https://rubygems.org"
         gem "activesupport", :require => true
       end


### PR DESCRIPTION
Added an argument to the gemfile method to allow overriding the
UI object.  Useful to override the default output format and
send those log events to a logfile or decorate them (timestamps,
severity, etc) before emitting them.