### PR TITLE
Create invalid gemspec error message spec that runs locally

### DIFF
--- a/spec/realworld/edgecases_spec.rb
+++ b/spec/realworld/edgecases_spec.rb
@@ -220,4 +220,13 @@ describe "real world edgecases", :realworld => true, :sometimes => true do
     expect(err).to eq("")
     expect(exitstatus).to eq(0) if exitstatus
   end
+
+  it "outputs a helpful error message when gems have invalid gemspecs" do
+    install_gemfile <<-G, :standalone => true
+      source 'https://rubygems.org'
+      gem "resque-scheduler", "2.2.0"
+    G
+    expect(out).to include("You have one or more invalid gemspecs that need to be fixed.")
+    expect(out).to include("resque-scheduler 2.2.0 has an invalid gemspec")
+  end
 end


### PR DESCRIPTION
- Move invalid gemspec spec involving `resque-scheduler 2.2.0` created in
  #4283 to realworld specs
- Related to [comments here](https://github.com/bundler/bundler/commit/a753d0182e6d4d91d7e401e40482c6cec5baadae#commitcomment-16716088)