### PR TITLE
Print an outdated warning when a project is locked to an old version of Bundler

### DIFF
--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -11,6 +11,8 @@ module Bundler
 
       warn_if_root
 
+      warn_if_outdated
+
       [:with, :without].each do |option|
         if options[option]
           options[option] = options[option].join(":").tr(" ", ":").split(":")
@@ -112,6 +114,19 @@ module Bundler
       Bundler.ui.warn "Don't run Bundler as root. Bundler can ask for sudo " \
         "if it is needed, and installing your bundle as root will break this " \
         "application for all non-root users on this machine.", :wrap => true
+    end
+
+    def warn_if_outdated
+      return if ENV["BUNDLE_POSTIT_TRAMPOLINING_VERSION"].nil?
+      installed_version = Gem::Version.new(ENV["BUNDLE_POSTIT_TRAMPOLINING_VERSION"])
+      running_version = Gem::Version.new(Bundler::VERSION)
+      if Bundler.settings[:warned_version].nil? || running_version > Gem::Version.new(Bundler.settings[:warned_version])
+        Bundler.settings[:warned_version] = running_version
+        Bundler.ui.warn "You're running Bundler #{installed_version} but this " \
+          "project uses #{running_version}. To update, run `bundle update " \
+          "--bundler`. You won't see this message again unless you upgrade " \
+          "to a newer version of Bundler.", :wrap => true
+      end
     end
 
     def confirm_without_groups

--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -118,7 +118,7 @@ module Bundler
 
     def warn_if_outdated
       return if ENV["BUNDLE_POSTIT_TRAMPOLINING_VERSION"].nil?
-      installed_version = Gem::Version.new(ENV["BUNDLE_POSTIT_TRAMPOLINING_VERSION"])
+      installed_version = Gem::Version.new(ENV["BUNDLE_POSTIT_TRAMPOLINING_VERSION"].dup)
       running_version = Gem::Version.new(Bundler::VERSION)
       if Bundler.settings[:warned_version].nil? || running_version > Gem::Version.new(Bundler.settings[:warned_version])
         Bundler.settings[:warned_version] = running_version

--- a/lib/bundler/postit_trampoline.rb
+++ b/lib/bundler/postit_trampoline.rb
@@ -51,10 +51,9 @@ end
 
 if Gem::Requirement.new(">= 1.13.pre".dup).satisfied_by?(Gem::Version.new(running_version))
   ENV["BUNDLE_POSTIT_TRAMPOLINING_VERSION"] = installed_version.to_s
-elsif ARGV.any? {|a| %w(install i).include? a }
-  # TODO: Change this to warn in Bundler 2.0
+elsif ARGV.empty? || ARGV.any? {|a| %w(install i).include? a }
   puts <<-WARN.strip
-You're running Bundler #{installed_version} but this project uses #{running_version}. To update, run `bundle update --bundler`.\n
+You're running Bundler #{installed_version} but this project uses #{running_version}. To update, run `bundle update --bundler`.
   WARN
 end
 

--- a/lib/bundler/postit_trampoline.rb
+++ b/lib/bundler/postit_trampoline.rb
@@ -49,7 +49,7 @@ rescue LoadError, NameError
   nil
 end
 
-if Gem::Version.new(running_version) >= Gem::Version.new("1.13.0.rc.1".dup)
+if Gem::Requirement.new(">= 1.13.pre".dup).satisfied_by?(Gem::Version.new(running_version))
   ENV["BUNDLE_POSTIT_TRAMPOLINING_VERSION"] = installed_version.to_s
 elsif ARGV.any? {|a| %w(install i).include? a }
   # TODO: Change this to warn in Bundler 2.0

--- a/lib/bundler/postit_trampoline.rb
+++ b/lib/bundler/postit_trampoline.rb
@@ -49,9 +49,10 @@ rescue LoadError, NameError
   nil
 end
 
-if Gem::Version.new(running_version) >= Gem::Version.new("1.13.0.pre.1")
+if Gem::Version.new(running_version) >= Gem::Version.new("1.13.0.pre.1".dup)
   ENV["BUNDLE_POSTIT_TRAMPOLINING_VERSION"] = installed_version.to_s
 elsif ARGV.any? {|a| %w(install i).include? a }
