### PR TITLE
[RubygemsIntegration] Add support for new activate_bin_path binstubs

### DIFF
--- a/lib/bundler/cli/exec.rb
+++ b/lib/bundler/cli/exec.rb
@@ -21,7 +21,7 @@ module Bundler
       validate_cmd!
       SharedHelpers.set_bundle_environment
       if bin_path = Bundler.which(cmd)
-        kernel_load(bin_path, *args) && return if ruby_shebang?(bin_path)
+        kernel_load(bin_path, *args) if ruby_shebang?(bin_path)
         # First, try to exec directly to something in PATH
         kernel_exec([bin_path, cmd], *args)
       else
@@ -61,6 +61,7 @@ module Bundler
       Bundler.ui = nil
       require "bundler/setup"
       Kernel.load(file)
+      exit
     rescue SystemExit
       raise
     rescue Exception => e # rubocop:disable Lint/RescueException

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -128,13 +128,13 @@ describe "bundle exec" do
       G
     end
 
-    bundle "exec rackup", :expect_err => true
+    bundle! "exec rackup", :expect_err => true
 
     expect(out).to eq("0.9.1")
     expect(err).to match("deprecated")
 
     Dir.chdir bundled_app2 do
-      bundle "exec rackup"
+      bundle! "exec rackup"
       expect(out).to eq("1.0.0")
     end
   end


### PR DESCRIPTION
This ought to fix the build!

\c @indirect 