### PR TITLE
[Definition] Ensure gemspec dependencies include all lockfile platforms

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -131,7 +131,9 @@ module Bundler
 
     def locked_gems
       @locked_gems ||=
-        if Bundler.default_lockfile.exist?
+        if defined?(@definition) && @definition
+          definition.locked_gems
+        elsif Bundler.default_lockfile.exist?
           lock = Bundler.read_file(Bundler.default_lockfile)
           LockfileParser.new(lock)
         end

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -7,7 +7,15 @@ module Bundler
   class Definition
     include GemHelpers
 
-    attr_reader :dependencies, :platforms, :ruby_version, :locked_deps, :gem_version_promoter, :requires
+    attr_reader(
+      :dependencies,
+      :gem_version_promoter,
+      :locked_deps,
+      :locked_gems,
+      :platforms,
+      :requires,
+      :ruby_version
+    )
 
     # Given a gemfile and lockfile creates a Bundler definition
     #
@@ -60,15 +68,15 @@ module Bundler
 
       if lockfile && File.exist?(lockfile)
         @lockfile_contents = Bundler.read_file(lockfile)
-        locked = LockfileParser.new(@lockfile_contents)
-        @platforms = locked.platforms
-        @locked_bundler_version = locked.bundler_version
-        @locked_ruby_version = locked.ruby_version
+        @locked_gems = LockfileParser.new(@lockfile_contents)
+        @platforms = @locked_gems.platforms
+        @locked_bundler_version = @locked_gems.bundler_version
+        @locked_ruby_version = @locked_gems.ruby_version
 
         if unlock != true
-          @locked_deps    = locked.dependencies
-          @locked_specs   = SpecSet.new(locked.specs)
-          @locked_sources = locked.sources
+          @locked_deps    = @locked_gems.dependencies
+          @locked_specs   = SpecSet.new(@locked_gems.specs)
+          @locked_sources = @locked_gems.sources
         else
           @unlock         = {}
           @locked_deps    = []
@@ -78,6 +86,7 @@ module Bundler
       else
         @unlock         = {}
         @platforms      = []
+        @locked_gems    = nil
         @locked_deps    = []
         @locked_specs   = SpecSet.new([])
         @locked_sources = []

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -626,6 +626,9 @@ module Bundler
         locked_dep = locked_deps_hash[dep]
 
         if in_locked_deps?(dep, locked_dep) || satisfies_locked_spec?(dep)
+          if dep.is_a?(Source::Gemspec)
+            dep.platforms.concat(@platforms.map {|p| Dependency::REVERSE_PLATFORM_MAP[p] }.flatten(1)).uniq!
+          end
           deps << dep
         elsif dep.source.is_a?(Source::Path) && dep.current_platform? && (!locked_dep || dep.source != locked_dep.source)
           @locked_specs.each do |s|

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -74,7 +74,7 @@ module Bundler
 
         group(development_group) do
           spec.development_dependencies.each do |dep|
-            gem dep.name, *(dep.requirement.as_list + [:type => :development, :platforms => gem_platforms])
+            gem dep.name, *(dep.requirement.as_list + [:type => :development])
           end
         end
       when 0

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -58,7 +58,7 @@ module Bundler
       expanded_path     = gemfile_root.join(path)
 
       gemspecs = Dir[File.join(expanded_path, "{,*}.gemspec")].map {|g| Bundler.load_gemspec(g) }.compact
-      gemspecs.select! {|s| s.name == name } if name
+      gemspecs.reject! {|s| s.name != name } if name
       Index.sort_specs(gemspecs)
       specs_by_name_and_version = gemspecs.group_by {|s| [s.name, s.version] }
 

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -50,22 +50,22 @@ module Bundler
     end
 
     def gemspec(opts = nil)
-      path              = opts && opts[:path] || "."
-      glob              = opts && opts[:glob]
-      name              = opts && opts[:name] || "{,*}"
-      development_group = opts && opts[:development_group] || :development
+      opts ||= {}
+      path              = opts[:path] || "."
+      glob              = opts[:glob]
+      name              = opts[:name]
+      development_group = opts[:development_group] || :development
       expanded_path     = gemfile_root.join(path)
 
-      gemspecs = Dir[File.join(expanded_path, "#{name}.gemspec")]
+      gemspecs = Dir[File.join(expanded_path, "{,*}.gemspec")].map {|g| Bundler.load_gemspec(g) }.compact
+      gemspecs.select! {|s| s.name == name } if name
+      Index.sort_specs(gemspecs)
+      specs_by_name_and_version = gemspecs.group_by {|s| [s.name, s.version] }
 
-      case gemspecs.size
+      case specs_by_name_and_version.size
       when 1
-        spec = Bundler.load_gemspec(gemspecs.first)
-
-        unless spec
-          raise InvalidOption, "There was an error loading the gemspec at " \
-            "#{file}. Make sure you can build the gem, then try again"
-        end
+        specs = specs_by_name_and_version.values.first
+        spec = specs.find {|s| s.match_platform(Gem::Platform.local) } || specs.first
 
         @gemspecs << spec
 

--- a/lib/bundler/index.rb
+++ b/lib/bundler/index.rb
@@ -67,10 +67,18 @@ module Bundler
         end
       end
 
-      results.sort_by do |s|
+      sort_specs(results)
+    end
+
+    def self.sort_specs(specs)
+      specs.sort_by do |s|
         platform_string = s.platform.to_s
         [s.version, platform_string == RUBY ? NULL : platform_string]
       end
+    end
+
+    def sort_specs(specs)
+      self.class.sort_specs(specs)
     end
 
     def local_search(query, base = nil)

