### PR TITLE
bundle init: Generate a Gemfile that is Rubocop compliant

### DIFF
--- a/lib/bundler/templates/Gemfile
+++ b/lib/bundler/templates/Gemfile
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 # A sample Gemfile
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
-# gem "rails"
+# gem 'rails'


### PR DESCRIPTION
Rationale: Rubocop complains when you use double quoted strings but not really _need_ it, since you don't perform any string interpolation.

This can be tweaked in the settings for Rubocop, but I think it would be good for Bundler to generate a Gemfile which is compliant by default (i.e. compliant with Rubocop's defalt settings).

(The same also goes for the content generated by `bundle gem`, but let's take this change as a starting point for discussion. If we can reach an agreement on this, then other files can be changed in a similar manner.)