### PR TITLE
Conservative updates

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -30,6 +30,7 @@ module Bundler
   autoload :Fetcher,                "bundler/fetcher"
   autoload :GemHelper,              "bundler/gem_helper"
   autoload :GemHelpers,             "bundler/gem_helpers"
+  autoload :GemVersionPromoter,     "bundler/gem_version_promoter"
   autoload :Graph,                  "bundler/graph"
   autoload :Index,                  "bundler/index"
   autoload :Installer,              "bundler/installer"

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -208,12 +208,16 @@ module Bundler
       "Update ruby specified in Gemfile.lock"
     method_option "bundler", :type => :string, :lazy_default => "> 0.a", :banner =>
       "Update the locked version of bundler"
+
+    # MODO: hide these from help to release undocumented?
     method_option "patch", :type => :boolean, :banner =>
       "Prefer updating only to next patch version"
     method_option "minor", :type => :boolean, :banner =>
       "Prefer updating only to next minor version"
     method_option "major", :type => :boolean, :banner =>
       "Prefer updating to next major version (default)"
+    method_option "strict", :type => :boolean, :banner =>
+      "Do not allow any gem to be updated past latest --patch/--minor/--major"
     def update(*gems)
       require "bundler/cli/update"
       Update.new(options, gems).run

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -208,15 +208,13 @@ module Bundler
       "Update ruby specified in Gemfile.lock"
     method_option "bundler", :type => :string, :lazy_default => "> 0.a", :banner =>
       "Update the locked version of bundler"
-
-    # MODO: hide these from help to release undocumented?
-    method_option "patch", :type => :boolean, :banner =>
+    method_option "patch", :type => :boolean, :hide => true, :banner =>
       "Prefer updating only to next patch version"
-    method_option "minor", :type => :boolean, :banner =>
+    method_option "minor", :type => :boolean, :hide => true, :banner =>
       "Prefer updating only to next minor version"
-    method_option "major", :type => :boolean, :banner =>
+    method_option "major", :type => :boolean, :hide => true, :banner =>
       "Prefer updating to next major version (default)"
-    method_option "strict", :type => :boolean, :banner =>
+    method_option "strict", :type => :boolean, :hide => true, :banner =>
       "Do not allow any gem to be updated past latest --patch/--minor/--major"
     def update(*gems)
       require "bundler/cli/update"

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -208,6 +208,12 @@ module Bundler
       "Update ruby specified in Gemfile.lock"
     method_option "bundler", :type => :string, :lazy_default => "> 0.a", :banner =>
       "Update the locked version of bundler"
+    method_option "patch", :type => :boolean, :banner =>
+      "Prefer updating only to next patch version"
+    method_option "minor", :type => :boolean, :banner =>
+      "Prefer updating only to next minor version"
+    method_option "major", :type => :boolean, :banner =>
+      "Prefer updating to next major version (default)"
     def update(*gems)
       require "bundler/cli/update"
       Update.new(options, gems).run

--- a/lib/bundler/cli/update.rb
+++ b/lib/bundler/cli/update.rb
@@ -40,7 +40,7 @@ module Bundler
       end
 
       patch_level = [:major, :minor, :patch].detect {|v| options.keys.include?(v.to_s) }
-      Bundler.definition.update_opts.level = patch_level
+      Bundler.definition.dependency_search.level = patch_level
 
       Bundler::Fetcher.disable_endpoint = options["full-index"]
 

--- a/lib/bundler/cli/update.rb
+++ b/lib/bundler/cli/update.rb
@@ -39,9 +39,10 @@ module Bundler
         Bundler.definition(:gems => gems, :sources => sources, :ruby => options[:ruby])
       end
 
-      patch_level = [:major, :minor, :patch].detect {|v| options.keys.include?(v.to_s) }
+      patch_level = [:major, :minor, :patch].select {|v| options.keys.include?(v.to_s) }
+      raise ProductionError, "Provide only one of the following options: #{patch_level.join(", ")}" unless patch_level.length <= 1
       Bundler.definition.gem_version_promoter.tap do |gvp|
-        gvp.level = patch_level || :major
+        gvp.level = patch_level.first || :major
         gvp.strict = options[:strict]
       end
 

--- a/lib/bundler/cli/update.rb
+++ b/lib/bundler/cli/update.rb
@@ -3,7 +3,7 @@ module Bundler
   class CLI::Update
     attr_reader :options, :gems
     def initialize(options, gems)
-      @options = options
+      @options = options.tap {|o|p o}
       @gems = gems
     end
 

--- a/lib/bundler/cli/update.rb
+++ b/lib/bundler/cli/update.rb
@@ -39,7 +39,7 @@ module Bundler
         Bundler.definition(:gems => gems, :sources => sources, :ruby => options[:ruby])
       end
 
-      patch_level = [:major, :minor, :patch].detect { |v| options.keys.include?(v.to_s) }
+      patch_level = [:major, :minor, :patch].detect {|v| options.keys.include?(v.to_s) }
       Bundler.definition.update_opts.level = patch_level
 
       Bundler::Fetcher.disable_endpoint = options["full-index"]

--- a/lib/bundler/cli/update.rb
+++ b/lib/bundler/cli/update.rb
@@ -40,7 +40,10 @@ module Bundler
       end
 
       patch_level = [:major, :minor, :patch].detect {|v| options.keys.include?(v.to_s) }
-      Bundler.definition.gem_version_promoter.level = patch_level || :major
+      Bundler.definition.gem_version_promoter.tap do |gvp|
+        gvp.level = patch_level || :major
+        gvp.strict = options[:strict]
+      end
 
       Bundler::Fetcher.disable_endpoint = options["full-index"]
 

--- a/lib/bundler/cli/update.rb
+++ b/lib/bundler/cli/update.rb
@@ -40,7 +40,7 @@ module Bundler
       end
 
       patch_level = [:major, :minor, :patch].detect {|v| options.keys.include?(v.to_s) }
-      Bundler.definition.gem_version_promoter.level = patch_level
+      Bundler.definition.gem_version_promoter.level = patch_level || :major
 
       Bundler::Fetcher.disable_endpoint = options["full-index"]
 

--- a/lib/bundler/cli/update.rb
+++ b/lib/bundler/cli/update.rb
@@ -39,7 +39,8 @@ module Bundler
         Bundler.definition(:gems => gems, :sources => sources, :ruby => options[:ruby])
       end
 
-      Bundler.definition.update_opts.level = [:major, :minor, :patch].detect { |v| options.keys.include?(v) }
+      patch_level = [:major, :minor, :patch].detect { |v| options.keys.include?(v.to_s) }
+      Bundler.definition.update_opts.level = patch_level
 
       Bundler::Fetcher.disable_endpoint = options["full-index"]
 

--- a/lib/bundler/cli/update.rb
+++ b/lib/bundler/cli/update.rb
@@ -40,7 +40,7 @@ module Bundler
       end
 
       patch_level = [:major, :minor, :patch].detect {|v| options.keys.include?(v.to_s) }
-      Bundler.definition.dependency_search.level = patch_level
+      Bundler.definition.gem_version_promoter.level = patch_level
 
       Bundler::Fetcher.disable_endpoint = options["full-index"]
 

--- a/lib/bundler/cli/update.rb
+++ b/lib/bundler/cli/update.rb
@@ -3,7 +3,7 @@ module Bundler
   class CLI::Update
     attr_reader :options, :gems
     def initialize(options, gems)
-      @options = options.tap {|o|p o}
+      @options = options
       @gems = gems
     end
 
@@ -38,6 +38,8 @@ module Bundler
 
         Bundler.definition(:gems => gems, :sources => sources, :ruby => options[:ruby])
       end
+
+      Bundler.definition.update_opts.level = [:major, :minor, :patch].detect { |v| options.keys.include?(v) }
 
       Bundler::Fetcher.disable_endpoint = options["full-index"]
 

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -7,7 +7,7 @@ module Bundler
   class Definition
     include GemHelpers
 
-    attr_reader :dependencies, :platforms, :ruby_version, :locked_deps, :dependency_search
+    attr_reader :dependencies, :platforms, :ruby_version, :locked_deps, :gem_version_promoter
 
     # Given a gemfile and lockfile creates a Bundler definition
     #
@@ -94,7 +94,7 @@ module Bundler
       end
       @unlocking ||= @unlock[:ruby] ||= (!@locked_ruby_version ^ !@ruby_version)
 
-      @dependency_search = Resolver::DependencySearch.new(@locked_specs, @unlock[:gems])
+      @gem_version_promoter = GemVersionPromoter.new(@locked_specs, @unlock[:gems])
 
       current_platform = Bundler.rubygems.platforms.map {|p| generic(p) }.compact.last
       add_platform(current_platform)
@@ -223,7 +223,7 @@ module Bundler
         else
           # Run a resolve against the locally available gems
           Bundler.ui.debug("Found changes from the lockfile, re-resolving dependencies because #{change_reason}")
-          last_resolve.merge Resolver.resolve(expanded_dependencies, index, source_requirements, last_resolve, ruby_version, dependency_search)
+          last_resolve.merge Resolver.resolve(expanded_dependencies, index, source_requirements, last_resolve, ruby_version, gem_version_promoter)
         end
       end
     end

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -83,8 +83,6 @@ module Bundler
         @locked_sources = []
       end
 
-      @update_opts = Resolver::UpdateOptions.new(@locked_specs)
-
       @unlock[:gems] ||= []
       @unlock[:sources] ||= []
       @unlock[:ruby] ||= if @ruby_version && @locked_ruby_version
@@ -95,6 +93,8 @@ module Bundler
         @ruby_version.diff(locked_ruby_version_object)
       end
       @unlocking ||= @unlock[:ruby] ||= (!@locked_ruby_version ^ !@ruby_version)
+
+      @update_opts = Resolver::UpdateOptions.new(@locked_specs, @unlock[:gems])
 
       current_platform = Bundler.rubygems.platforms.map {|p| generic(p) }.compact.last
       add_platform(current_platform)

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -7,7 +7,7 @@ module Bundler
   class Definition
     include GemHelpers
 
-    attr_reader :dependencies, :platforms, :ruby_version, :locked_deps, :update_opts
+    attr_reader :dependencies, :platforms, :ruby_version, :locked_deps, :dependency_search
 
     # Given a gemfile and lockfile creates a Bundler definition
     #
@@ -94,7 +94,7 @@ module Bundler
       end
       @unlocking ||= @unlock[:ruby] ||= (!@locked_ruby_version ^ !@ruby_version)
 
-      @update_opts = Resolver::UpdateOptions.new(@locked_specs, @unlock[:gems])
+      @dependency_search = Resolver::DependencySearch.new(@locked_specs, @unlock[:gems])
 
       current_platform = Bundler.rubygems.platforms.map {|p| generic(p) }.compact.last
       add_platform(current_platform)
@@ -223,7 +223,7 @@ module Bundler
         else
           # Run a resolve against the locally available gems
           Bundler.ui.debug("Found changes from the lockfile, re-resolving dependencies because #{change_reason}")
-          last_resolve.merge Resolver.resolve(expanded_dependencies, index, source_requirements, last_resolve, ruby_version, update_opts)
+          last_resolve.merge Resolver.resolve(expanded_dependencies, index, source_requirements, last_resolve, ruby_version, dependency_search)
         end
       end
     end

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -127,7 +127,7 @@ module Bundler
 
     def create_gem_version_promoter
       locked_specs = begin
-        if @unlocking && @locked_specs.empty?
+        if @unlocking && @locked_specs.empty? && !@lockfile_contents.empty?
           # Definition uses an empty set of locked_specs to indicate all gems
           # are unlocked, but GemVersionPromoter needs the locked_specs
           # for conservative comparison.

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -7,7 +7,7 @@ module Bundler
   class Definition
     include GemHelpers
 
-    attr_reader :dependencies, :platforms, :ruby_version, :locked_deps
+    attr_reader :dependencies, :platforms, :ruby_version, :locked_deps, :update_opts
 
     # Given a gemfile and lockfile creates a Bundler definition
     #
