### PR TITLE
[Exec] Load instead of exec-ing

### DIFF
--- a/lib/bundler/cli/exec.rb
+++ b/lib/bundler/cli/exec.rb
@@ -75,7 +75,7 @@ module Bundler
         "#!/usr/bin/env ruby\n",
         "#!#{Gem.ruby}\n",
       ]
-      first_line = File.read(file, possibilities.map(&:size).max, :mode => "rb")
+      first_line = File.open(file, "rb") {|f| f.read(possibilities.map(&:size).max) }
       possibilities.any? {|shebang| first_line.start_with?(shebang) }
     end
   end

--- a/lib/bundler/cli/exec.rb
+++ b/lib/bundler/cli/exec.rb
@@ -56,6 +56,7 @@ module Bundler
     def kernel_load(file, *args)
       args.pop if args.last.is_a?(Hash)
       ARGV.replace(args)
+      $0 = file
       ui = Bundler.ui
       Bundler.ui = nil
       require "bundler/setup"

--- a/lib/bundler/cli/exec.rb
+++ b/lib/bundler/cli/exec.rb
@@ -18,16 +18,30 @@ module Bundler
     end
 
     def run
-      ui = Bundler.ui
-      raise ArgumentError if cmd.nil?
-
+      validate_cmd!
       SharedHelpers.set_bundle_environment
-      bin_path = Bundler.which(@cmd)
+      if bin_path = Bundler.which(cmd)
+        kernel_load(bin_path, *args) && return if ruby_shebang?(bin_path)
+        # First, try to exec directly to something in PATH
+        kernel_exec([bin_path, cmd], *args)
+      else
+        # Just exec using the given command
+        kernel_exec(cmd, *args)
+      end
+    end
+
+  private
+
+    def validate_cmd!
+      return unless cmd.nil?
+      Bundler.ui.error "bundler: exec needs a command to run"
+      exit 128
+    end
+
+    def kernel_exec(*args)
+      ui = Bundler.ui
       Bundler.ui = nil
-      # First, try to exec directly to something in PATH
-      Kernel.exec([bin_path, @cmd], *args) if bin_path
-      # Just exec using the given command
-      Kernel.exec(@cmd, *args)
+      Kernel.exec(*args)
     rescue Errno::EACCES, Errno::ENOEXEC
       Bundler.ui = ui
       Bundler.ui.error "bundler: not executable: #{cmd}"
@@ -37,10 +51,27 @@ module Bundler
       Bundler.ui.error "bundler: command not found: #{cmd}"
       Bundler.ui.warn "Install missing gem executables with `bundle install`"
       exit 127
-    rescue ArgumentError
+    end
+
+    def kernel_load(file, *args)
+      args.pop if args.last.is_a?(Hash)
+      ARGV.replace(args)
+      ui = Bundler.ui
+      Bundler.ui = nil
+      require "bundler/setup"
+      Kernel.load(file)
+    rescue SystemExit
+      raise
+    rescue Exception => e # rubocop:disable Lint/RescueException
       Bundler.ui = ui
-      Bundler.ui.error "bundler: exec needs a command to run"
-      exit 128
+      Bundler.ui.error "bundler: failed to load command: #{cmd} (#{file})"
+      Bundler.ui.trace(e, nil, true)
+      exit 125
+    end
+
+    def ruby_shebang?(file)
+      first_line = File.open(file, "rb", &:readline)
+      first_line == "#!/usr/bin/env ruby\n" || first_line == "#!#{Gem.ruby}\n"
     end
   end
 end

--- a/lib/bundler/cli/exec.rb
+++ b/lib/bundler/cli/exec.rb
@@ -71,8 +71,12 @@ module Bundler
     end
 
     def ruby_shebang?(file)
-      first_line = File.open(file, "rb", &:readline)
-      first_line == "#!/usr/bin/env ruby\n" || first_line == "#!#{Gem.ruby}\n"
+      possibilities = [
+        "#!/usr/bin/env ruby\n",
+        "#!#{Gem.ruby}\n",
+      ]
+      first_line = File.read(file, possibilities.map(&:size).max, :mode => "rb")
+      possibilities.any? {|shebang| first_line.start_with?(shebang) }
     end
   end
 end

--- a/lib/bundler/cli/exec.rb
+++ b/lib/bundler/cli/exec.rb
@@ -66,7 +66,8 @@ module Bundler
     rescue Exception => e # rubocop:disable Lint/RescueException
       Bundler.ui = ui
       Bundler.ui.error "bundler: failed to load command: #{cmd} (#{file})"
-      abort "#{e.class}: #{e.message}\n#{e.backtrace.join("\n  ")}"
+      backtrace = e.backtrace.take_while {|bt| !bt.start_with?(__FILE__) }
+      abort "#{e.class}: #{e.message}\n  #{backtrace.join("\n  ")}"
     end
 
     def ruby_shebang?(file)

