### PR TITLE
Add helpful invalid gemspec error message for `bundle install --standalone`

### DIFF
--- a/lib/bundler/installer/standalone.rb
+++ b/lib/bundler/installer/standalone.rb
@@ -44,6 +44,9 @@ module Bundler
     def gem_path(path, spec)
       full_path = Pathname.new(path).absolute? ? path : File.join(spec.full_gem_path, path)
       Pathname.new(full_path).relative_path_from(Bundler.root.join(bundler_path)).to_s
+    rescue TypeError
+      error_message = "#{spec.name} #{spec.version} has an invalid gemspec"
+      raise Gem::InvalidSpecificationException.new(error_message)
     end
   end
 end

--- a/spec/install/gems/standalone_spec.rb
+++ b/spec/install/gems/standalone_spec.rb
@@ -303,4 +303,18 @@ describe "bundle install --standalone" do
       expect(extension_line).to eq "$:.unshift File.expand_path '../../bundle', __FILE__"
     end
   end
+
+  describe "with gem that has an invalid gemspec" do
+    before do
+      install_gemfile <<-G, :standalone => true
+        source 'https://rubygems.org'
+        gem "resque-scheduler", "2.2.0"
+      G
+    end
+
+    it "outputs a helpful error message" do
+      expect(out).to include("You have one or more invalid gemspecs that need to be fixed.")
+      expect(out).to include("resque-scheduler 2.2.0 has an invalid gemspec")
+    end
+  end
 end


### PR DESCRIPTION
- when a gem/dependency has an invalid gemspec
- addresses #4275

Output whould now be:
```
$ bundle install --standalone
Using mono_logger 1.1.0
Using multi_json 1.11.2
Using rack 1.6.4
Using redis 3.2.2
Using tilt 2.0.2
Using thread_safe 0.3.5
Using bundler 1.12.0.pre
Using rack-protection 1.5.3
Using vegas 0.1.11
Using redis-namespace 1.5.2
Using tzinfo 1.2.2
Using sinatra 1.4.7
Using rufus-scheduler 2.0.24
Using resque 1.24.1
Using resque-scheduler 2.2.0
You have one or more invalid gemspecs that need to be fixed.
resque-scheduler 2.2.0 has an invalid gemspec
```