### PR TITLE
[WIP] Properly detect path spec changes to avoid needless re-resolve

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -482,7 +482,7 @@ module Bundler
         end
       end
 
-      !locked || unlocking || dependencies_for_source_changed?(locked) || source.specs != locked.specs
+      !locked || unlocking || dependencies_for_source_changed?(source) || specs_for_source_changed?(source)
     end
 
     def dependencies_for_source_changed?(source)
@@ -490,6 +490,13 @@ module Bundler
       locked_deps_for_source = @locked_deps.select {|s| s.source == source }
 
       Set.new(deps_for_source) != Set.new(locked_deps_for_source)
+    end
+
+    def specs_for_source_changed?(source)
+      locked_index = Index.new
+      locked_index.use(@locked_specs.select {|s| source.can_lock?(s) })
+
+      source.specs != locked_index
     end
 
     # Get all locals and override their matching sources.

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -216,9 +216,11 @@ module Bundler
       @resolve ||= begin
         last_resolve = converge_locked_specs
         if Bundler.settings[:frozen] || (!@unlocking && nothing_changed?)
+          Bundler.ui.debug("Found no changes, using resolution from the lockfile")
           last_resolve
         else
           # Run a resolve against the locally available gems
+          Bundler.ui.debug("Found changes from the lockfile, re-resolving dependencies")
           last_resolve.merge Resolver.resolve(expanded_dependencies, index, source_requirements, last_resolve, ruby_version)
         end
       end
@@ -487,7 +489,7 @@ module Bundler
       deps_for_source = @dependencies.select {|s| s.source == source }
       locked_deps_for_source = @locked_deps.select {|s| s.source == source }
 
-      deps_for_source != locked_deps_for_source
+      Set.new(deps_for_source) != Set.new(locked_deps_for_source)
     end
 
     # Get all locals and override their matching sources.

--- a/lib/bundler/index.rb
+++ b/lib/bundler/index.rb
@@ -134,7 +134,7 @@ module Bundler
     def ==(other)
       all? do |spec|
         other_spec = other[spec].first
-        other_spec && (spec.dependencies & other_spec.dependencies).empty? && spec.source == other_spec.source
+        other_spec && Set.new(spec.dependencies) == Set.new(other_spec.dependencies) && spec.source == other_spec.source
       end
     end
 

--- a/lib/bundler/index.rb
+++ b/lib/bundler/index.rb
@@ -134,8 +134,14 @@ module Bundler
     def ==(other)
       all? do |spec|
         other_spec = other[spec].first
-        other_spec && Set.new(spec.dependencies) == Set.new(other_spec.dependencies) && spec.source == other_spec.source
+        other_spec && dependencies_eql?(spec, other_spec) && spec.source == other_spec.source
       end
+    end
+
+    def dependencies_eql?(spec, other_spec)
+      deps       = spec.dependencies.select {|d| d.type != :development }
+      other_deps = other_spec.dependencies.select {|d| d.type != :development }
+      Set.new(deps) == Set.new(other_deps)
     end
 
     def add_source(index)

--- a/spec/bundler/definition_spec.rb
+++ b/spec/bundler/definition_spec.rb
@@ -3,13 +3,12 @@ require "spec_helper"
 require "bundler/definition"
 
 describe Bundler::Definition do
-  before do
-    allow(Bundler).to receive(:settings) { Bundler::Settings.new(".") }
-    allow(Bundler).to receive(:default_gemfile) { Pathname.new("Gemfile") }
-    allow(Bundler).to receive(:ui) { double("UI", :info => "", :debug => "") }
-  end
-
   describe "#lock" do
+    before do
+      allow(Bundler).to receive(:settings) { Bundler::Settings.new(".") }
+      allow(Bundler).to receive(:default_gemfile) { Pathname.new("Gemfile") }
+      allow(Bundler).to receive(:ui) { double("UI", :info => "", :debug => "") }
+    end
     context "when it's not possible to write to the file" do
       subject { Bundler::Definition.new(nil, [], Bundler::SourceList.new, []) }
 
