### PR TITLE
A Proof of Concept for plugin system for bundler

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -11,6 +11,7 @@ require "bundler/version"
 require "bundler/constants"
 require "bundler/current_ruby"
 require "bundler/errors"
+require "bundler/plugin"
 
 module Bundler
   environment_preserver = EnvironmentPreserver.new(ENV, %w(PATH GEM_PATH))
@@ -449,4 +450,6 @@ module Bundler
       ENV.replace(backup)
     end
   end
+
+  Plugin.init
 end

--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -11,7 +11,6 @@ require "bundler/version"
 require "bundler/constants"
 require "bundler/current_ruby"
 require "bundler/errors"
-require "bundler/plugin"
 
 module Bundler
   environment_preserver = EnvironmentPreserver.new(ENV, %w(PATH GEM_PATH))
@@ -53,6 +52,7 @@ module Bundler
   autoload :SourceList,             "bundler/source_list"
   autoload :RubyGemsGemInstaller,   "bundler/rubygems_gem_installer"
   autoload :UI,                     "bundler/ui"
+  autoload :Plugin,                 "bundler/plugin"
 
   class << self
     attr_writer :bundle_path
@@ -450,6 +450,4 @@ module Bundler
       ENV.replace(backup)
     end
   end
-
-  Plugin.init
 end

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -86,8 +86,8 @@ module Bundler
         Kernel.exec(command_path, *ARGV[1..-1])
       end
 
-      return super unless Plugin.is_command? command
-      Plugin.exec(command, *ARGV[1..-1])
+      return super unless Bundler::Plugin.is_command? command
+      Bundler::Plugin.exec(command, *ARGV[1..-1])
     end
 
     desc "init [OPTIONS]", "Generates a Gemfile into the current working directory"
@@ -434,6 +434,17 @@ module Bundler
     desc "env", "Print information about the environment Bundler is running under"
     def env
       Env.new.write($stdout)
+    end
+
+    # TODO: change it to subcommand
+    desc "plugin PLUGIN [OPTIONS]", "Manage the plugins"
+    method_option "install", :type => :boolean, :default => false, :banner =>
+      "install a pluign"
+    method_option "git", :type => :string, :default => nil, :banner =>
+      "Git source of the plugin to install"
+    def plugin(name)
+      require "bundler/cli/plugin"
+      Plugin.new(options, name).run
     end
 
     # Reformat the arguments passed to bundle that include a --help flag

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -436,16 +436,9 @@ module Bundler
       Env.new.write($stdout)
     end
 
-    # TODO: change it to subcommand
-    desc "plugin PLUGIN [OPTIONS]", "Manage the plugins"
-    method_option "install", :type => :boolean, :default => false, :banner =>
-      "install a pluign"
-    method_option "git", :type => :string, :default => nil, :banner =>
-      "Git source of the plugin to install"
-    def plugin(name)
-      require "bundler/cli/plugin"
-      Plugin.new(options, name).run
-    end
+    require "bundler/cli/plugin"
+    desc "plugin SUBCOMMAND ...ARGS", "Manage the plugins"
+    subcommand "plugin", Plugin
 
     # Reformat the arguments passed to bundle that include a --help flag
     # into the corresponding `bundle help #{command}` call

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -82,9 +82,12 @@ module Bundler
     end
 
     def self.handle_no_command_error(command, has_namespace = $thor_runner)
-      return super unless command_path = Bundler.which("bundler-#{command}")
+      if command_path = Bundler.which("bundler-#{command}")
+        Kernel.exec(command_path, *ARGV[1..-1])
+      end
 
-      Kernel.exec(command_path, *ARGV[1..-1])
+      return super unless Plugin.is_command? command
+      Plugin.exec(command, *ARGV[1..-1])
     end
 
     desc "init [OPTIONS]", "Generates a Gemfile into the current working directory"

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -86,7 +86,7 @@ module Bundler
         Kernel.exec(command_path, *ARGV[1..-1])
       end
 
-      return super unless Bundler::Plugin.is_command? command
+      return super unless Bundler::Plugin.command? command
       Bundler::Plugin.exec(command, *ARGV[1..-1])
     end
 

--- a/lib/bundler/cli/plugin.rb
+++ b/lib/bundler/cli/plugin.rb
@@ -2,7 +2,6 @@
 require "bundler/vendored_thor"
 module Bundler
   class CLI::Plugin < Thor
