### PR TITLE
added required_ruby_version and require_relative to gemspec template

### DIFF
--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -1,7 +1,5 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require '<%=config[:namespaced_path]%>/version'
+require_relative 'lib/<%=config[:namespaced_path]%>/version'
 
 Gem::Specification.new do |spec|
   spec.name          = <%=config[:name].inspect%>
@@ -15,6 +13,7 @@ Gem::Specification.new do |spec|
 <%- if config[:mit] -%>
   spec.license       = "MIT"
 <%- end -%>
+  spec.required_ruby_version = Gem::Requirement.new(">= 1.9")
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.


### PR DESCRIPTION
require_relative is supported since 1.9.2 (which is EOL already). It think it's safe to use it in gem template.