@@ -29,6 +28,108 @@ describe Bundler::Definition do
         expect { subject.lock("Gemfile.lock") }.
           to raise_error(Bundler::TemporaryResourceError, /temporarily unavailable/)
       end
+    end
+  end
+
+  describe "detects changes" do
+    it "for a path gem with changes" do
+      build_lib "foo", "1.0", :path => lib_path("foo")
+
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem "foo", :path => "#{lib_path("foo")}"
+      G
+
+      build_lib "foo", "1.0", :path => lib_path("foo") do |s|
+        s.add_dependency "rack", "1.0"
+      end
+
+      bundle :install, :env => { "DEBUG" => 1 }
+
+      expect(out).to match(/re-resolving dependencies/)
+      lockfile_should_be <<-G
+        PATH
+          remote: #{lib_path("foo")}
+          specs:
+            foo (1.0)
+              rack (= 1.0)
+
+        GEM
+          remote: file:#{gem_repo1}/
+          specs:
+            rack (1.0.0)
+
+        PLATFORMS
+          ruby
+
+        DEPENDENCIES
+          foo!
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      G
+    end
+
+    it "for a path gem with deps and no changes" do
+      build_lib "foo", "1.0", :path => lib_path("foo") do |s|
+        s.add_dependency "rack", "1.0"
+      end
+
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem "foo", :path => "#{lib_path("foo")}"
+      G
+
+      bundle :check, :env => { "DEBUG" => 1 }
+
+      expect(out).to match(/using resolution from the lockfile/)
+      lockfile_should_be <<-G
+        PATH
+          remote: #{lib_path("foo")}
+          specs:
+            foo (1.0)
+              rack (= 1.0)
+
+        GEM
+          remote: file:#{gem_repo1}/
+          specs:
+            rack (1.0.0)
+
+        PLATFORMS
+          ruby
+
+        DEPENDENCIES
+          foo!
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      G
+    end
+
+    it "for a rubygems gem" do
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem "foo"
+      G
+
+      bundle :check, :env => { "DEBUG" => 1 }
+
+      expect(out).to match(/using resolution from the lockfile/)
+      lockfile_should_be <<-G
+        GEM
+          remote: file:#{gem_repo1}/
+          specs:
+            foo (1.0)
+
+        PLATFORMS
+          ruby
+
+        DEPENDENCIES
+          foo
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      G
     end
   end
 end

--- a/spec/bundler/definition_spec.rb
+++ b/spec/bundler/definition_spec.rb
@@ -73,6 +73,7 @@ describe Bundler::Definition do
     it "for a path gem with deps and no changes" do
       build_lib "foo", "1.0", :path => lib_path("foo") do |s|
         s.add_dependency "rack", "1.0"
+        s.add_development_dependency "net-ssh", "1.0"
       end
 
       install_gemfile <<-G

--- a/spec/bundler/definition_spec.rb
+++ b/spec/bundler/definition_spec.rb
@@ -6,7 +6,7 @@ describe Bundler::Definition do
   before do
     allow(Bundler).to receive(:settings) { Bundler::Settings.new(".") }
     allow(Bundler).to receive(:default_gemfile) { Pathname.new("Gemfile") }
-    allow(Bundler).to receive(:ui) { double("UI", :info => "") }
+    allow(Bundler).to receive(:ui) { double("UI", :info => "", :debug => "") }
   end
 
   describe "#lock" do

--- a/spec/install/gemfile/path_spec.rb
+++ b/spec/install/gemfile/path_spec.rb
@@ -363,6 +363,40 @@ describe "bundle install with explicit source paths" do
     expect(exitstatus).to eq(0) if exitstatus
   end
 