-
     desc "install PLUGIN ", "Install the plugin"
     method_option "git", :type => :string, :default => false, :banner =>
       "The git repo to install the plugin from"
@@ -17,6 +16,5 @@ module Bundler
 
       Bundler::Plugin.install(plugin, options[:git])
     end
-
   end
 end

--- a/lib/bundler/cli/plugin.rb
+++ b/lib/bundler/cli/plugin.rb
@@ -1,25 +1,22 @@
 # frozen_string_literal: true
+require "bundler/vendored_thor"
 module Bundler
-  class CLI::Plugin
-    attr_reader :name, :options
+  class CLI::Plugin < Thor
 
-    def initialize(options, name)
-      @options = options
-      @name = name
-    end
-
-    def run
-      if @options[:install]
-        unless @options[:git]
-          puts <<-E
-            Only git modules are supported
-            Pass the git path with --git option
-          E
-          return
-        end
-
-        Bundler::Plugin.install(@name, @options[:git])
+    desc "install PLUGIN ", "Install the plugin"
+    method_option "git", :type => :string, :default => false, :banner =>
+      "The git repo to install the plugin from"
+    def install(plugin)
+      unless options[:git]
+        puts <<-W
+          Only git modules are supported as of now
+          Pass the git path with --git option
+        W
+        return
       end
+
+      Bundler::Plugin.install(plugin, options[:git])
     end
+
   end
 end

--- a/lib/bundler/cli/plugin.rb
+++ b/lib/bundler/cli/plugin.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+module Bundler
+  class CLI::Plugin
+    attr_reader :name, :options
+
+    def initialize(options, name)
+      @options = options
+      @name = name
+    end
+
+    def run
+      if @options[:install]
+        unless @options[:git]
+          puts <<-E
+            Only git modules are supported
+            Pass the git path with --git option
+          E
+          return
+        end
+
+        Bundler::Plugin.install(@name, @options[:git])
+      end
+    end
+  end
+end

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -124,7 +124,7 @@ module Bundler
 
     def source(source, *args, &blk)
       options = args.last.is_a?(Hash) ? args.pop.dup : nil
-      if options and options.key? :type and Bundler::Plugin.source? options[:type]
+      if options && options.key?(:type) && Bundler::Plugin.source?(options[:type])
         unless block_given?
           raise InvalidOption, "You need to pass a block to source with type"
         end
@@ -339,9 +339,7 @@ module Bundler
 
       # A workaround for the demo, a real plugin system will have more elegant
       # and elaborate intrgration
-      if @plugin_source
-        opts["path"] = @plugin_source.call(name, version)
-      end
+      opts["path"] = @plugin_source.call(name, version) if @plugin_source
 
       %w(git path).each do |type|
         next unless param = opts[type]

--- a/lib/bundler/errors.rb
+++ b/lib/bundler/errors.rb
@@ -38,6 +38,7 @@ module Bundler
   class GemfileLockNotFound < BundlerError; status_code(22); end
   class GemfileEvalError < GemfileError; end
   class MarshalError < StandardError; end
+  class PluginError < BundlerError; end
 
   class PermissionError < BundlerError
     def initialize(path, permission_type = :write)

--- a/lib/bundler/plugin.rb
+++ b/lib/bundler/plugin.rb
@@ -3,6 +3,7 @@ module Bundler
   module Plugin
     class << self
       @@command = Hash.new
+      @@after_install_hooks = []
 
       def init
         # only a crude implementation for demo
@@ -48,6 +49,17 @@ module Bundler
 
         cmd.execute(args)
       end
+
+      def register_after_install(block)
+        puts "registed after install hook"
+        @@after_install_hooks << block
+      end
+
+      def post_install(gem)
+        @@after_install_hooks.each do |cb|
+          cb.call(gem)
+        end
+      end
     end
 
     class Base
@@ -55,6 +67,14 @@ module Bundler
         # TODO: pass the class
         Plugin.add_command command, self
       end
+
+      def self.add_hook(event, &block)
+        puts event.inspect
+        if event == "post-install"
+          Plugin.register_after_install( block)
+        end
+      end
+
 
       def execute(args)
       end

--- a/lib/bundler/plugin.rb
+++ b/lib/bundler/plugin.rb
@@ -63,14 +63,12 @@ module Bundler
       end
 
       def add_source(name, cls)
-        puts "Regiserign source plugin"
         raise "Source already registered" if source? name
 
         @@sources[name] = cls
       end
 
       def source?(name)
