### PR TITLE
Resolve respecting Ruby versions without `ruby` in the Gemfile

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -52,7 +52,7 @@ module Bundler
       @optional_groups = optional_groups
       @remote          = false
       @specs           = nil
-      @ruby_version    = ruby_version
+      @ruby_version    = ruby_version || Bundler::RubyVersion.system
 
       @lockfile_contents      = String.new
       @locked_bundler_version = nil

--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -129,13 +129,10 @@ module Bundler
       end
 
       def for?(platform, required_ruby_version)
-        if spec = @specs[platform]
-          if required_ruby_version && spec.respond_to?(:required_ruby_version) && spec_required_ruby_version = spec.required_ruby_version
-            spec_required_ruby_version.satisfied_by?(required_ruby_version.gem_version)
-          else
-            true
-          end
-        end
+        return true unless required_ruby_version && Bundler.rubygems.has_required_ruby_version?
+
+        spec = @specs[platform]
+        spec.nil? ? true : spec.required_ruby_version.satisfied_by?(required_ruby_version.gem_version)
       end
 
       def to_s

--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -169,6 +169,12 @@ module Bundler
       yield
     end
 
+    def has_required_ruby_version?
+      return @has_required_ruby_version if @calculated_has_required_ruby_version
+      @calculated_has_required_ruby_version = true
+      @has_required_ruby_version = Gem::Specification.new.respond_to?(:required_ruby_version)
+    end
+
     def loaded_gem_paths
       # RubyGems 2.2+ can put binary extension into dedicated folders,
       # therefore use RubyGems facilities to obtain their load paths.

--- a/spec/install/gems/resolving_spec.rb
+++ b/spec/install/gems/resolving_spec.rb
@@ -105,20 +105,37 @@ describe "bundle install with gem sources" do
 
     describe "when some gems require a different version of ruby" do
       it "does not try to install those gems" do
-        pending "waiting for a rubygems index that includes ruby version"
-
         update_repo gem_repo1 do
           build_gem "require_ruby" do |s|
             s.required_ruby_version = "> 9000"
           end
         end
 
-        install_gemfile <<-G
+        install_gemfile <<-G, :artifice => "compact_index"
           source "file://#{gem_repo1}"
           gem 'require_ruby'
         G
 
         expect(out).to_not include("Gem::InstallError: require_ruby requires Ruby version > 9000")
+        expect(out).to include("require_ruby-1.0 requires ruby version > 9000, which is incompatible with the current version, #{Bundler::RubyVersion.system}")
+      end
+    end
+
+    describe "when some gems require a different version of rubygems" do
+      it "does not try to install those gems" do
+        update_repo gem_repo1 do
+          build_gem "require_rubygems" do |s|
+            s.required_rubygems_version = "> 9000"
+          end
+        end
+
+        install_gemfile <<-G, :artifice => "compact_index"
+          source "file://#{gem_repo1}"
+          gem 'require_rubygems'
+        G
+
+        expect(out).to_not include("Gem::InstallError: require_rubygems requires RubyGems version > 9000")
+        expect(out).to include("require_rubygems-1.0 requires rubygems version > 9000, which is incompatible with the current version, #{Gem::VERSION}")
       end
     end
   end

--- a/spec/install/gems/resolving_spec.rb
+++ b/spec/install/gems/resolving_spec.rb
@@ -1,163 +1,161 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle install with gem sources" do
-  describe "install time dependencies" do
-    it "installs gems with implicit rake dependencies" do
+describe "bundle install with install-time dependencies" do
+  it "installs gems with implicit rake dependencies" do
+    install_gemfile <<-G
+      source "file://#{gem_repo1}"
+      gem "with_implicit_rake_dep"
+      gem "another_implicit_rake_dep"
+      gem "rake"
+    G
+
+    run <<-R
+      require 'implicit_rake_dep'
+      require 'another_implicit_rake_dep'
+      puts IMPLICIT_RAKE_DEP
+      puts ANOTHER_IMPLICIT_RAKE_DEP
+    R
+    expect(out).to eq("YES\nYES")
+  end
+
+  it "installs gems with a dependency with no type" do
+    build_repo2
+
+    path = "#{gem_repo2}/#{Gem::MARSHAL_SPEC_DIR}/actionpack-2.3.2.gemspec.rz"
+    spec = Marshal.load(Gem.inflate(File.read(path)))
+    spec.dependencies.each do |d|
+      d.instance_variable_set(:@type, :fail)
+    end
+    File.open(path, "w") do |f|
+      f.write Gem.deflate(Marshal.dump(spec))
+    end
+
+    install_gemfile <<-G
+      source "file://#{gem_repo2}"
+      gem "actionpack", "2.3.2"
+    G
+
+    should_be_installed "actionpack 2.3.2", "activesupport 2.3.2"
+  end
+
+  describe "with crazy rubygem plugin stuff" do
+    it "installs plugins" do
       install_gemfile <<-G
         source "file://#{gem_repo1}"
