### PR TITLE
Bundle outdated with major and minor options

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -242,6 +242,8 @@ module Bundler
     method_option "source", :type => :array, :banner => "Check against a specific source"
     method_option "strict", :type => :boolean, :banner =>
       "Only list newer versions allowed by your Gemfile requirements"
+    method_option "major", :type => :boolean, :banner => "Only list major newer versions"
+    method_option "minor", :type => :boolean, :banner => "Only list at least minor newer versions"
     def outdated(*gems)
       require "bundler/cli/outdated"
       Outdated.new(options, gems).run

--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -46,6 +46,18 @@ module Bundler
             active_spec = active_spec.delete_if {|b| b.respond_to?(:version) && b.version.prerelease? }
           end
           active_spec = active_spec.last
+
+          if options[:major]
+            current_major = current_spec.version.segments.first
+            active_major = active_spec.version.segments.first
+            active_spec = nil unless active_major > current_major
+          end
+
+          if options[:minor]
+            current_minor = current_spec.version.segments[0, 2].compact.join(".")
+            active_minor = active_spec.version.segments[0, 2].compact.join(".")
+            active_spec = nil unless active_minor > current_minor
+          end
         end
         next if active_spec.nil?
 

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -180,4 +180,59 @@ describe "bundle outdated" do
     bundle :outdated
     expect(out).to include("Installing foo 1.0")
   end
+
+  describe "with --major option" do
+    it "only reports gems that have a newer major version" do
+      update_repo2 do
+        build_gem "weakling", "0.2.0"
+        build_gem "activesupport", "3.0"
+      end
+
+      bundle "outdated --major"
+      expect(out).to_not include("weakling (newest")
+      expect(out).to include("activesupport (newest")
+    end
+
+    it "ignore gems not in semantic version" do
+      update_repo2 do
+        build_gem "weakling", "1"
+      end
+
+      bundle "outdated --major"
+      expect(out).to include("weakling (newest")
+    end
+  end
+
+  describe "with --minor option" do
+    it "only reports gems that have at least a newer minor version" do
+      update_repo2 do
+        build_gem "activesupport", "3.0.0"
+        build_gem "weakling", "0.2.0"
+      end
+
+      bundle "outdated --minor"
+      expect(out).to include("weakling (newest")
+      expect(out).to include("activesupport (newest")
+    end
+
+    it "ignore patch version" do
+      update_repo2 do
+        build_gem "activesupport", "2.3.6"
+        build_gem "weakling", "0.0.4"
+      end
+
+      bundle "outdated --minor"
+      expect(out).to_not include("weakling (newest")
+      expect(out).to_not include("activesupport (newest")
+    end
+
+    it "ignore gems not in semantic version" do
+      update_repo2 do
+        build_gem "weakling", "1"
+      end
+
+      bundle "outdated --minor"
+      expect(out).to include("weakling (newest")
+    end
+  end
 end


### PR DESCRIPTION
This feature adds the ability to specify a outdated command to show only the gems with a major or minor updates.

I was looking for this feature and found the issue https://github.com/bundler/bundler/issues/3805

@indirect, how can I improve this PR? 