### PR TITLE
update path already exists error message to not be specific to symlinks

### DIFF
--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -196,7 +196,7 @@ module Bundler
       end unless Bundler.bundle_path.exist?
     rescue Errno::EEXIST
       raise PathError, "Could not install to path `#{Bundler.settings[:path]}` " \
-        "because a file already exists at that same path. Either remove or rename the file so the directory can be created."
+        "because a file already exists at that path. Either remove or rename the file so the directory can be created."
     end
 
     def resolve_if_need(options)

--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -196,7 +196,7 @@ module Bundler
       end unless Bundler.bundle_path.exist?
     rescue Errno::EEXIST
       raise PathError, "Could not install to path `#{Bundler.settings[:path]}` " \
-        "because of an invalid symlink. Remove the symlink so the directory can be created."
+        "because a file already exists at that same path. Either remove or rename the file so the directory can be created."
     end
 
     def resolve_if_need(options)

--- a/spec/install/path_spec.rb
+++ b/spec/install/path_spec.rb
@@ -130,21 +130,21 @@ describe "bundle install" do
     end
   end
 
-  describe "to a dead symlink" do
+  describe "to a file" do
     before do
       in_app_root do
-        `ln -s /tmp/idontexist bundle`
+        `touch /tmp/idontexist bundle`
       end
     end
 
-    it "reports the symlink is dead" do
+    it "reports the file exists" do
       gemfile <<-G
         source "file://#{gem_repo1}"
         gem "rack"
       G
 
       bundle "install --path bundle"
-      expect(out).to match(/invalid symlink/)
+      expect(out).to match(/file already exists/)
     end
   end
 end


### PR DESCRIPTION
If i'm attempting to install my gems into a folder that conflicts with a file that already exists, Bundler will raise the following error: 
```
Could not install to path `vendor` because of an invalid symlink. Remove the symlink so the directory can be created.
```

But this error will be raised even if its just a regular ol file and not a symlink. IMO its a better user experience to drop the symlink mention and ask the user to simply move or rename the file.

Example:

```
Could not install to path `vendor` because a file already exists at that path. Either remove or rename the file so the directory can be created.
```