### PR TITLE
Fix `bundle outdated --minor` behavior

### DIFF
--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -56,18 +56,12 @@ module Bundler
           end
           active_spec = active_spec.last
 
-          if options[:major]
-            current_major = current_spec.version.segments.first
-            active_major = active_spec.version.segments.first
-            active_spec = nil unless active_major > current_major
-          end
-
-          if options[:minor]
-            current_minor = current_spec.version.segments[0, 2].compact.join(".")
-            active_minor = active_spec.version.segments[0, 2].compact.join(".")
-            active_spec = nil unless active_minor > current_minor
+          if options[:major] || options[:minor]
+            update_present = update_present_via_semver_portions(current_spec, active_spec, options)
+            active_spec = nil unless update_present
           end
         end
+
         next if active_spec.nil?
 
         gem_outdated = Gem::Version.new(active_spec.version) > Gem::Version.new(current_spec.version)
@@ -122,6 +116,23 @@ module Bundler
               "\nby running `bundle install --no-deployment`."
         raise ProductionError, error_message
       end
+    end
+
+    def update_present_via_semver_portions(current_spec, active_spec, options)
+      current_major = current_spec.version.segments.first
+      active_major = active_spec.version.segments.first
+
+      update_present = false
+
+      update_present = active_major > current_major if options[:major]
+
+      if options[:minor] && current_major == active_major
+        current_minor = current_spec.version.segments[1, 1].first
+        active_minor = active_spec.version.segments[1, 1].first
+        update_present = active_minor > current_minor
+      end
+
+      update_present
     end
   end
 end

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -241,12 +241,33 @@ describe "bundle outdated" do
     end
   end
 
-  shared_examples_for "incorrect semantic versioning is ignored" do
-    before { update_repo2 { build_gem "weakling", "1" } }
+  shared_examples_for "major version is ignored" do
+    before do
+      update_repo2 do
+        build_gem "activesupport", "3.3.5"
+        build_gem "weakling", "1.0.1"
+      end
+    end
 
-    it "ignores gems not in proper semantic version format" do
+    it "ignores gems that have updates in the major version" do
       subject
-      expect(out).to include("weakling (newest")
+      expect(out).to_not include("activesupport (newest")
+      expect(out).to_not include("weakling (newest")
+    end
+  end
+
+  shared_examples_for "minor version is ignored" do
+    before do
+      update_repo2 do
+        build_gem "activesupport", "2.4.5"
+        build_gem "weakling", "0.3.1"
+      end
+    end
+
+    it "ignores gems that have updates in the minor version" do
+      subject
+      expect(out).to_not include("activesupport (newest")
+      expect(out).to_not include("weakling (newest")
     end
   end
 
@@ -260,8 +281,8 @@ describe "bundle outdated" do
 
     it "ignores gems that have updates in the patch version" do
       subject
-      expect(out).to_not include("weakling (newest")
       expect(out).to_not include("activesupport (newest")
+      expect(out).to_not include("weakling (newest")
     end
   end
 
@@ -270,34 +291,34 @@ describe "bundle outdated" do
 
     it "only reports gems that have a newer major version" do
       update_repo2 do
-        build_gem "weakling", "0.2.0"
-        build_gem "activesupport", "3.0"
+        build_gem "activesupport", "3.3.5"
+        build_gem "weakling", "0.8.0"
       end
 
       subject
-      expect(out).to_not include("weakling (newest")
       expect(out).to include("activesupport (newest")
+      expect(out).to_not include("weakling (newest")
     end
 
+    it_behaves_like "minor version is ignored"
     it_behaves_like "patch version is ignored"
-    it_behaves_like "incorrect semantic versioning is ignored"
   end
 
   describe "with --minor option" do
     subject { bundle "outdated --minor" }
 
-    it "only reports gems that have at least a newer minor version" do
+    it "only reports gems that have a newer minor version" do
       update_repo2 do
-        build_gem "activesupport", "3.0.0"
-        build_gem "weakling", "0.2.0"
+        build_gem "activesupport", "2.7.5"
+        build_gem "weakling", "2.0.1"
       end
 
       subject
-      expect(out).to include("weakling (newest")
       expect(out).to include("activesupport (newest")
+      expect(out).to_not include("weakling (newest")
     end
 
+    it_behaves_like "major version is ignored"
     it_behaves_like "patch version is ignored"
-    it_behaves_like "incorrect semantic versioning is ignored"
   end
 end


### PR DESCRIPTION
If a `Gemfile` is as follows: 
```
source 'https://rubygems.org'
gem "activesupport", "2.3.5"
```

and the latest version of `activesupport` is `3.3.5`, running `bundle outdated --minor` should not report any potential updates, which it currently does/would. Users would be using the `--minor` flag potentially because they want to see what latest updates to their gems are available that aren't huge, possibly breaking version changes. With this PR, only if the latest version of `activesupport` is something like `2.5.5` would updates be reported for `activesupport` via `bundle outdated --minor`.

- Related to discussion at bundler/bundler-features#85