--- a/lib/bundler/cli/exec.rb
+++ b/lib/bundler/cli/exec.rb
@@ -65,8 +65,7 @@ module Bundler
     rescue Exception => e # rubocop:disable Lint/RescueException
       Bundler.ui = ui
       Bundler.ui.error "bundler: failed to load command: #{cmd} (#{file})"
-      Bundler.ui.trace(e, nil, true)
-      exit 125
+      abort "#{e.class}: #{e.message}\n#{e.backtrace.join("\n  ")}"
     end
 
     def ruby_shebang?(file)

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -363,4 +363,89 @@ describe "bundle exec" do
       expect(out).to match("true")
     end
   end
+
+  context "`load`ing a ruby file instead of `exec`ing" do
+    let(:path) { bundled_app("ruby_executable") }
+    let(:shebang) { "#!/usr/bin/env ruby" }
+    let(:executable) { <<-RUBY.gsub(/^ */, "").strip }
+      #{shebang}
+
+      require "rack"
+      puts "EXEC: \#{caller.grep(/load/).empty? ? 'exec' : 'load'}"
+      puts "ARGS: \#{$0} \#{ARGV.join(' ')}"
+      puts "RACK: \#{RACK}"
+    RUBY
+
+    before do
+      path.open("w") {|f| f << executable }
+      FileUtils.chmod("+x", path)
+
+      install_gemfile <<-G
+        gem "rack"
+      G
+    end
+
+    let(:exec) { "EXEC: load" }
+    let(:args) { "ARGS: #{path} arg1 arg2" }
+    let(:rack) { "RACK: 1.0.0" }
+    let(:exit_code) { 0 }
+    let(:expected) { [exec, args, rack].join("\n") }
+    let(:expected_err) { "" }
+
+    subject { bundle "exec #{path} arg1 arg2", :expect_err => true }
+
+    shared_examples_for "it runs" do
+      it "like a normally executed executable like a normally executed executable" do
+        subject
+        expect(exitstatus).to eq(exit_code) if exitstatus
+        expect(err).to eq(expected_err)
+        expect(out).to eq(expected)
+      end
+    end
+
+    it_behaves_like "it runs"
+
+    context "the executable exits explicitly" do
+      let(:executable) { super() << "\nexit #{exit_code}\nputs 'POST_EXIT'\n" }
+
+      context "with exit 0" do
+        it_behaves_like "it runs"
+      end
+
+      context "with exit 99" do
+        let(:exit_code) { 99 }
+        it_behaves_like "it runs"
+      end
+    end
+
+    context "the executable raises" do
+      let(:executable) { super() << "\nraise 'ERROR'" }
+      let(:exit_code) { 1 }
+      let(:expected) { super() << "\nbundler: failed to load command: #{path} (#{path})" }
+      let(:expected_err) { "RuntimeError: ERROR\n  #{path}:7:in `<top (required)>'" }
+      it_behaves_like "it runs"
+    end
+
+    context "when the file uses the current ruby shebang" do
+      let(:shebang) { "#!#{Gem.ruby}" }
+      it_behaves_like "it runs"
+    end
+
+    context "when Bundler.setup fails" do
+      before do
+        gemfile <<-G
+          gem 'rack', '2'
+        G
+        ENV["BUNDLER_FORCE_TTY"] = "true"
+      end
+
+      let(:exit_code) { Bundler::GemNotFound.new.status_code }
+      let(:expected) { <<-EOS.strip }
+\e[31mCould not find gem 'rack (= 2)' in any of the gem sources listed in your Gemfile or available on this machine.\e[0m
+\e[33mRun `bundle install` to install missing gems.\e[0m
+      EOS
+
+      it_behaves_like "it runs"
+    end
+  end
 end

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -378,7 +378,7 @@ describe "bundle exec" do
 
     before do
       path.open("w") {|f| f << executable }
-      FileUtils.chmod("+x", path)
+      path.chmod(0755)
 
       install_gemfile <<-G
         gem "rack"
@@ -422,7 +422,10 @@ describe "bundle exec" do
       let(:executable) { super() << "\nraise 'ERROR'" }
       let(:exit_code) { 1 }
       let(:expected) { super() << "\nbundler: failed to load command: #{path} (#{path})" }
-      let(:expected_err) { "RuntimeError: ERROR\n  #{path}:7:in `<top (required)>'" }
+      let(:expected_err) do
+        "RuntimeError: ERROR\n  #{path}:7" +
+          (Bundler.current_ruby.ruby_18? ? "" : ":in `<top (required)>'")
+      end
       it_behaves_like "it runs"
     end
 


### PR DESCRIPTION
Proof-of-concept to avoid `exec` where possible, instead just using `load` when we'd be launching the same interpreter anyways. About a .2 second gain in my limited testing. Over a second gain in jruby in my testing, somehow.

Not near ready for merging, but pretty cool for an hour of hacking.

- [x] Tests
- [ ] Centralize error handling
- [ ] Raise exceptions instead of exiting