@@ -57,6 +57,7 @@ module Bundler
       @lockfile_contents      = String.new
       @locked_bundler_version = nil
       @locked_ruby_version    = nil
+      @update_opts            = Resolver::UpdateOptions.new
 
       if lockfile && File.exist?(lockfile)
         @lockfile_contents = Bundler.read_file(lockfile)
@@ -221,7 +222,7 @@ module Bundler
         else
           # Run a resolve against the locally available gems
           Bundler.ui.debug("Found changes from the lockfile, re-resolving dependencies because #{change_reason}")
-          last_resolve.merge Resolver.resolve(expanded_dependencies, index, source_requirements, last_resolve, ruby_version)
+          last_resolve.merge Resolver.resolve(expanded_dependencies, index, source_requirements, last_resolve, ruby_version, update_opts)
         end
       end
     end

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -126,7 +126,6 @@ module Bundler
     end
 
     def create_gem_version_promoter
-      # MODO: unit test this
       locked_specs = begin
         if @unlocking && @locked_specs.empty?
           # Definition uses an empty set of locked_specs to indicate all gems

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -57,7 +57,6 @@ module Bundler
       @lockfile_contents      = String.new
       @locked_bundler_version = nil
       @locked_ruby_version    = nil
-      @update_opts            = Resolver::UpdateOptions.new
 
       if lockfile && File.exist?(lockfile)
         @lockfile_contents = Bundler.read_file(lockfile)
@@ -83,6 +82,8 @@ module Bundler
         @locked_specs   = SpecSet.new([])
         @locked_sources = []
       end
+
+      @update_opts = Resolver::UpdateOptions.new(@locked_specs)
 
       @unlock[:gems] ||= []
       @unlock[:sources] ||= []

--- a/lib/bundler/gem_version_promoter.rb
+++ b/lib/bundler/gem_version_promoter.rb
@@ -26,7 +26,8 @@ module Bundler
     end
 
     def sort_versions(dep, dep_specs)
-      before_result = "before sort_versions: #{debug_format_result(dep, dep_specs).inspect}"
+      # MODO Revisit env name - also see below
+      before_result = "before sort_versions: #{debug_format_result(dep, dep_specs).inspect}" if ENV["DEBUG_PATCH_RESOLVER"]
 
       result = @sort_versions[dep] ||= begin
         gem_name = dep.name
@@ -46,6 +47,7 @@ module Bundler
           end
         end
       end
+      # MODO: flush out this problem by freezing it?
       result.dup # not ideal, but elsewhere in bundler the resulting array is occasionally emptied, corrupting the cache.
     end
 

--- a/lib/bundler/gem_version_promoter.rb
+++ b/lib/bundler/gem_version_promoter.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Bundler
   class GemVersionPromoter
-    attr_reader :level
+    attr_reader :level, :locked_specs, :unlock_gems
     attr_accessor :strict, :minimal
 
     def initialize(locked_specs = SpecSet.new([]), unlock_gems = [])

--- a/lib/bundler/gem_version_promoter.rb
+++ b/lib/bundler/gem_version_promoter.rb
@@ -33,9 +33,9 @@ module Bundler
 
         # An Array per version returned, different entries for different platforms.
         # We only need the version here so it's ok to hard code this to the first instance.
-        locked_spec = @locked_specs[gem_name].first
+        locked_spec = locked_specs[gem_name].first
 
-        if @strict
+        if strict
           filter_dep_specs(dep_specs, locked_spec)
         else
           sort_dep_specs(dep_specs, locked_spec)
@@ -62,7 +62,7 @@ module Bundler
           gsv = gem_spec.version
           lsv = locked_spec.version
 
-          must_match = @level == :minor ? [0] : [0, 1]
+          must_match = level == :minor ? [0] : [0, 1]
 
           matches = must_match.map {|idx| gsv.segments[idx] == lsv.segments[idx] }
           (matches.uniq == [true]) ? (gsv >= lsv) : false
@@ -90,7 +90,7 @@ module Bundler
         case
         when a_ver.segments[0] != b_ver.segments[0]
           b_ver <=> a_ver
-        when !(@level == :minor) && (a_ver.segments[1] != b_ver.segments[1])
+        when !(level == :minor) && (a_ver.segments[1] != b_ver.segments[1])
           b_ver <=> a_ver
         else
           a_ver <=> b_ver
@@ -103,7 +103,7 @@ module Bundler
     end
 
     def unlocking_gem?(gem_name)
-      @unlock_gems.empty? || @unlock_gems.include?(gem_name)
+      unlock_gems.empty? || unlock_gems.include?(gem_name)
     end
 
     def move_version_to_end(specs, version, result)
@@ -116,8 +116,7 @@ module Bundler
     def debug_format_result(dep, res)
       a = [dep.to_s,
            res.map {|sg| [sg.version, sg.dependencies_for_activated_platforms.map {|dp| [dp.name, dp.requirement.to_s] }] }]
-      [a.first, a.last.map {|sg_data| [sg_data.first.version, sg_data.last.map {|aa| aa.join(" ") }] },
-       @level, @strict ? :strict : :not_strict]
+      [a.first, last_map, level, strict ? :strict : :not_strict]
     end
   end
 end

--- a/lib/bundler/gem_version_promoter.rb
+++ b/lib/bundler/gem_version_promoter.rb
@@ -21,7 +21,8 @@ module Bundler
         end
       end
 
-      @level = [:major, :minor, :patch].include?(v) ? v : @level_default
+      raise ArgumentError, "Unexpected level #{v}. Must be :major, :minor or :patch" unless [:major, :minor, :patch].include?(v)
+      @level = v
     end
 
     def sort_versions(dep, dep_specs)

--- a/lib/bundler/gem_version_promoter.rb
+++ b/lib/bundler/gem_version_promoter.rb
@@ -26,8 +26,7 @@ module Bundler
     end
 
     def sort_versions(dep, dep_specs)
-      # MODO Revisit env name - also see below
-      before_result = "before sort_versions: #{debug_format_result(dep, dep_specs).inspect}" if ENV["DEBUG_PATCH_RESOLVER"]
+      before_result = "before sort_versions: #{debug_format_result(dep, dep_specs).inspect}" if ENV["DEBUG_RESOLVER"]
 
       result = @sort_versions[dep] ||= begin
         gem_name = dep.name
@@ -41,9 +40,9 @@ module Bundler
         else
           sort_dep_specs(dep_specs, locked_spec)
         end.tap do |specs|
-          if ENV["DEBUG_PATCH_RESOLVER"] # MODO: proper debug flag name, check and proper debug output
-            STDERR.puts before_result
-            STDERR.puts " after sort_versions: #{debug_format_result(dep, specs).inspect}"
+          if ENV["DEBUG_RESOLVER"]
+            Bundler.ui.debug before_result
+            Bundler.ui.debug " after sort_versions: #{debug_format_result(dep, specs).inspect}"
           end
         end
       end

--- a/lib/bundler/gem_version_promoter.rb
+++ b/lib/bundler/gem_version_promoter.rb
@@ -29,7 +29,7 @@ module Bundler
     def sort_versions(dep, dep_specs)
       before_result = "before sort_versions: #{debug_format_result(dep, dep_specs).inspect}" if ENV["DEBUG_RESOLVER"]
 
-      result = @sort_versions[dep] ||= begin
+      @sort_versions[dep] ||= begin
         gem_name = dep.name
 
         # An Array per version returned, different entries for different platforms.
@@ -47,8 +47,6 @@ module Bundler
           end
         end
       end
-      # MODO: flush out this problem by freezing it?
-      result.dup # not ideal, but elsewhere in bundler the resulting array is occasionally emptied, corrupting the cache.
     end
 
     def major?

--- a/lib/bundler/gem_version_promoter.rb
+++ b/lib/bundler/gem_version_promoter.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+module Bundler
+  class GemVersionPromoter
+    attr_accessor :level, :strict, :minimal
+
+    def initialize(locked_specs = SpecSet.new([]), unlock_gems = [])
+      @level_default = :major
+      @level = @level_default
+      @strict = false
+      @minimal = false
+      @locked_specs = locked_specs
+      @unlock_gems = unlock_gems
+      @sort_versions = {}
+    end
+
+    def level=(value)
+      v = begin
+        case value
+        when String, Symbol
+          value.to_sym
+        end
+      end
+
+      @level = [:major, :minor, :patch].include?(v) ? v : @level_default
+    end
+
+    def sort_versions(dep, dep_specs)
+      before_result = "before sort_versions: #{debug_format_result(dep, dep_specs).inspect}"
+
+      result = @sort_versions[dep] ||= begin
+        gem_name = dep.name
+
+        # An Array per version returned, different entries for different platforms.
+        # We just need the version here so it's ok to hard code this to the first instance.
+        locked_spec = @locked_specs[gem_name].first
+
+        if @strict
+          filter_dep_specs(dep_specs, locked_spec)
+        else
+          sort_dep_specs(dep_specs, locked_spec)
+        end.tap do |specs|
+          if ENV["DEBUG_PATCH_RESOLVER"] # MODO: proper debug flag name, check and proper debug output
+            STDERR.puts before_result
+            STDERR.puts " after sort_versions: #{debug_format_result(dep, specs).inspect}"
+          end
+        end
+      end
+      result.dup # not ideal, but elsewhere in bundler the resulting array is occasionally emptied, corrupting the cache.
+    end
+
+  private
+
+    def filter_dep_specs(specs, locked_spec)
+      res = specs.select do |sg|
+        # SpecGroup is grouped by name/version, multiple entries for multiple platforms.
+        # We only need the name, which will be the same, so hard coding to first is ok.
+        gem_spec = sg.first
+
+        if locked_spec
+          gsv = gem_spec.version
+          lsv = locked_spec.version
+
+          must_match = @level == :minor ? [0] : [0, 1]
+
+          matches = must_match.map {|idx| gsv.segments[idx] == lsv.segments[idx] }
+          (matches.uniq == [true]) ? (gsv >= lsv) : false
+        else
+          true
+        end
+      end
+
+      sort_dep_specs(res, locked_spec)
+    end
+
+    # reminder: sort still filters anything older than locked version
+    # :major bundle update behavior can move a gem to an older version
+    # in order to satisfy the dependency tree.
+    def sort_dep_specs(specs, locked_spec)
+      return specs unless locked_spec
+      gem_name = locked_spec.name
+      locked_version = locked_spec.version
+
+      filtered = specs.select {|s| s.first.version >= locked_version }
+
+      filtered.sort do |a, b|
+        a_ver = a.first.version
+        b_ver = b.first.version
+        case
+        when a_ver.segments[0] != b_ver.segments[0]
+          b_ver <=> a_ver
+        when !(@level == :minor) && (a_ver.segments[1] != b_ver.segments[1])
+          b_ver <=> a_ver
+        when @minimal && !unlocking_gem?(gem_name)
+          b_ver <=> a_ver
+        when @minimal && unlocking_gem?(gem_name) &&
+          ![a_ver, b_ver].include?(locked_version) # MODO: revisit this case
+          b_ver <=> a_ver
+        else
+          a_ver <=> b_ver
+        end
+      end.tap do |result|
+        unless unlocking_gem?(gem_name)
+          move_version_to_end(specs, locked_version, result)
+        end
+      end
+    end
+
+    def unlocking_gem?(gem_name)
+      @unlock_gems.empty? || @unlock_gems.include?(gem_name)
+    end
+
+    def move_version_to_end(specs, version, result)
+      spec_group = specs.detect {|s| s.first.version.to_s == version.to_s }
+      return unless spec_group
+      result.reject! {|s| s.first.version.to_s == version.to_s }
+      result << spec_group
+    end
+
+    def debug_format_result(dep, res)
+      a = [dep.to_s,
+           res.map {|sg| [sg.version, sg.dependencies_for_activated_platforms.map {|dp| [dp.name, dp.requirement.to_s] }] }]
+      [a.first, a.last.map {|sg_data| [sg_data.first.version, sg_data.last.map {|aa| aa.join(" ") }] },
+       @level, @strict ? :strict : :not_strict, @minimal ? :minimal : :not_minimal]
+    end
+  end
+end

