### PR TITLE
Suggest usage of `--full-index` flag in case of Dependency API failure

### DIFF
--- a/lib/bundler/fetcher/dependency.rb
+++ b/lib/bundler/fetcher/dependency.rb
@@ -33,9 +33,13 @@ module Bundler
 
         returned_gems = spec_list.map(&:first).uniq
         specs(deps_list, full_dependency_list + returned_gems, spec_list + last_spec_list)
-      rescue HTTPError, MarshalError, GemspecError
+      rescue MarshalError
         Bundler.ui.info "" unless Bundler.ui.debug? # new line now that the dots are over
         Bundler.ui.debug "could not fetch from the dependency API, trying the full index"
+        nil
+      rescue HTTPError, GemspecError
+        Bundler.ui.info "" unless Bundler.ui.debug? # new line now that the dots are over
+        Bundler.ui.debug "could not fetch from the dependency API\nit's suggested to retry using the full index via `bundle install --full-index`"
         nil
       end
 


### PR DESCRIPTION
- Closes #4384

\cc @indirect Could use some review on this as to if the appropriate error message has been changed.