### PR TITLE
Place bundler loaded gems after -I and RUBYLIB

### DIFF
--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -35,6 +35,10 @@ module Bundler
       Gem::Command.build_args = args
     end
 
+    def load_path_insert_index
+      Gem.load_path_insert_index
+    end
+
     def loaded_specs(name)
       Gem.loaded_specs[name]
     end

--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -39,7 +39,7 @@ module Bundler
         load_paths = spec.load_paths.reject {|path| $LOAD_PATH.include?(path) }
 
         # See Gem::Specification#add_self_to_load_path (since RubyGems 1.8)
-        insert_index = Gem.load_path_insert_index
+        insert_index = Bundler.rubygems.load_path_insert_index
 
         if insert_index
           # Gem directories must come after -I and ENV['RUBYLIB']

--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -37,7 +37,17 @@ module Bundler
 
         Bundler.rubygems.mark_loaded(spec)
         load_paths = spec.load_paths.reject {|path| $LOAD_PATH.include?(path) }
-        $LOAD_PATH.unshift(*load_paths)
+
+        # See Gem::Specification#add_self_to_load_path (since RubyGems 1.8)
+        insert_index = Gem.load_path_insert_index
+
+        if insert_index
+          # Gem directories must come after -I and ENV['RUBYLIB']
+          $LOAD_PATH.insert(insert_index, *load_paths)
+        else
+          # We are probably testing in core, -I and RUBYLIB don't apply
+          $LOAD_PATH.unshift(*load_paths)
+        end
       end
 
       setup_manpath

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -109,11 +109,6 @@ describe "Bundler.setup" do
   end
 
   context "load order" do
-    after do
-      ENV.delete "RUBYLIB"
-      ENV.delete "RUBYOPT"
-    end
-
     it "puts loaded gems after -I and RUBYLIB" do
       install_gemfile <<-G
         source "file://#{gem_repo1}"

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -120,7 +120,7 @@ describe "Bundler.setup" do
         gem "rack"
       G
 
-      ENV["RUBYOPT"] = "-I dash_i_dir"
+      ENV["RUBYOPT"] = "-Idash_i_dir"
       ENV["RUBYLIB"] = "rubylib_dir"
 
       ruby <<-RUBY

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -108,6 +108,31 @@ describe "Bundler.setup" do
     end
   end
 
+  it "puts loaded gems after -I and RUBYLIB" do
+    install_gemfile <<-G
+      source "file://#{gem_repo1}"
+      gem "rack"
+    G
+
+    ruby <<-RUBY
+      require 'rubygems'
+      require 'bundler'
+      $LOAD_PATH.unshift('fake -I')
+      Bundler.setup
+
+      puts $LOAD_PATH
+    RUBY
+
+    load_path = out.split("\n")
+    rack_load_order = load_path.each_with_index do |dir, i|
+      break i if dir =~ /rack/
+    end
+
+    expect(err).to eq("")
+    expect(load_path.first).to eq("fake -I")
+    expect(rack_load_order).to be > 0
+  end
+
   it "raises if the Gemfile was not yet installed" do
     gemfile <<-G
       source "file://#{gem_repo1}"


### PR DESCRIPTION
Previously, gems were being placed at the front of the LOAD_PATH. This
meant you couldn't override a gem by setting -I or RUBYLIB.

This patch places -I and RUBYLIB in front of loaded gems and matches the
behavior in RubyGems.