### PR TITLE
Show executable's man page when --help or -h is present

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -437,7 +437,7 @@ module Bundler
     # into the corresponding `bundle help #{command}` call
     def self.reformatted_help_args(args)
       bundler_commands = all_commands.keys
-      help_flags = %w(--help -h)
+      help_flags = args.select {|a| %w(--help -h).include? a }
       command = args.select {|a| bundler_commands.include? a }
       other_flags = args.select {|a| a.include? "--" } - help_flags
       executables = args - command - help_flags - other_flags
@@ -447,7 +447,7 @@ module Bundler
       elsif executables.any?
         new_args << command.first
         new_args += executables
-        new_args << "--help"
+        new_args += help_flags
         new_args += other_flags
       else
         new_args += ["help", command.first]

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -439,11 +439,11 @@ module Bundler
       bundler_commands = all_commands.keys
       help_flags = %w(--help -h)
       exec_commands = %w(exec e)
-      help_used = args.select {|a| help_flags.include? a}
-      exec_used = args.select {|a| exec_commands.include? a}
+      help_used = args.select {|a| help_flags.include? a }
+      exec_used = args.select {|a| exec_commands.include? a }
       command = args.select {|a| bundler_commands.include? a }
       if exec_used.any? && help_used.any?
-        regex = %r{
+        regex = /
             ( # Matches `exec --help` or `exec --help foo`
               (#{exec_commands.join("|")})
               \s
@@ -456,10 +456,10 @@ module Bundler
               (#{exec_commands.join("|")})
               (.+)*
             )
-          }x
+          /x
         arg_str = args.join(" ")
         if arg_str =~ regex
-          ["help", "exec"]
+          %w(help exec)
         else
           args
         end

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -437,13 +437,22 @@ module Bundler
     # into the corresponding `bundle help #{command}` call
     def self.reformatted_help_args(args)
       bundler_commands = all_commands.keys
+      help_flags = %w(--help -h)
       command = args.select {|a| bundler_commands.include? a }
+      other_flags = args.select {|a| a.include? "--" } - help_flags
+      executables = args - command - help_flags - other_flags
+      new_args = []
       if command.empty?
         abort("Could not find command \"#{args.join(" ")}\".")
+      elsif executables.any?
+        new_args << command.first
+        new_args += executables
+        new_args << "--help"
+        new_args += other_flags
       else
-        command = command.first
+        new_args += ["help", command.first]
       end
-      ["help", command]
+      new_args
     end
 
   private

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -218,6 +218,24 @@ describe "bundle exec" do
     expect(out).to include("bundler: exec needs a command to run")
   end
 
+  describe "shows executable's man page" do
+    before(:each) do
+      install_gemfile <<-G
+        gem "rack"
+      G
+    end
+
+    it "when --help is present" do
+      bundle "exec echo --help"
+      expect(out).to include("Usage: echo [SHORT-OPTION]... [STRING]...")
+    end
+
+    it "when -h is present" do
+      bundle "exec echo --help"
+      expect(out).to include("Usage: echo [SHORT-OPTION]... [STRING]...")
+    end
+  end
+
   describe "with gem executables" do
     describe "run from a random directory" do
       before(:each) do

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -218,21 +218,54 @@ describe "bundle exec" do
     expect(out).to include("bundler: exec needs a command to run")
   end
 
-  describe "shows executable's man page" do
+  describe "with help flags" do
     before(:each) do
       install_gemfile <<-G
         gem "rack"
       G
     end
 
-    it "when --help is present" do
+    it "shows executable's man page when --help is after the executable" do
       bundle "exec echo --help"
       expect(out).to include("Usage: echo [SHORT-OPTION]... [STRING]...")
     end
 
-    it "when -h is present" do
-      bundle "exec echo --help"
+    it "shows executable's man page when --help is between exec and the executable" do
+      bundle "exec --help echo"
       expect(out).to include("Usage: echo [SHORT-OPTION]... [STRING]...")
+    end
+
+    it "uses executable's original behavior for -h" do
+      bundle "exec echo -h"
+      expect(out).to eq("-h")
+    end
+
+    it "shows bundle-exec's man page when --help is before exec" do
+      with_fake_man do
+        bundle "--help exec"
+      end
+      expect(out).to include(%(["#{root}/lib/bundler/man/bundle-exec"]))
+    end
+
+    it "shows bundle-exec's man page when -h is before exec" do
+      with_fake_man do
+        bundle "-h exec"
+      end
+      expect(out).to include(%(["#{root}/lib/bundler/man/bundle-exec"]))
+    end
+
+    it "shows bundle-exec's man page when --help is after exec" do
+      with_fake_man do
+        bundle "exec --help"
+      end
+      expect(out).to include(%(["#{root}/lib/bundler/man/bundle-exec"]))
+    end
+
+    it "shows bundle-exec's man page when -h is after exec" do
+      with_fake_man do
+        bundle "exec -h"
+      end
+      expect(out).to include(%(["#{root}/lib/bundler/man/bundle-exec"]))
     end
   end
 

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -219,53 +219,110 @@ describe "bundle exec" do
   end
 
   describe "with help flags" do
-    before(:each) do
-      install_gemfile <<-G
-        gem "rack"
-      G
-    end
-
-    it "shows executable's man page when --help is after the executable" do
-      bundle "exec echo --help"
-      expect(out).to include("Usage: echo [SHORT-OPTION]... [STRING]...")
-    end
-
-    it "shows executable's man page when --help is between exec and the executable" do
-      bundle "exec --help echo"
-      expect(out).to include("Usage: echo [SHORT-OPTION]... [STRING]...")
-    end
-
-    it "uses executable's original behavior for -h" do
-      bundle "exec echo -h"
-      expect(out).to eq("-h")
-    end
-
-    it "shows bundle-exec's man page when --help is before exec" do
-      with_fake_man do
-        bundle "--help exec"
+    describe "when exec is used" do
+      before(:each) do
+        install_gemfile <<-G
+          gem "rack"
+        G
       end
-      expect(out).to include(%(["#{root}/lib/bundler/man/bundle-exec"]))
+
+      it "shows executable's man page when --help is after the executable" do
+        bundle "exec cat --help"
+        expect(out).to include("Usage: cat [OPTION]... [FILE]...")
+      end
+
+      it "uses executable's original behavior for -h" do
+        bundle "exec cat -h"
+        expect(err).to include("cat: invalid option -- 'h'")
+      end
+
+      it "shows bundle-exec's man page when --help is between exec and the executable" do
+        with_fake_man do
+          bundle "exec --help cat"
+        end
+        expect(out).to include(%(["#{root}/lib/bundler/man/bundle-exec"]))
+      end
+
+      it "shows bundle-exec's man page when --help is before exec" do
+        with_fake_man do
+          bundle "--help exec"
+        end
+        expect(out).to include(%(["#{root}/lib/bundler/man/bundle-exec"]))
+      end
+
+      it "shows bundle-exec's man page when -h is before exec" do
+        with_fake_man do
+          bundle "-h exec"
+        end
+        expect(out).to include(%(["#{root}/lib/bundler/man/bundle-exec"]))
+      end
+
+      it "shows bundle-exec's man page when --help is after exec" do
+        with_fake_man do
+          bundle "exec --help"
+        end
+        expect(out).to include(%(["#{root}/lib/bundler/man/bundle-exec"]))
+      end
+
+      it "shows bundle-exec's man page when -h is after exec" do
+        with_fake_man do
+          bundle "exec -h"
+        end
+        expect(out).to include(%(["#{root}/lib/bundler/man/bundle-exec"]))
+      end
     end
 
-    it "shows bundle-exec's man page when -h is before exec" do
-      with_fake_man do
-        bundle "-h exec"
+    describe "when e is used" do
+      before(:each) do
+        install_gemfile <<-G
+          gem "rack"
+        G
       end
-      expect(out).to include(%(["#{root}/lib/bundler/man/bundle-exec"]))
-    end
 
-    it "shows bundle-exec's man page when --help is after exec" do
-      with_fake_man do
-        bundle "exec --help"
+      it "shows executable's man page when --help is after the executable" do
+        bundle "e cat --help"
+        expect(out).to include("Usage: cat [OPTION]... [FILE]...")
       end
-      expect(out).to include(%(["#{root}/lib/bundler/man/bundle-exec"]))
-    end
 
-    it "shows bundle-exec's man page when -h is after exec" do
-      with_fake_man do
-        bundle "exec -h"
+      it "uses executable's original behavior for -h" do
+        bundle "e cat -h"
+        expect(err).to include("cat: invalid option -- 'h'")
       end
-      expect(out).to include(%(["#{root}/lib/bundler/man/bundle-exec"]))
+
+      it "shows bundle-exec's man page when --help is between exec and the executable" do
+        with_fake_man do
+          bundle "e --help cat"
+        end
+        expect(out).to include(%(["#{root}/lib/bundler/man/bundle-exec"]))
+      end
+
+      it "shows bundle-exec's man page when --help is before exec" do
+        with_fake_man do
+          bundle "--help e"
+        end
+        expect(out).to include(%(["#{root}/lib/bundler/man/bundle-exec"]))
+      end
+
+      it "shows bundle-exec's man page when -h is before exec" do
+        with_fake_man do
+          bundle "-h e"
+        end
+        expect(out).to include(%(["#{root}/lib/bundler/man/bundle-exec"]))
+      end
+
+      it "shows bundle-exec's man page when --help is after exec" do
+        with_fake_man do
+          bundle "e --help"
+        end
+        expect(out).to include(%(["#{root}/lib/bundler/man/bundle-exec"]))
+      end
+
+      it "shows bundle-exec's man page when -h is after exec" do
+        with_fake_man do
+          bundle "e -h"
+        end
+        expect(out).to include(%(["#{root}/lib/bundler/man/bundle-exec"]))
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #4480, where `bundle exec foo --help` shows `bundle exec`'s man instead of `foo`'s man.

@RochesterinNYC