### PR TITLE
Display message showing locked Bundler version is being installed

### DIFF
--- a/lib/bundler/postit_trampoline.rb
+++ b/lib/bundler/postit_trampoline.rb
@@ -21,7 +21,7 @@ if ENV["BUNDLE_ENABLE_TRAMPOLINE"]
     begin
       installer = BundlerVendoredPostIt::PostIt::Installer.new(version)
       unless installer.installed?
-        warn "Installing locked Bundler version #{version}" 
+        warn "Installing locked Bundler version #{version}"
         installer.install!
       end
     rescue => e

--- a/lib/bundler/postit_trampoline.rb
+++ b/lib/bundler/postit_trampoline.rb
@@ -21,7 +21,7 @@ if ENV["BUNDLE_ENABLE_TRAMPOLINE"]
     begin
       installer = BundlerVendoredPostIt::PostIt::Installer.new(version)
       unless installer.installed?
-        warn "Installing locked Bundler version #{version}"
+        warn "Installing locked Bundler version #{version.to_s.gsub("= ", "")}..."
         installer.install!
       end
     rescue => e

--- a/lib/bundler/postit_trampoline.rb
+++ b/lib/bundler/postit_trampoline.rb
@@ -20,7 +20,10 @@ if ENV["BUNDLE_ENABLE_TRAMPOLINE"]
   if !version.satisfied_by?(installed_version)
     begin
       installer = BundlerVendoredPostIt::PostIt::Installer.new(version)
