### PR TITLE
Fix `bundle outdated` with `--patch` and/or `--minor` for non-semantically versioned gems

### DIFF
--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -127,20 +127,25 @@ module Bundler
       update_present = active_major > current_major if options[:major]
 
       if !update_present && (options[:minor] || options[:patch]) && current_major == active_major
-        current_minor = current_spec.version.segments[1, 1].first
-        active_minor = active_spec.version.segments[1, 1].first
+        current_minor = get_version_semver_portion_value(current_spec, 1)
+        active_minor = get_version_semver_portion_value(active_spec, 1)
 
         update_present = active_minor > current_minor if options[:minor]
 
         if !update_present && options[:patch] && current_minor == active_minor
-          current_patch = current_spec.version.segments[2, 1].first
-          active_patch = active_spec.version.segments[2, 1].first
+          current_patch = get_version_semver_portion_value(current_spec, 2)
+          active_patch = get_version_semver_portion_value(active_spec, 2)
 
           update_present = active_patch > current_patch
         end
       end
 
       update_present
+    end
+
+    def get_version_semver_portion_value(spec, version_portion_index)
+      version_section = spec.version.segments[version_portion_index, 1]
+      version_section.nil? ? 0 : (version_section.first || 0)
     end
   end
 end

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -14,6 +14,8 @@ describe "bundle outdated" do
       gem "foo", :git => "#{lib_path("foo")}"
       gem "activesupport", "2.3.5"
       gem "weakling", "~> 0.0.1"
+      gem "duradura", '7.0'
+      gem "terranova", '8'
     G
   end
 
@@ -244,7 +246,9 @@ describe "bundle outdated" do
   shared_examples_for "version update is detected" do
     it "reports that a gem has a newer version" do
       subject
+      expect(out).to include("Outdated gems included in the bundle:")
       expect(out).to include("activesupport (newest")
+      expect(out).to_not include("ERROR REPORT TEMPLATE")
     end
   end
 
@@ -284,6 +288,8 @@ describe "bundle outdated" do
   shared_examples_for "no version updates are detected" do
     it "does not detect any version updates" do
       subject
+      expect(out).to include("Bundle up to date!")
+      expect(out).to_not include("ERROR REPORT TEMPLATE")
       expect(out).to_not include("activesupport (newest")
       expect(out).to_not include("weakling (newest")
     end

--- a/spec/support/builders.rb
+++ b/spec/support/builders.rb
@@ -122,6 +122,10 @@ module Spec
 
         build_gem "weakling", "0.0.3"
 
+        build_gem "terranova", "8"
+
+        build_gem "duradura", "7.0"
+
         build_gem "multiple_versioned_deps" do |s|
           s.add_dependency "weakling", ">= 0.0.1", "< 0.1"
         end


### PR DESCRIPTION
- Examples of non-semantic versions: "7.0", "8", [`gitlab_meta` versioning](https://rubygems.org/gems/gitlab_meta/versions/7.0)
- Closes #4438