### PR TITLE
Improve readability of outdated

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -407,7 +407,6 @@ module Bundler
       "Use minimal formatting for more parseable output"
     method_option "only-explicit", :type => :boolean, :banner =>
       "Only list gems specified in your Gemfile, not their dependencies"
-    method_option "pretty", :type => :boolean, :banner => "Use pretty formatting"
     def outdated(*gems)
       require_relative "cli/outdated"
       Outdated.new(options, gems).run

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -407,6 +407,7 @@ module Bundler
       "Use minimal formatting for more parseable output"
     method_option "only-explicit", :type => :boolean, :banner =>
       "Only list gems specified in your Gemfile, not their dependencies"
+    method_option "pretty", :type => :boolean, :banner => "Use pretty formatting"
     def outdated(*gems)
       require_relative "cli/outdated"
       Outdated.new(options, gems).run

--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -98,10 +98,6 @@ module Bundler
       if outdated_gems.empty?
         display_nothing_outdated_message
       else
-        unless options[:parseable]
-          Bundler.ui.info(header_outdated_message)
-        end
-
         if options_include_groups
           outdated_gems.group_by {|g| g[:groups] }.sort.each do |groups, gems|
             contains_group = groups.split(", ").include?(options[:group])
@@ -137,14 +133,6 @@ module Bundler
 
     def groups_text(group_text, groups)
       "#{group_text}#{groups.split(",").size > 1 ? "s" : ""} \"#{groups}\""
-    end
-
-    def header_outdated_message
-      if options[:pre]
-        "Outdated gems included in the bundle (including pre-releases):"
-      else
-        "Outdated gems included in the bundle:"
-      end
     end
 
     def header_group_message(groups)

--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -282,7 +282,7 @@ module Bundler
           element.to_s.ljust(column_sizes[index])
         end
 
-        Bundler.ui.info row.join(" ") + "\n"
+        Bundler.ui.info row.join("  ") + "\n"
       end
     end
 

--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -87,10 +87,12 @@ module Bundler
           groups = dependency.groups.join(", ")
         end
 
-        outdated_gems_list << { :active_spec => active_spec,
-                                :current_spec => current_spec,
-                                :dependency => dependency,
-                                :groups => groups }
+        outdated_gems_list << {
+          :active_spec => active_spec,
+          :current_spec => current_spec,
+          :dependency => dependency,
+          :groups => groups,
+        }
       end
 
       if outdated_gems_list.empty?

--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -279,7 +279,7 @@ module Bundler
     end
 
     def table_header
-      header = ["Gem", "Locked", "Latest", "Requested", "Groups"]
+      header = ["Gem", "Current", "Latest", "Requested", "Groups"]
       header << "Path" if Bundler.ui.debug?
       header
     end

--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -265,12 +265,15 @@ module Bundler
       version_section.to_a[0].to_i
     end
 
-    def print_indented(data)
-      columns = data.first.size
+    def print_indented(matrix)
+      header = matrix[0]
+      data = matrix[1..-1]
 
-      column_sizes = Array.new(columns) do |index|
-        data.max_by {|row| row[index].length }[index].length
+      column_sizes = Array.new(header.size) do |index|
+        matrix.max_by {|row| row[index].length }[index].length
       end
+
+      Bundler.ui.info justify(header, column_sizes)
 
       data.sort_by! {|row| row[0] }
 

--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -96,7 +96,9 @@ module Bundler
       end
 
       if outdated_gems.empty?
-        display_nothing_outdated_message
+        unless options[:parseable]
+          Bundler.ui.info(nothing_outdated_message)
+        end
       else
         if options_include_groups
           relevant_outdated_gems = outdated_gems.group_by {|g| g[:groups] }.sort.flat_map do |groups, gems|
@@ -153,12 +155,6 @@ module Bundler
       end
 
       active_spec
-    end
-
-    def display_nothing_outdated_message
-      unless options[:parseable]
-        Bundler.ui.info(nothing_outdated_message)
-      end
     end
 
     def print_gems(gems_list)

--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -210,7 +210,7 @@ module Bundler
       dependency = dependency.requirement if dependency
 
       ret_val = [active_spec.name, current_version, spec_version, dependency.to_s, groups.to_s]
-      ret_val << active_spec.loaded_from.to_s if options[:verbose]
+      ret_val << active_spec.loaded_from.to_s if Bundler.ui.debug?
       ret_val
     end
 
@@ -280,7 +280,7 @@ module Bundler
 
     def table_header
       header = ["Gem", "Locked", "Latest", "Requested", "Groups"]
-      header << "Path" if options[:verbose]
+      header << "Path" if Bundler.ui.debug?
       header
     end
 

--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -266,11 +266,7 @@ module Bundler
       data.sort_by! {|row| row[0] }
 
       data.each do |row|
-        row = row.each_with_index.map do |element, index|
-          element.ljust(column_sizes[index])
-        end
-
-        Bundler.ui.info row.join("  ") + "\n"
+        Bundler.ui.info justify(row, column_sizes)
       end
     end
 
@@ -278,6 +274,12 @@ module Bundler
       header = ["Gem", "Locked", "Latest", "Requested", "Groups"]
       header << "Path" if options[:verbose]
       header
+    end
+
+    def justify(row, sizes)
+      row.each_with_index.map do |element, index|
+        element.ljust(sizes[index])
+      end.join("  ") + "\n"
     end
   end
 end

--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -276,7 +276,7 @@ module Bundler
 
     def table_header
       header = ["Gem", "Installed", "Latest", "Requested", "Groups"]
-      header << "Load Path" if options[:verbose]
+      header << "Path" if options[:verbose]
       header
     end
   end

--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -275,7 +275,7 @@ module Bundler
     end
 
     def table_header
-      header = ["Gem", "Installed", "Latest", "Requested", "Groups"]
+      header = ["Gem", "Locked", "Latest", "Requested", "Groups"]
       header << "Path" if options[:verbose]
       header
     end

--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -287,7 +287,7 @@ module Bundler
     end
 
     def table_header
