### PR TITLE
Create standalone bundler/setup.rb at a consistent path.

### DIFF
--- a/lib/bundler/installer/standalone.rb
+++ b/lib/bundler/installer/standalone.rb
@@ -38,7 +38,7 @@ module Bundler
     end
 
     def bundler_path
-      File.join(Bundler.settings[:path], "bundler")
+      Bundler.root.join(Bundler.settings[:path], "bundler")
     end
 
     def gem_path(path, spec)

--- a/spec/install/gems/standalone_spec.rb
+++ b/spec/install/gems/standalone_spec.rb
@@ -1,7 +1,54 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle install --standalone" do
+shared_examples "bundle install --standalone" do
+  shared_examples "common functionality" do
+    it "still makes the gems available to normal bundler" do
+      args = expected_gems.map {|k, v| "#{k} #{v}" }
+      should_be_installed(*args)
+    end
+
+    it "generates a bundle/bundler/setup.rb" do
+      expect(bundled_app("bundle/bundler/setup.rb")).to exist
+    end
+
+    it "makes the gems available without bundler" do
+      testrb = String.new <<-RUBY
+        $:.unshift File.expand_path("bundle")
+        require "bundler/setup"
+
+      RUBY
+      expected_gems.each do |k, _|
+        testrb << "\nrequire \"#{k}\""
+        testrb << "\nputs #{k.upcase}"
+      end
+      Dir.chdir(bundled_app) do
+        ruby testrb, :no_lib => true
+      end
+
+      expect(out).to eq(expected_gems.values.join("\n"))
+    end
+
+    it "works on a different system" do
+      FileUtils.mv(bundled_app, "#{bundled_app}2")
+
+      testrb = String.new <<-RUBY
+        $:.unshift File.expand_path("bundle")
+        require "bundler/setup"
+
+      RUBY
+      expected_gems.each do |k, _|
+        testrb << "\nrequire \"#{k}\""
+        testrb << "\nputs #{k.upcase}"
+      end
+      Dir.chdir("#{bundled_app}2") do
+        ruby testrb, :no_lib => true
+      end
+
+      expect(out).to eq(expected_gems.values.join("\n"))
+    end
+  end
+
   describe "with simple gems" do
     before do
       install_gemfile <<-G, :standalone => true
@@ -10,40 +57,14 @@ describe "bundle install --standalone" do
       G
     end
 
-    it "still makes the gems available to normal bundler" do
-      should_be_installed "actionpack 2.3.2", "rails 2.3.2"
+    let(:expected_gems) do
+      {
+        "actionpack" => "2.3.2",
+        "rails" => "2.3.2",
+      }
     end
 
-    it "generates a bundle/bundler/setup.rb" do
-      expect(bundled_app("bundle/bundler/setup.rb")).to exist
-    end
-
-    it "makes the gems available without bundler" do
-      ruby <<-RUBY, :no_lib => true
-        $:.unshift File.expand_path("bundle")
-        require "bundler/setup"
-
-        require "actionpack"
-        puts ACTIONPACK
-      RUBY
-
-      expect(out).to eq("2.3.2")
-    end
-
-    it "works on a different system" do
-      FileUtils.mv(bundled_app, "#{bundled_app}2")
-      Dir.chdir("#{bundled_app}2")
-
-      ruby <<-RUBY, :no_lib => true
-        $:.unshift File.expand_path("bundle")
-        require "bundler/setup"
-
-        require "actionpack"
-        puts ACTIONPACK
-      RUBY
-
-      expect(out).to eq("2.3.2")
-    end
+    include_examples "common functionality"
   end
 
   describe "with gems with native extension" do
@@ -58,249 +79,6 @@ describe "bundle install --standalone" do
       extension_line = File.read(bundled_app("bundle/bundler/setup.rb")).each_line.find {|line| line.include? "/extensions/" }.strip
       expect(extension_line).to start_with '$:.unshift "#{path}/../#{ruby_engine}/#{ruby_version}/extensions/'
       expect(extension_line).to end_with '/very_simple_binary-1.0"'
