### PR TITLE
Open editor with clean env

### DIFF
--- a/lib/bundler/cli/open.rb
+++ b/lib/bundler/cli/open.rb
@@ -16,7 +16,9 @@ module Bundler
       path = Bundler::CLI::Common.select_spec(name, :regex_match).full_gem_path
       Dir.chdir(path) do
         command = Shellwords.split(editor) + [path]
-        system(*command) || Bundler.ui.info("Could not run '#{command.join(" ")}'")
+        Bundler.with_clean_env do
+          system(*command)
+        end || Bundler.ui.info("Could not run '#{command.join(" ")}'")
       end
     end
   end

--- a/spec/commands/open_spec.rb
+++ b/spec/commands/open_spec.rb
@@ -78,4 +78,9 @@ describe "bundle open" do
     bundle "open rails", :env => { "EDITOR" => "echo editor", "VISUAL" => "", "BUNDLER_EDITOR" => "" }
     expect(out).to include("Installing foo 1.0")
   end
+
+  it "opens the editor with a clean env" do
+    bundle "open", :env => { "EDITOR" => "sh -c 'env'", "VISUAL" => "", "BUNDLER_EDITOR" => "" }
+    expect(out).not_to include("BUNDLE_GEMFILE=")
+  end
 end


### PR DESCRIPTION
Editors which have ruby embedded may be confused by bundler's environment, so strip it before launching the editor process.

Here's what happens when I try to `bundle open activesupport` within a rails app using homebrew-installed vim (which embeds ruby by default) but using a different version of ruby in my app:

```
$ bundle open activesupport
dyld: lazy symbol binding failed: Symbol not found: _rb_str_new_static
  Referenced from: /usr/local/rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/json-1.8.3/lib/json/ext/parser.bundle
  Expected in: flat namespace

dyld: Symbol not found: _rb_str_new_static
  Referenced from: /usr/local/rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/json-1.8.3/lib/json/ext/parser.bundle
  Expected in: flat namespace

Vim: Caught deadly signal TRAP
Vim: Finished.
Could not run 'vim /usr/local/rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/activesupport-4.2.6'
```

Vim is linked against OS X's ruby which is a different version, but is booting within a bundler environment with a GEM_PATH set to my application's ruby's gem directories.

Running the editor with a clean env fixes the problem and I can successfully open gems with vim.

Sidenote: I can't run the test suite locally. Following DEVELOPMENT.md I have graphviz and groff installed with homebrew, using ruby 2.3.0 via rbenv, and I run `rake spec:deps` then `rake spec` with the following result:

```
$ rake spec:deps
/usr/local/rbenv/versions/2.3.0/bin/ruby -S gem list -i "^automatiek$" -v "~> 0.1.0" || /usr/local/rbenv/versions/2.3.0/bin/ruby -S gem install automatiek -v "~> 0.1.0" --no-ri --no-rdoc
true
/usr/local/rbenv/versions/2.3.0/bin/ruby -S gem list -i "^mustache$" -v "= 0.99.6" || /usr/local/rbenv/versions/2.3.0/bin/ruby -S gem install mustache -v "= 0.99.6" --no-ri --no-rdoc
true
/usr/local/rbenv/versions/2.3.0/bin/ruby -S gem list -i "^rake$" -v "~> 10.0" || /usr/local/rbenv/versions/2.3.0/bin/ruby -S gem install rake -v "~> 10.0" --no-ri --no-rdoc
true
/usr/local/rbenv/versions/2.3.0/bin/ruby -S gem list -i "^rdiscount$" -v "~> 2.1.8" || /usr/local/rbenv/versions/2.3.0/bin/ruby -S gem install rdiscount -v "~> 2.1.8" --no-ri --no-rdoc
true
/usr/local/rbenv/versions/2.3.0/bin/ruby -S gem list -i "^ronn$" -v "~> 0.7.3" || /usr/local/rbenv/versions/2.3.0/bin/ruby -S gem install ronn -v "~> 0.7.3" --no-ri --no-rdoc
true
/usr/local/rbenv/versions/2.3.0/bin/ruby -S gem list -i "^rspec$" -v "~> 3.0" || /usr/local/rbenv/versions/2.3.0/bin/ruby -S gem install rspec -v "~> 3.0" --no-ri --no-rdoc
true
/usr/local/rbenv/versions/2.3.0/bin/ruby -S gem list -i "^rubocop$" -v "= 0.38.0" || /usr/local/rbenv/versions/2.3.0/bin/ruby -S gem install rubocop -v "= 0.38.0" --no-ri --no-rdoc
true
installing gems for the tests to use...
Successfully installed fakeweb-1.3.0
Successfully installed artifice-0.6
Successfully installed rack-1.6.4
Successfully installed compact_index-0.10.0
4 gems installed
Successfully installed sinatra-1.2.7
1 gem installed
Successfully installed rake-10.0.2
1 gem installed
Successfully installed builder-2.1.2
1 gem installed

You need to install GraphViz (http://graphviz.org/) to use this Gem.

For more information about Ruby-Graphviz :
* Doc : http://rdoc.info/projects/glejeune/Ruby-Graphviz
* Sources : http://github.com/glejeune/Ruby-Graphviz
* Mailing List : http://groups.google.com/group/ruby-graphviz

Last (important) changes :
Ruby-Graphviz no longer supports Ruby < 1.9.3

Successfully installed ruby-graphviz-1.2.2
1 gem installed
spec:deps ran for   0.010000   0.020000  10.020000 ( 24.491881)

$ rake spec
mkdir -p lib/bundler/man
/usr/local/rbenv/versions/2.3.0/bin/ruby -S ronn --roff --pipe man/bundle-config.ronn > lib/bundler/man/bundle-config
groff -Wall -mtty-char -mandoc -Tascii lib/bundler/man/bundle-config | col -b > lib/bundler/man/bundle-config.txt
# [... more groff ...]

/usr/local/rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
/usr/local/rbenv/gems/2.3.0/gems/rspec-support-3.4.1/lib/rspec/support/warnings.rb:7: warning: method redefined; discarding old deprecate
/usr/local/rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rspec-support-3.4.1/lib/rspec/support/warnings.rb:7: warning: previous definition of deprecate was here
# [... more rspec warnings ...]

/usr/local/rbenv/versions/2.3.0/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- rake (LoadError)
	from /usr/local/rbenv/versions/2.3.0/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /Users/sj26/Projects/bundler/spec/bundler/gem_helper_spec.rb:3:in `<top (required)>'
	from /usr/local/rbenv/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/configuration.rb:1361:in `load'
	from /usr/local/rbenv/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/configuration.rb:1361:in `block in load_spec_files'
	from /usr/local/rbenv/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/configuration.rb:1359:in `each'
	from /usr/local/rbenv/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/configuration.rb:1359:in `load_spec_files'
	from /usr/local/rbenv/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:106:in `setup'
	from /usr/local/rbenv/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:92:in `run'
	from /usr/local/rbenv/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:78:in `run'
	from /usr/local/rbenv/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:45:in `invoke'
	from /usr/local/rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/exe/rspec:4:in `<main>'
/usr/local/rbenv/versions/2.3.0/bin/ruby -I/usr/local/rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rspec-support-3.4.1/lib:/usr/local/rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib /usr/local/rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb failed
```

I can't follow what the spec suite is doing with the load and gem paths closely enough to figure out what's gone wrong.