### PR TITLE
Prevent endless recursive copy for `bundle package --all`

### DIFF
--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -133,9 +133,10 @@ module Bundler
         gemspec = gemspec_cache_hash.values.first
         root_gem_name = gemspec.name unless gemspec.nil?
       end
+
       specs.each do |spec|
         next if spec.name == "bundler"
-        next if File.exist?("#{root_gem_name}.gemspec") && spec.source.class == Bundler::Source::Path && root_gem_name && spec.name == root_gem_name
+        next if !Dir.glob("*.gemspec").empty? && spec.source.class == Bundler::Source::Path && root_gem_name && spec.name == root_gem_name
         spec.source.send(:fetch_gem, spec) if Bundler.settings[:cache_all_platforms] && spec.source.respond_to?(:fetch_gem, true)
         spec.source.cache(spec, custom_path) if spec.source.respond_to?(:cache)
       end

--- a/spec/commands/package_spec.rb
+++ b/spec/commands/package_spec.rb
@@ -31,33 +31,68 @@ describe "bundle package" do
         expect(bundled_app("vendor/cache/bundler-0.9.gem")).to_not exist
       end
     end
+
     context "with a gemspec" do
-      before do
-        File.open(bundled_app("mygem.gemspec"), "w") do |f|
-          f.write <<-G
-            Gem::Specification.new do |s|
-              s.name = "mygem"
-              s.version = "0.1.1"
-              s.summary = ""
-              s.authors = ["gem author"]
-              s.add_development_dependency "nokogiri", "=1.4.2"
-            end
-          G
+      context "that has the same name as the gem" do
+        before do
+          File.open(bundled_app("mygem.gemspec"), "w") do |f|
+            f.write <<-G
+              Gem::Specification.new do |s|
+                s.name = "mygem"
+                s.version = "0.1.1"
+                s.summary = ""
+                s.authors = ["gem author"]
+                s.add_development_dependency "nokogiri", "=1.4.2"
+              end
+            G
+          end
+        end
+
+        it "caches all dependencies except bundler and the gemspec specified gem" do
+          gemfile <<-D
+            source "file://#{gem_repo1}"
+            gem 'rack'
+            gemspec
+          D
+
+          bundle! "package --all"
+
+          expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
+          expect(bundled_app("vendor/cache/nokogiri-1.4.2.gem")).to exist
+          expect(bundled_app("vendor/cache/mygem-0.1.1.gem")).to_not exist
+          expect(bundled_app("vendor/cache/bundler-0.9.gem")).to_not exist
         end
       end
-      it "caches all dependencies except bundler and the gemspec specified gem" do
-        gemfile <<-D
-          source "file://#{gem_repo1}"
-          gem 'rack'
-          gemspec
-        D
 
-        bundle! "package --all"
+      context "that has a different name as the gem" do
+        before do
+          File.open(bundled_app("mygem_diffname.gemspec"), "w") do |f|
+            f.write <<-G
+              Gem::Specification.new do |s|
+                s.name = "mygem"
+                s.version = "0.1.1"
+                s.summary = ""
+                s.authors = ["gem author"]
+                s.add_development_dependency "nokogiri", "=1.4.2"
+              end
+            G
+          end
+        end
 
-        expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
-        expect(bundled_app("vendor/cache/nokogiri-1.4.2.gem")).to exist
-        expect(bundled_app("vendor/cache/mygem-0.1.1.gem")).to_not exist
-        expect(bundled_app("vendor/cache/bundler-0.9.gem")).to_not exist
+        it "caches all dependencies except bundler and the gemspec specified gem" do
+          gemfile <<-D
+            source "file://#{gem_repo1}"
+            gem 'rack'
+            gemspec
+          D
+
+          bundle! "package --all"
+
+          expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
+          expect(bundled_app("vendor/cache/nokogiri-1.4.2.gem")).to exist
+          expect(bundled_app("vendor/cache/mygem-0.1.1.gem")).to_not exist
+          expect(bundled_app("vendor/cache/bundler-0.9.gem")).to_not exist
+        end
       end
     end
   end


### PR DESCRIPTION
- prevents endless recursive copy regardless of gemspec file name (and whether it matches the name of the gem)

- Fixes #4392