-        puts "checking source plugin #name"
         @@sources.key? name
       end
 

--- a/lib/bundler/plugin.rb
+++ b/lib/bundler/plugin.rb
@@ -5,19 +5,31 @@ module Bundler
       @@command = Hash.new
 
       def init
-        # Just a crude implementation for demo
+        # only a crude implementation for demo
         Dir.glob(plugin_root.join("*").join("plugin.rb")).each do |file|
           require file
         end
       end
 
       def install(name, git_path)
-        git_proxy = Source::Git::GitProxy.new(plugin_root.join(name), git_path, "master")
+        git_proxy = Source::Git::GitProxy.new(plugin_cache.join(name), git_path, "master")
         git_proxy.checkout
+        git_proxy.copy_to(plugin_root.join(name))
+
+        unless File.file? plugin_root.join(name).join("plugin.rb")
+          raise "plugin.rb is not present in the repo"
+        end
+
+        Bundler.ui.info "Installed plugin #{name}"
+
       end
 
       def plugin_root
-        Bundler.user_bundle_path.join("plugin")
+        Bundler.user_bundle_path.join("plugins")
+      end
+
+      def plugin_cache
+        Bundler.user_cache.join("plugins")
       end
 
       def add_command(command, command_class)

--- a/lib/bundler/plugin.rb
+++ b/lib/bundler/plugin.rb
@@ -34,7 +34,7 @@ module Bundler
         sources = @sources
         post_install_hooks = @post_install_hooks
 
-        @commands = {}           
+        @commands = {}
         @post_install_hooks = []
         @sources = {}
 
@@ -80,13 +80,13 @@ module Bundler
         index.command? command
       end
 
-      def exec(command, args = nil)
+      def exec(command, *args)
         raise "Unknown command" unless index.command? command
 
         load_plugin index.command_plugin(command) unless @commands.key? command
 
         cmd = @commands[command].new
-        cmd.execute(args)
+        cmd.execute(command, args)
       end
 
       def register_post_install(&block)

--- a/lib/bundler/plugin.rb
+++ b/lib/bundler/plugin.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+module Bundler
+  module Plugin
+    class << self
+      @@command = Hash.new
+
+      def init
+        require Bundler.user_bundle_path + "plugin/demo-plugin/plugin.rb"
+      end
+
+      def add_command(command, command_class)
+        raise "Command already registered" if is_command? command
+
+        @@command[command] = command_class
+      end
+
+      def is_command?(command)
+        # TODO: check for inbuilt commands
+        @@command.key? command
+      end
+
+      def exec(command, args = nil)
+        cmd = @@command[command].new
+
+        cmd.execute(args)
+      end
+    end
+
+    class Base
+      def self.command(command)
+        # TODO: pass the class
+        Plugin.add_command command, self
+      end
+
+      def execute(args)
+      end
+    end
+
+  end
+end

--- a/lib/bundler/plugin.rb
+++ b/lib/bundler/plugin.rb
@@ -1,84 +1,122 @@
 # frozen_string_literal: true
+require "bundler/plugin/index"
 module Bundler
   module Plugin
 
     class << self
-      def init
-        @command = {}        # stores the list of loaded commands
-        @after_install_hooks = []
-        @sources = {}
 
-        # only a crude implementation for demo
-        require "bundler/plugin/base"
-        Dir.glob(plugin_root.join("*").join("plugin.rb")).each do |file|
-          require file
-        end
+      def init
+        @commands = {}             # The map of loaded commands
+        @post_install_hooks = []   # Array of blocks
+        @sources = {}              # The map of loaded sources
       rescue
       end
 
       def install(name, git_path)
         git_proxy = Source::Git::GitProxy.new(plugin_cache.join(name), git_path, "master")
         git_proxy.checkout
-        git_proxy.copy_to(plugin_root.join(name))
 
-        unless File.file? plugin_root.join(name).join("plugin.rb")
+        plugin_path = plugin_root.join(name)
+        git_proxy.copy_to(plugin_path)
+
+        unless File.file? plugin_path.join("plugin.rb")
+          Bundler.rm_rf(plugin_root.join(name))
           raise "plugin.rb is not present in the repo"
         end
 
-        Bundler.ui.info "Installed plugin #{name}"
+        register_plugin name, plugin_path
 
+        Bundler.ui.info "Installed plugin #{name}"
       end
 
