### PR TITLE
Fixes specifying ruby patch level in gemfile and gemspec

### DIFF
--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -125,7 +125,7 @@ module Bundler
       def for?(platform, required_ruby_version)
         if spec = @specs[platform]
           if required_ruby_version && spec.respond_to?(:required_ruby_version) && spec_required_ruby_version = spec.required_ruby_version
-            spec_required_ruby_version.satisfied_by?(required_ruby_version.gem_version)
+            spec_required_ruby_version.satisfied_by?(required_ruby_version.to_gem_version_with_patchlevel)
           else
             true
           end

--- a/lib/bundler/ruby_version.rb
+++ b/lib/bundler/ruby_version.rb
@@ -100,6 +100,15 @@ module Bundler
       @ruby_version ||= RubyVersion.new(RUBY_VERSION.dup, RUBY_PATCHLEVEL.to_s, ruby_engine, ruby_engine_version)
     end
 
+    def to_gem_version_with_patchlevel
+      @gem_version_with_patch ||= begin
+        patch_number = @patchlevel ? Gem::Requirement.create(@patchlevel).requirements.first.last : 0
+        Gem::Requirement.create("#{@gem_version}.#{patch_number}").requirements.first.last
+      rescue BadRequirementError
+        Gem::Requirement.create("#{@gem_version}.0").requirements.first.last
+      end
+    end
+
   private
 
     def matches?(requirements, version)

--- a/lib/bundler/ruby_version.rb
+++ b/lib/bundler/ruby_version.rb
@@ -102,10 +102,9 @@ module Bundler
 
     def to_gem_version_with_patchlevel
       @gem_version_with_patch ||= begin
-        patch_number = @patchlevel ? Gem::Requirement.create(@patchlevel).requirements.first.last : 0
-        Gem::Requirement.create("#{@gem_version}.#{patch_number}").requirements.first.last
-      rescue BadRequirementError
-        Gem::Requirement.create("#{@gem_version}.0").requirements.first.last
+        Gem::Version.create("#{@gem_version}.#{@patchlevel}")
+      rescue ArgumentError
+        @gem_version
       end
     end
 

--- a/spec/bundler/ruby_version_spec.rb
+++ b/spec/bundler/ruby_version_spec.rb
@@ -452,5 +452,31 @@ describe "Bundler::RubyVersion and its subclasses" do
         end
       end
     end
+
+    describe "#to_gem_version_with_patchlevel" do
+      shared_examples_for "the patchlevel is 0" do
+        it "uses 0 as patchlevel" do
+          expect(subject.to_gem_version_with_patchlevel.to_s).to eq("#{version}.0")
+        end
+      end
+
+      context "with nil patch number" do
+        let(:patchlevel) { nil }
+
+        it_behaves_like "the patchlevel is 0"
+      end
+
+      context "with negative patch number" do
+        let(:patchlevel) { -1 }
+
+        it_behaves_like "the patchlevel is 0"
+      end
+
+      context "with a valid patch number" do
+        it "uses the specified patchlevel as patchlevel" do
+          expect(subject.to_gem_version_with_patchlevel.to_s).to eq("#{version}.#{patchlevel}")
+        end
+      end
+    end
   end
 end

--- a/spec/bundler/ruby_version_spec.rb
+++ b/spec/bundler/ruby_version_spec.rb
@@ -454,22 +454,22 @@ describe "Bundler::RubyVersion and its subclasses" do
     end
 
     describe "#to_gem_version_with_patchlevel" do
-      shared_examples_for "the patchlevel is 0" do
-        it "uses 0 as patchlevel" do
-          expect(subject.to_gem_version_with_patchlevel.to_s).to eq("#{version}.0")
+      shared_examples_for "the patchlevel is omitted" do
+        it "does not include a patch level" do
+          expect(subject.to_gem_version_with_patchlevel.to_s).to eq(version)
         end
       end
 
       context "with nil patch number" do
         let(:patchlevel) { nil }
 
-        it_behaves_like "the patchlevel is 0"
+        it_behaves_like "the patchlevel is omitted"
       end
 
       context "with negative patch number" do
         let(:patchlevel) { -1 }
 
-        it_behaves_like "the patchlevel is 0"
+        it_behaves_like "the patchlevel is omitted"
       end
 
       context "with a valid patch number" do

--- a/spec/install/gemspecs_spec.rb
+++ b/spec/install/gemspecs_spec.rb
@@ -49,73 +49,60 @@ describe "bundle install" do
 
   context "when ruby version is specified in gemspec and gemfile" do
     it "installs when patch level is not specified and the version matches" do
-      build_lib("foo", :path => tmp.join("foo")) do |s|
-        s.write "Gemfile", <<-G
-        source "file://#{gem_repo1}"
-        ruby '#{RUBY_VERSION}', :engine_version => '#{RUBY_VERSION}', :engine => 'ruby'
-        gemspec
-        G
+      build_lib("foo", :path => bundled_app) do |s|
         s.required_ruby_version = RUBY_VERSION
       end
 
