### PR TITLE
Add `--count` flag to `bundle show` that outputs required and bundled gem counts

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -209,6 +209,7 @@ module Bundler
                            :banner => "List the paths of all gems that are required by your Gemfile."
     method_option "outdated", :type => :boolean,
                               :banner => "Show verbose output including whether gems are outdated."
+    method_option "count", :type => :boolean, :banner => "Show a count of required and actually bundled gems"
     def show(gem_name = nil)
       require "bundler/cli/show"
       Show.new(options, gem_name).run

--- a/lib/bundler/cli/show.rb
+++ b/lib/bundler/cli/show.rb
@@ -36,19 +36,25 @@ module Bundler
           Bundler.ui.info s.full_gem_path
         end
       else
-        Bundler.ui.info "Gems included by the bundle:"
-        Bundler.load.specs.sort_by(&:name).each do |s|
-          desc = "  * #{s.name} (#{s.version}#{s.git_version})"
-          if @verbose
-            latest = latest_specs.find {|l| l.name == s.name }
-            Bundler.ui.info <<-END.gsub(/^ +/, "")
-              #{desc}
-              \tSummary:  #{s.summary || "No description available."}
-              \tHomepage: #{s.homepage || "No website available."}
-              \tStatus:   #{outdated?(s, latest) ? "Outdated - #{s.version} < #{latest.version}" : "Up to date"}
-            END
-          else
-            Bundler.ui.info desc
+        Bundler.ui.info "Gems included by the bundle:" unless options[:count]
+        specs = Bundler.load.specs
+        if options[:count]
+          Bundler.ui.info "Required gems: #{Bundler.load.dependencies.count}"
+          Bundler.ui.info "Bundled gems: #{specs.count}"
+        else
+          specs.sort_by(&:name).each do |s|
+            desc = "  * #{s.name} (#{s.version}#{s.git_version})"
+            if @verbose
+              latest = latest_specs.find {|l| l.name == s.name }
+              Bundler.ui.info <<-END.gsub(/^ +/, "")
+                #{desc}
+                \tSummary:  #{s.summary || "No description available."}
+                \tHomepage: #{s.homepage || "No website available."}
+                \tStatus:   #{outdated?(s, latest) ? "Outdated - #{s.version} < #{latest.version}" : "Up to date"}
+              END
+            else
+              Bundler.ui.info desc
+            end
           end
         end
       end

--- a/spec/commands/show_spec.rb
+++ b/spec/commands/show_spec.rb
@@ -69,6 +69,13 @@ describe "bundle show" do
       expect(out).to include("\tHomepage: No website available.")
       expect(out).to include("\tStatus:   Up to date")
     end
+
+    it "prints count of all required gems and count of all dependencies" do
+      bundle "show --count"
+
+      expect(out).to include("Required gems: 1")
+      expect(out).to include("Bundled gems: 8")
+    end
   end
 
   context "with a git repo in the Gemfile" do


### PR DESCRIPTION
Output will look like:
```
$ bundle show --count
Specified gems: 3
Bundled gems: 54
```

- closes bundler/bundler-features#110