-      installer.install!
+      unless installer.installed?
+        warn "Installing locked Bundler version #{version}" 
+        installer.install!
+      end
     rescue => e
       abort <<-EOS.strip
 Installing the inferred bundler version (#{version}) failed.

--- a/lib/bundler/vendor/postit/lib/postit/installer.rb
+++ b/lib/bundler/vendor/postit/lib/postit/installer.rb
@@ -19,6 +19,7 @@ module BundlerVendoredPostIt::PostIt
 
     def install!
       return if installed?
+      puts "Installing locked Bundler version #{@bundler_version}"
       require 'rubygems/dependency_installer'
       installer = Gem::DependencyInstaller.new
       installer.install('bundler', @bundler_version)

--- a/lib/bundler/vendor/postit/lib/postit/installer.rb
+++ b/lib/bundler/vendor/postit/lib/postit/installer.rb
@@ -19,7 +19,6 @@ module BundlerVendoredPostIt::PostIt
 
     def install!
       return if installed?
-      puts "Installing locked Bundler version #{@bundler_version}"
       require 'rubygems/dependency_installer'
       installer = Gem::DependencyInstaller.new
       installer.install('bundler', @bundler_version)

--- a/spec/other/trampoline_spec.rb
+++ b/spec/other/trampoline_spec.rb
@@ -76,7 +76,7 @@ describe "bundler version trampolining" do
     it "guesses & installs the correct bundler version" do
       expect(system_gem_path.join("gems", "bundler-1.12.3")).not_to exist
       bundle! "--version"
-      expect(out).to eq("Bundler version 1.12.3")
+      expect(out).to include("Bundler version 1.12.3")
       expect(system_gem_path.join("gems", "bundler-1.12.3")).to exist
     end
 
@@ -88,6 +88,20 @@ Installing the inferred bundler version (= 9999) failed.
 If you'd like to update to the current bundler version (#{Bundler::VERSION}) in this project, run `bundle update --bundler`.
 The error was:
       E
+    end
+
+    it "displays installing message before install is started" do
+      expect(system_gem_path.join("gems", "bundler-1.12.3")).not_to exist
+      bundle! "--version"
+      expect(out).to include("Installing locked Bundler version = #{ENV["BUNDLER_VERSION"]}")
+    end
+
+    it "doesn't display installing message if locked version is installed" do
+      expect(system_gem_path.join("gems", "bundler-1.12.3")).not_to exist
+      bundle! "--version"
+      expect(system_gem_path.join("gems", "bundler-1.12.3")).to exist
+      bundle! "--version"
+      expect(out).not_to include("Installing locked Bundler version = #{ENV["BUNDLER_VERSION"]}")
     end
   end
 

--- a/spec/other/trampoline_spec.rb
+++ b/spec/other/trampoline_spec.rb
@@ -84,7 +84,7 @@ describe "bundler version trampolining" do
       ENV["BUNDLER_VERSION"] = "9999"
       bundle "--version", :expect_err => true
       expect(err).to start_with(<<-E.strip)
-Installing locked Bundler version = 9999
+Installing locked Bundler version 9999...
 Installing the inferred bundler version (= 9999) failed.
 If you'd like to update to the current bundler version (#{Bundler::VERSION}) in this project, run `bundle update --bundler`.
 The error was:
@@ -94,7 +94,7 @@ The error was:
     it "displays installing message before install is started" do
       expect(system_gem_path.join("gems", "bundler-1.12.3")).not_to exist
       bundle! "--version"
-      expect(err).to include("Installing locked Bundler version = #{ENV["BUNDLER_VERSION"]}")
+      expect(err).to include("Installing locked Bundler version #{ENV["BUNDLER_VERSION"]}...")
     end
 
     it "doesn't display installing message if locked version is installed" do
@@ -102,7 +102,7 @@ The error was:
       bundle! "--version"
       expect(system_gem_path.join("gems", "bundler-1.12.3")).to exist
       bundle! "--version"
-      expect(err).not_to include("Installing locked Bundler version = #{ENV["BUNDLER_VERSION"]}")
+      expect(err).not_to include("Installing locked Bundler version = #{ENV["BUNDLER_VERSION"]}...")
     end
   end
 

--- a/spec/other/trampoline_spec.rb
+++ b/spec/other/trampoline_spec.rb
@@ -76,7 +76,7 @@ describe "bundler version trampolining" do
     it "guesses & installs the correct bundler version" do
       expect(system_gem_path.join("gems", "bundler-1.12.3")).not_to exist
       bundle! "--version"
-      expect(out).to include("Bundler version 1.12.3")
+      expect(out).to eq("Bundler version 1.12.3")
       expect(system_gem_path.join("gems", "bundler-1.12.3")).to exist
     end
 
@@ -93,7 +93,7 @@ The error was:
     it "displays installing message before install is started" do
       expect(system_gem_path.join("gems", "bundler-1.12.3")).not_to exist
       bundle! "--version"
-      expect(out).to include("Installing locked Bundler version = #{ENV["BUNDLER_VERSION"]}")
+      expect(err).to include("Installing locked Bundler version = #{ENV["BUNDLER_VERSION"]}")
     end
 
     it "doesn't display installing message if locked version is installed" do
@@ -101,7 +101,7 @@ The error was:
       bundle! "--version"
       expect(system_gem_path.join("gems", "bundler-1.12.3")).to exist
       bundle! "--version"
-      expect(out).not_to include("Installing locked Bundler version = #{ENV["BUNDLER_VERSION"]}")
+      expect(err).not_to include("Installing locked Bundler version = #{ENV["BUNDLER_VERSION"]}")
     end
   end
 

--- a/spec/other/trampoline_spec.rb
+++ b/spec/other/trampoline_spec.rb
@@ -84,6 +84,7 @@ describe "bundler version trampolining" do
       ENV["BUNDLER_VERSION"] = "9999"
       bundle "--version", :expect_err => true
       expect(err).to start_with(<<-E.strip)
+Installing locked Bundler version = 9999
 Installing the inferred bundler version (= 9999) failed.
 If you'd like to update to the current bundler version (#{Bundler::VERSION}) in this project, run `bundle update --bundler`.
 The error was:


### PR DESCRIPTION
This is for #4753.

[This](https://github.com/bundler/bundler/issues/4753#issuecomment-233786976) always showed the installing message whether the locked Bundler version was installed or not, so I moved the line into `lib/bundler/vendor/postit/lib/postit/installer.rb`.

I've also added the appropriate specs for this.

@RochesterinNYC @segiddins @indirect