-    end
-  end
-
-  describe "with a combination of gems and git repos" do
-    before do
-      build_git "devise", "1.0"
-
-      install_gemfile <<-G, :standalone => true
-        source "file://#{gem_repo1}"
-        gem "rails"
-        gem "devise", :git => "#{lib_path("devise-1.0")}"
-      G
-    end
-
-    it "still makes the gems available to normal bundler" do
-      should_be_installed "actionpack 2.3.2", "rails 2.3.2", "devise 1.0"
-    end
-
-    it "generates a bundle/bundler/setup.rb" do
-      expect(bundled_app("bundle/bundler/setup.rb")).to exist
-    end
-
-    it "makes the gems available without bundler" do
-      ruby <<-RUBY, :no_lib => true
-        $:.unshift File.expand_path("bundle")
-        require "bundler/setup"
-
-        require "devise"
-        require "actionpack"
-        puts DEVISE
-        puts ACTIONPACK
-      RUBY
-
-      expect(out).to eq("1.0\n2.3.2")
-    end
-  end
-
-  describe "with groups" do
-    before do
-      build_git "devise", "1.0"
-
-      install_gemfile <<-G, :standalone => true
-        source "file://#{gem_repo1}"
-        gem "rails"
-
-        group :test do
-          gem "rspec"
-          gem "rack-test"
-        end
-      G
-    end
-
-    it "makes the gems available without bundler" do
-      ruby <<-RUBY, :no_lib => true
-        $:.unshift File.expand_path("bundle")
-        require "bundler/setup"
-
-        require "actionpack"
-        require "spec"
-        require "rack/test"
-        puts ACTIONPACK
-        puts SPEC
-        puts RACK_TEST
-      RUBY
-
-      expect(out).to eq("2.3.2\n1.2.7\n1.0")
-    end
-
-    it "allows creating a standalone file with limited groups" do
-      bundle "install --standalone default"
-
-      load_error_ruby <<-RUBY, "spec", :no_lib => true
-        $:.unshift File.expand_path("bundle")
-        require "bundler/setup"
-
-        require "actionpack"
-        puts ACTIONPACK
-        require "spec"
-      RUBY
-
-      expect(out).to eq("2.3.2")
-      expect(err).to eq("ZOMG LOAD ERROR")
-    end
-
-    it "allows --without to limit the groups used in a standalone" do
-      bundle "install --standalone --without test"
-
-      load_error_ruby <<-RUBY, "spec", :no_lib => true
-        $:.unshift File.expand_path("bundle")
-        require "bundler/setup"
-
-        require "actionpack"
-        puts ACTIONPACK
-        require "spec"
-      RUBY
-
-      expect(out).to eq("2.3.2")
-      expect(err).to eq("ZOMG LOAD ERROR")
-    end
-
-    it "allows --path to change the location of the standalone bundle" do
-      bundle "install --standalone --path path/to/bundle"
-
-      ruby <<-RUBY, :no_lib => true, :expect_err => false
-        $:.unshift File.expand_path("path/to/bundle")
-        require "bundler/setup"
-
-        require "actionpack"
-        puts ACTIONPACK
-      RUBY
-
-      expect(out).to eq("2.3.2")
-    end
-
-    it "allows remembered --without to limit the groups used in a standalone" do
-      bundle "install --without test"
-      bundle "install --standalone"
-
-      load_error_ruby <<-RUBY, "spec", :no_lib => true
-        $:.unshift File.expand_path("bundle")
-        require "bundler/setup"
-
-        require "actionpack"
-        puts ACTIONPACK
-        require "spec"
-      RUBY
-
-      expect(out).to eq("2.3.2")
-      expect(err).to eq("ZOMG LOAD ERROR")
-    end
-  end
-
-  describe "with gemcutter's dependency API" do
-    let(:source_uri) { "http://localgemserver.test" }
-
-    describe "simple gems" do
-      before do
-        gemfile <<-G
-          source "#{source_uri}"
-          gem "rails"
-        G
-      end
-
-      it "should run without errors" do
-        bundle "install --standalone", :artifice => "endpoint"
-
-        expect(exitstatus).to eq(0) if exitstatus
-      end
-
-      it "still makes the gems available to normal bundler" do
-        bundle "install --standalone", :artifice => "endpoint"
-
-        should_be_installed "actionpack 2.3.2", "rails 2.3.2"
-      end
-
-      it "generates a bundle/bundler/setup.rb" do
-        bundle "install --standalone", :artifice => "endpoint"
-
-        expect(bundled_app("bundle/bundler/setup.rb")).to exist
-      end
-
-      it "makes the gems available without bundler" do
-        bundle "install --standalone", :artifice => "endpoint"
-
-        ruby <<-RUBY, :no_lib => true
-          $:.unshift File.expand_path("bundle")
-          require "bundler/setup"
-
-          require "actionpack"
-          puts ACTIONPACK
-        RUBY
-
-        expect(out).to eq("2.3.2")
-      end
-
-      it "works on a different system" do
-        bundle "install --standalone", :artifice => "endpoint"
-
-        FileUtils.mv(bundled_app, "#{bundled_app}2")
-        Dir.chdir("#{bundled_app}2")
-
-        ruby <<-RUBY, :no_lib => true
-          $:.unshift File.expand_path("bundle")
-          require "bundler/setup"
-
-          require "actionpack"
-          puts ACTIONPACK
-        RUBY
-
-        expect(out).to eq("2.3.2")
-      end
-    end
-  end
-
-  describe "with --binstubs" do
-    before do
-      install_gemfile <<-G, :standalone => true, :binstubs => true
-        source "file://#{gem_repo1}"
-        gem "rails"
-      G
-    end
-
-    it "creates stubs that use the standalone load path" do
-      Dir.chdir(bundled_app) do
-        expect(`bin/rails -v`.chomp).to eql "2.3.2"
-      end
-    end
-
-    it "creates stubs that can be executed from anywhere" do
-      require "tmpdir"
-      Dir.chdir(Dir.tmpdir) do
-        expect(`#{bundled_app}/bin/rails -v`.chomp).to eql "2.3.2"
-      end
-    end
-
-    it "creates stubs with the correct load path" do
-      extension_line = File.read(bundled_app("bin/rails")).each_line.find {|line| line.include? "$:.unshift" }.strip
-      expect(extension_line).to eq "$:.unshift File.expand_path '../../bundle', __FILE__"
-    end
-  end
-
-  describe "with --binstubs run in a subdirectory" do
-    before do
-      FileUtils.mkdir_p("bob")
-      Dir.chdir("bob") do
-        install_gemfile <<-G, :standalone => true, :binstubs => true
-          source "file://#{gem_repo1}"
-          gem "rails"
-        G
-      end
-    end
-
-    # @todo This test fails because the bundler/setup.rb is written to the
-    # current directory.
-    xit "creates stubs that use the standalone load path" do
-      Dir.chdir(bundled_app) do
-        expect(`bin/rails -v`.chomp).to eql "2.3.2"
-      end
-    end
-
-    it "creates stubs with the correct load path" do
-      extension_line = File.read(bundled_app("bin/rails")).each_line.find {|line| line.include? "$:.unshift" }.strip
-      expect(extension_line).to eq "$:.unshift File.expand_path '../../bundle', __FILE__"
     end
   end
 