--- a/lib/bundler/gem_version_promoter.rb
+++ b/lib/bundler/gem_version_promoter.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 module Bundler
   class GemVersionPromoter
-    attr_accessor :level, :strict, :minimal
+    attr_reader :level
+    attr_accessor :strict, :minimal
 
     def initialize(locked_specs = SpecSet.new([]), unlock_gems = [])
       @level_default = :major
@@ -31,7 +32,7 @@ module Bundler
         gem_name = dep.name
 
         # An Array per version returned, different entries for different platforms.
-        # We just need the version here so it's ok to hard code this to the first instance.
+        # We only need the version here so it's ok to hard code this to the first instance.
         locked_spec = @locked_specs[gem_name].first
 
         if @strict

--- a/lib/bundler/gem_version_promoter.rb
+++ b/lib/bundler/gem_version_promoter.rb
@@ -2,13 +2,12 @@
 module Bundler
   class GemVersionPromoter
     attr_reader :level, :locked_specs, :unlock_gems
-    attr_accessor :strict, :minimal
+    attr_accessor :strict
 
     def initialize(locked_specs = SpecSet.new([]), unlock_gems = [])
       @level_default = :major
       @level = @level_default
       @strict = false
-      @minimal = false
       @locked_specs = locked_specs
       @unlock_gems = unlock_gems
       @sort_versions = {}
@@ -93,11 +92,6 @@ module Bundler
           b_ver <=> a_ver
         when !(@level == :minor) && (a_ver.segments[1] != b_ver.segments[1])
           b_ver <=> a_ver
-        when @minimal && !unlocking_gem?(gem_name)
-          b_ver <=> a_ver
-        when @minimal && unlocking_gem?(gem_name) &&
-          ![a_ver, b_ver].include?(locked_version) # MODO: revisit this case
-          b_ver <=> a_ver
         else
           a_ver <=> b_ver
         end
@@ -123,7 +117,7 @@ module Bundler
       a = [dep.to_s,
            res.map {|sg| [sg.version, sg.dependencies_for_activated_platforms.map {|dp| [dp.name, dp.requirement.to_s] }] }]
       [a.first, a.last.map {|sg_data| [sg_data.first.version, sg_data.last.map {|aa| aa.join(" ") }] },
-       @level, @strict ? :strict : :not_strict, @minimal ? :minimal : :not_minimal]
+       @level, @strict ? :strict : :not_strict]
     end
   end
 end

--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -172,14 +172,14 @@ module Bundler
     # ==== Returns
     # <GemBundle>,nil:: If the list of dependencies can be resolved, a
     #   collection of gemspecs is returned. Otherwise, nil is returned.
-    def self.resolve(requirements, index, source_requirements = {}, base = [], ruby_version = nil, dependency_search = DependencySearch.new)
+    def self.resolve(requirements, index, source_requirements = {}, base = [], ruby_version = nil, gem_version_promoter = GemVersionPromoter.new)
       base = SpecSet.new(base) unless base.is_a?(SpecSet)
-      resolver = new(index, source_requirements, base, ruby_version, dependency_search)
+      resolver = new(index, source_requirements, base, ruby_version, gem_version_promoter)
       result = resolver.start(requirements)
       SpecSet.new(result)
     end
 
-    def initialize(index, source_requirements, base, ruby_version, dependency_search = DependencySearch.new)
+    def initialize(index, source_requirements, base, ruby_version, gem_version_promoter = GemVersionPromoter.new)
       @index = index
       @source_requirements = source_requirements
       @base = base
@@ -188,7 +188,7 @@ module Bundler
       @base_dg = Molinillo::DependencyGraph.new
       @base.each {|ls| @base_dg.add_vertex(ls.name, Dependency.new(ls.name, ls.version), true) }
       @ruby_version = ruby_version
-      @dependency_search = dependency_search
+      @gem_version_promoter = gem_version_promoter
     end
 
     def start(requirements)
@@ -269,7 +269,8 @@ module Bundler
         end
       end
       platform_results = search.select {|sg| sg.for?(platform, @ruby_version) }.each {|sg| sg.activate_platform!(platform) }
-      @dependency_search.arrange_dep_specs(dependency, platform_results)
+      return platform_results if @gem_version_promoter.level == :major # default behavior
+      @gem_version_promoter.sort_versions(dependency, platform_results)
     end
 
     def index_for(dependency)
@@ -365,131 +366,6 @@ module Bundler
         version_platform_str << " #{platform}" unless platform.nil?
       end
       version_platform_strs.join(", ")
-    end
-
-    class DependencySearch
-      attr_accessor :level, :strict, :minimal
-
-      def initialize(locked_specs = SpecSet.new([]), unlock_gems = [])
-        @level_default = :major
-        @level = @level_default
-        @strict = false
-        @minimal = false
-        @locked_specs = locked_specs
-        @unlock_gems = unlock_gems
-      end
-
-      def unlocking_gem?(gem_name)
-        @unlock_gems.empty? || @unlock_gems.include?(gem_name)
-      end
-
-      def level=(value)
-        # MODO: figure this out mo' bettah
-        v = begin
-          value.to_sym
-        rescue
-          nil
-        end
-
-        @level = [:major, :minor, :patch].include?(v) ? v : @level_default
-      end
-
-      def arrange_dep_specs(dep, dep_specs)
-        return dep_specs if @level == :major
-
-        # MODO: bring search_for in here (copy index_for one liner?)
-        super_result = "super search_for: #{debug_format_result(dep, dep_specs).inspect}"
-
-        # MODO: figure out caching here plus what search_for provides
-        # @conservative_search_for[dep] ||=
-        begin
-          gem_name = dep.name
-
-          # An Array per version returned, different entries for different platforms.
-          # We just need the version here so it's ok to hard code this to the first instance.
-          locked_spec = @locked_specs[gem_name].first
-
-          if @strict
-            filter_dep_specs(dep_specs, locked_spec)
-          else
-            sort_dep_specs(dep_specs, locked_spec)
-          end.tap do |specs|
-            if ENV["DEBUG_PATCH_RESOLVER"] # MODO: proper debug flag name, check and proper debug output
-              STDERR.puts super_result
-              STDERR.puts "after search_for: #{debug_format_result(dep, specs).inspect}"
-            end
-          end
-        end
-      end
-
-      def debug_format_result(dep, res)
-        a = [dep.to_s,
-             res.map {|sg| [sg.version, sg.dependencies_for_activated_platforms.map {|dp| [dp.name, dp.requirement.to_s] }] }]
-        [a.first, a.last.map {|sg_data| [sg_data.first.version, sg_data.last.map {|aa| aa.join(" ") }] },
-         @level, @strict ? :strict : :not_strict, @minimal ? :minimal : :not_minimal]
-      end
-
-      def filter_dep_specs(specs, locked_spec)
-        res = specs.select do |sg|
-          # SpecGroup is grouped by name/version, multiple entries for multiple platforms.
-          # We only need the name, which will be the same, so hard coding to first is ok.
-          gem_spec = sg.first
-
-          if locked_spec
-            gsv = gem_spec.version
-            lsv = locked_spec.version
-
-            must_match = @level == :minor ? [0] : [0, 1]
-
-            matches = must_match.map {|idx| gsv.segments[idx] == lsv.segments[idx] }
-            (matches.uniq == [true]) ? (gsv >= lsv) : false
-          else
-            true
-          end
-        end
-
-        sort_dep_specs(res, locked_spec)
-      end
-
-      # reminder: sort still filters anything older than locked version
-      # :major bundle update behavior can move a gem to an older version
-      # in order to satisfy the dependency tree.
-      def sort_dep_specs(specs, locked_spec)
-        return specs unless locked_spec
-        gem_name = locked_spec.name
-        locked_version = locked_spec.version
-
-        filtered = specs.select {|s| s.first.version >= locked_version }
-
-        filtered.sort do |a, b|
-          a_ver = a.first.version
-          b_ver = b.first.version
-          case
-          when a_ver.segments[0] != b_ver.segments[0]
-            b_ver <=> a_ver
-          when !(@level == :minor) && (a_ver.segments[1] != b_ver.segments[1])
-            b_ver <=> a_ver
-          when @minimal && !unlocking_gem?(gem_name)
-            b_ver <=> a_ver
-          when @minimal && unlocking_gem?(gem_name) &&
-            ![a_ver, b_ver].include?(locked_version) # MODO: revisit this case
-            b_ver <=> a_ver
-          else
-            a_ver <=> b_ver
-          end
-        end.tap do |result|
-          unless unlocking_gem?(gem_name)
-            move_version_to_end(specs, locked_version, result)
-          end
-        end
-      end
-
-      def move_version_to_end(specs, version, result)
-        spec_group = specs.detect {|s| s.first.version.to_s == version.to_s }
-        return unless spec_group
-        result.reject! {|s| s.first.version.to_s == version.to_s }
-        result << spec_group
-      end
     end
   end
 end

--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -407,10 +407,10 @@ module Bundler
 
             (@strict ?
               filter_dep_specs(dep_specs, locked_spec) :
-              sort_dep_specs(dep_specs, locked_spec)).tap do |res|
+              sort_dep_specs(dep_specs, locked_spec)).tap do |specs|
               if ENV['DEBUG_PATCH_RESOLVER'] # MODO: proper debug flag check and proper debug output
                 STDERR.puts super_result
-                STDERR.puts "after search_for: #{debug_format_result(dep, res).inspect}"
+                STDERR.puts "after search_for: #{debug_format_result(dep, specs).inspect}"
               end
             end
           end
@@ -460,7 +460,7 @@ module Bundler
           case
           when a_ver.segments[0] != b_ver.segments[0]
             b_ver <=> a_ver
-          when !@level == :minor && (a_ver.segments[1] != b_ver.segments[1])
+          when !(@level == :minor) && (a_ver.segments[1] != b_ver.segments[1])
             b_ver <=> a_ver
           when @minimal && !unlocking_gem?(gem_name)
             b_ver <=> a_ver

--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -179,7 +179,7 @@ module Bundler
       SpecSet.new(result)
     end
 
-    def initialize(index, source_requirements, base, ruby_version, gem_version_promoter = GemVersionPromoter.new)
+    def initialize(index, source_requirements, base, ruby_version, gem_version_promoter)
       @index = index
       @source_requirements = source_requirements
       @base = base

--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -408,7 +408,7 @@ module Bundler
             (@strict ?
               filter_dep_specs(dep_specs, locked_spec) :
               sort_dep_specs(dep_specs, locked_spec)).tap do |specs|
-              if ENV['DEBUG_PATCH_RESOLVER'] # MODO: proper debug flag check and proper debug output
+              if ENV['DEBUG_PATCH_RESOLVER'] # MODO: proper debug flag name, check and proper debug output
                 STDERR.puts super_result
                 STDERR.puts "after search_for: #{debug_format_result(dep, specs).inspect}"
               end
@@ -419,7 +419,8 @@ module Bundler
       def debug_format_result(dep, res)
         a = [dep.to_s,
              res.map { |sg| [sg.version, sg.dependencies_for_activated_platforms.map { |dp| [dp.name, dp.requirement.to_s] }] }]
-        [a.first, a.last.map { |sg_data| [sg_data.first.version, sg_data.last.map { |aa| aa.join(' ') }] }, @level]
+        [a.first, a.last.map { |sg_data| [sg_data.first.version, sg_data.last.map { |aa| aa.join(' ') }] },
+         @level, @strict ? :strict : :not_strict, @minimal ? :minimal : :not_minimal]
       end
 
       def filter_dep_specs(specs, locked_spec)
@@ -435,7 +436,7 @@ module Bundler
             must_match = @level == :minor ? [0] : [0, 1]
 
             matches = must_match.map { |idx| gsv.segments[idx] == lsv.segments[idx] }
