### PR TITLE
use double quotes in the newgem spec templates

### DIFF
--- a/lib/bundler/templates/newgem/spec/newgem_spec.rb.tt
+++ b/lib/bundler/templates/newgem/spec/newgem_spec.rb.tt
@@ -1,11 +1,11 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe <%= config[:constant_name] %> do
-  it 'has a version number' do
+  it "has a version number" do
     expect(<%= config[:constant_name] %>::VERSION).not_to be nil
   end
 
-  it 'does something useful' do
+  it "does something useful" do
     expect(false).to eq(true)
   end
 end

--- a/lib/bundler/templates/newgem/spec/spec_helper.rb.tt
+++ b/lib/bundler/templates/newgem/spec/spec_helper.rb.tt
@@ -1,2 +1,2 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-require '<%= config[:namespaced_path] %>'
+$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
+require "<%= config[:namespaced_path] %>"

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -322,7 +322,7 @@ describe "bundle gem" do
       end
 
       it "requires 'test-gem'" do
-        expect(bundled_app("test_gem/spec/spec_helper.rb").read).to include("require 'test_gem'")
+        expect(bundled_app("test_gem/spec/spec_helper.rb").read).to include(%{require "test_gem"})
       end
 
       it "creates a default test which fails" do
@@ -585,7 +585,7 @@ describe "bundle gem" do
       end
 
       it "requires 'test/gem'" do
-        expect(bundled_app("test-gem/spec/spec_helper.rb").read).to include("require 'test/gem'")
+        expect(bundled_app("test-gem/spec/spec_helper.rb").read).to include(%{require "test/gem"})
       end
 
       it "creates a default test which fails" do

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -322,7 +322,7 @@ describe "bundle gem" do
       end
 
       it "requires 'test-gem'" do
-        expect(bundled_app("test_gem/spec/spec_helper.rb").read).to include(%{require "test_gem"})
+        expect(bundled_app("test_gem/spec/spec_helper.rb").read).to include(%(require "test_gem"))
       end
 
       it "creates a default test which fails" do
@@ -585,7 +585,7 @@ describe "bundle gem" do
       end
 
       it "requires 'test/gem'" do
-        expect(bundled_app("test-gem/spec/spec_helper.rb").read).to include(%{require "test/gem"})
+        expect(bundled_app("test-gem/spec/spec_helper.rb").read).to include(%(require "test/gem"))
       end
 
       it "creates a default test which fails" do


### PR DESCRIPTION
I just noticed this when generating a new gem, and I thought it would nice to be consistent across the templates.