+      def register_plugin(name, path)
+        commands = @commands
+        sources = @sources
+        post_install_hooks = @post_install_hooks
+
+        @commands = {}           
+        @post_install_hooks = []
+        @sources = {}
+
+        require "bundler/plugin/base"
+        require path.join("plugin.rb")
+
+        index.add_plugin name, @commands, @sources, @post_install_hooks
+      ensure
+        @commands = commands
+        @post_install_hooks = post_install_hooks
+        @sources = sources
+      end
+
+      def load_plugin(name)
+        require "bundler/plugin/base"
+        require plugin_root.join(name).join("plugin.rb")
+      end
+
+      def index
+        @index ||= Index.new(plugin_config_file)
+      end
+
+      # Directory where plugins will be stored
       def plugin_root
         Bundler.user_bundle_path.join("plugins")
       end
 
+      # The config file for activated plugins
       def plugin_config_file
         Bundler.user_bundle_path.join("plugin")
       end
 
+      # Cache to store the downloaded plugins
       def plugin_cache
         Bundler.user_cache.join("plugins")
       end
 
       def add_command(command, command_class)
-        raise "Command already registered" if is_command? command
-
-        @command[command] = command_class
+        @commands[command] = command_class
       end
 
       def is_command?(command)
-        # TODO: check for inbuilt commands
-        @command.key? command
+        index.command? command
       end
 
       def exec(command, args = nil)
-        cmd = @command[command].new
+        raise "Unknown command" unless index.command? command
 
+        load_plugin index.command_plugin(command) unless @commands.key? command
+
+        cmd = @commands[command].new
         cmd.execute(args)
       end
 
-      def register_after_install(&block)
-        @after_install_hooks << block
+      def register_post_install(&block)
+        @post_install_hooks << block
       end
 
       def post_install(gem)
-        @after_install_hooks.each do |cb|
+        if @post_install_hooks.length != index.post_install_hooks.length
+          @post_install_hooks = []
+          index.post_install_hooks.each { |p| load_plugin p }
+        end
+
+        @post_install_hooks.each do |cb|
           cb.call(gem)
         end
       end
 
       def add_source(name, cls)
-        raise "Source already registered" if source? name
-
         @sources[name] = cls
       end
 
       def source?(name)
-        @sources.key? name
+        index.source? name
       end
 
       def source(source_name, source)
+        raise "Unknown source" unless index.source? source_name
+
+        load_plugin index.source_plugin(source_name) unless @sources.key? source_name
+
         obj = @sources[source_name].new
 
         Proc.new do |name, version|

--- a/lib/bundler/plugin.rb
+++ b/lib/bundler/plugin.rb
@@ -5,7 +5,19 @@ module Bundler
       @@command = Hash.new
 
       def init
-        require Bundler.user_bundle_path + "plugin/demo-plugin/plugin.rb"
+        # Just a crude implementation for demo
+        Dir.glob(plugin_root.join("*").join("plugin.rb")).each do |file|
+          require file
+        end
+      end
+
+      def install(name, git_path)
+        git_proxy = Source::Git::GitProxy.new(plugin_root.join(name), git_path, "master")
+        git_proxy.checkout
+      end
+
+      def plugin_root
+        Bundler.user_bundle_path.join("plugin")
       end
 
       def add_command(command, command_class)

--- a/lib/bundler/plugin/base.rb
+++ b/lib/bundler/plugin/base.rb
@@ -1,25 +1,19 @@
 # frozen_string_literal: true
 module Bundler
-  module Plugin
-    class Base
-      def self.command(command)
-        # TODO: pass the class
-        Plugin.add_command command, self
-      end
-
-      def self.add_hook(event, &block)
-        if event == "post-install"
-          Plugin.register_post_install( &block)
-        end
-      end
-
-      def self.source(name)
-        Plugin.add_source name, self
-      end
-
-      def execute(command, args)
-      end
+  class Plugin::Base
+    def self.command(command)
+      Plugin.add_command command, self
     end
 
+    def self.add_hook(event, &block)
+      Plugin.register_post_install(&block) if event == "post-install"
+    end
+
+    def self.source(name)
+      Plugin.add_source name, self
+    end
+
+    def execute(command, args)
+    end
   end
 end

