### PR TITLE
[WIP] Split gem sources in lockfile

### DIFF
--- a/spec/bundler/source_list_spec.rb
+++ b/spec/bundler/source_list_spec.rb
@@ -286,7 +286,7 @@ describe Bundler::SourceList do
   end
 
   describe "#lock_sources" do
-    it "combines the rubygems sources into a single instance, removing duplicate remotes from the end" do
+    it "returns each rubygems source" do
       source_list.add_git_source("uri" => "git://third-git.org/path.git")
       source_list.add_rubygems_source("remotes" => ["https://duplicate-rubygems.org"])
       source_list.add_path_source("path" => "/third/path/to/gem")
@@ -303,15 +303,14 @@ describe Bundler::SourceList do
         Bundler::Source::Git.new("uri" => "git://first-git.org/path.git"),
         Bundler::Source::Git.new("uri" => "git://second-git.org/path.git"),
         Bundler::Source::Git.new("uri" => "git://third-git.org/path.git"),
+        Bundler::Source::Rubygems.new,
+        Bundler::Source::Rubygems.new("remotes" => ["https://duplicate-rubygems.org"]),
+        Bundler::Source::Rubygems.new("remotes" => ["https://first-rubygems.org"]),
+        Bundler::Source::Rubygems.new("remotes" => ["https://second-rubygems.org"]),
+        Bundler::Source::Rubygems.new("remotes" => ["https://third-rubygems.org"]),
         Bundler::Source::Path.new("path" => "/first/path/to/gem"),
         Bundler::Source::Path.new("path" => "/second/path/to/gem"),
         Bundler::Source::Path.new("path" => "/third/path/to/gem"),
-        Bundler::Source::Rubygems.new("remotes" => [
-          "https://duplicate-rubygems.org",
-          "https://first-rubygems.org",
-          "https://second-rubygems.org",
-          "https://third-rubygems.org",
-        ]),
       ]
     end
   end


### PR DESCRIPTION
### Tasklist
- [ ] remove the rubygems aggregate
- [ ] link every gem to a single remote, possibly by grouping multiple gems under a source and managing multiple sources
- [ ] allow one global source that is chosen when no other source is present
- [ ] by default, the global source is the local source
- [ ] throw an exception when a gem could have multiple sources (see case 1 below)
- [ ] change the lockfile format to accommodate the changes above

-----------
### Case 1: When a gem may be obtained from multiple sources.

```
source "https://rubygems.org"
gem "rake"

source "https://sidekiq.io" do
  gem "sidekiq-pro"
end
```

`sidekiq-pro` depends on `sidekiq`, which is hosted on rubygems.org (and not hosted on sidekiq.io)
so the gem `sidekiq` has no source, and could be available from rubygems.org, sidekiq.io, or both

**Solutions:**

* if it’s only available from one source, we need to lock it to that one
* if it’s available from more than one, we need to throw an exception and tell the user that they have to tell us which source to use. Then the user edits the gemfile to something like:

```
source "https://rubygems.org"
gem "rake"
gem "sidekiq"

source "https://sidekiq.io" do
  gem "sidekiq-pro"
end
```

and this way all gems have a definite source.