### PR TITLE
Corrected docs for package --all-platforms

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -259,7 +259,7 @@ module Bundler
 
     desc "cache [OPTIONS]", "Cache all the gems to vendor/cache", :hide => true
     method_option "all",  :type => :boolean, :banner => "Include all sources (including path and git)."
-    method_option "all-platforms", :type => :boolean, :banner => "Include gems for all platforms present in lock file, not just the current one"
+    method_option "all-platforms", :type => :boolean, :banner => "Include gems for all platforms present in the lockfile, not just the current one"
     method_option "no-prune", :type => :boolean, :banner => "Don't remove stale gems from the cache."
     def cache
       require "bundler/cli/cache"
@@ -268,7 +268,7 @@ module Bundler
 
     desc "package [OPTIONS]", "Locks and then caches all of the gems into vendor/cache"
     method_option "all",  :type => :boolean, :banner => "Include all sources (including path and git)."
-    method_option "all-platforms", :type => :boolean, :banner => "Include gems for all platforms present in lock file, not just the current one"
+    method_option "all-platforms", :type => :boolean, :banner => "Include gems for all platforms present in the lockfile, not just the current one"
     method_option "cache-path", :type => :string, :banner =>
       "Specify a different cache path than the default (vendor/cache)."
     method_option "gemfile", :type => :string, :banner => "Use the specified gemfile instead of Gemfile"

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -259,7 +259,7 @@ module Bundler
 
     desc "cache [OPTIONS]", "Cache all the gems to vendor/cache", :hide => true
     method_option "all",  :type => :boolean, :banner => "Include all sources (including path and git)."
-    method_option "all-platforms", :type => :boolean, :banner => "Include gems for all platforms, not just the current one"
+    method_option "all-platforms", :type => :boolean, :banner => "Include gems for all platforms present in lock file, not just the current one"
     method_option "no-prune", :type => :boolean, :banner => "Don't remove stale gems from the cache."
     def cache
       require "bundler/cli/cache"
@@ -268,7 +268,7 @@ module Bundler
 
     desc "package [OPTIONS]", "Locks and then caches all of the gems into vendor/cache"
     method_option "all",  :type => :boolean, :banner => "Include all sources (including path and git)."
-    method_option "all-platforms", :type => :boolean, :banner => "Include gems for all platforms, not just the current one"
+    method_option "all-platforms", :type => :boolean, :banner => "Include gems for all platforms present in lock file, not just the current one"
     method_option "cache-path", :type => :string, :banner =>
       "Specify a different cache path than the default (vendor/cache)."
     method_option "gemfile", :type => :string, :banner => "Use the specified gemfile instead of Gemfile"

--- a/man/bundle-package.ronn
+++ b/man/bundle-package.ronn
@@ -20,9 +20,10 @@ via the `--all` option. Once used, the `--all` option will be remembered.
 ## SUPPORT FOR MULTIPLE PLATFORMS
 
 When using gems that have different packages for different platforms, Bundler
-1.8 and newer support caching of gems for other platforms in `vendor/cache`.
-This needs to be enabled via the `--all-platforms` option. This setting will be
-remembered in your local bundler configuration.
+1.8 and newer support caching of gems for other platforms where the Gemfile
+has been resolved (i.e. present in the lock file) in `vendor/cache`.  This needs
+to be enabled via the `--all-platforms` option. This setting will be remembered
+in your local bundler configuration.
 
 ## REMOTE FETCHING
 

--- a/man/bundle-package.ronn
+++ b/man/bundle-package.ronn
@@ -21,7 +21,7 @@ via the `--all` option. Once used, the `--all` option will be remembered.
 
 When using gems that have different packages for different platforms, Bundler
 1.8 and newer support caching of gems for other platforms where the Gemfile
-has been resolved (i.e. present in the lock file) in `vendor/cache`.  This needs
+has been resolved (i.e. present in the lockfile) in `vendor/cache`.  This needs
 to be enabled via the `--all-platforms` option. This setting will be remembered
 in your local bundler configuration.
 


### PR DESCRIPTION
This fixes the doc package --all-platforms mentioning that only the platforms present in the lock files are cached. #4330 