### PR TITLE
Change behavior and improve clarity of error messages when local gems have invalid gemspecs

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -352,9 +352,9 @@ module Bundler
         spec
       end
     rescue Gem::InvalidSpecificationException => e
-      UI::Shell.new.warn "The gemspec at #{file} is not valid. " \
-        "The validation error was '#{e.message}'"
-      nil
+      error_message = "The gemspec at #{file} is not valid. Please fix this gemspec.\n" \
+        "The validation error was '#{e.message}'\n"
+      raise Gem::InvalidSpecificationException.new(error_message)
     end
 
     def clear_gemspec_cache

--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -150,6 +150,9 @@ module Bundler
         WARN
       end
       raise e
+    rescue Gem::InvalidSpecificationException => e
+      Bundler.ui.warn "You have one or more invalid gemspecs that need to be fixed."
+      raise e
     end
 
   private

--- a/lib/bundler/friendly_errors.rb
+++ b/lib/bundler/friendly_errors.rb
@@ -33,6 +33,8 @@ module Bundler
       when Interrupt
         Bundler.ui.error "\nQuitting..."
         Bundler.ui.trace error
+      when Gem::InvalidSpecificationException
+        Bundler.ui.error error.message, :wrap => true
       when SystemExit
       else request_issue_report_for(error)
       end

--- a/spec/bundler/bundler_spec.rb
+++ b/spec/bundler/bundler_spec.rb
@@ -73,5 +73,34 @@ describe Bundler do
         $VERBOSE = verbose
       end
     end
+
+    context "validate is true" do
+      subject { Bundler.load_gemspec_uncached(app_gemspec_path, true) }
+
+      context "and there are gemspec validation errors" do
+        let(:ui_shell) { double(:ui_shell) }
+
+        before do
+          allow(Bundler::UI::Shell).to receive(:new).and_return(ui_shell)
+          allow(Bundler.rubygems).to receive(:validate) {
+            raise Gem::InvalidSpecificationException.new("TODO is not an author")
+          }
+        end
+
+        it "should raise a Gem::InvalidSpecificationException and produce a helpful warning message" do
+          File.open(app_gemspec_path, "wb") do |file|
+            file.puts <<-GEMSPEC.gsub(/^\s+/, "")
+              Gem::Specification.new do |gem|
+                gem.author = "TODO"
+              end
+            GEMSPEC
+          end
+
+          expect { subject }.to raise_error(Gem::InvalidSpecificationException,
+            "The gemspec at #{app_gemspec_path} is not valid. "\
+            "Please fix this gemspec.\nThe validation error was 'TODO is not an author'\n")
+        end
+      end
+    end
   end
 end

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -341,8 +341,8 @@ describe "bundle exec" do
 
       bundle "exec irb", :expect_err => true
 
-      expect(out).to match("The gemspec at #{lib_path("foo-1.0").join("foo.gemspec")} is not valid")
-      expect(out).to match('"TODO" is not a summary')
+      expect(err).to match("The gemspec at #{lib_path("foo-1.0").join("foo.gemspec")} is not valid")
+      expect(err).to match('"TODO" is not a summary')
     end
   end
 

--- a/spec/install/gemfile/path_spec.rb
+++ b/spec/install/gemfile/path_spec.rb
@@ -157,8 +157,11 @@ describe "bundle install with explicit source paths" do
       gem "foo", :path => "#{lib_path("foo-1.0")}"
     G
 
-    expect(out).to match(/missing value for attribute version/)
     expect(out).to_not include("ERROR REPORT")
+    expect(out).to_not include("Your Gemfile has no gem server sources.")
+    expect(out).to match(/is not valid. Please fix this gemspec./)
+    expect(out).to match(/The validation error was 'missing value for attribute version'/)
+    expect(out).to match(/You have one or more invalid gemspecs that need to be fixed/)
   end
 
   it "supports gemspec syntax" do


### PR DESCRIPTION
Now, when a local gem's gemspec contains errors, an error is raised immediately and helpful message is provided. This message instructs the user to fix the gemspec before an attempt is made to fetch the local gem that has an incorrect gemspec.

- Addresses #4248