### PR TITLE
[Runtime] Fix the ordering of the load path when there are dependencies

### DIFF
--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -17,7 +17,7 @@ module Bundler
       Bundler.rubygems.replace_entrypoints(specs)
 
       # Activate the specs
-      specs.each do |spec|
+      load_paths = specs.map do |spec|
         unless spec.loaded_from
           raise GemNotFound, "#{spec.full_name} is missing. Run `bundle` to get it."
         end
@@ -36,18 +36,16 @@ module Bundler
         end
 
         Bundler.rubygems.mark_loaded(spec)
-        load_paths = spec.load_paths.reject {|path| $LOAD_PATH.include?(path) }
+        spec.load_paths.reject {|path| $LOAD_PATH.include?(path) }
+      end.flatten.reverse
 
-        # See Gem::Specification#add_self_to_load_path (since RubyGems 1.8)
-        insert_index = Bundler.rubygems.load_path_insert_index
-
-        if insert_index
-          # Gem directories must come after -I and ENV['RUBYLIB']
-          $LOAD_PATH.insert(insert_index, *load_paths)
-        else
-          # We are probably testing in core, -I and RUBYLIB don't apply
-          $LOAD_PATH.unshift(*load_paths)
-        end
+      # See Gem::Specification#add_self_to_load_path (since RubyGems 1.8)
+      if insert_index = Bundler.rubygems.load_path_insert_index
+        # Gem directories must come after -I and ENV['RUBYLIB']
+        $LOAD_PATH.insert(insert_index, *load_paths)
+      else
+        # We are probably testing in core, -I and RUBYLIB don't apply
+        $LOAD_PATH.unshift(*load_paths)
       end
 
       setup_manpath

--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -37,7 +37,7 @@ module Bundler
 
         Bundler.rubygems.mark_loaded(spec)
         spec.load_paths.reject {|path| $LOAD_PATH.include?(path) }
-      end.flatten.reverse
+      end.reverse.flatten
 
       # See Gem::Specification#add_self_to_load_path (since RubyGems 1.8)
       if insert_index = Bundler.rubygems.load_path_insert_index

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -161,7 +161,7 @@ describe "Bundler.setup" do
         "/gems/actionpack-2.3.2/lib",
         "/gems/actionmailer-2.3.2/lib",
         "/gems/activesupport-2.3.2/lib",
-        "/gems/rake-10.0.2/lib",
+        "/gems/rake-10.0.2/lib"
       )
     end
   end


### PR DESCRIPTION
It was previously getting reversed

closes #4482