-            (matches.uniq == [true]) ? gsv.send(:>=, lsv) : false
+            (matches.uniq == [true]) ? (gsv >= lsv) : false
           else
             true
           end

--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -172,14 +172,14 @@ module Bundler
     # ==== Returns
     # <GemBundle>,nil:: If the list of dependencies can be resolved, a
     #   collection of gemspecs is returned. Otherwise, nil is returned.
-    def self.resolve(requirements, index, source_requirements = {}, base = [], ruby_version = nil)
+    def self.resolve(requirements, index, source_requirements = {}, base = [], ruby_version = nil, update_opts = UpdateOptions.new)
       base = SpecSet.new(base) unless base.is_a?(SpecSet)
-      resolver = new(index, source_requirements, base, ruby_version)
+      resolver = new(index, source_requirements, base, ruby_version, update_opts)
       result = resolver.start(requirements)
       SpecSet.new(result)
     end
 
-    def initialize(index, source_requirements, base, ruby_version)
+    def initialize(index, source_requirements, base, ruby_version, update_opts = UpdateOptions.new)
       @index = index
       @source_requirements = source_requirements
       @base = base
@@ -188,6 +188,7 @@ module Bundler
       @base_dg = Molinillo::DependencyGraph.new
       @base.each {|ls| @base_dg.add_vertex(ls.name, Dependency.new(ls.name, ls.version), true) }
       @ruby_version = ruby_version
+      @update_opts = update_opts
     end
 
     def start(requirements)
@@ -363,6 +364,22 @@ module Bundler
         version_platform_str << " #{platform}" unless platform.nil?
       end
       version_platform_strs.join(", ")
+    end
+
+    class UpdateOptions
+      attr_accessor :level, :strict, :minimal
+
+      def initialize
+        @level_default = :major
+        @level = @level_default
+        @strict = false
+        @minimal = false
+      end
+
+      def level=(value)
+        v = value.to_sym rescue nil
+        @level = [:major, :minor, :patch].include?(v) ? v : @level_default
+      end
     end
   end
 end

--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -270,6 +270,7 @@ module Bundler
       end
       platform_results = search.select {|sg| sg.for?(platform, @ruby_version) }.each {|sg| sg.activate_platform!(platform) }
       return platform_results if @gem_version_promoter.level == :major # default behavior
+      # MODO: put this inside the cache
       @gem_version_promoter.sort_versions(dependency, platform_results)
     end
 

--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -268,7 +268,9 @@ module Bundler
           []
         end
       end
-      search.select {|sg| sg.for?(platform, @ruby_version) }.each {|sg| sg.activate_platform!(platform) }
+      @update_opts.arrange_dep_specs(dependency,
+        search.select {|sg| sg.for?(platform, @ruby_version) }.each {|sg| sg.activate_platform!(platform) }
+      )
     end
 
     def index_for(dependency)
@@ -366,19 +368,122 @@ module Bundler
       version_platform_strs.join(", ")
     end
 
+    # MODO: Rename DependencySearcher
     class UpdateOptions
       attr_accessor :level, :strict, :minimal
 
-      def initialize
+      def initialize(locked_specs)
         @level_default = :major
         @level = @level_default
         @strict = false
         @minimal = false
+        @locked_specs = locked_specs
       end
 
       def level=(value)
         v = value.to_sym rescue nil
         @level = [:major, :minor, :patch].include?(v) ? v : @level_default
+      end
+
+      def arrange_dep_specs(dep, dep_specs)
+        return dep_specs if @level == :major
+
+        # MODO: bring search_for in here (copy index_for one liner?)
+        super_result = "super search_for: #{debug_format_result(dep, dep_specs).inspect}"
+
+        # MODO: figure out caching here plus what search_for provides
+        res = # @conservative_search_for[dep] ||=
+          begin
+            gem_name = dep.name
+
+            # An Array per version returned, different entries for different platforms.
+            # We just need the version here so it's ok to hard code this to the first instance.
+            locked_spec = @locked_specs[gem_name].first
+
+            (@strict ?
+              filter_dep_specs(dep_specs, locked_spec) :
+              sort_dep_specs(dep_specs, locked_spec)).tap do |res|
+              if ENV['DEBUG_PATCH_RESOLVER'] # MODO: proper debug flag check and proper debug output
+                STDERR.puts super_result
+                STDERR.puts "after search_for: #{debug_format_result(dep, res).inspect}"
+              end
+            end
+          end
+      end
+
+      def debug_format_result(dep, res)
+        a = [dep.to_s,
+             res.map { |sg| [sg.version, sg.dependencies_for_activated_platforms.map { |dp| [dp.name, dp.requirement.to_s] }] }]
+        [a.first, a.last.map { |sg_data| [sg_data.first.version, sg_data.last.map { |aa| aa.join(' ') }] }]
+      end
+
+      def filter_dep_specs(specs, locked_spec)
+        res = specs.select do |sg|
+          # SpecGroup is grouped by name/version, multiple entries for multiple platforms.
+          # We only need the name, which will be the same, so hard coding to first is ok.
+          gem_spec = sg.first
+
+          if locked_spec
+            gsv = gem_spec.version
+            lsv = locked_spec.version
+
+            must_match = @level == :minor ? [0] : [0, 1]
+
+            matches = must_match.map { |idx| gsv.segments[idx] == lsv.segments[idx] }
+            (matches.uniq == [true]) ? gsv.send(:>=, lsv) : false
+          else
+            true
+          end
+        end
+
+        sort_dep_specs(res, locked_spec)
+      end
+
+      # reminder: sort still filters anything older than locked version
+      def sort_dep_specs(specs, locked_spec)
+        return specs unless locked_spec
+        gem_name = locked_spec.name
+        locked_version = locked_spec.version
+
+        filtered = specs.select { |s| s.first.version >= locked_version }
+
+        filtered.sort do |a, b|
+          a_ver = a.first.version
+          b_ver = b.first.version
+          gem_patch = @gems_to_update.gem_patch_for(gem_name)
+          new_version = gem_patch ? gem_patch.new_version : nil
+          case
+          when a_ver.segments[0] != b_ver.segments[0]
+            b_ver <=> a_ver
+          when !@level == :minor && (a_ver.segments[1] != b_ver.segments[1])
+            b_ver <=> a_ver
+          when @minimal && !@gems_to_update.unlocking_gem?(gem_name)
+            b_ver <=> a_ver
+          when @minimal && @gems_to_update.unlocking_gem?(gem_name) &&
+            (![a_ver, b_ver].include?(locked_version) &&
+              (!new_version || (new_version && a_ver >= new_version && b_ver >= new_version)))
+            b_ver <=> a_ver
+          else
+            a_ver <=> b_ver
+          end
+        end.tap do |result|
+          if @gems_to_update.unlocking_gem?(gem_name)
+            gem_patch = @gems_to_update.gem_patch_for(gem_name)
+            if gem_patch && gem_patch.new_version && @minimal
+              move_version_to_end(specs, gem_patch.new_version, result)
+            end
+          else
+            move_version_to_end(specs, locked_version, result)
+          end
+        end
+      end
+
+      def move_version_to_end(specs, version, result)
+        spec_group = specs.detect { |s| s.first.version.to_s == version.to_s }
+        if spec_group
+          result.reject! { |s| s.first.version.to_s === version.to_s }
+          result << spec_group
+        end
       end
     end
   end

--- a/lib/bundler/spec_set.rb
+++ b/lib/bundler/spec_set.rb
@@ -7,7 +7,7 @@ module Bundler
     extend Forwardable
     include TSort, Enumerable
 
-    def_delegators :@specs, :<<, :length, :add, :remove, :size
+    def_delegators :@specs, :<<, :length, :add, :remove, :size, :empty?
     def_delegators :sorted, :each
 
     def initialize(specs)

--- a/spec/bundler/definition_spec.rb
+++ b/spec/bundler/definition_spec.rb
@@ -136,18 +136,47 @@ describe Bundler::Definition do
 
   describe "initialize" do
     context "gem version promoter" do
-      before :each do
-        install_gemfile <<-G
+      context "with lockfile" do
+        before :each do
+          install_gemfile <<-G
           source "file://#{gem_repo1}"
           gem "foo"
-        G
+          G
+        end
+
+        it "should get a locked specs list when updating all" do
+          definition = Bundler::Definition.new(bundled_app("Gemfile.lock"), [], Bundler::SourceList.new, true)
+          locked_specs = definition.gem_version_promoter.locked_specs
+          expect(locked_specs.to_a.map(&:name)).to eq ["foo"]
+          expect(definition.instance_variable_get("@locked_specs").empty?).to eq true
+        end
       end
 
-      it "should get a locked specs list when updating all" do
-        definition = Bundler::Definition.new(bundled_app("Gemfile.lock"), [], Bundler::SourceList.new, true)
-        locked_specs = definition.gem_version_promoter.locked_specs
-        expect(locked_specs.to_a.map(&:name)).to eq ["foo"]
-        expect(definition.instance_variable_get("@locked_specs").empty?).to eq true
+      context "without gemfile or lockfile" do
+        it "should not attempt to parse empty lockfile contents" do
+          definition = Bundler::Definition.new(nil, [], mock_source_list, true)
+          expect(definition.gem_version_promoter.locked_specs.to_a).to eq []
+        end
+      end
+
+      def mock_source_list
+        Class.new do
+          def all_sources
+            []
+          end
+
+          def path_sources
+            []
+          end
+
+          def rubygems_remotes
+            []
+          end
+
+          def replace_sources!(arg)
+            nil
+          end
+        end.new
       end
     end
   end

--- a/spec/bundler/definition_spec.rb
+++ b/spec/bundler/definition_spec.rb
@@ -133,4 +133,22 @@ describe Bundler::Definition do
       G
     end
   end
+
+  describe "initialize" do
+    context "gem version promoter" do
+      before :each do
+        install_gemfile <<-G
+          source "file://#{gem_repo1}"
+          gem "foo"
+        G
+      end
+
+      it "should get a locked specs list when updating all" do
+        definition = Bundler::Definition.new(bundled_app("Gemfile.lock"), [], Bundler::SourceList.new, true)
+        locked_specs = definition.gem_version_promoter.locked_specs
+        expect(locked_specs.to_a.map(&:name)).to eq ["foo"]
+        expect(definition.instance_variable_get("@locked_specs").empty?).to eq true
+      end
+    end
+  end
 end

--- a/spec/bundler/gem_version_promoter_spec.rb
+++ b/spec/bundler/gem_version_promoter_spec.rb
@@ -155,5 +155,15 @@ describe Bundler::GemVersionPromoter do
         end
       end
     end
+
+    context "debug output" do
+      it "should not kerblooie on its own debug output" do
+        gvp = unlocking(:level => :patch)
+        dep = Bundler::DepProxy.new(dep("foo", "1.2.0").first, "ruby")
+        result = gvp.send(:debug_format_result, dep, [build_spec_group("foo", "1.2.0"),
+                                                      build_spec_group("foo", "1.3.0")])
+        expect(result.class).to eq Array
+      end
+    end
   end
 end

