### PR TITLE
no-color => color option rename

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -43,9 +43,9 @@ module Bundler
     stop_on_unknown_option! :exec
 
     default_task :install
-    class_option "no-color", :type => :boolean, :desc => "Disable colorization in output"
-    class_option "retry",    :type => :numeric, :aliases => "-r", :banner => "NUM",
-                             :desc => "Specify the number of times you wish to attempt network commands"
+    class_option "color",   :type => :boolean, :desc => "Colorize output", :default => true
+    class_option "retry",   :type => :numeric, :aliases => "-r", :banner => "NUM",
+                            :desc => "Specify the number of times you wish to attempt network commands"
     class_option "verbose", :type => :boolean, :desc => "Enable verbose output mode", :aliases => "-V"
 
     def help(cli = nil)

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -148,8 +148,8 @@ module Bundler
       "Don't update the existing gem cache."
     method_option "force", :type => :boolean, :banner =>
       "Force downloading every gem."
-    method_option "no-prune", :type => :boolean, :banner =>
-      "Don't remove stale gems from the cache."
+    method_option "prune", :type => :boolean, :banner =>
+      "Remove stale gems from the cache.", :default => true
     method_option "path", :type => :string, :banner =>
       "Specify a different path than the system default ($BUNDLE_PATH or $GEM_HOME). Bundler will remember this value for future installs on this machine"
     method_option "quiet", :type => :boolean, :banner =>
@@ -260,7 +260,7 @@ module Bundler
     desc "cache [OPTIONS]", "Cache all the gems to vendor/cache", :hide => true
     method_option "all",  :type => :boolean, :banner => "Include all sources (including path and git)."
     method_option "all-platforms", :type => :boolean, :banner => "Include gems for all platforms present in the lockfile, not just the current one"
-    method_option "no-prune", :type => :boolean, :banner => "Don't remove stale gems from the cache."
+    method_option "prune", :type => :boolean, :banner => "Remove stale gems from the cache.", :default => true
     def cache
       require "bundler/cli/cache"
       Cache.new(options).run
@@ -273,7 +273,7 @@ module Bundler
       "Specify a different cache path than the default (vendor/cache)."
     method_option "gemfile", :type => :string, :banner => "Use the specified gemfile instead of Gemfile"
     method_option "no-install", :type => :boolean, :banner => "Don't actually install the gems, just package."
-    method_option "no-prune", :type => :boolean, :banner => "Don't remove stale gems from the cache."
+    method_option "prune", :type => :boolean, :banner => "Remove stale gems from the cache.", :default => true
     method_option "path", :type => :string, :banner =>
       "Specify a different path than the system default ($BUNDLE_PATH or $GEM_HOME). Bundler will remember this value for future installs on this machine"
     method_option "quiet", :type => :boolean, :banner => "Only output warnings and errors."

--- a/lib/bundler/cli/cache.rb
+++ b/lib/bundler/cli/cache.rb
@@ -12,7 +12,7 @@ module Bundler
       setup_cache_all
       Bundler.settings[:cache_all_platforms] = options["all-platforms"] if options.key?("all-platforms")
       Bundler.load.cache
-      Bundler.settings[:no_prune] = true if options["no-prune"]
+      Bundler.settings[:no_prune] = false if options["prune"]
       Bundler.load.lock
     rescue GemNotFound => e
       Bundler.ui.error(e.message)

--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -85,7 +85,7 @@ module Bundler
       Bundler.settings[:bin]      = nil if options["binstubs"] && options["binstubs"].empty?
       Bundler.settings[:shebang]  = options["shebang"] if options["shebang"]
       Bundler.settings[:jobs]     = options["jobs"] if options["jobs"]
-      Bundler.settings[:no_prune] = true if options["no-prune"]
+      Bundler.settings[:no_prune] = false if options["prune"]
       Bundler.settings[:no_install] = true if options["no-install"]
       Bundler.settings[:clean]    = options["clean"] if options["clean"]
       Bundler.settings.without    = options[:without]

--- a/lib/bundler/ui/shell.rb
+++ b/lib/bundler/ui/shell.rb
@@ -9,7 +9,7 @@ module Bundler
       attr_writer :shell
 
       def initialize(options = {})
-        if options["no-color"] || !STDOUT.tty?
+        if !options["color"] || !STDOUT.tty?
           Thor::Base.shell = Thor::Shell::Basic
         end
         @shell = Thor::Base.shell.new

--- a/spec/commands/help_spec.rb
+++ b/spec/commands/help_spec.rb
@@ -83,6 +83,6 @@ describe "bundle help" do
     with_fake_man do
       bundle "instill -h", :expect_err => true
     end
-    expect(err).to include('Could not find command "instill -h --no-color".')
+    expect(err).to include('Could not find command "instill -h".')
   end
 end

--- a/spec/install/path_spec.rb
+++ b/spec/install/path_spec.rb
@@ -68,7 +68,7 @@ describe "bundle install" do
       if type == :env
         ENV["BUNDLE_PATH"] = location
       elsif type == :global
-        bundle "config path #{location}", "no-color" => nil
+        bundle "config path #{location}", "color" => nil
       end
     end
 

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -83,7 +83,7 @@ module Spec
       with_sudo = options.delete(:sudo)
       sudo = with_sudo == :preserve_env ? "sudo -E" : "sudo" if with_sudo
 
-      options["no-color"] = true unless options.key?("no-color") || %w(exec conf).include?(cmd.to_s[0..3])
+      options["color"] = false unless options.key?("color") || %w(exec conf).include?(cmd.to_s[0..3])
 
       bundle_bin = File.expand_path("../../../exe/bundle", __FILE__)
 
@@ -105,7 +105,7 @@ module Spec
 
     def bundle_ruby(options = {})
       expect_err = options.delete(:expect_err)
-      options["no-color"] = true unless options.key?("no-color")
+      options["color"] = false unless options.key?("color")
 
       bundle_bin = File.expand_path("../../../exe/bundle_ruby", __FILE__)
 


### PR DESCRIPTION
Commands like `bundle show` offer a `--no-color` option, but also create a `--no-no-color` option, which is a bit odd.

```
$ bundle help show
Usage:
  bundle show GEM [OPTIONS]

Options:
      [--no-color], [--no-no-color]         # Disable colorization in output
```

This change changes the option to be `color` first and `no-color` second. It still supports `--no-color`, as Thor provides this option by default for boolean options, and prevents a `--no-no-color` option from being created using the `--color` option instead.

```
$ dbundle help show
Usage:
  bundle show GEM [OPTIONS]

Options:
      [--color], [--no-color]                   # Colorize output
```

I hope the tests all pass, because I got many random failing specs locally. I will try to fix the specs if they do occur, but how can I get it to run stable local as well? Running it in a clean vagrant machine on ruby 2.3. (edit update: seemed to work fine on travis)