### PR TITLE
Use Travis' cache by default for new gem

### DIFF
--- a/lib/bundler/templates/newgem/.travis.yml.tt
+++ b/lib/bundler/templates/newgem/.travis.yml.tt
@@ -1,5 +1,7 @@
 sudo: false
 language: ruby
+cache:
+  - bundler
 rvm:
   - <%= RUBY_VERSION %>
 before_install: gem install bundler -v <%= Bundler::VERSION %>


### PR DESCRIPTION
> (Bundler caching is not yet enabled automatically)
> You can explicitly enable Bundler caching in your .travis.yml:
> ```
> language: ruby
> cache: bundler
> ```

ref: https://docs.travis-ci.com/user/caching/#Bundler