--- a/lib/bundler/plugin/base.rb
+++ b/lib/bundler/plugin/base.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+module Bundler
+  module Plugin
+    class Base
+      def self.command(command)
+        # TODO: pass the class
+        Plugin.add_command command, self
+      end
+
+      def self.add_hook(event, &block)
+        if event == "post-install"
+          Plugin.register_after_install( &block)
+        end
+      end
+
+      def self.source(name)
+        Plugin.add_source name, self
+      end
+
+      def execute(args)
+      end
+    end
+
+  end
+end

--- a/lib/bundler/plugin/base.rb
+++ b/lib/bundler/plugin/base.rb
@@ -9,7 +9,7 @@ module Bundler
 
       def self.add_hook(event, &block)
         if event == "post-install"
-          Plugin.register_after_install( &block)
+          Plugin.register_post_install( &block)
         end
       end
 

--- a/lib/bundler/plugin/base.rb
+++ b/lib/bundler/plugin/base.rb
@@ -17,7 +17,7 @@ module Bundler
         Plugin.add_source name, self
       end
 
-      def execute(args)
+      def execute(command, args)
       end
     end
 

--- a/lib/bundler/plugin/index.rb
+++ b/lib/bundler/plugin/index.rb
@@ -1,75 +1,80 @@
 # frozen_string_literal: true
 module Bundler
-  module Plugin
-    # This class keeps the index of which plugin 
-    class Index 
+  # This class keeps the index of which command, source or hook maps to which plugin
+  class Plugin::Index
+    def initialize(config)
+      @config_file = config
 
-      def initialize(config)
-        @config_file = config
+      # These maps to their plugin names (not classes as in Plugin class)
+      @commands = {}
+      @post_install_hooks = []
+      @sources = {}
 
-        @commands = {}
-        @post_install_hooks = []
-        @sources = {}
+      load_config
+    end
 
-        load_config
+    def load_config
+      SharedHelpers.filesystem_access(config_file, :read) do
+        valid_file = config_file && config_file.exist? && !config_file.size.zero?
+        return unless valid_file
+        require "bundler/psyched_yaml"
+        config = YAML.load_file(@config_file)
+        @commands = config[:commands]
+        @post_install_hooks = config[:post_install_hooks]
+        @sources = config[:sources]
       end
+    end
 
-      def load_config
-        SharedHelpers.filesystem_access(config_file, :read) do
-          valid_file = config_file && config_file.exist? && !config_file.size.zero?
-          return if !valid_file
-          require "bundler/psyched_yaml"
-          config = YAML.load_file(@config_file)
-          @commands = config[:commands]
-          @post_install_hooks = config[:post_install_hooks]
-          @sources = config[:sources]
-        end
-      end
+    def save_config
+      index = {
+        :commands => @commands,
+        :post_install_hooks => @post_install_hooks,
+        :sources => @sources,
+      }
 
-      def save_config
-        hash = {:commands => @commands, :post_install_hooks => @post_install_hooks, :sources => @sources}
-        SharedHelpers.filesystem_access(@config_file) do |p|
-          FileUtils.mkdir_p(p.dirname)
-          require "bundler/psyched_yaml"
-          File.open(p, "w") {|f| f.puts YAML.dump(hash) }
-        end
+      SharedHelpers.filesystem_access(@config_file) do |p|
+        require "bundler/psyched_yaml"
+        FileUtils.mkdir_p(p.dirname)
+        File.open(p, "w") {|f| f.puts YAML.dump(index) }
       end
+    end
 
-      def config_file
-        @config_file
-      end
+    def config_file
+      @config_file
+    end
 
-      # We keep track which command  or source belong to which plugin 
-      # and which all plugins declare a specific hook
-      def add_plugin(plugin, commands, sources, post_install_hooks)
-        raise "Command already registed" unless (commands.keys & @commands.keys).empty?
-        raise "Source already registed" unless (sources.keys & @sources.keys).empty?
-        
-        commands.keys.each { |cmd| @commands[cmd] = plugin }
-        sources.keys.each { |source| @sources[source] = plugin }
-        @post_install_hooks << plugin
-        save_config
-      end
+    # We keep track which command  or source belong to which plugin
+    # and which all plugins declare a specific hook
+    def add_plugin(plugin, commands, sources, post_install_hooks)
+      raise "Command already registed" unless (commands.keys & @commands.keys).empty?
+      raise "Source already registed" unless (sources.keys & @sources.keys).empty?
 
-      def command?(command)
-        @commands.key? command
-      end
+      commands.keys.each {|cmd| @commands[cmd] = plugin }
+      sources.keys.each {|source| @sources[source] = plugin }
+      @post_install_hooks << plugin
+      save_config
+    end
 
