### PR TITLE
Git repos should not be updated when --local is passed

### DIFF
--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -215,6 +215,10 @@ module Bundler
         @allow_remote || @allow_cached
       end
 
+      def allow_git_remote_ops?
+        @allow_remote
+      end
+
     private
 
       def serialize_gemspecs_in(destination)


### PR DESCRIPTION
* Running `bundle install --local` without having the gems locally fails, because it can not checkout the git repo
* After running `bundle install` at least once
  * following runs of `bundle install` complete successfully and do not checkout the git repositories
  * following runs of `bundle install --local` complete successfully and do not checkout the git repositories