### PR TITLE
Add alternative error message for when `--deployment` and `--system` flags are both used on `bundle install`

### DIFF
--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -45,11 +45,7 @@ module Bundler
       # Just disable color in deployment mode
       Bundler.ui.shell = Thor::Shell::Basic.new if options[:deployment]
 
-      if (options[:path] || options[:deployment]) && options[:system]
-        Bundler.ui.error "You have specified both a path to install your gems to, \n" \
-                         "as well as --system. Please choose."
-        exit 1
-      end
+      check_for_options_conflicts
 
       if options["trust-policy"]
         unless Bundler.rubygems.security_policies.keys.include?(options["trust-policy"])
@@ -184,6 +180,15 @@ module Bundler
     def print_post_install_message(name, msg)
       Bundler.ui.confirm "Post-install message from #{name}:"
       Bundler.ui.info msg
+    end
+
+    def check_for_options_conflicts
+      if (options[:path] || options[:deployment]) && options[:system]
+        error_message = String.new
+        error_message << "You have specified both a path to install your gems to as well as --system. Please choose.\n" if options[:path]
+        error_message << "You have specified both --deployment as well as --system. Please choose.\n" if options[:deployment]
+        raise InvalidOption.new(error_message)
+      end
     end
   end
 end

--- a/spec/install/deploy_spec.rb
+++ b/spec/install/deploy_spec.rb
@@ -19,6 +19,21 @@ describe "install with --deployment or --frozen" do
     expect(out).to include("The --frozen flag requires a Gemfile.lock")
   end
 
+  it "disallows --deployment --system" do
+    bundle "install --deployment --system"
+    expect(out).to include("You have specified both --deployment")
+    expect(out).to include("Please choose.")
+    expect(exitstatus).to eq(15) if exitstatus
+  end
+
+  it "disallows --deployment --path --system" do
+    bundle "install --deployment --path . --system"
+    expect(out).to include("You have specified both a path to install your gems to")
+    expect(out).to include("You have specified both --deployment")
+    expect(out).to include("Please choose.")
+    expect(exitstatus).to eq(15) if exitstatus
+  end
+
   it "works after you try to deploy without a lock" do
     bundle "install --deployment"
     bundle :install

--- a/spec/install/path_spec.rb
+++ b/spec/install/path_spec.rb
@@ -39,6 +39,7 @@ describe "bundle install" do
     it "disallows --path vendor/bundle --system" do
       bundle "install --path vendor/bundle --system"
       expect(out).to include("Please choose.")
+      expect(exitstatus).to eq(15) if exitstatus
     end
 
     it "remembers to disable system gems after the first time with bundle --path vendor/bundle" do


### PR DESCRIPTION
Calling `bundle install --deployment --system` currently results in the following error message:

```
$ bundle install --deployment --system
You have specified both a path to install your gems to,
as well as --system. Please choose.
```
 which is a little confusing.

This PR changes the behavior to:

```
$ bundle install --deployment --system
You have specified both --deployment as well as --system. Please choose. #<-- in red
```