-      def command_plugin(command)
-        @commands[command]
-      end
+    def command?(command)
+      @commands.key? command
+    end
 
-      def source?(source)
-        @sources.key? source
-      end
+    # Return the plugin name to which the command belongs
+    def command_plugin(command)
+      @commands[command]
+    end
 
-      def source_plugin(source)
-        @sources[source]
-      end
+    def source?(source)
+      @sources.key? source
+    end
 
-      def post_install_hooks
-        @post_install_hooks
-      end
+    def source_plugin(source)
+      @sources[source]
+    end
+
+    # Returns the array of plugin names to which declare the hook
+    def post_install_hooks
+      @post_install_hooks
     end
   end
 end

--- a/lib/bundler/plugin/index.rb
+++ b/lib/bundler/plugin/index.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+module Bundler
+  module Plugin
+    # This class keeps the index of which plugin 
+    class Index 
+
+      def initialize(config)
+        @config_file = config
+
+        @commands = {}
+        @post_install_hooks = []
+        @sources = {}
+
+        load_config
+      end
+
+      def load_config
+        SharedHelpers.filesystem_access(config_file, :read) do
+          valid_file = config_file && config_file.exist? && !config_file.size.zero?
+          return if !valid_file
+          require "bundler/psyched_yaml"
+          config = YAML.load_file(@config_file)
+          @commands = config[:commands]
+          @post_install_hooks = config[:post_install_hooks]
+          @sources = config[:sources]
+        end
+      end
+
+      def save_config
+        hash = {:commands => @commands, :post_install_hooks => @post_install_hooks, :sources => @sources}
+        SharedHelpers.filesystem_access(@config_file) do |p|
+          FileUtils.mkdir_p(p.dirname)
+          require "bundler/psyched_yaml"
+          File.open(p, "w") {|f| f.puts YAML.dump(hash) }
+        end
+      end
+
+      def config_file
+        @config_file
+      end
+
+      # We keep track which command  or source belong to which plugin 
+      # and which all plugins declare a specific hook
+      def add_plugin(plugin, commands, sources, post_install_hooks)
+        raise "Command already registed" unless (commands.keys & @commands.keys).empty?
+        raise "Source already registed" unless (sources.keys & @sources.keys).empty?
+        
+        commands.keys.each { |cmd| @commands[cmd] = plugin }
+        sources.keys.each { |source| @sources[source] = plugin }
+        @post_install_hooks << plugin
+        save_config
+      end
+
+      def command?(command)
+        @commands.key? command
+      end
+
+      def command_plugin(command)
+        @commands[command]
+      end
+
+      def source?(source)
+        @sources.key? source
+      end
+
+      def source_plugin(source)
+        @sources[source]
+      end
+
+      def post_install_hooks
+        @post_install_hooks
+      end
+    end
+  end
+end

--- a/lib/bundler/source/path.rb
+++ b/lib/bundler/source/path.rb
@@ -230,6 +230,9 @@ module Bundler
           message = "#{type} hook#{location} failed for #{installer.spec.full_name}"
           raise InstallHookError, message
         end
+        if type == :post_install
+          Bundler::Plugin.post_install(installer)
+        end
       end
     end
   end

--- a/lib/bundler/source/path.rb
+++ b/lib/bundler/source/path.rb
@@ -230,9 +230,7 @@ module Bundler
           message = "#{type} hook#{location} failed for #{installer.spec.full_name}"
           raise InstallHookError, message
         end
-        if type == :post_install
-          Bundler::Plugin.post_install(installer)
-        end
+        Bundler::Plugin.post_install(installer) if type == :post_install
       end
     end
   end

--- a/lib/bundler/source/rubygems.rb
+++ b/lib/bundler/source/rubygems.rb
@@ -171,6 +171,7 @@ module Bundler
         end
         spec.loaded_from = loaded_from(spec)
 
+        Bundler::Plugin.post_install(installed_spec)
         spec.post_install_message
       ensure
         Bundler.rm_rf(install_path) if Bundler.requires_sudo?

--- a/spec/plugin/plugins.rb
+++ b/spec/plugin/plugins.rb
@@ -14,6 +14,27 @@ describe "bundle plugin" do
     end
   end
 
