### PR TITLE
Installing gems without version after the ones with version for tests

### DIFF
--- a/spec/support/rubygems_ext.rb
+++ b/spec/support/rubygems_ext.rb
@@ -36,7 +36,7 @@ module Spec
         FileUtils.rm_rf(Path.base_system_gems)
         FileUtils.mkdir_p(Path.base_system_gems)
         puts "installing gems for the tests to use..."
-        DEPS.each {|n, v| install_gem(n, v) }
+        DEPS.sort {|a, _| a[1].nil? ? 1 : -1 }.each {|n, v| install_gem(n, v) }
         File.open(manifest_path, "w") {|f| f << manifest.join }
       end
 


### PR DESCRIPTION
`rake < 2` should be installed before `artifice`.

On `ruby 1.8.7` it fails randomly because of no specific order of hash traversal.

https://travis-ci.org/bundler/bundler/builds/141867428