### PR TITLE
Checking out missing git repos (but not being installed) - Fixing #3981

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -167,6 +167,12 @@ module Bundler
       missing
     end
 
+    def missing_dependencies
+      missing = []
+      resolve.materialize(current_dependencies, missing)
+      missing
+    end
+
     def requested_specs
       @requested_specs ||= begin
         groups = requested_groups

--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -185,7 +185,7 @@ module Bundler
         local = Bundler.ui.silence do
           begin
             tmpdef = Definition.build(Bundler.default_gemfile, Bundler.default_lockfile, nil)
-            true unless tmpdef.new_platform? || tmpdef.missing_specs.any?
+            true unless tmpdef.new_platform? || tmpdef.missing_dependencies.any?
           rescue BundlerError
           end
         end

--- a/spec/install/git_spec.rb
+++ b/spec/install/git_spec.rb
@@ -19,7 +19,7 @@ describe "bundle install" do
       build_git "foo"
 
       gemfile <<-G
-        gem "foo", :git =>"file://#{lib_path("foo-1.0")}", group: :development
+        gem "foo", :git => "file://#{lib_path("foo-1.0")}", :group => :development
       G
 
       lockfile <<-L

--- a/spec/install/git_spec.rb
+++ b/spec/install/git_spec.rb
@@ -38,6 +38,7 @@ describe "bundle install" do
       bundle "install --path=vendor/bundle --without development"
 
       expect(out).to include("Bundle complete!")
+      expect(vendored_gems("bundler/gems/foo-1.0-#{revision_for(lib_path("foo-1.0"))[0..11]}")).to be_directory
     end
   end
 end

--- a/spec/install/git_spec.rb
+++ b/spec/install/git_spec.rb
@@ -14,5 +14,30 @@ describe "bundle install" do
       expect(out).to include("Using foo 1.0 from #{lib_path("foo")} (at master@#{revision_for(lib_path("foo"))[0..6]})")
       should_be_installed "foo 1.0"
     end
+
+    it "should check out git repos that are missing but not being installed" do
+      build_git "foo"
+
+      gemfile <<-G
+        gem "foo", :git =>"file://#{lib_path("foo-1.0")}", group: :development
+      G
+
+      lockfile <<-L
+        GIT
+          remote: file://#{lib_path("foo-1.0")}
+          specs:
+            foo (1.0)
+
+        PLATFORMS
+          ruby
+
+        DEPENDENCIES
+          foo!
+      L
+
+      bundle "install --path=vendor/bundle --without development"
+
+      expect(out).to include("Bundle complete!")
+    end
   end
 end


### PR DESCRIPTION
Fixes #3981.

As far as I investigated the problem is, being in `without` group, it is not marked in missing_spec and so it is not resolved while resolving specs at https://github.com/bundler/bundler/blob/master/lib/bundler/installer.rb#L183
and https://github.com/bundler/bundler/blob/master/lib/bundler/installer.rb#L195
but it is in the definition's index at
https://github.com/bundler/bundler/blob/master/lib/bundler/definition.rb#L209
leading to 
https://github.com/bundler/bundler/blob/master/lib/bundler/source/git.rb#L150
where it checks for the presence of the folder at 
https://github.com/bundler/bundler/blob/master/lib/bundler/source/path.rb#L135

Possible solutions are :
- add it to the list of missing_specs
- check while building the index in Definition class and don't add it.