### PR TITLE
[WIP] `bundle outdated` with gem on multiple platforms will not show updates for both platforms

### DIFF
--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -50,7 +50,7 @@ module Bundler
         if options["strict"]
           active_spec = definition.specs.detect {|spec| spec.name == current_spec.name && spec.platform == current_spec.platform }
         else
-          active_specs = definition.index[current_spec.name].select {|spec| spec.platform == current_spec.platform }.sort_by(&:version)
+          active_specs = definition.index[current_spec.name].select {|spec| spec.match_platform current_spec.platform }.sort_by(&:version)
           if !current_spec.version.prerelease? && !options[:pre] && active_specs.size > 1
             active_spec = active_specs.delete_if {|b| b.respond_to?(:version) && b.version.prerelease? }
           end

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -265,10 +265,17 @@ describe "bundle outdated" do
       G
     end
 
-    it "reports that updates are available" do
+    it "reports that updates are available if the Ruby platform is used" do
       bundle "outdated"
-      expect(out).to include("Outdated gems included in the bundle:")
-      expect(out).to include("laduradura (newest 5.15.3, installed 5.15.2, requested = 5.15.2)")
+      expect(out).to include("Bundle up to date!")
+    end
+
+    it "reports that updates are available if the JRuby platform is used" do
+      simulate_ruby_engine "jruby" do
+        bundle "outdated"
+        expect(out).to include("Outdated gems included in the bundle:")
+        expect(out).to include("laduradura (newest 5.15.3, installed 5.15.2, requested = 5.15.2)")
+      end
     end
   end
 

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -257,6 +257,21 @@ describe "bundle outdated" do
     end
   end
 
+  context "update available for a gem on the same platform while multiple platforms used for gem" do
+    before do
+      install_gemfile <<-G
+        source "file://#{gem_repo2}"
+        gem "laduradura", '= 5.15.2', :platforms => [:ruby, :jruby]
+      G
+    end
+
+    it "reports that updates are available" do
+      bundle "outdated"
+      expect(out).to include("Outdated gems included in the bundle:")
+      expect(out).to include("laduradura (newest 5.15.3, installed 5.15.2, requested = 5.15.2)")
+    end
+  end
+
   shared_examples_for "version update is detected" do
     it "reports that a gem has a newer version" do
       subject


### PR DESCRIPTION
Opening this pull request to run the specs with Travis as a sanity check.

Having this odd issue where if I manually run `dbundle outdated` with a copy of the `tmp` directory, it runs as expected -- it doesn't show an update for `ruby-2.3.0`, but it shows an update for `jruby-9.0.5.0`

However, when I run `rspec`, the specs I've put in place fail.

---

Closes #4664 
