### PR TITLE
Fix the combination of gem :require and env or install_if

### DIFF
--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -68,9 +68,9 @@ module Bundler
       groups = [:default] if groups.empty?
 
       @definition.dependencies.each do |dep|
-        # Skip the dependency if it is not in any of the requested
-        # groups
-        next unless (dep.groups & groups).any? && dep.current_platform?
+        # Skip the dependency if it is not in any of the requested groups, or
+        # not for the current platform, or doesn't match the gem constraints.
+        next unless (dep.groups & groups).any? && dep.should_include?
 
         required_file = nil
 


### PR DESCRIPTION
If you guard the installation of a gem with `env` or `install_if`, and that gem declaration has a `:require` option specified, it tried to require the gem even though it hadn't been installed. It looks like a spot was missed when the `env` command was added in the first place.