### PR TITLE
Allow `Bundler::RubyVersion` to handle -1 for RUBY_PATCHLEVEL

### DIFF
--- a/lib/bundler/ruby_version.rb
+++ b/lib/bundler/ruby_version.rb
@@ -103,6 +103,9 @@ module Bundler
   private
 
     def matches?(requirements, version)
+      # Handles RUBY_PATCHLEVEL of -1 for instances like ruby-head
+      return requirements == version if requirements.to_s == "-1" || version.to_s == "-1"
+
       Array(requirements).all? do |requirement|
         Gem::Requirement.create(requirement).satisfied_by?(Gem::Version.create(version))
       end

--- a/spec/bundler/ruby_version_spec.rb
+++ b/spec/bundler/ruby_version_spec.rb
@@ -328,6 +328,28 @@ describe "Bundler::RubyVersion and its subclasses" do
 
         it_behaves_like "there is a difference in the engine versions"
       end
+
+      context "with a patchlevel of -1" do
+        let(:version)              { ">= 2.0.0" }
+        let(:patchlevel)           { "-1" }
+        let(:engine)               { "ruby" }
+        let(:engine_version)       { "~> 2.0.1" }
+        let(:other_version)        { version }
+        let(:other_engine)         { engine }
+        let(:other_engine_version) { engine_version }
+
+        context "and comparing with another patchlevel of -1" do
+          let(:other_patchlevel) { patchlevel }
+
+          it_behaves_like "there are no differences"
+        end
+
+        context "and comparing with a patchlevel that is not -1" do
+          let(:other_patchlevel)     { "642" }
+
+          it_behaves_like "there is a difference in the patchlevels"
+        end
+      end
     end
 
     describe "#system" do


### PR DESCRIPTION
Fixes how the `matches?` method in `Bundler::RubyVersion` handles a `RUBY_PATCHLEVEL` of `-1`, which seems to be the case with ruby-head.

Closes #4317 