### PR TITLE
Only show potential updates on same platform for `bundle outdated`

### DIFF
--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -50,11 +50,11 @@ module Bundler
         if options["strict"]
           active_spec = definition.specs.detect {|spec| spec.name == current_spec.name }
         else
-          active_spec = definition.index[current_spec.name].sort_by(&:version)
-          if !current_spec.version.prerelease? && !options[:pre] && active_spec.size > 1
-            active_spec = active_spec.delete_if {|b| b.respond_to?(:version) && b.version.prerelease? }
+          active_specs = definition.index[current_spec.name].sort_by(&:version)
+          if !current_spec.version.prerelease? && !options[:pre] && active_specs.size > 1
+            active_spec = active_specs.delete_if {|b| b.respond_to?(:version) && b.version.prerelease? }
           end
-          active_spec = active_spec.last
+          active_spec = active_specs.last
 
           if options[:major] || options[:minor] || options[:patch]
             update_present = update_present_via_semver_portions(current_spec, active_spec, options)

--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -48,9 +48,9 @@ module Bundler
         dependency = current_dependencies[current_spec.name]
 
         if options["strict"]
-          active_spec = definition.specs.detect {|spec| spec.name == current_spec.name }
+          active_spec = definition.specs.detect {|spec| spec.name == current_spec.name && spec.platform == current_spec.platform }
         else
-          active_specs = definition.index[current_spec.name].sort_by(&:version)
+          active_specs = definition.index[current_spec.name].select {|spec| spec.platform == current_spec.platform }.sort_by(&:version)
           if !current_spec.version.prerelease? && !options[:pre] && active_specs.size > 1
             active_spec = active_specs.delete_if {|b| b.respond_to?(:version) && b.version.prerelease? }
           end

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -243,6 +243,20 @@ describe "bundle outdated" do
     end
   end
 
+  context "update available for a gem on a different platform" do
+    before do
+      install_gemfile <<-G
+        source "file://#{gem_repo2}"
+        gem "laduradura", '= 5.15.2'
+      G
+    end
+
+    it "reports that no updates are available" do
+      bundle "outdated"
+      expect(out).to include("Bundle up to date!")
+    end
+  end
+
   shared_examples_for "version update is detected" do
     it "reports that a gem has a newer version" do
       subject

--- a/spec/support/builders.rb
+++ b/spec/support/builders.rb
@@ -120,6 +120,16 @@ module Spec
           s.add_dependency "weakling", ">= 0.0.3"
         end
 
+        build_gem "laduradura", "5.15.2"
+        build_gem "laduradura", "5.15.2" do |s|
+          s.platform = "java"
+          s.write "lib/laduradura.rb", "LADURADURA = '5.15.2 JAVA'"
+        end
+        build_gem "laduradura", "5.15.3" do |s|
+          s.platform = "java"
+          s.write "lib/laduradura.rb", "LADURADURA = '5.15.2 JAVA'"
+        end
+
         build_gem "weakling", "0.0.3"
 
         build_gem "terranova", "8"


### PR DESCRIPTION
This fixes the following behavior:

Say you're using a gem `laduradura` on platform `java` with version `v1.0.1`. The latest `java` platform version of this gem is `v1.0.1` but the latest `ruby` platform version of this gem is `v1.0.2`. Running `bundle outdated` will currently tell you that you can update `laduradura` to `v1.0.2`.

This is a bad user experience as the user is given the suggestion to update `laduradura` to `v1.0.2`, despite this version being on a completely different platform than the one that the user is currently using `laduradura` on.

With this PR, `bundle outdated` will only report potential version updates to gems for the same platforms those gems are being used on.

- Fixes #4450