### PR TITLE
Use 'bundle gem --exe' as primary option name, instead of '--bin'.

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -322,7 +322,7 @@ module Bundler
     end
 
     desc "gem GEM [OPTIONS]", "Creates a skeleton for creating a rubygem"
-    method_option :bin, :type => :boolean, :default => false, :aliases => "-b", :desc => "Generate a binary for your library."
+    method_option :exe, :type => :boolean, :default => false, :aliases => ["--bin", "-b"], :desc => "Generate a binary executable for your library."
     method_option :coc, :type => :boolean, :desc => "Generate a code of conduct file. Set a default with `bundle config gem.coc true`."
     method_option :edit, :type => :string, :aliases => "-e", :required => false, :banner => "EDITOR",
       :lazy_default => [ENV["BUNDLER_EDITOR"], ENV["VISUAL"], ENV["EDITOR"]].find {|e| !e.nil? && !e.empty? },

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -322,7 +322,7 @@ module Bundler
     end
 
     desc "gem GEM [OPTIONS]", "Creates a skeleton for creating a rubygem"
-    method_option :exe, :type => :boolean, :default => false, :aliases => ["--bin", "-b"], :desc => "Generate a binary executable for your library."
+    method_option :exe, :type => :boolean, :default => false, :desc => "Generate a binary executable for your library."
     method_option :coc, :type => :boolean, :desc => "Generate a code of conduct file. Set a default with `bundle config gem.coc true`."
     method_option :edit, :type => :string, :aliases => "-e", :required => false, :banner => "EDITOR",
       :lazy_default => [ENV["BUNDLER_EDITOR"], ENV["VISUAL"], ENV["EDITOR"]].find {|e| !e.nil? && !e.empty? },

--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -44,7 +44,7 @@ module Bundler
         :test             => options[:test],
         :test_task        => test_task,
         :ext              => options[:ext],
-        :bin              => options[:bin],
+        :exe              => options[:exe],
         :bundler_version  => bundler_dependency_version
       }
       ensure_safe_gem_name(name, constant_array)
@@ -107,7 +107,7 @@ module Bundler
         templates.merge!("CODE_OF_CONDUCT.md.tt" => "CODE_OF_CONDUCT.md")
       end
 
-      templates.merge!("exe/newgem.tt" => "exe/#{name}") if options[:bin]
+      templates.merge!("exe/newgem.tt" => "exe/#{name}") if config[:exe]
 
       if options[:ext]
         templates.merge!(

--- a/man/bundle-gem.ronn
+++ b/man/bundle-gem.ronn
@@ -24,13 +24,13 @@ configuration file using the following names:
 
 ## OPTIONS
 
-* `-b` or `--bin`:
-  Specify that Bundler should create a binary (as `exe/GEM_NAME`) in the
-  generated rubygem project. This binary will also be added to the
+* `--exe` or `-b` or `--bin`:
+  Specify that Bundler should create a binary executable (as `exe/GEM_NAME`)
+  in the generated rubygem project. This binary will also be added to the
   `GEM_NAME.gemspec` manifest. This behavior is disabled by default.
 
-* `--no-bin`:
-  Do not create a binary (overrides `--bin` specified in the global config).
+* `--no-exe`:
+  Do not create a binary (overrides `--exe` specified in the global config).
 
 * `--coc`:
   Add a `CODE_OF_CONDUCT.md` file to the root of the generated project. If

--- a/man/bundle-gem.ronn
+++ b/man/bundle-gem.ronn
@@ -24,7 +24,7 @@ configuration file using the following names:
 
 ## OPTIONS
 
-* `--exe` or `-b` or `--bin`:
+* `--exe`:
   Specify that Bundler should create a binary executable (as `exe/GEM_NAME`)
   in the generated rubygem project. This binary will also be added to the
   `GEM_NAME.gemspec` manifest. This behavior is disabled by default.

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -456,14 +456,14 @@ describe "bundle gem" do
       end
     end
 
-    context "--bin parameter set" do
+    context "--exe parameter set" do
       before do
         reset!
         in_app_root
-        bundle "gem #{gem_name} --bin"
+        bundle "gem #{gem_name} --exe"
       end
 
-      it "builds bin skeleton" do
+      it "builds exe skeleton" do
         expect(bundled_app("test-gem/exe/test-gem")).to exist
       end
 

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -199,6 +199,22 @@ describe "bundle gem" do
       end
     end
 
+    context "--exe parameter set" do
+      before do
+        reset!
+        in_app_root
+        bundle "gem #{gem_name} --exe"
+      end
+
+      it "builds exe skeleton" do
+        expect(bundled_app("test_gem/exe/test_gem")).to exist
+      end
+
+      it "requires 'test-gem'" do
+        expect(bundled_app("test_gem/exe/test_gem").read).to match(/require "test_gem"/)
+      end
+    end
+
     context "--bin parameter set" do
       before do
         reset!
@@ -206,7 +222,7 @@ describe "bundle gem" do
         bundle "gem #{gem_name} --bin"
       end
 
-      it "builds bin skeleton" do
+      it "builds exe skeleton" do
         expect(bundled_app("test_gem/exe/test_gem")).to exist
       end
 

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -58,7 +58,7 @@ describe "bundle gem" do
     system_gems ["rake-10.0.2"]
 
     in_app_root
-    bundle "gem newgem --bin"
+    bundle "gem newgem --exe"
 
     process_file(bundled_app("newgem", "newgem.gemspec")) do |line|
       # Simulate replacing TODOs with real values
@@ -204,22 +204,6 @@ describe "bundle gem" do
         reset!
         in_app_root
         bundle "gem #{gem_name} --exe"
-      end
-
-      it "builds exe skeleton" do
-        expect(bundled_app("test_gem/exe/test_gem")).to exist
-      end
-
-      it "requires 'test-gem'" do
-        expect(bundled_app("test_gem/exe/test_gem").read).to match(/require "test_gem"/)
-      end
-    end
-
-    context "--bin parameter set" do
-      before do
-        reset!
-        in_app_root
-        bundle "gem #{gem_name} --bin"
       end
 
       it "builds exe skeleton" do


### PR DESCRIPTION
This takes #4225 further to completely deprecate usage of the --bin and -b flags for bundle gem in favor of --exe, which mirrors the new terminology for the files the flag creates.

This is a follow-up on the discussion at bundler/bundler-features#105 and PR #4226, but with those commits applied to the `2-0-dev` branch.