### PR TITLE
Fix the `Bundler::Fetcher::Downloader` rspec warning in test suite

### DIFF
--- a/spec/bundler/fetcher/downloader_spec.rb
+++ b/spec/bundler/fetcher/downloader_spec.rb
@@ -12,7 +12,7 @@ describe Bundler::Fetcher::Downloader do
   describe "fetch" do
     let(:counter)      { 0 }
     let(:httpv)        { "1.1" }
-    let(:http_response) { nil }
+    let(:http_response) { double(:response) }
 
     before do
       allow(subject).to receive(:request).with(uri, options).and_return(http_response)


### PR DESCRIPTION
Fixes the following warning in the test suite:
```
Bundler::Fetcher::Downloader
  fetch
    when the # requests counter is greater than the redirect limit
WARNING: An expectation of `:body` was set on `nil`. To allow
expectations on `nil` and suppress this message, set
`config.allow_expectations_on_nil` to `true`. To disallow
expectations on `nil`, set `config.allow_expectations_on_nil` to
`false`. Called from
/home/travis/build/bundler/bundler/spec/bundler/fetcher/downloader_spec.rb:19:in
`block (3 levels) in <top (required)>'.
```