-      header = ["Gem", "Installed", "New", "Requested", "Groups"]
+      header = ["Gem", "Installed", "Latest", "Requested", "Groups"]
       header << "Load Path" if options[:verbose]
       header
     end

--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -287,7 +287,7 @@ module Bundler
     end
 
     def table_header
-      header = ["Gem Name", "Installed", "New", "Requested", "Groups"]
+      header = ["Gem", "Installed", "New", "Requested", "Groups"]
       header << "Load Path" if options[:verbose]
       header
     end

--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -279,7 +279,7 @@ module Bundler
     def justify(row, sizes)
       row.each_with_index.map do |element, index|
         element.ljust(sizes[index])
-      end.join("  ") + "\n"
+      end.join("  ").strip + "\n"
     end
   end
 end

--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -3,7 +3,7 @@
 module Bundler
   class CLI::Outdated
     attr_reader :options, :gems, :options_include_groups, :filter_options_patch, :sources, :strict
-    attr_accessor :outdated_gems_list
+    attr_accessor :outdated_gems
 
     def initialize(options, gems)
       @options = options
@@ -12,7 +12,7 @@ module Bundler
 
       @filter_options_patch = options.keys & %w[filter-major filter-minor filter-patch]
 
-      @outdated_gems_list = []
+      @outdated_gems = []
 
       @options_include_groups = [:group, :groups].any? do |v|
         options.keys.include?(v.to_s)
@@ -87,7 +87,7 @@ module Bundler
           groups = dependency.groups.join(", ")
         end
 
