### PR TITLE
[Travis] Test against Rubygems `2.6.4` and Ruby `2.3.1`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ env:
   # We need to know if changes to rubygems will break bundler on release
   - RGV=master
   # Test the latest rubygems release with all of our supported rubies
-  - RGV=v2.6.3
+  - RGV=v2.6.4
   - RGV=v2.4.8
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ addons:
       secure: "TrzIv116JLGUxm6PAUskCYrv8KTDguncKROVwbnjVPKTGDAgoDderd8JUdDEXrKoZ9qGLD2TPYKExt9/QDl71E+qHdWnVqWv4HKCUk2P9z/VLKzHuggOUBkCXiJUhjywUieCJhI3N92bfq2EjSBbu2/OFHqWOjLQ+QCooTEBjv8="
 
 rvm:
-  - 2.3.0
+  - 2.3.1
   - 2.2
   - 2.1
   - 2.0.0

--- a/Rakefile
+++ b/Rakefile
@@ -65,7 +65,7 @@ namespace :spec do
       sh "sudo apt-get install graphviz -y 2>&1 | tail -n 2"
 
       # Install the gems with a consistent version of RubyGems
-      sh "gem update --system 2.6.3"
+      sh "gem update --system 2.6.4"
 
       $LOAD_PATH.unshift("./spec")
       require "support/rubygems_ext"
@@ -122,7 +122,7 @@ begin
       rubyopt = ENV["RUBYOPT"]
       # When editing this list, also edit .travis.yml!
       branches = %w(master)
-      releases = %w(v1.3.6 v1.3.7 v1.4.2 v1.5.3 v1.6.2 v1.7.2 v1.8.29 v2.0.14 v2.1.11 v2.2.5 v2.4.8 v2.6.3)
+      releases = %w(v1.3.6 v1.3.7 v1.4.2 v1.5.3 v1.6.2 v1.7.2 v1.8.29 v2.0.14 v2.1.11 v2.2.5 v2.4.8 v2.6.4)
       (branches + releases).each do |rg|
         desc "Run specs with Rubygems #{rg}"
         RSpec::Core::RakeTask.new(rg) do |t|


### PR DESCRIPTION
- Side note: this feels like something we might be able to automate if we had a CI pipeline that could do periodic resource checks (i.e. watch for new version of Rubygems or Ruby).