@@ -333,4 +111,195 @@ describe "bundle install --standalone" do
       expect(out).to include("bar 1.0 has an invalid gemspec")
     end
   end
+
+  describe "with a combination of gems and git repos" do
+    before do
+      build_git "devise", "1.0"
+
+      install_gemfile <<-G, :standalone => true
+        source "file://#{gem_repo1}"
+        gem "rails"
+        gem "devise", :git => "#{lib_path("devise-1.0")}"
+      G
+    end
+
+    let(:expected_gems) do
+      {
+        "actionpack" => "2.3.2",
+        "devise" => "1.0",
+        "rails" => "2.3.2",
+      }
+    end
+
+    include_examples "common functionality"
+  end
+
+  describe "with groups" do
+    before do
+      build_git "devise", "1.0"
+
+      install_gemfile <<-G, :standalone => true
+        source "file://#{gem_repo1}"
+        gem "rails"
+
+        group :test do
+          gem "rspec"
+          gem "rack-test"
+        end
+      G
+    end
+
+    let(:expected_gems) do
+      {
+        "actionpack" => "2.3.2",
+        "rails" => "2.3.2",
+      }
+    end
+
+    include_examples "common functionality"
+
+    it "allows creating a standalone file with limited groups" do
+      bundle "install --standalone default"
+
+      Dir.chdir(bundled_app) do
+        load_error_ruby <<-RUBY, "spec", :no_lib => true
+          $:.unshift File.expand_path("bundle")
+          require "bundler/setup"
+
+          require "actionpack"
+          puts ACTIONPACK
+          require "spec"
+        RUBY
+      end
+
+      expect(out).to eq("2.3.2")
+      expect(err).to eq("ZOMG LOAD ERROR")
+    end
+
+    it "allows --without to limit the groups used in a standalone" do
+      bundle "install --standalone --without test"
+
+      Dir.chdir(bundled_app) do
+        load_error_ruby <<-RUBY, "spec", :no_lib => true
+          $:.unshift File.expand_path("bundle")
+          require "bundler/setup"
+
+          require "actionpack"
+          puts ACTIONPACK
+          require "spec"
+        RUBY
+      end
+
+      expect(out).to eq("2.3.2")
+      expect(err).to eq("ZOMG LOAD ERROR")
+    end
+
+    it "allows --path to change the location of the standalone bundle" do
+      bundle "install --standalone --path path/to/bundle"
+
+      Dir.chdir(bundled_app) do
+        ruby <<-RUBY, :no_lib => true, :expect_err => false
+          $:.unshift File.expand_path("path/to/bundle")
+          require "bundler/setup"
+
+          require "actionpack"
+          puts ACTIONPACK
+        RUBY
+      end
+
+      expect(out).to eq("2.3.2")
+    end
+
+    it "allows remembered --without to limit the groups used in a standalone" do
+      bundle "install --without test"
+      bundle "install --standalone"
+
+      Dir.chdir(bundled_app) do
+        load_error_ruby <<-RUBY, "spec", :no_lib => true
+          $:.unshift File.expand_path("bundle")
+          require "bundler/setup"
+
+          require "actionpack"
+          puts ACTIONPACK
+          require "spec"
+        RUBY
+      end
+
+      expect(out).to eq("2.3.2")
+      expect(err).to eq("ZOMG LOAD ERROR")
+    end
+  end
+
+  describe "with gemcutter's dependency API" do
+    let(:source_uri) { "http://localgemserver.test" }
+
+    describe "simple gems" do
+      before do
+        gemfile <<-G
+          source "#{source_uri}"
+          gem "rails"
+        G
+        bundle "install --standalone", :artifice => "endpoint"
+      end
+
+      let(:expected_gems) do
+        {
+          "actionpack" => "2.3.2",
+          "rails" => "2.3.2",
+        }
+      end
+
+      include_examples "common functionality"
+    end
+  end
+
+  describe "with --binstubs" do
+    before do
+      install_gemfile <<-G, :standalone => true, :binstubs => true
+        source "file://#{gem_repo1}"
+        gem "rails"
+      G
+    end
+
+    let(:expected_gems) do
+      {
+        "actionpack" => "2.3.2",
+        "rails" => "2.3.2",
+      }
+    end
+
+    include_examples "common functionality"
+
+    it "creates stubs that use the standalone load path" do
+      Dir.chdir(bundled_app) do
+        expect(`bin/rails -v`.chomp).to eql "2.3.2"
+      end
+    end
+
+    it "creates stubs that can be executed from anywhere" do
+      require "tmpdir"
+      Dir.chdir(Dir.tmpdir) do
+        expect(`#{bundled_app("bin/rails")} -v`.chomp).to eql "2.3.2"
+      end
+    end
+
+    it "creates stubs with the correct load path" do
+      extension_line = File.read(bundled_app("bin/rails")).each_line.find {|line| line.include? "$:.unshift" }.strip
+      expect(extension_line).to eq "$:.unshift File.expand_path '../../bundle', __FILE__"
+    end
+  end
+end
+
+describe "bundle install --standalone" do
+  include_examples("bundle install --standalone")
+end
+
+describe "bundle install --standalone run in a subdirectory" do
+  before do
+    subdir = bundled_app("bob")
+    FileUtils.mkdir_p(subdir)
+    Dir.chdir(subdir)
+  end
+
+  include_examples("bundle install --standalone")
 end


### PR DESCRIPTION
While chasing a threading / chdir bug in #4264, I discovered `bundler/setup.rb` isn't written to a proper directory when run in a subdirectory and binstubs don't work (https://github.com/bundler/bundler/pull/4264#issuecomment-179506385).

This changes that so `bundler/setup.rb` is written relative to `Bundler.root` instead of `cwd` and expands test coverage a bit.

