### PR TITLE
fixes checksums of rubygems index on windows

### DIFF
--- a/lib/bundler/vendor/compact_index_client/lib/compact_index_client/updater.rb
+++ b/lib/bundler/vendor/compact_index_client/lib/compact_index_client/updater.rb
@@ -49,7 +49,7 @@ class Bundler::CompactIndexClient
 
     def checksum_for_file(path)
       return nil unless path.file?
-      Digest::MD5.file(path).hexdigest
+      Digest::MD5.hexdigest(IO.read(path))
     end
   end
 end


### PR DESCRIPTION
`Digest::MD5.file(path)` uses `File.open(path) { |f| f.read }` which will inject `\r\n` style newlines on windows. Using `IO.read(path)` avoids the carriage returns and produces matching checksums on windows.

Closes #4472.