### PR TITLE
Manually set a process title when using load

### DIFF
--- a/lib/bundler/cli/exec.rb
+++ b/lib/bundler/cli/exec.rb
@@ -57,6 +57,7 @@ module Bundler
       args.pop if args.last.is_a?(Hash)
       ARGV.replace(args)
       $0 = file
+      Process.setproctitle(process_title(file, *args))
       ui = Bundler.ui
       Bundler.ui = nil
       require "bundler/setup"
@@ -68,6 +69,14 @@ module Bundler
       Bundler.ui.error "bundler: failed to load command: #{cmd} (#{file})"
       backtrace = e.backtrace.take_while {|bt| !bt.start_with?(__FILE__) }
       abort "#{e.class}: #{e.message}\n  #{backtrace.join("\n  ")}"
+    end
+
+    def process_title(file, *args)
+      if args.empty?
+        file
+      else
+        "#{file} #{args.join(" ")}".strip
+      end
     end
 
     def ruby_shebang?(file)

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -462,6 +462,7 @@ describe "bundle exec" do
       puts "EXEC: \#{caller.grep(/load/).empty? ? 'exec' : 'load'}"
       puts "ARGS: \#{$0} \#{ARGV.join(' ')}"
       puts "RACK: \#{RACK}"
+      puts "PROCESS: \#{`ps --no-headers -oargs -p\#{Process.pid}`.strip}"
     RUBY
 
     before do
@@ -476,8 +477,9 @@ describe "bundle exec" do
     let(:exec) { "EXEC: load" }
     let(:args) { "ARGS: #{path} arg1 arg2" }
     let(:rack) { "RACK: 1.0.0" }
+    let(:process) { "PROCESS: #{path} arg1 arg2" }
     let(:exit_code) { 0 }
-    let(:expected) { [exec, args, rack].join("\n") }
+    let(:expected) { [exec, args, rack, process].join("\n") }
     let(:expected_err) { "" }
 
     subject { bundle "exec #{path} arg1 arg2", :expect_err => true }
@@ -511,7 +513,7 @@ describe "bundle exec" do
       let(:exit_code) { 1 }
       let(:expected) { super() << "\nbundler: failed to load command: #{path} (#{path})" }
       let(:expected_err) do
-        "RuntimeError: ERROR\n  #{path}:7" +
+        "RuntimeError: ERROR\n  #{path}:8" +
           (Bundler.current_ruby.ruby_18? ? "" : ":in `<top (required)>'")
       end
       it_behaves_like "it runs"


### PR DESCRIPTION
With bundler 1.11.2, the process name for rake tasks include the task name:

    $ bundle exec rake foo:bar

    $ ps ux | grep rake
     user         1758 62.2  2.4 385816 202032 pts/3   Sl+  16:16   0:04 ruby /usr/bin/rake foo:bar

On bundler 1.12.0, the process name changed:

    $ bundle exec rake foo:bar
 
    $ ps ux | grep rake
     user         1758 62.2  2.4 385816 202032 pts/3   Sl+  16:16   0:04 /usr/bin/rake

The change in behaviour is caused by bundler 1.12 using `load` (instead of `exec`) where
possible, and manually using `$0=` to set the command name. Unfortunately, that also alters
the process title visible with ps, and using `Process.setproctitle` can help reverse that.

The tests are green on my ruby 2.3.1/linux system, but I haven't run them on older rubies or non-linux environments. I'm assuming they'll need some modifications to be maximally compatible, but let's see what happens.

See also: #4488 