### PR TITLE
Update documentation for OSX homebrew

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -25,7 +25,7 @@ Bundler doesn't use a Gemfile to list development dependencies, because when we 
 
      and for OS X (with brew installed)
 
-        $ brew install graphviz groff
+        $ brew install graphviz homebrew/dupes/groff
 
   2. Install Bundler's development dependencies
 


### PR DESCRIPTION
`however brew install graphviz groff` won't work and I tried `brew install graphviz homebrew/dupes/groff` as homebrew suggested, it worked.