### PR TITLE
[Fetcher] Switch from bundler.rubygems.org to index.rubygems.org

### DIFF
--- a/lib/bundler/fetcher/base.rb
+++ b/lib/bundler/fetcher/base.rb
@@ -21,7 +21,7 @@ module Bundler
         @fetch_uri ||= begin
           if remote_uri.host == "rubygems.org"
             uri = remote_uri.dup
-            uri.host = "bundler.rubygems.org"
+            uri.host = "index.rubygems.org"
             uri
           else
             remote_uri

--- a/spec/bundler/fetcher/base_spec.rb
+++ b/spec/bundler/fetcher/base_spec.rb
@@ -42,9 +42,9 @@ describe Bundler::Fetcher::Base do
     before { allow(subject).to receive(:remote_uri).and_return(remote_uri_obj) }
 
     context "when the remote uri's host is rubygems.org" do
-      it "should create a copy of the remote uri with bundler.rubygems.org as the host" do
+      it "should create a copy of the remote uri with index.rubygems.org as the host" do
         fetched_uri = subject.fetch_uri
-        expect(fetched_uri.host).to eq("bundler.rubygems.org")
+        expect(fetched_uri.host).to eq("index.rubygems.org")
         expect(fetched_uri).to_not be(remote_uri_obj)
       end
     end


### PR DESCRIPTION
@dwradcliffe @indirect by my understanding, this is what we need to do to get the new index behind fastly?