-        gem "with_implicit_rake_dep"
-        gem "another_implicit_rake_dep"
-        gem "rake"
+        gem "net_b"
       G
 
-      run <<-R
-        require 'implicit_rake_dep'
-        require 'another_implicit_rake_dep'
-        puts IMPLICIT_RAKE_DEP
-        puts ANOTHER_IMPLICIT_RAKE_DEP
-      R
-      expect(out).to eq("YES\nYES")
+      should_be_installed "net_b 1.0"
     end
 
-    it "installs gems with a dependency with no type" do
-      build_repo2
-
-      path = "#{gem_repo2}/#{Gem::MARSHAL_SPEC_DIR}/actionpack-2.3.2.gemspec.rz"
-      spec = Marshal.load(Gem.inflate(File.read(path)))
-      spec.dependencies.each do |d|
-        d.instance_variable_set(:@type, :fail)
-      end
-      File.open(path, "w") do |f|
-        f.write Gem.deflate(Marshal.dump(spec))
-      end
-
+    it "installs plugins depended on by other plugins" do
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
-        gem "actionpack", "2.3.2"
+        source "file://#{gem_repo1}"
+        gem "net_a"
       G
 
-      should_be_installed "actionpack 2.3.2", "activesupport 2.3.2"
+      should_be_installed "net_a 1.0", "net_b 1.0"
     end
 
-    describe "with crazy rubygem plugin stuff" do
-      it "installs plugins" do
-        install_gemfile <<-G
-          source "file://#{gem_repo1}"
-          gem "net_b"
-        G
+    it "installs multiple levels of dependencies" do
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem "net_c"
+        gem "net_e"
+      G
 
-        should_be_installed "net_b 1.0"
-      end
+      should_be_installed "net_a 1.0", "net_b 1.0", "net_c 1.0", "net_d 1.0", "net_e 1.0"
+    end
 
-      it "installs plugins depended on by other plugins" do
-        install_gemfile <<-G
-          source "file://#{gem_repo1}"
-          gem "net_a"
-        G
-
-        should_be_installed "net_a 1.0", "net_b 1.0"
-      end
-
-      it "installs multiple levels of dependencies" do
-        install_gemfile <<-G
+    context "with ENV['DEBUG_RESOLVER'] set" do
+      it "produces debug output" do
+        gemfile <<-G
           source "file://#{gem_repo1}"
           gem "net_c"
           gem "net_e"
         G
 
-        should_be_installed "net_a 1.0", "net_b 1.0", "net_c 1.0", "net_d 1.0", "net_e 1.0"
-      end
-
-      context "with ENV['DEBUG_RESOLVER'] set" do
-        it "produces debug output" do
-          gemfile <<-G
-            source "file://#{gem_repo1}"
-            gem "net_c"
-            gem "net_e"
-          G
-
-          resolve_output = capture(:stdout) do
-            bundle :install, :env => { "DEBUG_RESOLVER" => "1" }
-          end
-
-          expect(resolve_output).to include("Creating possibility state for net_c")
+        resolve_output = capture(:stdout) do
+          bundle :install, :env => { "DEBUG_RESOLVER" => "1" }
         end
-      end
 
-      context "with ENV['DEBUG_RESOLVER_TREE'] set" do
-        it "produces debug output" do
-          gemfile <<-G
-            source "file://#{gem_repo1}"
-            gem "net_c"
-            gem "net_e"
-          G
-
-          resolve_output = capture(:stdout) do
-            bundle :install, :env => { "DEBUG_RESOLVER_TREE" => "1" }
-          end
-
-          expect(resolve_output).to include(" net_b")
-          expect(resolve_output).to include(" net_build_extensions (1.0)")
-        end
+        expect(resolve_output).to include("Creating possibility state for net_c")
       end
     end
 
