### PR TITLE
Add error with message/explanation for `bundle outdated` in a frozen state

### DIFF
--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -10,6 +10,8 @@ module Bundler
     end
 
     def run
+      check_for_deployment_mode
+
       sources = Array(options[:source])
 
       gems.each do |gem_name|
@@ -107,6 +109,18 @@ module Bundler
         Bundler.ui.info "Bundle up to date!\n" unless options[:parseable]
       else
         exit 1
+      end
+    end
+
+  private
+
+    def check_for_deployment_mode
+      if Bundler.settings[:frozen]
+        error_message = "You are trying to check outdated gems in deployment mode. " \
+              "Run `bundle outdated` elsewhere.\n" \
+              "\nIf this is a development machine, remove the #{Bundler.default_gemfile} freeze" \
+              "\nby running `bundle install --no-deployment`."
+        raise ProductionError, error_message
       end
     end
   end

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -273,4 +273,26 @@ describe "bundle outdated" do
       expect(out).to include("weakling (newest")
     end
   end
+
+  context "after bundle install --deployment" do
+    before do
+      install_gemfile <<-G, :deployment => true
+        source "file://#{gem_repo2}"
+
+        gem "rack"
+        gem "foo"
+      G
+    end
+
+    it "outputs a helpful message about being in deployment mode" do
+      update_repo2 { build_gem "activesupport", "3.0" }
+
+      bundle "outdated"
+      expect(exitstatus).to_not be_zero if exitstatus
+      expect(out).to include("You are trying to check outdated gems in deployment mode.")
+      expect(out).to include("Run `bundle outdated` elsewhere.")
+      expect(out).to include("If this is a development machine, remove the ")
+      expect(out).to include("Gemfile freeze\nby running `bundle install --no-deployment`.")
+    end
+  end
 end


### PR DESCRIPTION
Adds a helpful error message for when you run `bundle outdated` after having run `bundle install --deployment`.

```
You are trying to check outdated gems in deployment mode. Run `bundle outdated` elsewhere.

If this is a development machine, remove the /path/to/Gemfile freeze
by running `bundle install --no-deployment`.
```
- closes #4287