### PR TITLE
instruction to install certain packages for dev setup

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -19,15 +19,19 @@ bugs](https://github.com/bundler/bundler/issues?labels=small&state=open) and [sm
 
 Bundler doesn't use a Gemfile to list development dependencies, because when we tried it we couldn't tell if we were awake or it was just another level of dreams. To work on Bundler, you'll probably want to do a couple of things.
 
-  1. Install Bundler's development dependencies
+  1. Install `groff-base` and `graphviz` packages using your package manager, e.g for ubuntu
+
+        $ sudo apt-get install graphviz groff-base -y
+
+  2. Install Bundler's development dependencies
 
         $ rake spec:deps
 
-  2. Run the test suite, to make sure things are working
+  3. Run the test suite, to make sure things are working
 
         $ rake spec
 
-  3. Set up a shell alias to run Bundler from your clone, e.g. a Bash alias:
+  4. Set up a shell alias to run Bundler from your clone, e.g. a Bash alias:
 
         $ alias dbundle='ruby -I /path/to/bundler/lib /path/to/bundler/exe/bundle'
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -23,6 +23,10 @@ Bundler doesn't use a Gemfile to list development dependencies, because when we 
 
         $ sudo apt-get install graphviz groff-base -y
 
+     and for OS X (with brew installed)
+
+        $ brew install graphviz groff
+
   2. Install Bundler's development dependencies
 
         $ rake spec:deps


### PR DESCRIPTION
Without installing graphviz groff-base packages many tests were failing.