### PR TITLE
Add resolver-style error messages for required Ruby conflicts

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -246,7 +246,7 @@ module Bundler
         else
           # Run a resolve against the locally available gems
           Bundler.ui.debug("Found changes from the lockfile, re-resolving dependencies because #{change_reason}")
-          last_resolve.merge Resolver.resolve(expanded_dependencies, index, source_requirements, last_resolve, ruby_version, gem_version_promoter, additional_base_requirements_for_resolve)
+          last_resolve.merge Resolver.resolve(expanded_dependencies, index, source_requirements, last_resolve, gem_version_promoter, additional_base_requirements_for_resolve)
         end
       end
     end

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -343,8 +343,9 @@ module Bundler
       return unless @locked_ruby_version
       @locked_ruby_version_object ||= begin
         unless version = RubyVersion.from_string(@locked_ruby_version)
-          raise LockfileError, "Failed to create a `RubyVersion` object from " \
-            "`#{@locked_ruby_version}` found in #{@lockfile} -- try running `bundle update --ruby`."
+          raise LockfileError, "The Ruby version #{@locked_ruby_version} from " \
+            "#{@lockfile} could not be parsed. " \
+            "Try running bundle update --ruby to resolve this."
         end
         version
       end

--- a/lib/bundler/ruby_version.rb
+++ b/lib/bundler/ruby_version.rb
@@ -128,6 +128,11 @@ module Bundler
       end
     end
 
+    def exact?
+      return @exact if defined?(@exact)
+      @exact = versions.all? {|v| Gem::Requirement.create(v).exact? }
+    end
+
   private
 
     def matches?(requirements, version)

--- a/lib/bundler/rubygems_ext.rb
+++ b/lib/bundler/rubygems_ext.rb
@@ -159,6 +159,11 @@ module Gem
     def none?
       @none ||= (to_s == ">= 0")
     end unless allocate.respond_to?(:none?)
+
+    def exact?
+      return false unless @requirements.size == 1
+      @requirements[0][0] == "="
+    end unless allocate.respond_to?(:exact?)
   end
 
   class Platform

--- a/spec/install/gems/resolving_spec.rb
+++ b/spec/install/gems/resolving_spec.rb
@@ -126,23 +126,26 @@ describe "bundle install with install-time dependencies" do
           end
         end
 
-        install_gemfile <<-G
-          source "file://#{gem_repo2}"
+        install_gemfile <<-G, :artifice => "compact_index", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo2 }
+          source "http://localgemserver.test/"
           ruby "#{RUBY_VERSION}"
           gem 'require_ruby'
         G
 
         expect(out).to_not include("Gem::InstallError: require_ruby requires Ruby version > 9000")
 
-        nice_error = <<-E.strip.gsub(/^ {8}/, "")
-          Fetching source index from file:#{gem_repo1}/
+        nice_error = strip_whitespace(<<-E).strip
+          Fetching gem metadata from http://localgemserver.test/.
+          Fetching version metadata from http://localgemserver.test/
           Resolving dependencies...
-          Bundler could not find compatible versions for gem "require_ruby":
+          Bundler could not find compatible versions for gem "ruby\0":
             In Gemfile:
