### PR TITLE
Cleans up unused Runtime#dependencies_for method

### DIFF
--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -109,14 +109,6 @@ module Bundler
       end
     end
 
-    def dependencies_for(*groups)
-      if groups.empty?
-        dependencies
-      else
-        dependencies.select {|d| (groups & d.groups).any? }
-      end
-    end
-
     alias_method :gems, :specs
 
     def cache(custom_path = nil)


### PR DESCRIPTION
Hi!

I was checking out things in the code and couldn't find any existent usage of this method. I might be missing something but opening the PR just in case.

The method seems to be publicly accessible if someone goes `Bundler.load.dependencies_for(...)` e.g., but i am assuming that's not something "officially supported" anyways?