--- a/spec/bundler/gem_version_promoter_spec.rb
+++ b/spec/bundler/gem_version_promoter_spec.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe Bundler::GemVersionPromoter do
+  context "conservative resolver" do
+    def versions(result)
+      result.flatten.map(&:version).map(&:to_s)
+    end
+
+    def make_instance(*args)
+      @gvp = Bundler::GemVersionPromoter.new(*args).tap do |gvp|
+        gvp.class.class_eval { public :filter_dep_specs, :sort_dep_specs }
+      end
+    end
+
+    def unlocking(options = {})
+      make_instance(Bundler::SpecSet.new([]), ["foo"]).tap do |p|
+        p.level = options[:level] if options[:level]
+        p.strict = options[:strict] if options[:strict]
+        p.minimal = options[:minimal] if options[:minimal]
+      end
+    end
+
+    def keep_locked(options = {})
+      make_instance(Bundler::SpecSet.new([]), ["bar"]).tap do |p|
+        p.level = options[:level] if options[:level]
+        p.strict = options[:strict] if options[:strict]
+        p.minimal = options[:minimal] if options[:minimal]
+      end
+    end
+
+    def build_spec_group(name, version)
+      build_spec(name, version).map {|s| Array(s) }
+    end
+
+    # Rightmost (highest array index) in result is most preferred.
+    # Leftmost (lowest array index) in result is least preferred.
+    # `build_spec_group` has all version of gem in index.
+    # `build_spec` is the version currently in the .lock file.
+    #
+    # In default (not strict) mode, all versions in the index will
+    # be returned, allowing Bundler the best chance to resolve all
+    # dependencies, but sometimes resulting in upgrades that some
+    # would not consider conservative.
+    context "filter specs (strict) (minor not allowed)" do
+      it "when keeping build_spec, keep current, next release" do
+        keep_locked(:level => :patch)
+        res = @gvp.filter_dep_specs(
+          build_spec_group("foo", %w(1.7.8 1.7.9 1.8.0)),
+          build_spec("foo", "1.7.8").first)
+        expect(versions(res)).to eq %w(1.7.9 1.7.8)
+      end
+
+      it "when unlocking prefer next release first" do
+        unlocking
+        res = @gvp.filter_dep_specs(
+          build_spec_group("foo", %w(1.7.8 1.7.9 1.8.0)),
+          build_spec("foo", "1.7.8").first)
+        expect(versions(res)).to eq %w(1.7.8 1.7.9)
+      end
+
+      it "when unlocking keep current when already at latest release" do
+        unlocking
+        res = @gvp.filter_dep_specs(
+          build_spec_group("foo", %w(1.7.9 1.8.0 2.0.0)),
+          build_spec("foo", "1.7.9").first)
+        expect(versions(res)).to eq %w(1.7.9)
+      end
+    end
+
+    context "filter specs (strict) (minor preferred)" do
+      it "should have specs"
+    end
+
+    context "sort specs (not strict) (minor not allowed)" do
+      it "when not unlocking, same order but make sure build_spec version is most preferred to stay put" do
+        keep_locked
+        res = @gvp.sort_dep_specs(
+          build_spec_group("foo", %w(1.7.6 1.7.7 1.7.8 1.7.9 1.8.0 1.8.1 2.0.0 2.0.1)),
+          build_spec("foo", "1.7.7").first)
+        expect(versions(res)).to eq %w(2.0.0 2.0.1 1.8.0 1.8.1 1.7.8 1.7.9 1.7.7)
+      end
+
+      it "when unlocking favor next release, then current over minor increase" do
+        unlocking
+        res = @gvp.sort_dep_specs(
+          build_spec_group("foo", %w(1.7.7 1.7.8 1.7.9 1.8.0)),
+          build_spec("foo", "1.7.8").first)
+        expect(versions(res)).to eq %w(1.8.0 1.7.8 1.7.9)
+      end
+
+      it "when unlocking do proper integer comparison, not string" do
+        unlocking
+        res = @gvp.sort_dep_specs(
+          build_spec_group("foo", %w(1.7.7 1.7.8 1.7.9 1.7.15 1.8.0)),
+          build_spec("foo", "1.7.8").first)
+        expect(versions(res)).to eq %w(1.8.0 1.7.8 1.7.9 1.7.15)
+      end
+
+      it "leave current when unlocking but already at latest release" do
+        unlocking
+        res = @gvp.sort_dep_specs(
+          build_spec_group("foo", %w(1.7.9 1.8.0 2.0.0)),
+          build_spec("foo", "1.7.9").first)
+        expect(versions(res)).to eq %w(2.0.0 1.8.0 1.7.9)
+      end
+
+      it "when prefer_minimal, and not updating this gem, order is strictly oldest to newest" do
+        keep_locked(:minimal => true)
+        versions = %w(1.7.5 1.7.8 1.7.9 1.8.0 2.0.0 2.1.0 3.0.0 3.0.1 3.1.0)
+        res = @gvp.sort_dep_specs(
+          build_spec_group("foo", versions),
+          build_spec("foo", "1.7.5").first)
+        expect(versions(res)).to eq versions.reverse
+      end
+
+      it "when prefer_minimal, and updating this gem, order is oldest to newest except current" do
+        unlocking(:minimal => true)
+        versions = %w(1.7.5 1.7.8 1.7.9 1.8.0 2.0.0 2.1.0 3.0.0 3.0.1 3.1.0)
+        res = @gvp.sort_dep_specs(
+          build_spec_group("foo", versions),
+          build_spec("foo", "1.7.5").first)
+        expect(versions(res)).to eq %w(3.1.0 3.0.1 3.0.0 2.1.0 2.0.0 1.8.0 1.7.5 1.7.9 1.7.8)
+      end
+    end
+
+    context "sort specs (not strict) (minor allowed)" do
+      it "when unlocking favor next release, then minor increase over current" do
+        unlocking(:level => :minor)
+        res = @gvp.sort_dep_specs(
+          build_spec_group("foo", %w(0.2.0 0.3.0 0.3.1 0.9.0 1.0.0 2.0.0 2.0.1)),
+          build_spec("foo", "0.2.0").first)
+        expect(versions(res)).to eq %w(2.0.0 2.0.1 1.0.0 0.2.0 0.3.0 0.3.1 0.9.0)
+      end
+
+      it "new version specified"
+
+      it "new version specified, prefer_minimal"
+    end
+
+    context "caching search results" do
+      it "should dup the output to protect the cache" do
+        # Bundler will (somewhere) do this on occasion during a large resolution.
+        # Let's protect against it.
+        gvp = Bundler::GemVersionPromoter.new
+
+        dep = Bundler::DepProxy.new(Gem::Dependency.new("foo", ">= 0"), "ruby")
+        sg = build_spec_group("foo", %w(2.4.0))
+        res = gvp.sort_versions(dep, sg)
+        res.clear
+        expect(gvp.sort_versions(dep, sg)).to_not eq []
+      end
+    end
+  end
+end

--- a/spec/bundler/gem_version_promoter_spec.rb
+++ b/spec/bundler/gem_version_promoter_spec.rb
@@ -40,7 +40,7 @@ describe Bundler::GemVersionPromoter do
     # be returned, allowing Bundler the best chance to resolve all
     # dependencies, but sometimes resulting in upgrades that some
     # would not consider conservative.