-        outdated_gems_list << {
+        outdated_gems << {
           :active_spec => active_spec,
           :current_spec => current_spec,
           :dependency => dependency,
@@ -95,7 +95,7 @@ module Bundler
         }
       end
 
-      if outdated_gems_list.empty?
+      if outdated_gems.empty?
         display_nothing_outdated_message
       else
         unless options[:parseable]
@@ -103,7 +103,7 @@ module Bundler
         end
 
         if options_include_groups
-          outdated_gems_list.group_by {|g| g[:groups] }.sort.each do |groups, gems|
+          outdated_gems.group_by {|g| g[:groups] }.sort.each do |groups, gems|
             contains_group = groups.split(", ").include?(options[:group])
             next unless options[:groups] || contains_group
 
@@ -114,7 +114,7 @@ module Bundler
             print_gems(gems)
           end
         elsif options[:pretty]
-          outdated_gems_list.map! do |gem|
+          outdated_gems.map! do |gem|
             current_version = "#{gem[:current_spec].version}#{gem[:current_spec].git_version}"
             spec_version = "#{gem[:active_spec].version}#{gem[:active_spec].git_version}"
             dependency = gem[:dependency].requirement if gem[:dependency] && gem[:dependency].specific?
@@ -124,9 +124,9 @@ module Bundler
             ret_val
           end
 
-          print_indented table_header, *outdated_gems_list
+          print_indented table_header, *outdated_gems
         else
-          print_gems(outdated_gems_list)
+          print_gems(outdated_gems)
         end
 
         exit 1

--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -116,7 +116,7 @@ module Bundler
             dependency = gem[:dependency].requirement if gem[:dependency] && gem[:dependency].specific?
 
             ret_val = [gem[:active_spec].name, current_version, spec_version, dependency.to_s, gem[:groups].to_s]
-            ret_val << gem[:active_spec].loaded_from if options[:verbose]
+            ret_val << gem[:active_spec].loaded_from.to_s if options[:verbose]
             ret_val
           end
 
@@ -260,14 +260,14 @@ module Bundler
       columns = data.first.size
 
       column_sizes = Array.new(columns) do |index|
-        data.max_by {|row| row[index].to_s.length }[index].length
+        data.max_by {|row| row[index].length }[index].length
       end
 
       data.sort_by! {|row| row[0] }
 
       data.each do |row|
         row = row.each_with_index.map do |element, index|
-          element.to_s.ljust(column_sizes[index])
+          element.ljust(column_sizes[index])
         end
 
         Bundler.ui.info row.join("  ") + "\n"

--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -112,9 +112,6 @@ module Bundler
             print_gems(gems)
           end
         elsif options[:pretty]
-          header = ["Gem Name", "Installed", "New", "Requested", "Groups"]
-          header << "Load Path" if options[:verbose]
-
           outdated_gems_list.map! do |gem|
             current_version = "#{gem[:current_spec].version}#{gem[:current_spec].git_version}"
             spec_version = "#{gem[:active_spec].version}#{gem[:active_spec].git_version}"
@@ -125,7 +122,7 @@ module Bundler
             ret_val
           end
 
-          print_indented header, *outdated_gems_list
+          print_indented table_header, *outdated_gems_list
         else
           print_gems(outdated_gems_list)
         end
@@ -285,6 +282,12 @@ module Bundler
 
         Bundler.ui.info row.join(" ") + "\n"
       end
+    end
+
+    def table_header
+      header = ["Gem Name", "Installed", "New", "Requested", "Groups"]
+      header << "Load Path" if options[:verbose]
+      header
     end
   end
 end

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "bundle outdated" do
       bundle "outdated"
 
       expected_output = <<~TABLE.gsub("x", "\\\h").tr(".", "\.").strip
-        Gem            Locked       Latest       Requested  Groups
+        Gem            Current      Latest       Requested  Groups
         activesupport  2.3.5        3.0          = 2.3.5    default
         foo            1.0 xxxxxxx  1.0 xxxxxxx  >= 0       default
         weakling       0.0.3        0.2          ~> 0.0.1   default
@@ -53,8 +53,8 @@ RSpec.describe "bundle outdated" do
       bundle "outdated"
 
       expected_output = <<~TABLE
-        Gem  Locked  Latest  Requested  Groups
-        AAA  1.0.0   2.0.0   = 1.0.0    default
+        Gem  Current  Latest  Requested  Groups
+        AAA  1.0.0    2.0.0   = 1.0.0    default
       TABLE
 
       expect(out).to include(expected_output.strip)
@@ -94,9 +94,9 @@ RSpec.describe "bundle outdated" do
       bundle "outdated"
 
       expected_output = <<~TABLE.strip
-        Gem            Locked  Latest  Requested  Groups
-        activesupport  2.3.5   3.0     = 2.3.5    development, test
-        terranova      8       9       = 8        default
+        Gem            Current  Latest  Requested  Groups
+        activesupport  2.3.5    3.0     = 2.3.5    development, test
+        terranova      8        9       = 8        default
       TABLE
 
       expect(out).to end_with(expected_output)
@@ -127,9 +127,9 @@ RSpec.describe "bundle outdated" do
       bundle "outdated --verbose"
 
       expected_output = <<~TABLE.strip
-        Gem            Locked  Latest  Requested  Groups   Path
-        activesupport  2.3.5   3.0     = 2.3.5    default
-        terranova      8       9       = 8        default  #{default_bundle_path("specifications/terranova-9.gemspec")}
+        Gem            Current  Latest  Requested  Groups   Path
+        activesupport  2.3.5    3.0     = 2.3.5    default
+        terranova      8        9       = 8        default  #{default_bundle_path("specifications/terranova-9.gemspec")}
       TABLE
 
       expect(out).to end_with(expected_output)
@@ -169,8 +169,8 @@ RSpec.describe "bundle outdated" do
       test_group_option("default")
 
       expected_output = <<~TABLE.strip
-        Gem        Locked  Latest  Requested  Groups
-        terranova  8       9       = 8        default
+        Gem        Current  Latest  Requested  Groups
+        terranova  8        9       = 8        default
       TABLE
 
       expect(out).to end_with(expected_output)
@@ -180,9 +180,9 @@ RSpec.describe "bundle outdated" do
       test_group_option("development")
 
       expected_output = <<~TABLE.strip
-        Gem            Locked  Latest  Requested  Groups
-        activesupport  2.3.5   3.0     = 2.3.5    development, test
-        duradura       7.0     8.0     = 7.0      development, test
+        Gem            Current  Latest  Requested  Groups
+        activesupport  2.3.5    3.0     = 2.3.5    development, test
+        duradura       7.0      8.0     = 7.0      development, test
       TABLE
 
       expect(out).to end_with(expected_output)
@@ -192,9 +192,9 @@ RSpec.describe "bundle outdated" do
       test_group_option("test")
 
       expected_output = <<~TABLE.strip
-        Gem            Locked  Latest  Requested  Groups
-        activesupport  2.3.5   3.0     = 2.3.5    development, test
-        duradura       7.0     8.0     = 7.0      development, test
+        Gem            Current  Latest  Requested  Groups
+        activesupport  2.3.5    3.0     = 2.3.5    development, test
+        duradura       7.0      8.0     = 7.0      development, test
       TABLE
 
       expect(out).to end_with(expected_output)
@@ -226,8 +226,8 @@ RSpec.describe "bundle outdated" do
       bundle "outdated --groups"
 
       expected_output = <<~TABLE.strip
-        Gem  Locked  Latest  Requested  Groups
-        bar  2.0.0   3.0.0
+        Gem  Current  Latest  Requested  Groups
+        bar  2.0.0    3.0.0
       TABLE
 
       expect(out).to end_with(expected_output)
@@ -263,10 +263,10 @@ RSpec.describe "bundle outdated" do
       bundle "outdated --groups"
 
       expected_output = <<~TABLE.strip
-        Gem            Locked  Latest  Requested  Groups
-        activesupport  2.3.5   3.0     = 2.3.5    development, test
-        duradura       7.0     8.0     = 7.0      development, test
-        terranova      8       9       = 8        default
+        Gem            Current  Latest  Requested  Groups
+        activesupport  2.3.5    3.0     = 2.3.5    development, test
+        duradura       7.0      8.0     = 7.0      development, test
+        terranova      8        9       = 8        default
       TABLE
 
       expect(out).to end_with(expected_output)
@@ -289,8 +289,8 @@ RSpec.describe "bundle outdated" do
       bundle "outdated --local"
 
       expected_output = <<~TABLE.strip
-        Gem            Locked  Latest  Requested  Groups
-        activesupport  2.3.4   2.3.5   = 2.3.4    default
+        Gem            Current  Latest  Requested  Groups
+        activesupport  2.3.4    2.3.5   = 2.3.4    default
       TABLE
 
       expect(out).to end_with(expected_output)
@@ -351,7 +351,7 @@ RSpec.describe "bundle outdated" do
       bundle "outdated foo"
 
       expected_output = <<~TABLE.gsub("x", "\\\h").tr(".", "\.").strip
-        Gem  Locked       Latest       Requested  Groups
+        Gem  Current      Latest       Requested  Groups
         foo  1.0 xxxxxxx  1.0 xxxxxxx  >= 0       default
       TABLE
 
@@ -381,8 +381,8 @@ RSpec.describe "bundle outdated" do
         bundle "outdated --pre"
 
         expected_output = <<~TABLE.strip
-          Gem            Locked  Latest      Requested  Groups
-          activesupport  2.3.5   3.0.0.beta  = 2.3.5    default
+          Gem            Current  Latest      Requested  Groups
+          activesupport  2.3.5    3.0.0.beta  = 2.3.5    default
         TABLE
 
         expect(out).to end_with(expected_output)
@@ -404,7 +404,7 @@ RSpec.describe "bundle outdated" do
         bundle "outdated"
 
         expected_output = <<~TABLE.strip
-          Gem            Locked        Latest        Requested       Groups
+          Gem            Current       Latest        Requested       Groups
           activesupport  3.0.0.beta.1  3.0.0.beta.2  = 3.0.0.beta.1  default
         TABLE
 
@@ -424,8 +424,8 @@ RSpec.describe "bundle outdated" do
       bundle :outdated, filter_strict_option => true
 
       expected_output = <<~TABLE.strip
-        Gem       Locked  Latest  Requested  Groups
-        weakling  0.0.3   0.0.5   ~> 0.0.1   default
+        Gem       Current  Latest  Requested  Groups
+        weakling  0.0.3    0.0.5   ~> 0.0.1   default
       TABLE
 
       expect(out).to end_with(expected_output)
@@ -458,8 +458,8 @@ RSpec.describe "bundle outdated" do
         bundle :outdated, filter_strict_option => true, "filter-patch" => true
 
         expected_output = <<~TABLE.strip
-          Gem       Locked  Latest  Requested  Groups
-          weakling  0.0.3   0.0.5   >= 0.0.1   default
+          Gem       Current  Latest  Requested  Groups
+          weakling  0.0.3    0.0.5   >= 0.0.1   default
         TABLE
 
         expect(out).to end_with(expected_output)
@@ -480,8 +480,8 @@ RSpec.describe "bundle outdated" do
         bundle :outdated, filter_strict_option => true, "filter-minor" => true
 
         expected_output = <<~TABLE.strip
-          Gem       Locked  Latest  Requested  Groups
-          weakling  0.0.3   0.1.5   >= 0.0.1   default
+          Gem       Current  Latest  Requested  Groups
+          weakling  0.0.3    0.1.5   >= 0.0.1   default
         TABLE
 
         expect(out).to end_with(expected_output)
@@ -502,8 +502,8 @@ RSpec.describe "bundle outdated" do
         bundle :outdated, filter_strict_option => true, "filter-major" => true
 
         expected_output = <<~TABLE.strip
-          Gem       Locked  Latest  Requested  Groups
-          weakling  0.0.3   1.1.5   >= 0.0.1   default
+          Gem       Current  Latest  Requested  Groups
+          weakling  0.0.3    1.1.5   >= 0.0.1   default
         TABLE
 
         expect(out).to end_with(expected_output)
@@ -616,8 +616,8 @@ RSpec.describe "bundle outdated" do
           bundle "outdated"
 
           expected_output = <<~TABLE.strip
-            Gem         Locked  Latest  Requested  Groups
-            laduradura  5.15.2  5.15.3  = 5.15.2   default
+            Gem         Current  Latest  Requested  Groups
+            laduradura  5.15.2   5.15.3  = 5.15.2   default
           TABLE
 
           expect(out).to end_with(expected_output)
@@ -817,10 +817,10 @@ RSpec.describe "bundle outdated" do
         bundle "outdated --patch --filter-patch"
 
         expected_output = <<~TABLE.strip
-          Gem    Locked  Latest  Requested  Groups
-          major  1.0.0   1.0.1   >= 0       default
-          minor  1.0.0   1.0.1   >= 0       default
-          patch  1.0.0   1.0.1   >= 0       default
+          Gem    Current  Latest  Requested  Groups
+          major  1.0.0    1.0.1   >= 0       default
+          minor  1.0.0    1.0.1   >= 0       default
+          patch  1.0.0    1.0.1   >= 0       default
         TABLE
 
         expect(out).to end_with(expected_output)
@@ -830,9 +830,9 @@ RSpec.describe "bundle outdated" do
         bundle "outdated --minor --filter-minor"
 
         expected_output = <<~TABLE.strip
-          Gem    Locked  Latest  Requested  Groups
-          major  1.0.0   1.1.0   >= 0       default
-          minor  1.0.0   1.1.0   >= 0       default
+          Gem    Current  Latest  Requested  Groups
+          major  1.0.0    1.1.0   >= 0       default
+          minor  1.0.0    1.1.0   >= 0       default
         TABLE
 
         expect(out).to end_with(expected_output)
@@ -884,9 +884,9 @@ RSpec.describe "bundle outdated" do
         bundle "outdated --patch --update-strict --filter-patch"
 
         expected_output = <<~TABLE.strip
-          Gem  Locked  Latest  Requested  Groups
-          bar  2.0.3   2.0.5
-          foo  1.4.3   1.4.4   >= 0       default
+          Gem  Current  Latest  Requested  Groups
+          bar  2.0.3    2.0.5
+          foo  1.4.3    1.4.4   >= 0       default
         TABLE
 
         expect(out).to end_with(expected_output)
@@ -917,8 +917,8 @@ RSpec.describe "bundle outdated" do
       bundle "outdated --only-explicit"
 
       expected_output = <<~TABLE.strip
-        Gem       Locked  Latest  Requested  Groups
-        weakling  0.2     0.3     >= 0       default
+        Gem       Current  Latest  Requested  Groups
+        weakling  0.2      0.3     >= 0       default
       TABLE
 
       expect(out).to end_with(expected_output)

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -91,12 +91,45 @@ RSpec.describe "bundle outdated" do
       update_repo2 { build_gem "activesupport", "3.0" }
       update_repo2 { build_gem "terranova", "9" }
 
+      bundle "outdated"
+
+      expected_output = <<~TABLE.strip
+        Gem            Locked  Latest  Requested  Groups
+        activesupport  2.3.5   3.0     = 2.3.5    development, test
+        terranova      8       9       = 8        default
+      TABLE
+
+      expect(out).to end_with(expected_output)
+    end
+  end
+
+  describe "with --verbose option" do
+    it "shows the location of the latest version's gemspec if installed" do
+      bundle! "config set clean false"
+
+      update_repo2 { build_gem "activesupport", "3.0" }
+      update_repo2 { build_gem "terranova", "9" }
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+
+        gem "terranova", '9'
+        gem 'activesupport', '2.3.5'
+      G
+
+      gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+
+        gem "terranova", '8'
+        gem 'activesupport', '2.3.5'
+      G
+
       bundle "outdated --verbose"
 
       expected_output = <<~TABLE.strip
-        Gem            Locked  Latest  Requested  Groups             Path
-        activesupport  2.3.5   3.0     = 2.3.5    development, test
-        terranova      8       9       = 8        default
+        Gem            Locked  Latest  Requested  Groups   Path
+        activesupport  2.3.5   3.0     = 2.3.5    default
+        terranova      8       9       = 8        default  #{default_bundle_path("specifications/terranova-9.gemspec")}
       TABLE
 
       expect(out).to end_with(expected_output)

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -29,13 +29,15 @@ RSpec.describe "bundle outdated" do
 
       bundle "outdated"
 
-      expect(out).to include("activesupport (newest 3.0, installed 2.3.5, requested = 2.3.5)")
-      expect(out).to include("weakling (newest 0.2, installed 0.0.3, requested ~> 0.0.1)")
-      expect(out).to include("foo (newest 1.0")
+      expected_output = <<~TABLE.gsub("x", "\\\h").tr(".", "\.").strip
+        Gem            Locked       Latest       Requested  Groups
+        activesupport  2.3.5        3.0          = 2.3.5    default
+        foo            1.0 xxxxxxx  1.0 xxxxxxx  >= 0       default
+        weakling       0.0.3        0.2          ~> 0.0.1   default
+        zebra          1.0 xxxxxxx  1.0 xxxxxxx  >= 0       default
+      TABLE
 
-      # Gem names are one per-line, between "*" and their parenthesized version.
-      gem_list = out.split("\n").map {|g| g[/\* (.*) \(/, 1] }.compact
-      expect(gem_list).to eq(gem_list.sort)
+      expect(out).to match(Regexp.new(expected_output))
     end
 
     it "returns non zero exit status if outdated gems present" do
@@ -70,8 +72,14 @@ RSpec.describe "bundle outdated" do
       update_repo2 { build_gem "terranova", "9" }
 
       bundle "outdated --verbose"
-      expect(out).to include("activesupport (newest 3.0, installed 2.3.5, requested = 2.3.5) in groups \"development, test\"")
-      expect(out).to include("terranova (newest 9, installed 8, requested = 8) in group \"default\"")
+
+      expected_output = <<~TABLE.strip
+        Gem            Locked  Latest  Requested  Groups             Path
+        activesupport  2.3.5   3.0     = 2.3.5    development, test
+        terranova      8       9       = 8        default
+      TABLE
+
+      expect(out).to end_with(expected_output)
     end
   end
 
@@ -89,7 +97,7 @@ RSpec.describe "bundle outdated" do
       G
     end
 
-    def test_group_option(group = nil, gems_list_size = 1)
+    def test_group_option(group)
       update_repo2 do
         build_gem "activesupport", "3.0"
         build_gem "terranova", "9"
@@ -97,49 +105,46 @@ RSpec.describe "bundle outdated" do
       end
 
       bundle "outdated --group #{group}"
-
-      # Gem names are one per-line, between "*" and their parenthesized version.
-      gem_list = out.split("\n").map {|g| g[/\* (.*) \(/, 1] }.compact
-      expect(gem_list).to eq(gem_list.sort)
-      expect(gem_list.size).to eq gems_list_size
     end
 
     it "works when the bundle is up to date" do
       bundle "outdated --group"
-      expect(out).to include("Bundle up to date!")
+      expect(out).to end_with("Bundle up to date!")
     end
 
     it "returns a sorted list of outdated gems from one group => 'default'" do
       test_group_option("default")
 
-      expect(out).to include("===== Group \"default\" =====")
-      expect(out).to include("terranova (")
+      expected_output = <<~TABLE.strip
+        Gem        Locked  Latest  Requested  Groups
+        terranova  8       9       = 8        default
+      TABLE
 
-      expect(out).not_to include("===== Groups \"development, test\" =====")
-      expect(out).not_to include("activesupport")
-      expect(out).not_to include("duradura")
+      expect(out).to end_with(expected_output)
     end
 
     it "returns a sorted list of outdated gems from one group => 'development'" do
-      test_group_option("development", 2)
+      test_group_option("development")
 
-      expect(out).not_to include("===== Group \"default\" =====")
-      expect(out).not_to include("terranova (")
+      expected_output = <<~TABLE.strip
+        Gem            Locked  Latest  Requested  Groups
+        activesupport  2.3.5   3.0     = 2.3.5    development, test
+        duradura       7.0     8.0     = 7.0      development, test
+      TABLE
 
-      expect(out).to include("===== Groups \"development, test\" =====")
-      expect(out).to include("activesupport")
-      expect(out).to include("duradura")
+      expect(out).to end_with(expected_output)
     end
 
     it "returns a sorted list of outdated gems from one group => 'test'" do
-      test_group_option("test", 2)
+      test_group_option("test")
 
-      expect(out).not_to include("===== Group \"default\" =====")
-      expect(out).not_to include("terranova (")
+      expected_output = <<~TABLE.strip
+        Gem            Locked  Latest  Requested  Groups
+        activesupport  2.3.5   3.0     = 2.3.5    development, test
+        duradura       7.0     8.0     = 7.0      development, test
+      TABLE
 
-      expect(out).to include("===== Groups \"development, test\" =====")
-      expect(out).to include("activesupport")
-      expect(out).to include("duradura")
+      expect(out).to end_with(expected_output)
     end
   end
 
@@ -167,12 +172,12 @@ RSpec.describe "bundle outdated" do
     it "returns a sorted list of outdated gems" do
       bundle "outdated --groups"
 
-      expect(out).to include("===== Without group =====")
-      expect(out).to include("bar (newest 3.0.0, installed 2.0.0)")
+      expected_output = <<~TABLE.strip
+        Gem  Locked  Latest  Requested  Groups
+        bar  2.0.0   3.0.0
+      TABLE
 
-      # Gem names are one per-line, between "*" and their parenthesized version.
-      gem_list = out.split("\n").map {|g| g[/\* (.*) \(/, 1] }.compact
-      expect(gem_list).to eq(gem_list.sort)
+      expect(out).to end_with(expected_output)
     end
   end
 
@@ -203,15 +208,15 @@ RSpec.describe "bundle outdated" do
       end
 
       bundle "outdated --groups"
-      expect(out).to include("===== Group \"default\" =====")
-      expect(out).to include("terranova (newest 9, installed 8, requested = 8)")
-      expect(out).to include("===== Groups \"development, test\" =====")
-      expect(out).to include("activesupport (newest 3.0, installed 2.3.5, requested = 2.3.5)")
-      expect(out).to include("duradura (newest 8.0, installed 7.0, requested = 7.0)")
 
-      expect(out).not_to include("weakling (")
+      expected_output = <<~TABLE.strip
+        Gem            Locked  Latest  Requested  Groups
+        activesupport  2.3.5   3.0     = 2.3.5    development, test
+        duradura       7.0     8.0     = 7.0      development, test
+        terranova      8       9       = 8        default
+      TABLE
 
-      # TODO: check gems order inside the group
+      expect(out).to end_with(expected_output)
     end
   end
 
@@ -230,7 +235,12 @@ RSpec.describe "bundle outdated" do
 
       bundle "outdated --local"
 
-      expect(out).to include("activesupport (newest 2.3.5, installed 2.3.4, requested = 2.3.4)")
+      expected_output = <<~TABLE.strip
+        Gem            Locked  Latest  Requested  Groups
+        activesupport  2.3.4   2.3.5   = 2.3.4    default
+      TABLE
+
+      expect(out).to end_with(expected_output)
     end
 
     it "doesn't hit repo2" do
@@ -286,8 +296,13 @@ RSpec.describe "bundle outdated" do
       end
 
       bundle "outdated foo"
-      expect(out).not_to include("activesupport (newest")
-      expect(out).to include("foo (newest 1.0")
+
+      expected_output = <<~TABLE.gsub("x", "\\\h").tr(".", "\.").strip
+        Gem  Locked       Latest       Requested  Groups
+        foo  1.0 xxxxxxx  1.0 xxxxxxx  >= 0       default
+      TABLE
+
+      expect(out).to match(Regexp.new(expected_output))
     end
   end
 
@@ -311,7 +326,13 @@ RSpec.describe "bundle outdated" do
         end
 
         bundle "outdated --pre"
-        expect(out).to include("activesupport (newest 3.0.0.beta, installed 2.3.5, requested = 2.3.5)")
+
+        expected_output = <<~TABLE.strip
+          Gem            Locked  Latest      Requested  Groups
+          activesupport  2.3.5   3.0.0.beta  = 2.3.5    default
+        TABLE
+
+        expect(out).to end_with(expected_output)
       end
     end
 
@@ -328,7 +349,13 @@ RSpec.describe "bundle outdated" do
         G
 
         bundle "outdated"
-        expect(out).to include("(newest 3.0.0.beta.2, installed 3.0.0.beta.1, requested = 3.0.0.beta.1)")
+
+        expected_output = <<~TABLE.strip
+          Gem            Locked        Latest        Requested       Groups
+          activesupport  3.0.0.beta.1  3.0.0.beta.2  = 3.0.0.beta.1  default
+        TABLE
+
+        expect(out).to end_with(expected_output)
       end
     end
   end
@@ -343,8 +370,12 @@ RSpec.describe "bundle outdated" do
 
       bundle :outdated, filter_strict_option => true
 
-      expect(out).to_not include("activesupport (newest")
-      expect(out).to include("(newest 0.0.5, installed 0.0.3, requested ~> 0.0.1)")
+      expected_output = <<~TABLE.strip
+        Gem       Locked  Latest  Requested  Groups
+        weakling  0.0.3   0.0.5   ~> 0.0.1   default
+      TABLE
+
+      expect(out).to end_with(expected_output)
     end
 
     it "only reports gem dependencies when they can actually be updated" do
@@ -373,8 +404,12 @@ RSpec.describe "bundle outdated" do
 
         bundle :outdated, filter_strict_option => true, "filter-patch" => true
 
-        expect(out).to_not include("activesupport (newest")
-        expect(out).to include("(newest 0.0.5, installed 0.0.3")
+        expected_output = <<~TABLE.strip
+          Gem       Locked  Latest  Requested  Groups
+          weakling  0.0.3   0.0.5   >= 0.0.1   default
+        TABLE
+
+        expect(out).to end_with(expected_output)
       end
 
       it "only reports gems that match requirement and minor filter level" do
@@ -391,8 +426,12 @@ RSpec.describe "bundle outdated" do
 
         bundle :outdated, filter_strict_option => true, "filter-minor" => true
 
-        expect(out).to_not include("activesupport (newest")
-        expect(out).to include("(newest 0.1.5, installed 0.0.3")
+        expected_output = <<~TABLE.strip
+          Gem       Locked  Latest  Requested  Groups
+          weakling  0.0.3   0.1.5   >= 0.0.1   default
+        TABLE
+
+        expect(out).to end_with(expected_output)
       end
 
       it "only reports gems that match requirement and major filter level" do
@@ -409,8 +448,12 @@ RSpec.describe "bundle outdated" do
 
         bundle :outdated, filter_strict_option => true, "filter-major" => true
 
-        expect(out).to_not include("activesupport (newest")
-        expect(out).to include("(newest 1.1.5, installed 0.0.3")
+        expected_output = <<~TABLE.strip
+          Gem       Locked  Latest  Requested  Groups
+          weakling  0.0.3   1.1.5   >= 0.0.1   default
+        TABLE
+
+        expect(out).to end_with(expected_output)
       end
     end
   end
@@ -518,7 +561,13 @@ RSpec.describe "bundle outdated" do
           G
 
           bundle "outdated"
-          expect(out).to include("laduradura (newest 5.15.3, installed 5.15.2, requested = 5.15.2)")
+
+          expected_output = <<~TABLE.strip
+            Gem         Locked  Latest  Requested  Groups
+            laduradura  5.15.2  5.15.3  = 5.15.2   default
+          TABLE
+
+          expect(out).to end_with(expected_output)
         end
       end
     end
@@ -527,7 +576,10 @@ RSpec.describe "bundle outdated" do
   shared_examples_for "version update is detected" do
     it "reports that a gem has a newer version" do
       subject
-      expect(out).to include("activesupport (newest")
+
+      outdated_gems = out.split("\n").drop_while {|l| !l.start_with?("Gem") }[1..-1]
+
+      expect(outdated_gems.size).to be > 0
     end
   end
 
@@ -582,9 +634,7 @@ RSpec.describe "bundle outdated" do
   shared_examples_for "no version updates are detected" do
     it "does not detect any version updates" do
       subject
-      expect(out).to include("updates to display.")
-      expect(out).to_not include("activesupport (newest")
-      expect(out).to_not include("weakling (newest")
+      expect(out).to end_with("updates to display.")
     end
   end
 
@@ -707,26 +757,32 @@ RSpec.describe "bundle outdated" do
       it "shows nothing when patching and filtering to minor" do
         bundle "outdated --patch --filter-minor"
 
-        expect(out).to include("No minor updates to display.")
-        expect(out).not_to include("patch (newest")
-        expect(out).not_to include("minor (newest")
-        expect(out).not_to include("major (newest")
+        expect(out).to end_with("No minor updates to display.")
       end
 
       it "shows all gems when patching and filtering to patch" do
         bundle "outdated --patch --filter-patch"
 
-        expect(out).to include("patch (newest 1.0.1")
-        expect(out).to include("minor (newest 1.0.1")
-        expect(out).to include("major (newest 1.0.1")
+        expected_output = <<~TABLE.strip
+          Gem    Locked  Latest  Requested  Groups
+          major  1.0.0   1.0.1   >= 0       default
+          minor  1.0.0   1.0.1   >= 0       default
+          patch  1.0.0   1.0.1   >= 0       default
+        TABLE
+
+        expect(out).to end_with(expected_output)
       end
 
       it "shows minor and major when updating to minor and filtering to patch and minor" do
         bundle "outdated --minor --filter-minor"
 
-        expect(out).not_to include("patch (newest")
-        expect(out).to include("minor (newest 1.1.0")
-        expect(out).to include("major (newest 1.1.0")
+        expected_output = <<~TABLE.strip
+          Gem    Locked  Latest  Requested  Groups
+          major  1.0.0   1.1.0   >= 0       default
+          minor  1.0.0   1.1.0   >= 0       default
+        TABLE
+
+        expect(out).to end_with(expected_output)
       end
 
       it "shows minor when updating to major and filtering to minor with parseable" do
@@ -774,9 +830,13 @@ RSpec.describe "bundle outdated" do
       it "shows gems with update-strict updating to patch and filtering to patch" do
         bundle "outdated --patch --update-strict --filter-patch"
 
-        expect(out).to include("foo (newest 1.4.4")
-        expect(out).to include("bar (newest 2.0.5")
-        expect(out).not_to include("qux (newest")
+        expected_output = <<~TABLE.strip
+          Gem  Locked  Latest  Requested  Groups
+          bar  2.0.3   2.0.5
+          foo  1.4.3   1.4.4   >= 0       default
+        TABLE
+
+        expect(out).to end_with(expected_output)
       end
     end
   end
@@ -803,8 +863,12 @@ RSpec.describe "bundle outdated" do
 
       bundle "outdated --only-explicit"
 
-      expect(out).to include("weakling (newest 0.3")
-      expect(out).not_to include("bar (newest 2.2")
+      expected_output = <<~TABLE.strip
+        Gem       Locked  Latest  Requested  Groups
+        weakling  0.2     0.3     >= 0       default
+      TABLE
+
+      expect(out).to end_with(expected_output)
     end
   end
 end

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe "bundle outdated" do
     end
   end
 
-  describe "with --group option and outdated transitive dependencies" do
+  describe "with --groups option and outdated transitive dependencies" do
     before do
       update_repo2 do
         build_gem "bar", %w[2.0.0]

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -517,7 +517,6 @@ RSpec.describe "bundle outdated" do
           G
 
           bundle "outdated"
-          expect(out).to include("Outdated gems included in the bundle:")
           expect(out).to include("laduradura (newest 5.15.3, installed 5.15.2, requested = 5.15.2)")
         end
       end
@@ -527,7 +526,6 @@ RSpec.describe "bundle outdated" do
   shared_examples_for "version update is detected" do
     it "reports that a gem has a newer version" do
       subject
-      expect(out).to include("Outdated gems included in the bundle:")
       expect(out).to include("activesupport (newest")
       expect(out).to_not include("ERROR REPORT TEMPLATE")
     end

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -40,6 +40,26 @@ RSpec.describe "bundle outdated" do
       expect(out).to match(Regexp.new(expected_output))
     end
 
+    it "excludes header row from the sorting" do
+      update_repo2 do
+        build_gem "AAA", %w[1.0.0 2.0.0]
+      end
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+        gem "AAA", "1.0.0"
+      G
+
+      bundle "outdated"
+
+      expected_output = <<~TABLE
+        Gem  Locked  Latest  Requested  Groups
+        AAA  1.0.0   2.0.0   = 1.0.0    default
+      TABLE
+
+      expect(out).to include(expected_output.strip)
+    end
+
     it "returns non zero exit status if outdated gems present" do
       update_repo2 do
         build_gem "activesupport", "3.0"

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -527,7 +527,6 @@ RSpec.describe "bundle outdated" do
     it "reports that a gem has a newer version" do
       subject
       expect(out).to include("activesupport (newest")
-      expect(out).to_not include("ERROR REPORT TEMPLATE")
     end
   end
 
@@ -583,7 +582,6 @@ RSpec.describe "bundle outdated" do
     it "does not detect any version updates" do
       subject
       expect(out).to include("updates to display.")
-      expect(out).to_not include("ERROR REPORT TEMPLATE")
       expect(out).to_not include("activesupport (newest")
       expect(out).to_not include("weakling (newest")
     end

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe "bundle outdated" do
 
     it "not outdated gems" do
       bundle "outdated --groups"
-      expect(out).to include("Bundle up to date!")
+      expect(out).to end_with("Bundle up to date!")
     end
 
     it "returns a sorted list of outdated gems by groups" do
@@ -299,7 +299,8 @@ RSpec.describe "bundle outdated" do
         end
 
         bundle "outdated"
-        expect(out).not_to include("activesupport (3.0.0.beta > 2.3.5)")
+
+        expect(out).to end_with("Bundle up to date!")
       end
     end
 
@@ -354,7 +355,7 @@ RSpec.describe "bundle outdated" do
 
       bundle :outdated, filter_strict_option => true
 
-      expect(out).to_not include("rack (1.2")
+      expect(out).to end_with("Bundle up to date!")
     end
 
     describe "and filter options" do
@@ -493,7 +494,7 @@ RSpec.describe "bundle outdated" do
 
     it "reports that no updates are available" do
       bundle "outdated"
-      expect(out).to include("Bundle up to date!")
+      expect(out).to end_with("Bundle up to date!")
     end
   end
 
@@ -505,7 +506,7 @@ RSpec.describe "bundle outdated" do
       G
 
       bundle "outdated"
-      expect(out).to include("Bundle up to date!")
+      expect(out).to end_with("Bundle up to date!")
     end
 
     it "reports that updates are available if the JRuby platform is used" do

--- a/spec/install/gemfile/path_spec.rb
+++ b/spec/install/gemfile/path_spec.rb
@@ -227,7 +227,6 @@ RSpec.describe "bundle install with explicit source paths" do
       gem "foo", :path => "#{lib_path("foo-1.0")}"
     G
 
-    expect(err).to_not include("ERROR REPORT")
     expect(err).to_not include("Your Gemfile has no gem server sources.")
     expect(err).to match(/is not valid. Please fix this gemspec./)
     expect(err).to match(/The validation error was 'missing value for attribute version'/)

--- a/spec/other/platform_spec.rb
+++ b/spec/other/platform_spec.rb
@@ -1187,7 +1187,7 @@ G
       bundle "outdated"
 
       expected_output = <<~TABLE.gsub("x", "\\\h").tr(".", "\.").strip
-        Gem            Locked       Latest       Requested  Groups
+        Gem            Current      Latest       Requested  Groups
         activesupport  2.3.5        3.0          = 2.3.5    default
         foo            1.0 xxxxxxx  1.0 xxxxxxx  >= 0       default
       TABLE
@@ -1214,7 +1214,7 @@ G
         bundle "outdated"
 
         expected_output = <<~TABLE.gsub("x", "\\\h").tr(".", "\.").strip
-          Gem            Locked       Latest       Requested  Groups
+          Gem            Current      Latest       Requested  Groups
           activesupport  2.3.5        3.0          = 2.3.5    default
           foo            1.0 xxxxxxx  1.0 xxxxxxx  >= 0       default
         TABLE

--- a/spec/other/platform_spec.rb
+++ b/spec/other/platform_spec.rb
@@ -1185,8 +1185,14 @@ G
       G
 
       bundle "outdated"
-      expect(out).to include("activesupport (newest 3.0, installed 2.3.5, requested = 2.3.5")
-      expect(out).to include("foo (newest 1.0")
+
+      expected_output = <<~TABLE.gsub("x", "\\\h").tr(".", "\.").strip
+        Gem            Locked       Latest       Requested  Groups
+        activesupport  2.3.5        3.0          = 2.3.5    default
+        foo            1.0 xxxxxxx  1.0 xxxxxxx  >= 0       default
+      TABLE
+
+      expect(out).to match(Regexp.new(expected_output))
     end
 
     it "returns list of outdated gems when the ruby version matches for any engine" do
@@ -1206,8 +1212,14 @@ G
         G
 
         bundle "outdated"
-        expect(out).to include("activesupport (newest 3.0, installed 2.3.5, requested = 2.3.5)")
-        expect(out).to include("foo (newest 1.0")
+
+        expected_output = <<~TABLE.gsub("x", "\\\h").tr(".", "\.").strip
+          Gem            Locked       Latest       Requested  Groups
+          activesupport  2.3.5        3.0          = 2.3.5    default
+          foo            1.0 xxxxxxx  1.0 xxxxxxx  >= 0       default
+        TABLE
+
+        expect(out).to match(Regexp.new(expected_output))
       end
     end
 


### PR DESCRIPTION
Haven't fixed tests since wanted buy-in.

Before:

```
Outdated gems included in the bundle:
  * active_model_serializers (newest 0.9.5, installed 0.8.3, requested ~> 0.8.0) in group "default"
  * activerecord-import (newest 0.13.0, installed 0.10.0) in group "default"
  * addressable (newest 2.4.0, installed 2.3.5, requested = 2.3.5) in group "default"
  * airbrake (newest 5.2.3, installed 5.1.0) in group "default"
  * bootstrap-sass (newest 3.3.6, installed 3.3.5.1) in group "default"
  * capistrano (newest 3.5.0, installed 3.4.0, requested ~> 3.4) in group "development"
  * capistrano-rails (newest 1.1.6, installed 1.1.3, requested ~> 1.1.1) in group "development"
```

After:

```
--pretty
Outdated gems included in the bundle:
Gem Name                New        Installed  Requested  Groups
airbrake                5.3.0      5.0.3                 default
better_errors           2.1.1      1.0.1      ~> 1.0.1   development
bootstrap-sass          3.3.6      3.3.0.1    ~> 3.3.0.1 default
factory_girl_rails      4.7.0      4.4.1                 test, development

--pretty --verbose
Outdated gems included in the bundle:
Gem Name                New        Installed  Requested  Groups            Load Path
airbrake                5.3.0      5.0.3                 default           /Users/todd/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/specifications/airbrake-5.3.0.gemspec
better_errors           2.1.1      1.0.1      ~> 1.0.1   development       /Users/todd/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/specifications/better_errors-2.1.1.gemspec
bootstrap-sass          3.3.6      3.3.0.1    ~> 3.3.0.1 default           /Users/todd/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/specifications/bootstrap-sass-3.3.6.gemspec
factory_girl            4.7.0      4.4.0                                   /Users/todd/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/specifications/factory_girl-4.7.0.gemspec
factory_girl_rails      4.7.0      4.4.1                 test, development /Users/todd/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/specifications/factory_girl_rails-4.7.0.gemspec
```
