### PR TITLE
Clarify comment in `bundle gem` gemspec

### DIFF
--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -16,8 +16,8 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 <%- end -%>
 
-  # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
-  # delete this section to allow pushing this gem to any host.
+  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
+  # or by delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)
     spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
   else


### PR DESCRIPTION
The comment feels a bit misleading. it sounds like this allows Rubygems pushes by default which it does not