### PR TITLE
fix standalone executable when dest of symlink

### DIFF
--- a/lib/bundler/templates/Executable.standalone
+++ b/lib/bundler/templates/Executable.standalone
@@ -6,7 +6,9 @@
 # this file is here to facilitate running it.
 #
 
-$:.unshift File.expand_path '../<%= standalone_path %>', __FILE__
+require 'pathname'
+path = Pathname.new(__FILE__)
+$:.unshift File.expand_path '../<%= standalone_path %>', path.realpath
 
 require 'bundler/setup'
-load File.expand_path '../<%= executable_path %>', __FILE__
+load File.expand_path '../<%= executable_path %>', path.realpath

--- a/spec/commands/binstubs_spec.rb
+++ b/spec/commands/binstubs_spec.rb
@@ -157,7 +157,7 @@ describe "bundle binstubs <gem>" do
     it "includes the standalone path" do
       bundle "binstubs rack --standalone"
       standalone_line = File.read(bundled_app("bin/rackup")).each_line.find {|line| line.include? "$:.unshift" }.strip
-      expect(standalone_line).to eq "$:.unshift File.expand_path '../../bundle', __FILE__"
+      expect(standalone_line).to eq "$:.unshift File.expand_path '../../bundle', path.realpath"
     end
   end
 


### PR DESCRIPTION
When an executable is the destination of a symlink `__FILE__` contains
the path to the symlink, rather than the actual path of the current
file.

`Pathname#realpath` resolves symlinks to get the actual location on disk.