--- a/lib/bundler/lazy_specification.rb
+++ b/lib/bundler/lazy_specification.rb
@@ -5,6 +5,8 @@ require "bundler/match_platform"
 
 module Bundler
   class LazySpecification
+    Identifier = Struct.new(:name, :version, :source, :platform, :dependencies)
+
     include MatchPlatform
 
     attr_reader :name, :version, :dependencies, :platform
@@ -69,7 +71,7 @@ module Bundler
     end
 
     def identifier
-      @__identifier ||= [name, version, source, platform, dependencies].hash
+      @__identifier ||= Identifier.new(name, version, source, platform, dependencies)
     end
 
   private

--- a/lib/bundler/lazy_specification.rb
+++ b/lib/bundler/lazy_specification.rb
@@ -61,7 +61,11 @@ module Bundler
     end
 
     def to_s
-      @__to_s ||= "#{name} (#{version})"
+      @__to_s ||= if platform == Gem::Platform::RUBY || platform.nil?
+        "#{name} (#{version})"
+      else
+        "#{name} (#{version}-#{platform})"
+      end
     end
 
     def identifier

--- a/lib/bundler/lockfile_parser.rb
+++ b/lib/bundler/lockfile_parser.rb
@@ -207,8 +207,10 @@ module Bundler
     def parse_spec(line)
       if line =~ NAME_VERSION_4
         name = $1
-        version = Gem::Version.new($2)
-        platform = $3 ? Gem::Platform.new($3) : Gem::Platform::RUBY
+        version = $2
+        platform = $3
+        version = Gem::Version.new(version)
+        platform = platform ? Gem::Platform.new(platform) : Gem::Platform::RUBY
         @current_spec = LazySpecification.new(name, version, platform)
         @current_spec.source = @current_source
 

--- a/lib/bundler/source/gemspec.rb
+++ b/lib/bundler/source/gemspec.rb
@@ -8,6 +8,10 @@ module Bundler
         super
         @gemspec = options["gemspec"]
       end
+
+      def as_path_source
+        Path.new(options)
+      end
     end
   end
 end

--- a/lib/bundler/source/path.rb
+++ b/lib/bundler/source/path.rb
@@ -11,7 +11,7 @@ module Bundler
       DEFAULT_GLOB = "{,*,*/*}.gemspec".freeze
 
       def initialize(options)
-        @options = options
+        @options = options.dup
         @glob = options["glob"] || DEFAULT_GLOB
 
         @allow_cached = false
@@ -60,7 +60,7 @@ module Bundler
       end
 
       def eql?(other)
-        return unless other.class == Path || other.class == Gemspec
+        return unless other.class == self.class
         expanded_path == expand(other.path) &&
           version == other.version
       end

--- a/spec/commands/package_spec.rb
+++ b/spec/commands/package_spec.rb
@@ -127,7 +127,7 @@ describe "bundle package" do
           source "file://#{gem_repo1}"
           gem 'rack'
           gemspec :name => 'mygem'
-          gemspec :name => 'mygem_client'
+          gemspec :name => 'mygem_test'
         D
 
         bundle! "package --all"

--- a/spec/install/gemfile/gemspec_spec.rb
+++ b/spec/install/gemfile/gemspec_spec.rb
@@ -67,7 +67,7 @@ describe "bundle install from an existing gemspec" do
 
   it "should raise if there are too many gemspecs available" do
     build_lib("foo", :path => tmp.join("foo")) do |s|
-      s.write("foo2.gemspec", "")
+      s.write("foo2.gemspec", build_spec("foo", "4.0").first.to_ruby)
     end
 
     error = install_gemfile(<<-G, :expect_err => true)
@@ -196,7 +196,17 @@ describe "bundle install from an existing gemspec" do
       before do
         build_lib("foo", :path => tmp.join("foo")) do |s|
           s.add_dependency "rack", "=1.0.0"
-          s.platform = platform if explicit_platform
+        end
+
+        if explicit_platform
+          create_file(
+            tmp.join("foo", "foo-#{platform}.gemspec"),
+            build_spec("foo", "1.0", platform) do
+              dep "rack", "=1.0.0"
+              @spec.authors = "authors"
+              @spec.summary = "summary"
+            end.first.to_ruby
+          )
         end
 
         gemfile <<-G

--- a/spec/install/gemfile/path_spec.rb
+++ b/spec/install/gemfile/path_spec.rb
@@ -241,7 +241,7 @@ describe "bundle install with explicit source paths" do
 
   it "raises if there are multiple gemspecs" do
     build_lib "foo", "1.0", :path => lib_path("foo") do |s|
-      s.write "bar.gemspec"
+      s.write "bar.gemspec", build_spec("bar", "1.0").first.to_ruby
     end
 
     install_gemfile <<-G

--- a/spec/support/builders.rb
+++ b/spec/support/builders.rb
@@ -393,6 +393,8 @@ module Spec
           s.name     = name
           s.version  = Gem::Version.new(v)
           s.platform = platform
+          s.authors  = ["no one in particular"]
+          s.summary  = "a gemspec used only for testing"
           DepBuilder.run(s, &block) if block_given?
         end
       end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -217,6 +217,7 @@ module Spec
       opts[:retry] ||= 0
       bundle :install, opts
     end
+    bang :install_gemfile
 
     def lock_gemfile(*args)
       gemfile(*args)


### PR DESCRIPTION
Closes #4798 

This is necessary since `gemspec`  declares platforms for the dependency as the reverse platform map of the generic local platform, thus missing out on all those platforms that aren't currently being resolved for