+  # TODO: Change this to warn in Bundler 2.0
   puts <<-WARN.strip
 You're running Bundler #{installed_version} but this project uses #{running_version}. To update, run `bundle update --bundler`.\n
   WARN

--- a/lib/bundler/postit_trampoline.rb
+++ b/lib/bundler/postit_trampoline.rb
@@ -51,7 +51,7 @@ end
 
 if Gem::Version.new(running_version) >= Gem::Version.new("1.13.0.pre.1")
   ENV["BUNDLE_POSTIT_TRAMPOLINING_VERSION"] = installed_version.to_s
-else
+elsif ARGV.any? {|a| %w(install i).include? a }
   puts <<-WARN.strip
 You're running Bundler #{installed_version} but this project uses #{running_version}. To update, run `bundle update --bundler`.\n
   WARN

--- a/lib/bundler/postit_trampoline.rb
+++ b/lib/bundler/postit_trampoline.rb
@@ -49,9 +49,11 @@ rescue LoadError, NameError
   nil
 end
 
-if installed_version.to_s != running_version.to_s
-  puts <<-WARN
-You're running Bundler #{installed_version.to_s} but this project uses #{running_version.to_s}. To update, run `bundle update --bundler`. You won't see this message again unless you upgrade to a newer version of Bundler.\n
+if Gem::Version.new(running_version) >= Gem::Version.new("1.13.0.pre.1")
+  ENV["BUNDLE_POSTIT_TRAMPOLINING_VERSION"] = installed_version.to_s
+else
+  puts <<-WARN.strip
+You're running Bundler #{installed_version} but this project uses #{running_version}. To update, run `bundle update --bundler`.\n
   WARN
 end
 

--- a/lib/bundler/postit_trampoline.rb
+++ b/lib/bundler/postit_trampoline.rb
@@ -49,7 +49,7 @@ rescue LoadError, NameError
   nil
 end
 
-if Gem::Version.new(running_version) >= Gem::Version.new("1.13.0.pre.1".dup)
+if Gem::Version.new(running_version) >= Gem::Version.new("1.13.0.rc.1".dup)
   ENV["BUNDLE_POSTIT_TRAMPOLINING_VERSION"] = installed_version.to_s
 elsif ARGV.any? {|a| %w(install i).include? a }
   # TODO: Change this to warn in Bundler 2.0

--- a/lib/bundler/postit_trampoline.rb
+++ b/lib/bundler/postit_trampoline.rb
@@ -49,6 +49,12 @@ rescue LoadError, NameError
   nil
 end
 
+if installed_version.to_s != running_version.to_s
+  puts <<-WARN
+You're running Bundler #{installed_version.to_s} but this project uses #{running_version.to_s}. To update, run `bundle update --bundler`. You won't see this message again unless you upgrade to a newer version of Bundler.\n
+  WARN
+end
+
 if !Gem::Version.correct?(running_version.to_s) || !version.satisfied_by?(Gem::Version.create(running_version))
   abort "The running bundler (#{running_version}) does not match the required `#{version}`"
 end

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -491,13 +491,12 @@ describe "bundle install with gem sources" do
       gemfile <<-G
         source "file://#{gem_repo1}"
       G
-      ENV["BUNDLER_VERSION"] = "1.13.0.pre.1"
 
       bundle :install, :env => { "BUNDLE_POSTIT_TRAMPOLINING_VERSION" => "999" }
-      expect(out).to include("You're running Bundler 999 but this project uses #{ENV["BUNDLER_VERSION"]}.")
+      expect(out).to include("You're running Bundler 999 but this project uses #{Bundler::VERSION}.")
 
       bundle :install, :env => { "BUNDLE_POSTIT_TRAMPOLINING_VERSION" => "999" }
-      expect(out).not_to include("You're running Bundler 999 but this project uses #{ENV["BUNDLER_VERSION"]}.")
+      expect(out).not_to include("You're running Bundler 999 but this project uses #{Bundler::VERSION}.")
     end
   end
 end

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -487,7 +487,7 @@ describe "bundle install with gem sources" do
   end
 
   describe "warns user if Bundler is outdated" do