+  describe "malformatted plugin" do
+    it "doesn't install" do
+      build_git "foo" do |s|
+        s.write "plugin.rb", <<-RUBY
+          class DemoPlugin < Bundler::Plugin::Base
+            command "demop"
+
+            raise "I am malformatted"
+            def execute(command, args)
+              puts "hello world"
+            end
+          end
+        RUBY
+      end
+
+      bundle "plugin install foo --git file://#{lib_path("foo-1.0")}"
+
+      expect(out).not_to include("Installed plugin foo")
+    end
+  end
+
   describe "command line plugin" do
     it "executes" do
       build_git "foo" do |s|
@@ -42,7 +63,7 @@ describe "bundle plugin" do
             command "demop"
 
             def execute(command, args)
-              puts "Hello World! You gave me " + args.join(" ") 
+              puts "Hello World! You gave me " + args.join(" ")
             end
           end
         RUBY
@@ -54,7 +75,6 @@ describe "bundle plugin" do
 
       expect(out).to include("Hello World! You gave me chocolate margarita burger")
     end
-
   end
 
   describe "source plugins" do
@@ -148,5 +168,4 @@ describe "bundle plugin" do
       end
     end
   end
-
 end

--- a/spec/plugin/plugins.rb
+++ b/spec/plugin/plugins.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe "bundle plugin" do
+  describe "install a plugin" do
+    it "downloads the plugin to user bundler dir" do
+      build_git "foo" do |s|
+        s.write "plugin.rb", ""
+      end
+
+      bundle "plugin foo --install --git file://#{lib_path("foo-1.0")}"
+      expect(out).to include("Installed plugin foo")
+
+      expect(Bundler::Plugin.plugin_root.join("foo")).to be_directory
+    end
+  end
+
+  describe "command line plugin" do
+    it "executes" do
+      build_git "foo" do |s|
+        s.write "plugin.rb", <<-P
+          class DemoPlugin < Bundler::Plugin::Base
+            command "demop"
+
+            def execute(args)
+              puts "hello world"
+            end
+          end
+        P
+      end
+
+      bundle "plugin foo --install --git file://#{lib_path("foo-1.0")}"
+
+      bundle "demop"
+
+      expect(out).to include("hello world")
+    end
+  end
+end

--- a/spec/plugin/plugins.rb
+++ b/spec/plugin/plugins.rb
@@ -8,7 +8,7 @@ describe "bundle plugin" do
         s.write "plugin.rb", ""
       end
 
-      bundle "plugin foo --install --git file://#{lib_path("foo-1.0")}"
+      bundle "plugin install foo --git file://#{lib_path("foo-1.0")}"
 
       expect(out).to include("Installed plugin foo")
     end
@@ -28,7 +28,7 @@ describe "bundle plugin" do
         RUBY
       end
 
-      bundle "plugin foo --install --git file://#{lib_path("foo-1.0")}"
+      bundle "plugin install foo --git file://#{lib_path("foo-1.0")}"
 
       bundle "demop"
 
@@ -49,7 +49,7 @@ describe "bundle plugin" do
           RUBY
         end
 
-        bundle "plugin foo --install --git file://#{lib_path("foo-1.0")}"
+        bundle "plugin install foo --git file://#{lib_path("foo-1.0")}"
       end
 
       it "runs after a rubygem is installed" do
@@ -90,7 +90,7 @@ describe "bundle plugin" do
           RUBY
         end
 
-        bundle "plugin foo --install --git file://#{lib_path("foo-1.0")}"
+        bundle "plugin install foo --git file://#{lib_path("foo-1.0")}"
       end
 
       it "handles source blocks with type options" do


### PR DESCRIPTION
A proof of concept for the plugin system of bundler. This is only to demonstrate some of the ideas I proposed in my proposal to gsoc2016 proposal for bundler. This demo lacks many central features as listed below (and some I may have forgotten to list :P) but presents the overall central idea.

This includes:
- [x] Command line plugin
- [x] Life event hooks (only for post install at present)
- [x] Source plugin (pre-installed)
- [x] On-demand loading of plugins

The major limitations of this demo are:
- [ ] Proper management of plugins installations and activation
- [ ] Lack of installation via RubyGems, only git install is included. This in not difficult and can be easily done when we unify the plugin installation with bundler installation system.
- [ ] Dynamic fetch of the plugin (The Gemfile DSL `plugin` directive and auto installation of source plugin). Was messy  to implement without the above feature.
- [ ] Distinction between user and project level plugins