### PR TITLE
do not log the credentials used to contact a gem server

### DIFF
--- a/lib/bundler/errors.rb
+++ b/lib/bundler/errors.rb
@@ -30,7 +30,12 @@ module Bundler
   class GemspecError < BundlerError; status_code(14); end
   class InvalidOption < BundlerError; status_code(15); end
   class ProductionError < BundlerError; status_code(16); end
-  class HTTPError < BundlerError; status_code(17); end
+  class HTTPError < BundlerError
+    status_code(17)
+    def filter_uri(uri)
+      URICredentialsFilter.credential_filtered_uri(uri)
+    end
+  end
   class RubyVersionMismatch < BundlerError; status_code(18); end
   class SecurityError < BundlerError; status_code(19); end
   class LockfileError < BundlerError; status_code(20); end

--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -19,6 +19,7 @@ module Bundler
     # This is the error raised if OpenSSL fails the cert verification
     class CertificateFailureError < HTTPError
       def initialize(remote_uri)
+        remote_uri = filter_uri(remote_uri)
         super "Could not verify the SSL certificate for #{remote_uri}.\nThere" \
           " is a chance you are experiencing a man-in-the-middle attack, but" \
           " most likely your system doesn't have the CA certificates needed" \
@@ -39,6 +40,7 @@ module Bundler
     # This error is raised if HTTP authentication is required, but not provided.
     class AuthenticationRequiredError < HTTPError
       def initialize(remote_uri)
+        remote_uri = filter_uri(remote_uri)
         super "Authentication is required for #{remote_uri}.\n" \
           "Please supply credentials for this source. You can do this by running:\n" \
           " bundle config #{remote_uri} username:password"
@@ -47,6 +49,7 @@ module Bundler
     # This error is raised if HTTP authentication is provided, but incorrect.
     class BadAuthenticationError < HTTPError
       def initialize(remote_uri)
+        remote_uri = filter_uri(remote_uri)
         super "Bad username or password for #{remote_uri}.\n" \
           "Please double-check your credentials and correct them."
       end

--- a/lib/bundler/fetcher/downloader.rb
+++ b/lib/bundler/fetcher/downloader.rb
@@ -58,7 +58,7 @@ module Bundler
           raise NetworkDownError, "Could not reach host #{uri.host}. Check your network " \
           "connection and try again."
         else
-          raise HTTPError, "Network error while fetching #{uri}"
+          raise HTTPError, "Network error while fetching #{URICredentialsFilter.credential_filtered_uri(uri)}"
         end
       end
     end

--- a/spec/bundler/fetcher/downloader_spec.rb
+++ b/spec/bundler/fetcher/downloader_spec.rb
@@ -224,6 +224,18 @@ describe Bundler::Fetcher::Downloader do
           expect { subject.request(uri, options) }.to raise_error(Bundler::HTTPError,
             "Network error while fetching http://www.uri-to-fetch.com/api/v2/endpoint")
         end
+
+        context "when the there are credentials provided in the request" do
+          let(:uri) { URI("http://username:password@www.uri-to-fetch.com/api/v2/endpoint") }
+          before do
+            allow(net_http_get).to receive(:basic_auth).with("username", "password")
+          end
+
+          it "should raise a Bundler::HTTPError that doesn't contain the password" do
+            expect { subject.request(uri, options) }.to raise_error(Bundler::HTTPError,
+              "Network error while fetching http://username@www.uri-to-fetch.com/api/v2/endpoint")
+          end
+        end
       end
 
       context "when error message is about no route to host" do

--- a/spec/bundler/fetcher/index_spec.rb
+++ b/spec/bundler/fetcher/index_spec.rb
@@ -19,6 +19,11 @@ describe Bundler::Fetcher::Index do
 
   context "error handling" do
     shared_examples_for "the error is properly handled" do
+      let(:remote_uri) { URI("http://remote-uri.org") }
+      before do
+        allow(subject).to receive(:remote_uri).and_return(remote_uri)
+      end
+
       context "when certificate verify failed" do
         let(:error_message) { "certificate verify failed" }
 
@@ -30,25 +35,18 @@ describe Bundler::Fetcher::Index do
 
       context "when a 401 response occurs" do
         let(:error_message) { "401" }
-        let(:remote_uri) { double(:remote_uri, :to_s => "http://remote_uri.org") }
-
-        before { allow(subject).to receive(:remote_uri).and_return(remote_uri) }
 
         it "should raise a Bundler::Fetcher::AuthenticationRequiredError" do
           expect { subject.specs(gem_names) }.to raise_error(Bundler::Fetcher::AuthenticationRequiredError,
-            %r{Authentication is required for http://remote_uri.org})
+            %r{Authentication is required for http://remote-uri.org})
         end
       end
 
       context "when a 403 response occurs" do
-        let(:error_message)     { "403" }
-        let(:remote_uri)        { double(:remote_uri) }
-        let(:remote_uri_string) { "http://remote_uri.org" }
+        let(:error_message) { "403" }
 
         before do
-          allow(subject).to receive(:remote_uri).and_return(remote_uri)
           allow(remote_uri).to receive(:userinfo).and_return(userinfo)
-          allow(remote_uri).to receive(:to_s).and_return(remote_uri_string)
         end
 
         context "and there was userinfo" do
@@ -56,7 +54,7 @@ describe Bundler::Fetcher::Index do
 
           it "should raise a Bundler::Fetcher::BadAuthenticationError" do
             expect { subject.specs(gem_names) }.to raise_error(Bundler::Fetcher::BadAuthenticationError,
-              %r{Bad username or password for http://remote_uri.org})
+              %r{Bad username or password for http://remote-uri.org})
           end
         end
 
@@ -65,7 +63,7 @@ describe Bundler::Fetcher::Index do
 
           it "should raise a Bundler::Fetcher::AuthenticationRequiredError" do
             expect { subject.specs(gem_names) }.to raise_error(Bundler::Fetcher::AuthenticationRequiredError,
-              %r{Authentication is required for http://remote_uri.org})
+              %r{Authentication is required for http://remote-uri.org})
           end
         end
       end


### PR DESCRIPTION
Currently a network error results in the credentials being output in deploy logs, for example.

Not sure if there is a better approach or this needs to be changed in more locations.