-    it "warns only once and is > 1.13.0.pre.1" do
+    it "warns only once and is > 1.13.0.rc.1" do
       gemfile <<-G
         source "file://#{gem_repo1}"
       G

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -3,6 +3,18 @@ require "spec_helper"
 
 describe "bundle install with gem sources" do
   describe "the simple case" do
+    it "warns user (once) if Bundler is outdated" do
+      gemfile <<-G
+        source "file://#{gem_repo1}"
+      G
+
+      bundle :install, :env => { "BUNDLE_POSTIT_TRAMPOLINING_VERSION" => "999" }
+      expect(out).to include("You're running Bundler 999 but this project uses #{Bundler::VERSION}.")
+
+      bundle :install, :env => { "BUNDLE_POSTIT_TRAMPOLINING_VERSION" => "999" }
+      expect(out).not_to include("You're running Bundler 999 but this project uses #{Bundler::VERSION}.")
+    end
+
     it "prints output and returns if no dependencies are specified" do
       gemfile <<-G
         source "file://#{gem_repo1}"

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -3,18 +3,6 @@ require "spec_helper"
 
 describe "bundle install with gem sources" do
   describe "the simple case" do
-    it "warns user (once) if Bundler is outdated" do
-      gemfile <<-G
-        source "file://#{gem_repo1}"
-      G
-
-      bundle :install, :env => { "BUNDLE_POSTIT_TRAMPOLINING_VERSION" => "999" }
-      expect(out).to include("You're running Bundler 999 but this project uses #{Bundler::VERSION}.")
-
-      bundle :install, :env => { "BUNDLE_POSTIT_TRAMPOLINING_VERSION" => "999" }
-      expect(out).not_to include("You're running Bundler 999 but this project uses #{Bundler::VERSION}.")
-    end
-
     it "prints output and returns if no dependencies are specified" do
       gemfile <<-G
         source "file://#{gem_repo1}"
@@ -495,6 +483,21 @@ describe "bundle install with gem sources" do
       expect(exitstatus).to eq(17) if exitstatus
       expect(out).to eq("Please CGI escape your usernames and passwords before " \
                         "setting them for authentication.")
+    end
+  end
+
+  describe "warns user if Bundler is outdated" do
+    it "warns only once and is > 1.13.0.pre.1" do
+      gemfile <<-G
+        source "file://#{gem_repo1}"
+      G
+      ENV["BUNDLER_VERSION"] = "1.13.0.pre.1"
+
+      bundle :install, :env => { "BUNDLE_POSTIT_TRAMPOLINING_VERSION" => "999" }
+      expect(out).to include("You're running Bundler 999 but this project uses #{ENV["BUNDLER_VERSION"]}.")
+
+      bundle :install, :env => { "BUNDLE_POSTIT_TRAMPOLINING_VERSION" => "999" }
+      expect(out).not_to include("You're running Bundler 999 but this project uses #{ENV["BUNDLER_VERSION"]}.")
     end
   end
 end

--- a/spec/other/trampoline_spec.rb
+++ b/spec/other/trampoline_spec.rb
@@ -146,7 +146,7 @@ The error was:
       ENV["BUNDLER_VERSION"] = "1.12.0"
       bundle! "install"
       expect(out).to include(<<-WARN.strip)
-You're running Bundler #{Bundler::VERSION} but this project uses #{ENV["BUNDLER_VERSION"]}. To update, run `bundle update --bundler`.\n
+You're running Bundler #{Bundler::VERSION} but this project uses #{ENV["BUNDLER_VERSION"]}. To update, run `bundle update --bundler`.
       WARN
     end
   end

--- a/spec/other/trampoline_spec.rb
+++ b/spec/other/trampoline_spec.rb
@@ -7,6 +7,21 @@ describe "bundler version trampolining" do
     FileUtils.rm_rf(system_gem_path)
     FileUtils.cp_r(base_system_gems, system_gem_path)
   end
