### PR TITLE
Add :gitlab option to DSL

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -248,6 +248,11 @@ module Bundler
         repo_name ||= user_name
         "https://#{user_name}@bitbucket.org/#{user_name}/#{repo_name}.git"
       end
+
+      git_source(:gitlab) do |repo_name|
+        repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
+        "https://gitlab.com/#{repo_name}.git"
+      end
     end
 
     def with_source(source)

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -62,6 +62,18 @@ describe Bundler::Dsl do
         bitbucket_uri = "https://mcorp@bitbucket.org/mcorp/mcorp.git"
         expect(subject.dependencies.first.source.uri).to eq(bitbucket_uri)
       end
+
+      it "converts :gitlab to :git" do
+        subject.gem("sparks", :gitlab => "indirect/sparks")
+        gitlab_uri = "https://gitlab.com/indirect/sparks.git"
+        expect(subject.dependencies.first.source.uri).to eq(gitlab_uri)
+      end
+
+      it "converts 'mcorp' to 'mcorp/mcorp' in :gitlab" do
+        subject.gem("sparks", :gitlab => "mcorp")
+        gitlab_uri = "https://gitlab.com/mcorp/mcorp.git"
+        expect(subject.dependencies.first.source.uri).to eq(gitlab_uri)
+      end
     end
   end
 


### PR DESCRIPTION
Since GitLab is getting more attention in the OSS development community, i propose to include :gitlab option to the DSL, so it would be easy to specify dependencies to the gems hosted on GitLab.


`gem 'some_gem', gitlab: 'some gem' `

Inspired by https://news.ycombinator.com/item?id=11091577