### PR TITLE
Fix RubyGems printing packaging messages during the specs

### DIFF
--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -15,6 +15,7 @@ module Spec
       ENV["BUNDLE_DISABLE_POSTIT"] = "1"
       Bundler.send(:remove_instance_variable, :@settings) if Bundler.send(:instance_variable_defined?, :@settings)
       Bundler.ui = nil
+      Bundler.ui # force it to initialize
     end
 
     def self.bang(method)


### PR DESCRIPTION
Closes #4755.
My bad!