+  context "warnings" do
+    it "warns user if Bundler is outdated and is < 1.13.0.pre.1" do
+      ENV["BUNDLER_VERSION"] = "1.12.0"
+      bundle! "--version"
+      expect(out).to include(<<-WARN.strip)
+You're running Bundler #{Bundler::VERSION} but this project uses #{ENV["BUNDLER_VERSION"]}. To update, run `bundle update --bundler`.\n
+      WARN
+
+      ENV["BUNDLER_VERSION"] = "1.13.0.pre.1"
+      bundle! "--version"
+      expect(out).not_to include(<<-WARN.strip)
+You're running Bundler #{Bundler::VERSION} but this project uses #{ENV["BUNDLER_VERSION"]}. To update, run `bundle update --bundler`.\n
+      WARN
+    end
+  end
 
   context "version guessing" do
     shared_examples_for "guesses" do |version|

--- a/spec/other/trampoline_spec.rb
+++ b/spec/other/trampoline_spec.rb
@@ -7,21 +7,6 @@ describe "bundler version trampolining" do
     FileUtils.rm_rf(system_gem_path)
     FileUtils.cp_r(base_system_gems, system_gem_path)
   end
-  context "warnings" do
-    it "warns user if Bundler is outdated and is < 1.13.0.pre.1" do
-      ENV["BUNDLER_VERSION"] = "1.12.0"
-      bundle! "--version"
-      expect(out).to include(<<-WARN.strip)
-You're running Bundler #{Bundler::VERSION} but this project uses #{ENV["BUNDLER_VERSION"]}. To update, run `bundle update --bundler`.\n
-      WARN
-
-      ENV["BUNDLER_VERSION"] = "1.13.0.pre.1"
-      bundle! "--version"
-      expect(out).not_to include(<<-WARN.strip)
-You're running Bundler #{Bundler::VERSION} but this project uses #{ENV["BUNDLER_VERSION"]}. To update, run `bundle update --bundler`.\n
-      WARN
-    end
-  end
 
   context "version guessing" do
     shared_examples_for "guesses" do |version|
@@ -147,6 +132,22 @@ The error was:
       R
       expect(err).to be_empty
       expect(out).to eq("1.12.0")
+    end
+  end
+
+  context "warnings" do
+    before do
+      simulate_bundler_version("1.12.0") do
+        install_gemfile ""
+      end
+    end
+
+    it "warns user if Bundler is outdated and is < 1.13.0.pre.1" do
+      ENV["BUNDLER_VERSION"] = "1.12.0"
+      bundle! "install"
+      expect(out).to include(<<-WARN.strip)
+You're running Bundler #{Bundler::VERSION} but this project uses #{ENV["BUNDLER_VERSION"]}. To update, run `bundle update --bundler`.\n
+      WARN
     end
   end
 end

--- a/spec/other/trampoline_spec.rb
+++ b/spec/other/trampoline_spec.rb
@@ -142,7 +142,7 @@ The error was:
       end
     end
 
-    it "warns user if Bundler is outdated and is < 1.13.0.pre.1" do
+    it "warns user if Bundler is outdated and is < 1.13.0.rc.1" do
       ENV["BUNDLER_VERSION"] = "1.12.0"
       bundle! "install"
       expect(out).to include(<<-WARN.strip)

--- a/spec/other/trampoline_spec.rb
+++ b/spec/other/trampoline_spec.rb
@@ -131,7 +131,7 @@ The error was:
         puts Bundler::VERSION
       R
       expect(err).to be_empty
-      expect(out).to eq("1.12.0")
+      expect(out).to include("1.12.0")
     end
   end
 


### PR DESCRIPTION
@indirect @RochesterinNYC 

I'm a bit stumped.

The original issue on bundler/bundler#4707 mentions that this warning should only be printed once unless the user updates their version of Bundler, and that the warned version should be stored in `Bundler.settings[:warned_version]`.

The issue is that, AFAIK, this file, `postit_trampoline.rb` is the last place where I can access both the `installed_version` (system version) and the `running_version` (project's version) of Bundler before it completely switches over to the `running_version`.

Since `Bundler.settings` still hasn't been initialized at this point, I can't store the `running_version` in `Bundler.settings[:warned_version]`.

Right now, this warning is shown every time a `bundle` command is issued in a project directory where `installed_version != running_version`.

Is there any other way I can store the warned version from this file?

---

Closes #4707 