-    context "filter specs (strict) (minor not allowed)" do
+    context "filter specs (strict) level patch" do
       it "when keeping build_spec, keep current, next release" do
         keep_locked(:level => :patch)
         res = @gvp.filter_dep_specs(
@@ -66,11 +66,25 @@ describe Bundler::GemVersionPromoter do
       end
     end
 
-    context "filter specs (strict) (minor preferred)" do
-      it "should have specs" # MODO: so, y'know, like, maybe ... make some?
+    context "filter specs (strict) level minor" do
+      it "when unlocking favor next releases, remove minor and major increases" do
+        unlocking(:level => :minor)
+        res = @gvp.filter_dep_specs(
+          build_spec_group("foo", %w(0.2.0 0.3.0 0.3.1 0.9.0 1.0.0 2.0.0 2.0.1)),
+          build_spec("foo", "0.2.0").first)
+        expect(versions(res)).to eq %w(0.2.0 0.3.0 0.3.1 0.9.0)
+      end
+
+      it "when keep locked, keep current, then favor next release, remove minor and major increases" do
+        keep_locked(:level => :minor)
+        res = @gvp.filter_dep_specs(
+          build_spec_group("foo", %w(0.2.0 0.3.0 0.3.1 0.9.0 1.0.0 2.0.0 2.0.1)),
+          build_spec("foo", "0.2.0").first)
+        expect(versions(res)).to eq %w(0.3.0 0.3.1 0.9.0 0.2.0)
+      end
     end
 
-    context "sort specs (not strict) (minor not allowed)" do
+    context "sort specs (not strict) level patch" do
       it "when not unlocking, same order but make sure build_spec version is most preferred to stay put" do
         keep_locked(:level => :patch)
         res = @gvp.sort_dep_specs(
@@ -104,7 +118,7 @@ describe Bundler::GemVersionPromoter do
       end
     end
 
-    context "sort specs (not strict) (minor allowed)" do
+    context "sort specs (not strict) level minor" do
       it "when unlocking favor next release, then minor increase over current" do
         unlocking(:level => :minor)
         res = @gvp.sort_dep_specs(

--- a/spec/bundler/gem_version_promoter_spec.rb
+++ b/spec/bundler/gem_version_promoter_spec.rb
@@ -127,5 +127,33 @@ describe Bundler::GemVersionPromoter do
         expect(gvp.sort_versions(dep, sg)).to_not eq []
       end
     end
+
+    context "level error handling" do
+      subject { Bundler::GemVersionPromoter.new }
+
+      it "should raise if not major, minor or patch is passed" do
+        expect { subject.level = :minjor }.to raise_error ArgumentError
+      end
+
+      it "should raise if invalid classes passed" do
+        [123, nil].each do |value|
+          expect { subject.level = value }.to raise_error ArgumentError
+        end
+      end
+
+      it "should accept major, minor patch symbols" do
+        [:major, :minor, :patch].each do |value|
+          subject.level = value
+          expect(subject.level).to eq value
+        end
+      end
+
+      it "should accept major, minor patch strings" do
+        %w(major minor patch).each do |value|
+          subject.level = value
+          expect(subject.level).to eq value.to_sym
+        end
+      end
+    end
   end
 end

--- a/spec/bundler/gem_version_promoter_spec.rb
+++ b/spec/bundler/gem_version_promoter_spec.rb
@@ -17,7 +17,6 @@ describe Bundler::GemVersionPromoter do
       make_instance(Bundler::SpecSet.new([]), ["foo"]).tap do |p|
         p.level = options[:level] if options[:level]
         p.strict = options[:strict] if options[:strict]
-        p.minimal = options[:minimal] if options[:minimal]
       end
     end
 
@@ -25,7 +24,6 @@ describe Bundler::GemVersionPromoter do
       make_instance(Bundler::SpecSet.new([]), ["bar"]).tap do |p|
         p.level = options[:level] if options[:level]
         p.strict = options[:strict] if options[:strict]
-        p.minimal = options[:minimal] if options[:minimal]
       end
     end
 
@@ -69,7 +67,7 @@ describe Bundler::GemVersionPromoter do
     end
 
     context "filter specs (strict) (minor preferred)" do
-      it "should have specs"
+      it "should have specs" # MODO: so, y'know, like, maybe ... make some?
     end
 
     context "sort specs (not strict) (minor not allowed)" do
@@ -104,24 +102,6 @@ describe Bundler::GemVersionPromoter do
           build_spec("foo", "1.7.9").first)
         expect(versions(res)).to eq %w(2.0.0 1.8.0 1.7.9)
       end
-
-      it "when prefer_minimal, and not updating this gem, order is strictly oldest to newest" do
-        keep_locked(:minimal => true)
-        versions = %w(1.7.5 1.7.8 1.7.9 1.8.0 2.0.0 2.1.0 3.0.0 3.0.1 3.1.0)
-        res = @gvp.sort_dep_specs(
-          build_spec_group("foo", versions),
-          build_spec("foo", "1.7.5").first)
-        expect(versions(res)).to eq versions.reverse
-      end
-
-      it "when prefer_minimal, and updating this gem, order is oldest to newest except current" do
-        unlocking(:minimal => true)
-        versions = %w(1.7.5 1.7.8 1.7.9 1.8.0 2.0.0 2.1.0 3.0.0 3.0.1 3.1.0)
-        res = @gvp.sort_dep_specs(
-          build_spec_group("foo", versions),
-          build_spec("foo", "1.7.5").first)
-        expect(versions(res)).to eq %w(3.1.0 3.0.1 3.0.0 2.1.0 2.0.0 1.8.0 1.7.5 1.7.9 1.7.8)
-      end
     end
 
     context "sort specs (not strict) (minor allowed)" do
@@ -132,10 +112,6 @@ describe Bundler::GemVersionPromoter do
           build_spec("foo", "0.2.0").first)
         expect(versions(res)).to eq %w(2.0.0 2.0.1 1.0.0 0.2.0 0.3.0 0.3.1 0.9.0)
       end
-
-      it "new version specified"
-
-      it "new version specified, prefer_minimal"
     end
 
     context "caching search results" do

--- a/spec/bundler/gem_version_promoter_spec.rb
+++ b/spec/bundler/gem_version_promoter_spec.rb
@@ -88,9 +88,9 @@ describe Bundler::GemVersionPromoter do
       it "when not unlocking, same order but make sure build_spec version is most preferred to stay put" do
         keep_locked(:level => :patch)
         res = @gvp.sort_dep_specs(
-          build_spec_group("foo", %w(1.7.6 1.7.7 1.7.8 1.7.9 1.8.0 1.8.1 2.0.0 2.0.1)),
+          build_spec_group("foo", %w(1.5.4 1.6.5 1.7.6 1.7.7 1.7.8 1.7.9 1.8.0 1.8.1 2.0.0 2.0.1)),
           build_spec("foo", "1.7.7").first)
-        expect(versions(res)).to eq %w(2.0.0 2.0.1 1.8.0 1.8.1 1.7.8 1.7.9 1.7.7)
+        expect(versions(res)).to eq %w(1.5.4 1.6.5 1.7.6 2.0.0 2.0.1 1.8.0 1.8.1 1.7.8 1.7.9 1.7.7)
       end
 
       it "when unlocking favor next release, then current over minor increase" do
@@ -98,7 +98,7 @@ describe Bundler::GemVersionPromoter do
         res = @gvp.sort_dep_specs(
           build_spec_group("foo", %w(1.7.7 1.7.8 1.7.9 1.8.0)),
           build_spec("foo", "1.7.8").first)
-        expect(versions(res)).to eq %w(1.8.0 1.7.8 1.7.9)
+        expect(versions(res)).to eq %w(1.7.7 1.8.0 1.7.8 1.7.9)
       end
 
       it "when unlocking do proper integer comparison, not string" do
@@ -106,7 +106,7 @@ describe Bundler::GemVersionPromoter do
         res = @gvp.sort_dep_specs(
           build_spec_group("foo", %w(1.7.7 1.7.8 1.7.9 1.7.15 1.8.0)),
           build_spec("foo", "1.7.8").first)
-        expect(versions(res)).to eq %w(1.8.0 1.7.8 1.7.9 1.7.15)
+        expect(versions(res)).to eq %w(1.7.7 1.8.0 1.7.8 1.7.9 1.7.15)
       end
 
       it "leave current when unlocking but already at latest release" do

--- a/spec/bundler/gem_version_promoter_spec.rb
+++ b/spec/bundler/gem_version_promoter_spec.rb
@@ -114,20 +114,6 @@ describe Bundler::GemVersionPromoter do
       end
     end
 
-    context "caching search results" do
-      it "should dup the output to protect the cache" do
-        # Bundler will (somewhere) do this on occasion during a large resolution.
-        # Let's protect against it.
-        gvp = Bundler::GemVersionPromoter.new
-
-        dep = Bundler::DepProxy.new(Gem::Dependency.new("foo", ">= 0"), "ruby")
-        sg = build_spec_group("foo", %w(2.4.0))
-        res = gvp.sort_versions(dep, sg)
-        res.clear
-        expect(gvp.sort_versions(dep, sg)).to_not eq []
-      end
-    end
-
     context "level error handling" do
       subject { Bundler::GemVersionPromoter.new }
 

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -443,18 +443,8 @@ describe "bundle update conservative" do
         gem 'foo'
       G
 
-      # bundle "update --patch_preferred" # preferred is a bit lengthy
-      # bundle "update --patch"
-      require_relative '../../lib/bundler/cli'
-      require_relative '../../lib/bundler/cli/update'
-      #Bundler::CLI::Update.new({patch: true}, [])
-      # Bundler.with_clean_env do
-      #   ENV['BUNDLE_GEMFILE'] = bundled_app.to_s
-      #   Bundler::CLI::Update.new({}, [])
-      # end
-      bundle 'update'
+      bundle "update --patch"
 
-      # switch i guess is recognized as a gem name, so no update at all occurs
       should_be_installed "foo 1.0.1"
     end
   end

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -428,7 +428,7 @@ end
 
 describe "bundle update conservative" do
   context "patch preferred" do
-    it "single gem without dependencies" do
+    it "single gem without dependencies name specified" do
       build_repo4 do
         build_gem "foo", %w(1.0.0 1.0.1 1.1.0 2.0.0)
       end
@@ -448,10 +448,30 @@ describe "bundle update conservative" do
 
       should_be_installed "foo 1.0.1"
     end
+
+    it "single gem without dependencies update all" do
+      build_repo4 do
+        build_gem "foo", %w(1.0.0 1.0.1 1.1.0 2.0.0)
+      end
+
+      install_gemfile <<-G
+        source "file://#{gem_repo4}"
+        gem 'foo', '1.0.0'
+      G
+
+      gemfile <<-G
+        source "file://#{gem_repo4}"
+        gem 'foo'
+      G
+
+      # bundle "update --patch foo", {:env => {'DEBUG_PATCH_RESOLVER' => true}}
+      bundle "update --patch"
+
+      should_be_installed "foo 1.0.1"
+    end
   end
 
   context "minor preferred" do
-
   end
 
   context "strict" do
@@ -461,6 +481,5 @@ describe "bundle update conservative" do
   end
 
   context "dry run" do
-
   end
 end

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -449,7 +449,7 @@ describe "bundle update conservative" do
       should_be_installed "foo 1.0.1"
     end
 
-    it "single gem without dependencies update all with debugging" do
+    it "single gem without dependencies update all" do
       build_repo4 do
         build_gem "foo", %w(1.0.0 1.0.1 1.1.0 2.0.0)
       end
@@ -464,7 +464,7 @@ describe "bundle update conservative" do
         gem 'foo'
       G
 
-      bundle "update --patch", :env => { "DEBUG_RESOLVER" => true }
+      bundle "update --patch"
 
       should_be_installed "foo 1.0.1"
     end

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -443,7 +443,7 @@ describe "bundle update conservative" do
         gem 'foo'
       G
 
-      bundle "update --patch"
+      bundle "update --patch foo", {:env => {'DEBUG_PATCH_RESOLVER' => true}}
 
       should_be_installed "foo 1.0.1"
     end

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -426,6 +426,7 @@ describe "bundle update --ruby" do
   end
 end
 
+# these specs are slow and focus on integration and therefore are not exhaustive. unit specs elsewhere handle that.
 describe "bundle update conservative" do
   context "patch preferred" do
     it "single gem without dependencies name specified" do
@@ -443,7 +444,6 @@ describe "bundle update conservative" do
         gem 'foo'
       G
 
-      # bundle "update --patch foo", {:env => {'DEBUG_PATCH_RESOLVER' => true}}
       bundle "update --patch foo"
 
       should_be_installed "foo 1.0.1"
@@ -464,14 +464,16 @@ describe "bundle update conservative" do
         gem 'foo'
       G
 
-      # bundle "update --patch foo", {:env => {'DEBUG_PATCH_RESOLVER' => true}}
       bundle "update --patch"
 
       should_be_installed "foo 1.0.1"
     end
+
+    it "warns on minor or major increment elsewhere"
   end
 
   context "minor preferred" do
+    it "warns on major increment elsewhere"
   end
 
   context "strict" do
@@ -481,5 +483,8 @@ describe "bundle update conservative" do
   end
 
   context "dry run" do
+    it "should show what would happen"
+
+    it "should replace/be the same as what outdated shows"
   end
 end

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -425,3 +425,51 @@ describe "bundle update --ruby" do
     end
   end
 end
+
+describe "bundle update conservative" do
+  context "patch preferred" do
+    it "single gem without dependencies" do
+      build_repo4 do
+        build_gem "foo", %w(1.0.0 1.0.1 1.1.0 2.0.0)
+      end
+
+      install_gemfile <<-G
+        source "file://#{gem_repo4}"
+        gem 'foo', '1.0.0'
+      G
+
+      gemfile <<-G
+        source "file://#{gem_repo4}"
+        gem 'foo'
+      G
+
+      # bundle "update --patch_preferred" # preferred is a bit lengthy
+      # bundle "update --patch"
+      require_relative '../../lib/bundler/cli'
+      require_relative '../../lib/bundler/cli/update'
+      #Bundler::CLI::Update.new({patch: true}, [])
+      # Bundler.with_clean_env do
+      #   ENV['BUNDLE_GEMFILE'] = bundled_app.to_s
+      #   Bundler::CLI::Update.new({}, [])
+      # end
+      bundle 'update'
+
+      # switch i guess is recognized as a gem name, so no update at all occurs
+      should_be_installed "foo 1.0.1"
+    end
+  end
+
+  context "minor preferred" do
+
+  end
+
+  context "strict" do
+    it "patch preferred"
+
+    it "minor preferred"
+  end
+
+  context "dry run" do
+
+  end
+end

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -473,7 +473,7 @@ describe "bundle update conservative" do
       should_be_installed "foo 1.4.5", "bar 2.1.1", "qux 1.0.1"
     end
 
-    it "warns on minor or major increment elsewhere"
+    it "warns on minor or major increment elsewhere" ## include in prior test
   end
 
   context "minor preferred" do
@@ -483,7 +483,9 @@ describe "bundle update conservative" do
       should_be_installed "foo 1.5.1", "bar 3.0.0", "qux 1.0.0"
     end
 
-    it "warns on major increment elsewhere"
+    it "warns on major increment elsewhere" ## include in prior test
+
+    it "warns when something unlocked doesn't update at all"
   end
 
   context "strict" do
@@ -500,9 +502,9 @@ describe "bundle update conservative" do
     end
   end
 
-  context "dry run" do
-    it "should show what would happen"
+  context "other commands" do
+    it "Installer could support --dry-run flag for install and update"
 
-    it "should replace/be the same as what outdated shows"
+    it "outdated should conform its flags to the resolver flags"
   end
 end

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -502,6 +502,14 @@ describe "bundle update conservative" do
     end
   end
 
+  context "error handling" do
+    it "raises if too many flags are provided" do
+      bundle "update --patch --minor"
+
+      expect(out).to eq "Provide only one of the following options: minor, patch"
+    end
+  end
+
   context "other commands" do
     it "Installer could support --dry-run flag for install and update"
 

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -449,7 +449,7 @@ describe "bundle update conservative" do
       should_be_installed "foo 1.0.1"
     end
 
-    it "single gem without dependencies update all" do
+    it "single gem without dependencies update all with debugging" do
       build_repo4 do
         build_gem "foo", %w(1.0.0 1.0.1 1.1.0 2.0.0)
       end
@@ -464,7 +464,7 @@ describe "bundle update conservative" do
         gem 'foo'
       G
 
-      bundle "update --patch"
+      bundle "update --patch", :env => { "DEBUG_RESOLVER" => true }
 
       should_be_installed "foo 1.0.1"
     end

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -443,7 +443,8 @@ describe "bundle update conservative" do
         gem 'foo'
       G
 
-      bundle "update --patch foo", {:env => {'DEBUG_PATCH_RESOLVER' => true}}
+      # bundle "update --patch foo", {:env => {'DEBUG_PATCH_RESOLVER' => true}}
+      bundle "update --patch foo"
 
       should_be_installed "foo 1.0.1"
     end

--- a/spec/plugins/install_spec.rb
+++ b/spec/plugins/install_spec.rb
@@ -9,7 +9,7 @@ describe "bundler plugin install" do
     end
   end
 
-  it "shows propper message when gem in not found in the source" do
+  it "shows proper message when gem in not found in the source" do
     bundle "plugin install no-foo --source file://#{gem_repo1}"
 
     expect(out).to include("Could not find")

--- a/spec/resolver/basic_spec.rb
+++ b/spec/resolver/basic_spec.rb
@@ -177,5 +177,13 @@ describe "Resolving" do
       # minimal option altogether. If that's what you need, use the Gemfile dependency.
       should_consv_resolve_and_include [:minor, :minimal], [], %w(foo-1.4.4 bar-2.0.4)
     end
+
+    it 'will not revert to a previous version'
+
+    it 'has taken care of all MODOs'
+
+    it 'has moved DependencySearch into its own file'
+
+    it 'has moved search_for impl out of Resolver into DependencySearch' # method called by Molinillo, but bulk can go off to dep_search
   end
 end

--- a/spec/resolver/basic_spec.rb
+++ b/spec/resolver/basic_spec.rb
@@ -103,74 +103,74 @@ describe "Resolving" do
     should_resolve_and_include %w(foo-1.0.0 bar-1.0.0), [{}, [], Bundler::RubyVersion.new("1.8.7", nil, nil, nil)]
   end
 
-  context 'conservative' do
+  context "conservative" do
     before :each do
       @index = build_index do
-        gem('foo', '1.3.7') { dep 'bar', '~> 2.0' }
-        gem('foo', '1.3.8') { dep 'bar', '~> 2.0' }
-        gem('foo', '1.4.3') { dep 'bar', '~> 2.0' }
-        gem('foo', '1.4.4') { dep 'bar', '~> 2.0' }
-        gem('foo', '1.4.5') { dep 'bar', '~> 2.1' }
-        gem('foo', '1.5.0') { dep 'bar', '~> 2.1' }
-        gem('foo', '1.5.1') { dep 'bar', '~> 3.0' }
-        gem 'bar', %w(2.0.3 2.0.4 2.0.5 2.1.0 2.1.1 3.0.0)
+        gem("foo", "1.3.7") { dep "bar", "~> 2.0" }
+        gem("foo", "1.3.8") { dep "bar", "~> 2.0" }
+        gem("foo", "1.4.3") { dep "bar", "~> 2.0" }
+        gem("foo", "1.4.4") { dep "bar", "~> 2.0" }
+        gem("foo", "1.4.5") { dep "bar", "~> 2.1" }
+        gem("foo", "1.5.0") { dep "bar", "~> 2.1" }
+        gem("foo", "1.5.1") { dep "bar", "~> 3.0" }
+        gem "bar", %w(2.0.3 2.0.4 2.0.5 2.1.0 2.1.1 3.0.0)
       end
-      dep 'foo'
+      dep "foo"
 
       @locked = locked(%w(foo 1.4.3), %w(bar 2.0.3))
     end
 
-    it 'resolves all gems to latest patch' do
+    it "resolves all gems to latest patch" do
       # strict is not set, so bar goes up a minor version due to dependency from foo 1.4.5
       should_consv_resolve_and_include :patch, [], %w(foo-1.4.5 bar-2.1.1)
     end
 
-    it 'resolves all gems to latest patch strict' do
+    it "resolves all gems to latest patch strict" do
       # strict is set, so foo can only go up to 1.4.4 to avoid bar going up a minor version, and bar can go up to 2.0.5
       should_consv_resolve_and_include [:patch, :strict], [], %w(foo-1.4.4 bar-2.0.5)
     end
 
-    it 'resolves all gems to latest patch minimal' do
+    it "resolves all gems to latest patch minimal" do
       # minimal is set, so foo goes up the next available to 1.4.4 and bar goes up to next available 2.0.4
       should_consv_resolve_and_include [:patch, :minimal], [], %w(foo-1.4.4 bar-2.0.4)
     end
 
-    it 'resolves foo only to latest patch - same dependency case' do
+    it "resolves foo only to latest patch - same dependency case" do
       @locked = locked(%w(foo 1.3.7), %w(bar 2.0.3))
       # bar is locked, and the lock holds here because the dependency on bar doesn't change on the matching foo version.
-      should_consv_resolve_and_include :patch, ['foo'], %w(foo-1.3.8 bar-2.0.3)
+      should_consv_resolve_and_include :patch, ["foo"], %w(foo-1.3.8 bar-2.0.3)
     end
 
-    it 'resolves foo only to latest patch - changing dependency case' do
+    it "resolves foo only to latest patch - changing dependency case" do
       # bar is locked, but locks don't apply to _changing_ dependencies and since the dependency of the
       # selected foo gem changes, the latest matching of bar-2.1.1
       # (this could be considered a bug, but possibly hard to solve for)
-      should_consv_resolve_and_include :patch, ['foo'], %w(foo-1.4.5 bar-2.1.1)
+      should_consv_resolve_and_include :patch, ["foo"], %w(foo-1.4.5 bar-2.1.1)
     end
 
-    it 'resolves foo only to latest patch strict' do
+    it "resolves foo only to latest patch strict" do
       # adding strict helps solve the possibly unexpected behavior of bar changing in the prior test case,
       # because no versions will be returned for bar ~> 2.1, so the engine falls back to ~> 2.0 (turn on
       # debugging to see this happen).
-      should_consv_resolve_and_include [:patch, :strict], ['foo'], %w(foo-1.4.4 bar-2.0.3)
+      should_consv_resolve_and_include [:patch, :strict], ["foo"], %w(foo-1.4.4 bar-2.0.3)
     end
 
-    it 'resolves bar only to latest patch' do
+    it "resolves bar only to latest patch" do
       # bar is locked, so foo can only go up to 1.4.4
-      should_consv_resolve_and_include :patch, ['bar'], %w(foo-1.4.3 bar-2.0.5)
+      should_consv_resolve_and_include :patch, ["bar"], %w(foo-1.4.3 bar-2.0.5)
     end
 
-    it 'resolves all gems to latest minor' do
+    it "resolves all gems to latest minor" do
       # strict is not set, so bar goes up a major version due to dependency from foo 1.4.5
       should_consv_resolve_and_include :minor, [], %w(foo-1.5.1 bar-3.0.0)
     end
 
-    it 'resolves all gems to latest minor strict' do
+    it "resolves all gems to latest minor strict" do
       # strict is set, so foo can only go up to 1.5.0 to avoid bar going up a major version
       should_consv_resolve_and_include [:minor, :strict], [], %w(foo-1.5.0 bar-2.1.1)
     end
 
-    it 'resolves all gems to latest minor minimal' do
+    it "resolves all gems to latest minor minimal" do
       # minimal is set, and it takes precedence over minor. not sure what is the PoLS in this case. Not sure
       # if minimal is a great option in the first place. It exists to help a case where there are many, many
       # versions and I'd rather go from 1.0.2 to 1.0.3 instead of 1.0.45. But, we could consider killing the

--- a/spec/resolver/basic_spec.rb
+++ b/spec/resolver/basic_spec.rb
@@ -178,12 +178,8 @@ describe "Resolving" do
       should_consv_resolve_and_include [:minor, :minimal], [], %w(foo-1.4.4 bar-2.0.4)
     end
 
-    it 'will not revert to a previous version'
-
-    it 'has taken care of all MODOs'
-
-    it 'has moved DependencySearch into its own file'
-
-    it 'has moved search_for impl out of Resolver into DependencySearch' # method called by Molinillo, but bulk can go off to dep_search
+    it "will not revert to a previous version"
+    it "has taken care of all MODOs"
+    it "bring over all sort/filter specs from bundler-patch"
   end
 end

--- a/spec/resolver/basic_spec.rb
+++ b/spec/resolver/basic_spec.rb
@@ -191,7 +191,5 @@ describe "Resolving" do
     it "could revert to a previous version"
 
     it "will not revert to a previous version in strict mode"
-
-    it "bring over all sort/filter specs from bundler-patch"
   end
 end

--- a/spec/resolver/basic_spec.rb
+++ b/spec/resolver/basic_spec.rb
@@ -134,12 +134,6 @@ describe "Resolving" do
       should_conservative_resolve_and_include [:patch, :strict], [], %w(foo-1.4.4 bar-2.0.5)
     end
 
-    it "resolves all gems to latest patch minimal" do
-      # MODO: remove minimal
-      # minimal is set, so foo goes up the next available to 1.4.4 and bar goes up to next available 2.0.4
-      should_conservative_resolve_and_include [:patch, :minimal], [], %w(foo-1.4.4 bar-2.0.4)
-    end
-
     it "resolves foo only to latest patch - same dependency case" do
       @locked = locked(%w(foo 1.3.7), %w(bar 2.0.3))
       # bar is locked, and the lock holds here because the dependency on bar doesn't change on the matching foo version.
@@ -183,15 +177,6 @@ describe "Resolving" do
     it "resolves all gems to latest minor strict" do
       # strict is set, so foo can only go up to 1.5.0 to avoid bar going up a major version
       should_conservative_resolve_and_include [:minor, :strict], [], %w(foo-1.5.0 bar-2.1.1)
-    end
-
-    it "resolves all gems to latest minor minimal" do
-      # MODO: remove minimal
-      # minimal is set, and it takes precedence over minor. not sure what is the PoLS in this case. Not sure
-      # if minimal is a great option in the first place. It exists to help a case where there are many, many
-      # versions and I'd rather go from 1.0.2 to 1.0.3 instead of 1.0.45. But, we could consider killing the
-      # minimal option altogether. If that's what you need, use the Gemfile dependency.
-      should_conservative_resolve_and_include [:minor, :minimal], [], %w(foo-1.4.4 bar-2.0.4)
     end
 
     it "could revert to a previous version"

--- a/spec/resolver/basic_spec.rb
+++ b/spec/resolver/basic_spec.rb
@@ -100,8 +100,19 @@ describe "Resolving" do
       deps << Bundler::DepProxy.new(d, "ruby")
     end
 
-    got = Bundler::Resolver.resolve(deps, @index, {}, [], Bundler::RubyVersion.new("1.8.7", nil, nil, nil))
-    got = got.map(&:full_name).sort
-    expect(got).to eq(%w(foo-1.0.0 bar-1.0.0).sort)
+    should_resolve_and_include %w(foo-1.0.0 bar-1.0.0), [{}, [], Bundler::RubyVersion.new("1.8.7", nil, nil, nil)]
+  end
+
+  context 'conservative' do
+    context 'patch' do
+      it 'resolves single gem with no dependencies' do
+        @index = build_index do
+          gem "foo", %w(1.0.0 1.0.1 1.0.2 1.1.0 2.0.0)
+        end
+        dep 'foo'
+
+        should_consv_resolve_and_include :patch, locked('foo', '1.0.0'), %w(foo-1.0.2)
+      end
+    end
   end
 end

--- a/spec/resolver/basic_spec.rb
+++ b/spec/resolver/basic_spec.rb
@@ -113,6 +113,7 @@ describe "Resolving" do
         gem("foo", "1.4.5") { dep "bar", "~> 2.1" }
         gem("foo", "1.5.0") { dep "bar", "~> 2.1" }
         gem("foo", "1.5.1") { dep "bar", "~> 3.0" }
+        gem("foo", "2.0.0") { dep "bar", "~> 3.0" }
         gem "bar", %w(2.0.3 2.0.4 2.0.5 2.1.0 2.1.1 3.0.0)
       end
       dep "foo"
@@ -177,6 +178,14 @@ describe "Resolving" do
     it "resolves all gems to latest minor strict" do
       # strict is set, so foo can only go up to 1.5.0 to avoid bar going up a major version
       should_conservative_resolve_and_include [:minor, :strict], [], %w(foo-1.5.0 bar-2.1.1)
+    end
+
+    it "resolves all gems to latest major" do
+      should_conservative_resolve_and_include :major, [], %w(foo-2.0.0 bar-3.0.0)
+    end
+
+    it "resolves all gems to latest major strict" do
+      should_conservative_resolve_and_include [:major, :strict], [], %w(foo-2.0.0 bar-3.0.0)
     end
 
     it "could revert to a previous version"

--- a/spec/resolver/basic_spec.rb
+++ b/spec/resolver/basic_spec.rb
@@ -207,15 +207,12 @@ describe "Resolving" do
         @locked = locked(%w(foo 1.4.3), %w(bar 2.2.3))
       end
 
-      after :each do
-        ENV["DEBUG_RESOLVER"] = nil
-      end
-
       it "could revert to a previous version level patch" do
         should_conservative_resolve_and_include :patch, [], %w(foo-1.4.4 bar-2.1.1)
       end
 
       it "will not revert to a previous version in strict mode level patch" do
+        pending "possible issue with molinillo - needs further research"
         ENV["DEBUG_RESOLVER"] = "true"
         should_conservative_resolve_and_include [:patch, :strict], [], %w(foo-1.4.3 bar-2.1.1)
       end
@@ -225,6 +222,7 @@ describe "Resolving" do
       end
 
       it "will not revert to a previous version in strict mode level minor" do
+        pending "possible issue with molinillo - needs further research"
         should_conservative_resolve_and_include [:minor, :strict], [], %w(foo-1.4.3 bar-2.1.1)
       end
     end

--- a/spec/resolver/basic_spec.rb
+++ b/spec/resolver/basic_spec.rb
@@ -104,15 +104,78 @@ describe "Resolving" do
   end
 
   context 'conservative' do
-    context 'patch' do
-      it 'resolves single gem with no dependencies' do
-        @index = build_index do
-          gem "foo", %w(1.0.0 1.0.1 1.0.2 1.1.0 2.0.0)
-        end
-        dep 'foo'
-
-        should_consv_resolve_and_include :patch, locked('foo', '1.0.0'), %w(foo-1.0.2)
+    before :each do
+      @index = build_index do
+        gem('foo', '1.3.7') { dep 'bar', '~> 2.0' }
+        gem('foo', '1.3.8') { dep 'bar', '~> 2.0' }
+        gem('foo', '1.4.3') { dep 'bar', '~> 2.0' }
+        gem('foo', '1.4.4') { dep 'bar', '~> 2.0' }
+        gem('foo', '1.4.5') { dep 'bar', '~> 2.1' }
+        gem('foo', '1.5.0') { dep 'bar', '~> 2.1' }
+        gem('foo', '1.5.1') { dep 'bar', '~> 3.0' }
+        gem 'bar', %w(2.0.3 2.0.4 2.0.5 2.1.0 2.1.1 3.0.0)
       end
+      dep 'foo'
+
+      @locked = locked(%w(foo 1.4.3), %w(bar 2.0.3))
+    end
+
+    it 'resolves all gems to latest patch' do
+      # strict is not set, so bar goes up a minor version due to dependency from foo 1.4.5
+      should_consv_resolve_and_include :patch, [], %w(foo-1.4.5 bar-2.1.1)
+    end
+
+    it 'resolves all gems to latest patch strict' do
+      # strict is set, so foo can only go up to 1.4.4 to avoid bar going up a minor version, and bar can go up to 2.0.5
+      should_consv_resolve_and_include [:patch, :strict], [], %w(foo-1.4.4 bar-2.0.5)
+    end
+
+    it 'resolves all gems to latest patch minimal' do
+      # minimal is set, so foo goes up the next available to 1.4.4 and bar goes up to next available 2.0.4
+      should_consv_resolve_and_include [:patch, :minimal], [], %w(foo-1.4.4 bar-2.0.4)
+    end
+
+    it 'resolves foo only to latest patch - same dependency case' do
+      @locked = locked(%w(foo 1.3.7), %w(bar 2.0.3))
+      # bar is locked, and the lock holds here because the dependency on bar doesn't change on the matching foo version.
+      should_consv_resolve_and_include :patch, ['foo'], %w(foo-1.3.8 bar-2.0.3)
+    end
+
+    it 'resolves foo only to latest patch - changing dependency case' do
+      # bar is locked, but locks don't apply to _changing_ dependencies and since the dependency of the
+      # selected foo gem changes, the latest matching of bar-2.1.1
+      # (this could be considered a bug, but possibly hard to solve for)
+      should_consv_resolve_and_include :patch, ['foo'], %w(foo-1.4.5 bar-2.1.1)
+    end
+
+    it 'resolves foo only to latest patch strict' do
+      # adding strict helps solve the possibly unexpected behavior of bar changing in the prior test case,
+      # because no versions will be returned for bar ~> 2.1, so the engine falls back to ~> 2.0 (turn on
+      # debugging to see this happen).
+      should_consv_resolve_and_include [:patch, :strict], ['foo'], %w(foo-1.4.4 bar-2.0.3)
+    end
+
+    it 'resolves bar only to latest patch' do
+      # bar is locked, so foo can only go up to 1.4.4
+      should_consv_resolve_and_include :patch, ['bar'], %w(foo-1.4.3 bar-2.0.5)
+    end
+
+    it 'resolves all gems to latest minor' do
+      # strict is not set, so bar goes up a major version due to dependency from foo 1.4.5
+      should_consv_resolve_and_include :minor, [], %w(foo-1.5.1 bar-3.0.0)
+    end
+
+    it 'resolves all gems to latest minor strict' do
+      # strict is set, so foo can only go up to 1.5.0 to avoid bar going up a major version
+      should_consv_resolve_and_include [:minor, :strict], [], %w(foo-1.5.0 bar-2.1.1)
+    end
+
+    it 'resolves all gems to latest minor minimal' do
+      # minimal is set, and it takes precedence over minor. not sure what is the PoLS in this case. Not sure
+      # if minimal is a great option in the first place. It exists to help a case where there are many, many
+      # versions and I'd rather go from 1.0.2 to 1.0.3 instead of 1.0.45. But, we could consider killing the
+      # minimal option altogether. If that's what you need, use the Gemfile dependency.
+      should_consv_resolve_and_include [:minor, :minimal], [], %w(foo-1.4.4 bar-2.0.4)
     end
   end
 end

--- a/spec/support/indexes.rb
+++ b/spec/support/indexes.rb
@@ -58,12 +58,12 @@ module Spec
     def should_consv_resolve_and_include(opts, unlock, specs)
       # empty unlock means unlock all
       opts = Array(opts)
-      searcher = Bundler::Resolver::UpdateOptions.new(@locked, unlock).tap do |s|
+      search = Bundler::Resolver::DependencySearch.new(@locked, unlock).tap do |s|
         s.level = opts.first
         s.strict = opts.include?(:strict)
         s.minimal = opts.include?(:minimal)
       end
-      should_resolve_and_include specs, [{}, [], nil, searcher]
+      should_resolve_and_include specs, [{}, [], nil, search]
     end
 
     def an_awesome_index

--- a/spec/support/indexes.rb
+++ b/spec/support/indexes.rb
@@ -49,12 +49,20 @@ module Spec
       build_spec(*args, &blk).first
     end
 
-    def locked(name, versions)
-      Bundler::SpecSet.new(build_spec(name, Array(versions)))
+    def locked(*args)
+      Bundler::SpecSet.new(args.map do |name, version|
+        gem(name, version)
+      end)
     end
 
-    def should_consv_resolve_and_include(level, locked, specs)
-      searcher = Bundler::Resolver::UpdateOptions.new(locked).tap { |s| s.level = level }
+    def should_consv_resolve_and_include(opts, unlock, specs)
+      # empty unlock means unlock all
+      opts = Array(opts)
+      searcher = Bundler::Resolver::UpdateOptions.new(@locked, unlock).tap do |s|
+        s.level = opts.first
+        s.strict = opts.include?(:strict)
+        s.minimal = opts.include?(:minimal)
+      end
       should_resolve_and_include specs, [{}, [], nil, searcher]
     end
 

--- a/spec/support/indexes.rb
+++ b/spec/support/indexes.rb
@@ -58,7 +58,7 @@ module Spec
     def should_consv_resolve_and_include(opts, unlock, specs)
       # empty unlock means unlock all
       opts = Array(opts)
-      search = Bundler::Resolver::DependencySearch.new(@locked, unlock).tap do |s|
+      search = Bundler::GemVersionPromoter.new(@locked, unlock).tap do |s|
         s.level = opts.first
         s.strict = opts.include?(:strict)
         s.minimal = opts.include?(:minimal)

--- a/spec/support/indexes.rb
+++ b/spec/support/indexes.rb
@@ -61,7 +61,6 @@ module Spec
       search = Bundler::GemVersionPromoter.new(@locked, unlock).tap do |s|
         s.level = opts.first
         s.strict = opts.include?(:strict)
-        s.minimal = opts.include?(:minimal)
       end
       should_resolve_and_include specs, [{}, @base, nil, search]
     end

--- a/spec/support/indexes.rb
+++ b/spec/support/indexes.rb
@@ -55,7 +55,7 @@ module Spec
       end)
     end
 
