### PR TITLE
Invalid lockfile local should not block install or update.

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -480,7 +480,16 @@ module Bundler
         end
       end
 
-      !locked || unlocking || dependencies_for_source_changed?(locked) || source.specs != locked.specs
+      return true unless locked
+      return true if unlocking
+      return true if dependencies_for_source_changed?(locked)
+      begin
+        locked_specs = locked.specs
+      rescue GitError
+        locked_specs = Bundler::Index.new
+      end
+      return true if source.specs != locked_specs
+      false
     end
 
     def dependencies_for_source_changed?(source)


### PR DESCRIPTION
Hey @indirect,

I finally got around to reproducing this issue ( https://github.com/bundler/bundler/pull/4172#issuecomment-185566638 ) in a minimal ruby project ( https://github.com/drn/bundler-locals-issue-project ). There are instructions in the README.

Basically both `bundle install` and `bundle update gem` raise the exception:
```
https://github.com/drn/bundler-locals-issue-gem (at TA-1000@d8a205d) is not yet checked
out. Run `bundle install` first.
```

I dug into the bundler source code and traced the exception to this line:
https://github.com/bundler/bundler/blob/master/lib/bundler/definition.rb#L483

The issue arises if there are no other dependencies in the project that are unlocking. All the other conditions are false, so source.specs != locked.specs triggers. source.specs returns a Bundler::Index instance. However, locked.specs raises an exception.

The exception that's raised is in https://github.com/bundler/bundler/blob/master/lib/bundler/source/git.rb#L192. The error message is:
The path/Users/darrencheng/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/bundler/gems/bundler-locals-issue-gem-d8a205d072a3does not exist., which in turn raises a GitError which isn't handled in the specs_changed? method.

The changes in this pull request patches the issue, but maybe there is a better fix for the issue? Potentially ensuring unlocking = true if a GitError is raised?