### PR TITLE
[EnvironmentPreserver] Fix restoring environment

### DIFF
--- a/lib/bundler/environment_preserver.rb
+++ b/lib/bundler/environment_preserver.rb
@@ -14,7 +14,10 @@ module Bundler
       env = @original.clone
       @keys.each do |key|
         value = env[key]
-        env[@prefix + key] = value unless value.nil? || value.empty?
+        original_value = env[@prefix + key]
+        if !value.nil? && !value.empty? && original_value.nil?
+          env[@prefix + key] = value
+        end
       end
       env
     end

--- a/lib/bundler/environment_preserver.rb
+++ b/lib/bundler/environment_preserver.rb
@@ -11,7 +11,7 @@ module Bundler
 
     # @return [Hash]
     def backup
-      env = restore.clone
+      env = @original.clone
       @keys.each do |key|
         value = env[key]
         env[@prefix + key] = value unless value.nil? || value.empty?

--- a/spec/bundler/environment_preserver_spec.rb
+++ b/spec/bundler/environment_preserver_spec.rb
@@ -32,6 +32,18 @@ describe Bundler::EnvironmentPreserver do
         expect(subject.key?("BUNDLE_ORIG_foo")).to eq(false)
       end
     end
+
+    context "when an original key is set" do
+      let(:env) { { "foo" => "my-foo", "BUNDLE_ORIG_foo" => "orig-foo" } }
+
+      it "should keep the original value in the BUNDLE_ORIG_ variable" do
+        expect(subject["BUNDLE_ORIG_foo"]).to eq("orig-foo")
+      end
+
+      it "should keep the variable" do
+        expect(subject["foo"]).to eq("my-foo")
+      end
+    end
   end
 
   describe "#restore" do


### PR DESCRIPTION
This allows a bundle exec after the path has been changed inside
a bundle exec'd program to access the changes

Fixes a regression in 1.12

\c @indirect @RochesterinNYC 