-    def should_consv_resolve_and_include(opts, unlock, specs)
+    def should_conservative_resolve_and_include(opts, unlock, specs)
       # empty unlock means unlock all
       opts = Array(opts)
       search = Bundler::GemVersionPromoter.new(@locked, unlock).tap do |s|
@@ -63,7 +63,7 @@ module Spec
         s.strict = opts.include?(:strict)
         s.minimal = opts.include?(:minimal)
       end
-      should_resolve_and_include specs, [{}, [], nil, search]
+      should_resolve_and_include specs, [{}, @base, nil, search]
     end
 
     def an_awesome_index

--- a/spec/support/indexes.rb
+++ b/spec/support/indexes.rb
@@ -13,7 +13,7 @@ module Spec
 
     alias_method :platforms, :platform
 
-    def resolve(args=[])
+    def resolve(args = [])
       @platforms ||= ["ruby"]
       deps = []
       @deps.each do |d|
@@ -30,7 +30,7 @@ module Spec
       expect(got).to eq(specs.sort)
     end
 
-    def should_resolve_and_include(specs, args=[])
+    def should_resolve_and_include(specs, args = [])
       got = resolve(args)
       got = got.map(&:full_name).sort
       specs.each do |s|


### PR DESCRIPTION
A port of bundler-patch to bundler proper.

