### PR TITLE
Add `--patch` flag for `bundle outdated`

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -244,7 +244,8 @@ module Bundler
     method_option "strict", :type => :boolean, :banner =>
       "Only list newer versions allowed by your Gemfile requirements"
     method_option "major", :type => :boolean, :banner => "Only list major newer versions"
-    method_option "minor", :type => :boolean, :banner => "Only list at least minor newer versions"
+    method_option "minor", :type => :boolean, :banner => "Only list minor newer versions"
+    method_option "patch", :type => :boolean, :banner => "Only list patch newer versions"
     method_option "parseable", :aliases => "--porcelain", :type => :boolean, :banner =>
       "Use minimal formatting for more parseable output"
     def outdated(*gems)

--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -56,7 +56,7 @@ module Bundler
           end
           active_spec = active_spec.last
 
-          if options[:major] || options[:minor]
+          if options[:major] || options[:minor] || options[:patch]
             update_present = update_present_via_semver_portions(current_spec, active_spec, options)
             active_spec = nil unless update_present
           end
@@ -126,10 +126,18 @@ module Bundler
 
       update_present = active_major > current_major if options[:major]
 
-      if options[:minor] && current_major == active_major
+      if (options[:minor] || options[:patch]) && current_major == active_major
         current_minor = current_spec.version.segments[1, 1].first
         active_minor = active_spec.version.segments[1, 1].first
-        update_present = active_minor > current_minor
+
+        if options[:minor]
+          update_present = active_minor > current_minor
+        elsif options[:patch] && current_minor == active_minor
+          current_patch = current_spec.version.segments[2, 1].first
+          active_patch = active_spec.version.segments[2, 1].first
+
+          update_present = active_patch > current_patch
+        end
       end
 
       update_present

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -321,4 +321,22 @@ describe "bundle outdated" do
     it_behaves_like "major version is ignored"
     it_behaves_like "patch version is ignored"
   end
+
+  describe "with --patch option" do
+    subject { bundle "outdated --patch" }
+
+    it "only reports gems that have a newer patch version" do
+      update_repo2 do
+        build_gem "activesupport", "2.3.7"
+        build_gem "weakling", "0.3.1"
+      end
+
+      subject
+      expect(out).to include("activesupport (newest")
+      expect(out).to_not include("weakling (newest")
+    end
+
+    it_behaves_like "major version is ignored"
+    it_behaves_like "minor version is ignored"
+  end
 end


### PR DESCRIPTION
- `bundle outdated --patch` will only report updates in the patch
  version (`v#.#.patch`)
- Related to discussion at bundler/bundler-features#85