+  context "existing lockfile" do
+    it "rubygems gems don't re-resolve without changes" do
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem 'rack-obama', '1.0'
+        gem 'net-ssh', '1.0'
+      G
+
+      bundle :check, :env => { "DEBUG" => 1 }
+      expect(out).to match(/using resolution from the lockfile/)
+      should_be_installed "rack-obama 1.0", "net-ssh 1.0"
+    end
+
+    it "source path gems w/deps don't re-resolve without changes" do
+      build_lib "rack-obama", "1.0", :path => lib_path("omg") do |s|
+        s.add_dependency "yard"
+      end
+
+      build_lib "net-ssh", "1.0", :path => lib_path("omg") do |s|
+        s.add_dependency "yard"
+      end
+
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem 'rack-obama', :path => "#{lib_path("omg")}"
+        gem 'net-ssh', :path => "#{lib_path("omg")}"
+      G
+
+      bundle :check, :env => { "DEBUG" => 1 }
+      expect(out).to match(/using resolution from the lockfile/)
+      should_be_installed "rack-obama 1.0", "net-ssh 1.0"
+    end
+  end
+
   it "installs executable stubs" do
     build_lib "foo" do |s|
       s.executables = ["foo"]
@@ -381,7 +415,7 @@ describe "bundle install with explicit source paths" do
       build_lib "foo", "1.0", :path => lib_path("foo") do |s|
         s.add_dependency "bar"
       end
-      build_lib "bar", "1.0", :path => lib_path("foo/bar")
+      build_lib "bar", "1.0", :path => lib_path("foo")
 
       install_gemfile <<-G
         gem "foo", :path => "#{lib_path("foo")}"
@@ -399,7 +433,7 @@ describe "bundle install with explicit source paths" do
     end
 
     it "unlocks all gems when a child dependency gem is updated" do
-      build_lib "bar", "2.0", :path => lib_path("foo/bar")
+      build_lib "bar", "2.0", :path => lib_path("foo")
 
       bundle "install"
 
@@ -418,6 +452,7 @@ describe "bundle install with explicit source paths" do
     end
 
     it "gets dependencies that are updated in the path" do
+      build_lib "rack", "1.0.0", :path => lib_path("foo")
       build_lib "foo", "1.0", :path => lib_path("foo") do |s|
         s.add_dependency "rack"
       end

--- a/spec/install/gemfile/path_spec.rb
+++ b/spec/install/gemfile/path_spec.rb
@@ -415,7 +415,7 @@ describe "bundle install with explicit source paths" do
       build_lib "foo", "1.0", :path => lib_path("foo") do |s|
         s.add_dependency "bar"
       end
-      build_lib "bar", "1.0", :path => lib_path("foo")
+      build_lib "bar", "1.0", :path => lib_path("foo/bar")
 
       install_gemfile <<-G
         gem "foo", :path => "#{lib_path("foo")}"
@@ -433,7 +433,7 @@ describe "bundle install with explicit source paths" do
     end
 
     it "unlocks all gems when a child dependency gem is updated" do
-      build_lib "bar", "2.0", :path => lib_path("foo")
+      build_lib "bar", "2.0", :path => lib_path("foo/bar")
 
       bundle "install"
 
@@ -452,7 +452,6 @@ describe "bundle install with explicit source paths" do
     end
 
     it "gets dependencies that are updated in the path" do
-      build_lib "rack", "1.0.0", :path => lib_path("foo")
       build_lib "foo", "1.0", :path => lib_path("foo") do |s|
         s.add_dependency "rack"
       end


### PR DESCRIPTION
* Use sets to compare dependencies
* Exclude dev dependencies when comparing indexes for equality
* Create an index from the Gemfile.lock's `@locked_specs` instead of from current gemspecs and use this for comparison to the current gemspecs.

More details...

Fixes an issue where we can mistakenly "think" the path gems have changed,
causing Bundler::Resolver.resolve to run again, merging in the prior lockfile
results.  We think the path gems have changed because the dependencies comparison cared about order using array == array.  We don't care about order so we can use set equality.  Additionally, we weren't properly detecting changes to path gems because we compared the current path gemspecs to themselves instead of the path specs from the lockfile.

**Before (with lockfile)**

time bundle check: 1.3 seconds
time bin/rails r 1: 7.2 seconds
rails boot memory[1]: 140 MB

**After (with lockfile)**

time bundle check: 0.46 seconds
time bin/rails r 1: 6.5 seconds
rails boot memory[1]: 125 MB

[1] `RAILS_ENV=production bin/rails r 'top = `/usr/bin/top -l 1 -pid #{Process.pid} | grep -E "ruby.+M"`; memory = top.split[7].to_i; puts memory'`