-      Dir.chdir(tmp.join("foo")) do
-        bundle "install"
-        should_be_installed "foo 1.0"
-      end
+      install_gemfile <<-G
+        ruby '#{RUBY_VERSION}', :engine_version => '#{RUBY_VERSION}', :engine => 'ruby'
+        gemspec
+      G
+      should_be_installed "foo 1.0"
     end
 
     it "installs when patch level is specified and the version still matches the current version" do
-      build_lib("foo", :path => tmp.join("foo")) do |s|
-        s.write "Gemfile", <<-G
-        source "file://#{gem_repo1}"
-        ruby '#{RUBY_VERSION}', :engine_version => '#{RUBY_VERSION}', :engine => 'ruby', :patchlevel => '#{RUBY_PATCHLEVEL}'
-        gemspec
-        G
+      build_lib("foo", :path => bundled_app) do |s|
         s.required_ruby_version = "#{RUBY_VERSION}.#{RUBY_PATCHLEVEL}"
       end
 
-      Dir.chdir(tmp.join("foo")) do
-        bundle "install"
-        should_be_installed "foo 1.0"
-      end
+      install_gemfile <<-G
+        ruby '#{RUBY_VERSION}', :engine_version => '#{RUBY_VERSION}', :engine => 'ruby', :patchlevel => '#{RUBY_PATCHLEVEL}'
+        gemspec
+      G
+      should_be_installed "foo 1.0"
     end
 
     it "fails and complains about patchlevel on patchlevel mismatch" do
       patchlevel = RUBY_PATCHLEVEL.to_i + 1
-      build_lib("foo", :path => tmp.join("foo")) do |s|
-        s.write "Gemfile", <<-G
-        source "file://#{gem_repo1}"
-        ruby '#{RUBY_VERSION}', :engine_version => '#{RUBY_VERSION}', :engine => 'ruby', :patchlevel => '#{patchlevel}'
-        gemspec
-        G
+      build_lib("foo", :path => bundled_app) do |s|
         s.required_ruby_version = "#{RUBY_VERSION}.#{patchlevel}"
       end
 
-      Dir.chdir(tmp.join("foo")) do
-        bundle "install"
-        expect(out).to include("Ruby patchlevel")
-        expect(out).to include("but your Gemfile specified")
-        expect(exitstatus).to eq(18) if exitstatus
-      end
+      install_gemfile <<-G
+        ruby '#{RUBY_VERSION}', :engine_version => '#{RUBY_VERSION}', :engine => 'ruby', :patchlevel => '#{patchlevel}'
+        gemspec
+      G
+
+      expect(out).to include("Ruby patchlevel")
+      expect(out).to include("but your Gemfile specified")
+      expect(exitstatus).to eq(18) if exitstatus
     end
 
     it "fails and complains about version on version mismatch" do
       version = Gem::Requirement.create(RUBY_VERSION).requirements.first.last.bump.version
-      build_lib("foo", :path => tmp.join("foo")) do |s|
-        s.write "Gemfile", <<-G
-        source "file://#{gem_repo1}"
-        ruby '#{version}', :engine_version => '#{version}', :engine => 'ruby'
-        gemspec
-        G
+
+      build_lib("foo", :path => bundled_app) do |s|
         s.required_ruby_version = version
       end
 
-      Dir.chdir(tmp.join("foo")) do
-        bundle "install"
-        expect(out).to include("Ruby version")
-        expect(out).to include("but your Gemfile specified")
-        expect(exitstatus).to eq(18) if exitstatus
-      end
+      install_gemfile <<-G
+        ruby '#{version}', :engine_version => '#{version}', :engine => 'ruby'
+        gemspec
+      G
+
+      expect(out).to include("Ruby version")
+      expect(out).to include("but your Gemfile specified")
+      expect(exitstatus).to eq(18) if exitstatus
     end
   end
 end

--- a/spec/install/gemspecs_spec.rb
+++ b/spec/install/gemspecs_spec.rb
@@ -61,6 +61,7 @@ describe "bundle install" do
     end
 
     it "installs when patch level is specified and the version still matches the current version" do
+      pending "this feature does not support dev ruby versions" if RUBY_PATCHLEVEL < 0
       build_lib("foo", :path => bundled_app) do |s|
         s.required_ruby_version = "#{RUBY_VERSION}.#{RUBY_PATCHLEVEL}"
       end
@@ -73,6 +74,7 @@ describe "bundle install" do
     end
 
     it "fails and complains about patchlevel on patchlevel mismatch" do
+      pending "this feature does not support dev ruby versions" if RUBY_PATCHLEVEL < 0
       patchlevel = RUBY_PATCHLEVEL.to_i + 1
       build_lib("foo", :path => bundled_app) do |s|
         s.required_ruby_version = "#{RUBY_VERSION}.#{patchlevel}"


### PR DESCRIPTION
- [x] add failing spec
- [x] add fix (with passing spec) and more specs to cover edge cases
- [x] ~~change error message to a more meaningful one~~ fixed the bug and a meaningful error message is now being shown

spec always passes on 2.2.0p0, probably because the patch version is 0