### PR TITLE
[WIP] Rescue StandardError instead of Exception

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -9,7 +9,7 @@ module Bundler
 
     def self.start(*)
       super
-    rescue Exception => e
+    rescue => e
       Bundler.ui = UI::Shell.new
       raise e
     end

--- a/lib/bundler/cli/exec.rb
+++ b/lib/bundler/cli/exec.rb
@@ -63,7 +63,7 @@ module Bundler
       Kernel.load(file)
     rescue SystemExit
       raise
-    rescue Exception => e # rubocop:disable Lint/RescueException
+    rescue => e
       Bundler.ui = ui
       Bundler.ui.error "bundler: failed to load command: #{cmd} (#{file})"
       backtrace = e.backtrace.take_while {|bt| !bt.start_with?(__FILE__) }

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -39,7 +39,8 @@ module Bundler
       @gemfile = expanded_gemfile_path
       contents ||= Bundler.read_file(gemfile.to_s)
       instance_eval(contents, gemfile.to_s, 1)
-    rescue Exception => e
+    rescue StandardError, SyntaxError => e
+
       message = "There was an error " \
         "#{e.is_a?(GemfileEvalError) ? "evaluating" : "parsing"} " \
         "`#{File.basename gemfile.to_s}`: #{e.message}"

--- a/lib/bundler/friendly_errors.rb
+++ b/lib/bundler/friendly_errors.rb
@@ -96,7 +96,7 @@ module Bundler
 
   def self.with_friendly_errors
     yield
-  rescue Exception => e
+  rescue => e
     FriendlyErrors.log_error(e)
     exit FriendlyErrors.exit_status(e)
   end

--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -241,7 +241,7 @@ module Bundler
       gem_from_path(path, security_policies[policy]).spec
     rescue Gem::Package::FormatError
       raise GemspecError, "Could not read gem at #{path}. It may be corrupted."
-    rescue Exception, Gem::Exception, Gem::Security::Exception => e
+    rescue StandardError, Gem::Exception, Gem::Security::Exception => e
       if e.is_a?(Gem::Security::Exception) ||
           e.message =~ /unknown trust policy|unsigned gem/i ||
           e.message =~ /couldn't verify (meta)?data signature/i

--- a/lib/bundler/worker.rb
+++ b/lib/bundler/worker.rb
@@ -63,7 +63,7 @@ module Bundler
 
     def apply_func(obj, i)
       @func.call(obj, i)
-    rescue Exception => e
+    rescue => e
       WrappedException.new(e)
     end
 


### PR DESCRIPTION
@indirect

Hey Y'all,

I wanted to try submitting my first bundler patch. I took a look at the PullReview for bundler and saw there was an issue with rescuing Exception in several files.  I went though and basically replaced Exception with StandardError. 

There were a situation where StandardError was not passing tests on its own. In the dsl.rb I needed to rescue both StandardError and SyntaxError. 

I noticed a couple tests continued to fail. They fail on both master and my branch so I am not sure if its my code or my environment. 

> rspec ./spec/runtime/setup_spec.rb:137 # Bundler.setup load order orders the load path correctly when there are dependencies
> rspec ./spec/commands/help_spec.rb:29 # bundle help simply outputs the txt file when there is no man on the path

I would love to hear any feedback y'all have on the PR or the failing tests. 

Thanks!