-    describe "when a required ruby version" do
-      context "allows only an older version" do
-        it "installs the older version" do
-          update_repo gem_repo1 do
-            build_gem "rack", "9001.0.0" do |s|
-              s.required_ruby_version = "> 9000"
-            end
-          end
+    context "with ENV['DEBUG_RESOLVER_TREE'] set" do
+      it "produces debug output" do
+        gemfile <<-G
+          source "file://#{gem_repo1}"
+          gem "net_c"
+          gem "net_e"
+        G
 
-          install_gemfile <<-G, :artifice => "compact_index"
-            ruby "#{RUBY_VERSION}"
-            source "file://#{gem_repo1}"
-            gem 'rack'
-          G
-
-          expect(out).to_not include("rack-9001.0.0 requires ruby version > 9000")
-          should_be_installed("rack 1.0")
+        resolve_output = capture(:stdout) do
+          bundle :install, :env => { "DEBUG_RESOLVER_TREE" => "1" }
         end
+
+        expect(resolve_output).to include(" net_b")
+        expect(resolve_output).to include(" net_build_extensions (1.0)")
       end
+    end
+  end
 
-      context "allows no gems" do
-        it "does not try to install those gems" do
-          update_repo gem_repo1 do
-            build_gem "require_ruby" do |s|
-              s.required_ruby_version = "> 9000"
-            end
+  describe "when a required ruby version" do
+    context "allows only an older version" do
+      it "installs the older version" do
+        update_repo gem_repo1 do
+          build_gem "rack", "9001.0.0" do |s|
+            s.required_ruby_version = "> 9000"
           end
-
-          install_gemfile <<-G, :artifice => "compact_index"
-            source "file://#{gem_repo1}"
-            gem 'require_ruby'
-          G
-
-          expect(out).to_not include("Gem::InstallError: require_ruby requires Ruby version > 9000")
-          expect(out).to include("require_ruby-1.0 requires ruby version > 9000, which is incompatible with the current version, #{Bundler::RubyVersion.system}")
         end
+
+        install_gemfile <<-G, :artifice => "compact_index"
+          ruby "#{RUBY_VERSION}"
+          source "file://#{gem_repo1}"
+          gem 'rack'
+        G
+
+        expect(out).to_not include("rack-9001.0.0 requires ruby version > 9000")
+        should_be_installed("rack 1.0")
       end
     end
 
-    describe "when a required rubygems version disallows a gem" do
+    context "allows no gems" do
       it "does not try to install those gems" do
         update_repo gem_repo1 do
-          build_gem "require_rubygems" do |s|
-            s.required_rubygems_version = "> 9000"
+          build_gem "require_ruby" do |s|
+            s.required_ruby_version = "> 9000"
           end
         end
 
         install_gemfile <<-G, :artifice => "compact_index"
           source "file://#{gem_repo1}"
-          gem 'require_rubygems'
+          gem 'require_ruby'
         G
 
-        expect(out).to_not include("Gem::InstallError: require_rubygems requires RubyGems version > 9000")
-        expect(out).to include("require_rubygems-1.0 requires rubygems version > 9000, which is incompatible with the current version, #{Gem::VERSION}")
+        expect(out).to_not include("Gem::InstallError: require_ruby requires Ruby version > 9000")
+        expect(out).to include("require_ruby-1.0 requires ruby version > 9000, which is incompatible with the current version, #{Bundler::RubyVersion.system}")
       end
+    end
+  end
+
+  describe "when a required rubygems version disallows a gem" do
+    it "does not try to install those gems" do
+      update_repo gem_repo1 do
+        build_gem "require_rubygems" do |s|
+          s.required_rubygems_version = "> 9000"
+        end
+      end
+
+      install_gemfile <<-G, :artifice => "compact_index"
+        source "file://#{gem_repo1}"
+        gem 'require_rubygems'
+      G
+
+      expect(out).to_not include("Gem::InstallError: require_rubygems requires RubyGems version > 9000")
+      expect(out).to include("require_rubygems-1.0 requires rubygems version > 9000, which is incompatible with the current version, #{Gem::VERSION}")
     end
   end
 end


### PR DESCRIPTION
This is an extension of #4650 that adds the currently running Ruby as the Ruby that is being resolved against, making it possible to install (and lock to) usable versions of gems even in Gemfiles that don't explicitly declare a Ruby version.
