### PR TITLE
Raise new `Bundler::VirtualProtocolError` in response to `Errno::EPROTO`

### DIFF
--- a/lib/bundler/errors.rb
+++ b/lib/bundler/errors.rb
@@ -98,4 +98,13 @@ module Bundler
 
     status_code(26)
   end
+
+  class VirtualProtocolError < BundlerError
+    def message
+      "There was an error relating to virtualization and file access." \
+      "It is likely that you need to grant access to or mount some file system correctly."
+    end
+
+    status_code(27)
+  end
 end

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -107,6 +107,8 @@ module Bundler
       raise PermissionError.new(path, action)
     rescue Errno::EAGAIN
       raise TemporaryResourceError.new(path, action)
+    rescue Errno::EPROTO
+      raise VirtualProtocolError.new
     end
 
     def const_get_safely(constant_name, namespace)

--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -360,6 +360,15 @@ describe Bundler::SharedHelpers do
           Bundler::TemporaryResourceError)
       end
     end
+
+    context "system throws Errno::EPROTO" do
+      let(:file_op_block) { proc {|_path| raise Errno::EPROTO } }
+
+      it "raises a VirtualProtocolError" do
+        expect { subject.filesystem_access("/path", &file_op_block) }.to raise_error(
+          Bundler::VirtualProtocolError)
+      end
+    end
   end
 
   describe "#const_get_safely" do


### PR DESCRIPTION
- Related to #4163, #3932, and #3581

Ideally, a custom error and/or error message would be returned in these cases rather than just error out because of the uncaught `Errno::EPROTO`.

I'd like some feedback on what the appropriate error message should be however. The caveat is that it seems like a wide range of errors (possibly any error?) that occur in the presence of virtualization will raise this `Errno::EPROTO` error.

