### PR TITLE
before/after install hooks support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.12.0.rc.4 (2016-04-20)
+
+Features:
+  - Support for `before_install` and `after_install` hooks added.
+	
 ## 1.12.0.rc.3 (2016-04-19)
 
 Bugfixes:

--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -30,6 +30,7 @@ module Bundler
   autoload :GemHelper,              "bundler/gem_helper"
   autoload :GemHelpers,             "bundler/gem_helpers"
   autoload :Graph,                  "bundler/graph"
+  autoload :Hooks,                  "bundler/hooks"
   autoload :Index,                  "bundler/index"
   autoload :Installer,              "bundler/installer"
   autoload :Injector,               "bundler/injector"

--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -99,6 +99,8 @@ module Bundler
       definition = Bundler.definition
       definition.validate_ruby!
 
+      Bundler::Hooks.run(:before_install)
+
       Installer.install(Bundler.root, definition, options)
       Bundler.load.cache if Bundler.app_cache.exist? && !options["no-cache"] && !Bundler.settings[:frozen]
 
@@ -134,6 +136,9 @@ module Bundler
         require "bundler/cli/clean"
         Bundler::CLI::Clean.new(options).run
       end
+
+      Bundler::Hooks.run(:after_install)
+
     rescue GemNotFound, VersionConflict => e
       if options[:local] && Bundler.app_cache.exist?
         Bundler.ui.warn "Some gems seem to be missing from your #{Bundler.settings.app_cache_path} directory."

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -121,6 +121,14 @@ module Bundler
       @dependencies << dep
     end
 
+    def before_install(&blk)
+      Bundler::Hooks.register_hook(:before_install, blk)
+    end
+
+    def after_install(&blk)
+      Bundler::Hooks.register_hook(:after_install, blk)
+    end
+
     def source(source, &blk)
       source = normalize_source(source)
       if block_given?

--- a/lib/bundler/hooks.rb
+++ b/lib/bundler/hooks.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+module Bundler
+  class Hooks
+    @hooks = {}
+
+    class << self
+      # Run the hooks for the given hook name
+      def run(name)
+        Bundler.ui.info("Running '#{name}' hooks.") unless hooks_for(name).empty?
+
+        hooks_for(name).each(&:call)
+      end
+
+      # Register a block for the given hook_name
+      def register_hook(hook_name, block)
+        hooks_for(hook_name).each do |blk|
+          # Simple but effective proc compartion
+          return nil if blk.source_location == block.source_location
+        end
+        hooks_for(hook_name) << block
+      end
+
+    private
+
+      def hooks_for(hook_name)
+        @hooks[hook_name] ||= []
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Why:
Running a code block at specific moments of bundler activities like dependency installation is a feature which allows users to customize the their environment based on bundler and installed gems.

### What are the new features:
  * `after_install` method added to `Bundler` dsl
  * `before_install` method added to `Bundler` dsl

related to: https://github.com/bundler/bundler-features/issues/118