-              ruby (= #{RUBY_VERSION})
+              ruby\0 (= 2.3.1)
 
               require_ruby was resolved to 1.0, which depends on
-                ruby (> 9000)
+                ruby\0 (> 9000)
+
+          Could not find gem 'ruby\0 (> 9000)', which is required by gem 'require_ruby', in any of the sources.
         E
         expect(out).to eq(nice_error)
       end

--- a/spec/install/gems/resolving_spec.rb
+++ b/spec/install/gems/resolving_spec.rb
@@ -140,7 +140,7 @@ describe "bundle install with install-time dependencies" do
           Resolving dependencies...
           Bundler could not find compatible versions for gem "ruby\0":
             In Gemfile:
-              ruby\0 (= 2.3.1)
+              ruby\0 (~> #{RUBY_VERSION}.0)
 
               require_ruby was resolved to 1.0, which depends on
                 ruby\0 (> 9000)

--- a/spec/install/gems/resolving_spec.rb
+++ b/spec/install/gems/resolving_spec.rb
@@ -119,7 +119,7 @@ describe "bundle install with install-time dependencies" do
     end
 
     context "allows no gems" do
-      it "does not try to install those gems" do
+      it "raises an error during resolution" do
         build_repo2 do
           build_gem "require_ruby" do |s|
             s.required_ruby_version = "> 9000"
@@ -128,11 +128,23 @@ describe "bundle install with install-time dependencies" do
 
         install_gemfile <<-G
           source "file://#{gem_repo2}"
+          ruby "#{RUBY_VERSION}"
           gem 'require_ruby'
         G
 
         expect(out).to_not include("Gem::InstallError: require_ruby requires Ruby version > 9000")
-        expect(out).to include("require_ruby-1.0 requires ruby version > 9000, which is incompatible with the current version, #{Bundler::RubyVersion.system}")
+
+        nice_error = <<-E.strip.gsub(/^ {8}/, "")
+          Fetching source index from file:#{gem_repo1}/
+          Resolving dependencies...
+          Bundler could not find compatible versions for gem "require_ruby":
+            In Gemfile:
+              ruby (= #{RUBY_VERSION})
+
+              require_ruby was resolved to 1.0, which depends on
+                ruby (> 9000)
+        E
+        expect(out).to eq(nice_error)
       end
     end
   end

--- a/spec/install/gemspecs_spec.rb
+++ b/spec/install/gemspecs_spec.rb
@@ -50,7 +50,7 @@ describe "bundle install" do
   context "when ruby version is specified in gemspec and gemfile" do
     it "installs when patch level is not specified and the version matches" do
       build_lib("foo", :path => bundled_app) do |s|
-        s.required_ruby_version = RUBY_VERSION
+        s.required_ruby_version = "~> #{RUBY_VERSION}.0"
       end
 
       install_gemfile <<-G

--- a/spec/resolver/basic_spec.rb
+++ b/spec/resolver/basic_spec.rb
@@ -92,15 +92,18 @@ describe "Resolving" do
       gem "bar", "2.0.0" do |s|
         s.required_ruby_version = "~> 2.0.0"
       end
+
+      gem "ruby\0", "1.8.7"
     end
     dep "foo"
+    dep "ruby\0", "1.8.7"
 
     deps = []
     @deps.each do |d|
       deps << Bundler::DepProxy.new(d, "ruby")
     end
 
-    should_resolve_and_include %w(foo-1.0.0 bar-1.0.0), [{}, [], Bundler::RubyVersion.new("1.8.7", nil, nil, nil)]
+    should_resolve_and_include %w(foo-1.0.0 bar-1.0.0), [{}, []]
   end
 
   context "conservative" do

--- a/spec/support/indexes.rb
+++ b/spec/support/indexes.rb
@@ -62,7 +62,7 @@ module Spec
         s.level = opts.first
         s.strict = opts.include?(:strict)
       end
-      should_resolve_and_include specs, [{}, @base, nil, search]
+      should_resolve_and_include specs, [{}, @base, search]
     end
 
     def an_awesome_index


### PR DESCRIPTION
*Proposal:* When a gem in the Gemfile requires a Ruby version different than the Gemfile's `ruby`, print a conflict error message that looks more or less exactly like any other resolution conflict error.

*Current behavior:* On `master` today, Bundler will ignore the gem's required_ruby_version until install-time, and raise an exception like "require_ruby-1.0 requires ruby version > 9000, which is incompatible with the current version`.

After #4650 has been merged, Bundler will correctly reject gems that require a different version of Ruby, and instead print the error "Could not find `required_ruby` in any of the sources in your Gemfile".

*Rationale for change:* I believe that error message is surprising and misleading. The source _does_ contain `required ruby`, and I think we'll get bug reports about how our error message is wrong.