### PR TITLE
don't error on missing rubygem cred if custom host

### DIFF
--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -92,14 +92,14 @@ module Bundler
   protected
 
     def rubygem_push(path)
-      unless  Pathname.new("~/.gem/credentials").expand_path.file?
-        raise "Your rubygems.org credentials aren't set. Run `gem push` to set them."
-      end
       allowed_push_host = nil
       gem_command = "gem push '#{path}'"
       if @gemspec.respond_to?(:metadata)
         allowed_push_host = @gemspec.metadata["allowed_push_host"]
         gem_command += " --host #{allowed_push_host}" if allowed_push_host
+      end
+      unless allowed_push_host || Pathname.new("~/.gem/credentials").expand_path.file?
+        raise "Your rubygems.org credentials aren't set. Run `gem push` to set them."
       end
       sh(gem_command)
       Bundler.ui.confirm "Pushed #{name} #{version} to #{allowed_push_host ? allowed_push_host : "rubygems.org."}"


### PR DESCRIPTION
only raise error asking user to set rubygem credentials during gem push
if `allowed_push_host` is not set.

Fixes https://github.com/bundler/bundler/issues/4437

Apologies if this is a half baked PR.
- I looked around to add tests for this, but there is little test coverage over this area I simply wasn't sure how to add a test around this particular change.
- I also wasn't sure where to put this in the `CHANGELOG` as the latest entry there is already released.