### PR TITLE
[Travis] Remove special frozen string literal build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,10 +97,7 @@ matrix:
     # Ruby-head (we want to know how we're doing, but not fail the build)
     - rvm: ruby-head
       env: RGV=master
-    # Ruby-head with enabled frozen string literal
-    - rvm: ruby-head
-      env:
-        - RGV=master RUBYOPT="--enable-frozen-string-literal --debug=frozen-string-literal"
+
   allow_failures:
     - rvm: 1.8.7
       env: RGV=v2.1.11


### PR DESCRIPTION
That build entry is redundant  -- we test frozen string literals in all of the 2.3.0 builds now.