Core team questions:
- [x] bundler-patch also works in vulnerable gem updates based on ruby-advisory-db content. I presume the core team would consider this out of scope for Bundler proper? I probably would, and there's no reason bundler-patch couldn't continue to exist as a plugin with this behavior.
- [x] "resolves foo only to latest patch - changing dependency case" - more comments on that spec. It's a weird edge case. Hopefully the specs and comments make it clear.
- [x] Name of new class: GemVersionPromoter. It's gone through a few renames already and every option I think of I hate now :)
- [x] The `--minimal` flag is also something bundler-patch has that has debatable value. Would love to hear opinions on it and could be easily swayed to remove it or keep it. If I'm on 1.0.1, and both 1.0.2 and 1.0.15 exist, `--minimal` will resolve to `1.0.2` instead of the latest `1.0.15`. Dunno if there's value in that.
- [x]  even without `--strict` mode, this code will _remove_ older versions from the options handed back to Molinillo (in `--patch` and `--minor` cases). This is a weird case, but I have seen `bundle update` proper regress a gem version backwards if its parent gem changed to an older dependency (I guess in a bug fix case). I'm ok with this, but it could be considered an inconsistency with the default `--major` case.
- [x] if we roll this out first as an undocumented feature, do we require a config option to toggle it on? We wouldn't have to have one, none of the new behavior will kick in until a new flag (`--patch` or `--minor`) is passed. 

---

Notes for issues to create that could be handled separately after this PR, esp. if we release undocumented/unsupported to begin with.

- Updating `outdated` to use the new flags and resolution
- adding some warnings when dependent updates go past --patch or --minor level (with an instruction to use --strict if they don’t want that)
- adding a warning when an unlocked gem doesn't move (possibly w/ a reason why?). the lack of feedback otherwise can be disconcerting, like "did I not do it right?"
- possibly adding a dry-run flag - though after looking at that today, that would make the most sense inside Installer, and make that flag an option for both install and update (drilling through all of the calls to push that option in looks like it would be annoying).
- man page documentation