### PR TITLE
Add --parseable (with --porcelain alias) to `bundle outdated` for minimal output

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -245,6 +245,8 @@ module Bundler
       "Only list newer versions allowed by your Gemfile requirements"
     method_option "major", :type => :boolean, :banner => "Only list major newer versions"
     method_option "minor", :type => :boolean, :banner => "Only list at least minor newer versions"
+    method_option "parseable", :aliases => "--porcelain", :type => :boolean, :banner =>
+      "Use minimal formatting for more parseable output"
     def outdated(*gems)
       require "bundler/cli/outdated"
       Outdated.new(options, gems).run

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -79,6 +79,43 @@ describe "bundle outdated" do
     end
   end
 
+  shared_examples_for "a minimal output is desired" do
+    context "and gems are outdated" do
+      before do
+        update_repo2 do
+          build_gem "activesupport", "3.0"
+          build_gem "weakling", "0.2"
+        end
+      end
+
+      it "outputs a sorted list of outdated gems with a more minimal format" do
+        minimal_output = "activesupport (newest 3.0, installed 2.3.5, requested = 2.3.5)\n" \
+                         "weakling (newest 0.2, installed 0.0.3, requested ~> 0.0.1)"
+        subject
+        expect(out).to eq(minimal_output)
+      end
+    end
+
+    context "and no gems are outdated" do
+      it "has empty output" do
+        subject
+        expect(out).to eq("")
+      end
+    end
+  end
+
+  describe "with --parseable option" do
+    subject { bundle "outdated --parseable" }
+
+    it_behaves_like "a minimal output is desired"
+  end
+
+  describe "with aliased --porcelain option" do
+    subject { bundle "outdated --porcelain" }
+
+    it_behaves_like "a minimal output is desired"
+  end
+
   describe "with specified gems" do
     it "returns list of outdated gems" do
       update_repo2 do


### PR DESCRIPTION
- This flag changes the output of bundle outdated from:
```
  * activesupport (newest 3.0, installed 2.3.5, requested = 2.3.5) in groups "development, test"
```
to
```
activesupport (newest 3.0, installed 2.3.5, requested = 2.3.5)"
```
and removes the extraneous output relating to fetching gem metadata,
version metadata, git updates, and resolving dependencies.

- Addresses bundler/bundler-features#85