### PR TITLE
Don't incorrectly relativize sibling `--path` with the same prefix

### DIFF
--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -69,7 +69,7 @@ module Bundler
 
       if Bundler.settings[:path]
         absolute_path = File.expand_path(Bundler.settings[:path])
-        relative_path = absolute_path.sub(File.expand_path("."), ".")
+        relative_path = absolute_path.sub(File.expand_path(".") + File::SEPARATOR, "." + File::SEPARATOR)
         Bundler.ui.confirm "Bundled gems are installed into #{relative_path}."
       else
         Bundler.ui.confirm "Use `bundle show [gemname]` to see where a bundled gem is installed."

--- a/spec/install/post_bundle_message_spec.rb
+++ b/spec/install/post_bundle_message_spec.rb
@@ -81,6 +81,20 @@ describe "post bundle message" do
         expect(out).to include("Gems in the groups emo, obama and test were not installed")
         expect(out).to include(bundle_complete_message)
       end
+
+      it "with an absolute --path inside the cwd" do
+        bundle "install --path #{bundled_app}/cache"
+        expect(out).to include("Bundled gems are installed into ./cache")
+        expect(out).to_not include("Gems in the group")
+        expect(out).to include(bundle_complete_message)
+      end
+
+      it "with an absolute --path outside the cwd" do
+        bundle "install --path #{bundled_app}_cache"
+        expect(out).to include("Bundled gems are installed into #{bundled_app}_cache")
+        expect(out).to_not include("Gems in the group")
+        expect(out).to include(bundle_complete_message)
+      end
     end
 
     describe "with misspelled or non-existent gem name" do


### PR DESCRIPTION
Given current working directory `/foo/app`, when you install with
`--path /foo/app_cache`, ensure that the messaging says:

    Bundled gems are installed into /foo/app_cache

instead of the incorrect:

    Bundled gems are installed into ._cache