### PR TITLE
Add URI to http response output in debug mode

### DIFF
--- a/lib/bundler/fetcher/downloader.rb
+++ b/lib/bundler/fetcher/downloader.rb
@@ -14,7 +14,7 @@ module Bundler
         raise HTTPError, "Too many redirects" if counter >= redirect_limit
 
         response = request(uri, options)
-        Bundler.ui.debug("HTTP #{response.code} #{response.message}")
+        Bundler.ui.debug("HTTP #{response.code} #{response.message} #{uri}")
 
         case response
         when Net::HTTPSuccess, Net::HTTPNotModified

--- a/spec/bundler/fetcher/downloader_spec.rb
+++ b/spec/bundler/fetcher/downloader_spec.rb
@@ -31,7 +31,7 @@ describe Bundler::Fetcher::Downloader do
       let(:http_response) { Net::HTTPSuccess.new("1.1", 200, "Success") }
 
       it "should log the HTTP response code and message to debug" do
-        expect(Bundler).to receive_message_chain(:ui, :debug).with("HTTP 200 Success")
+        expect(Bundler).to receive_message_chain(:ui, :debug).with("HTTP 200 Success #{uri}")
         subject.fetch(uri, options, counter)
       end
     end


### PR DESCRIPTION
Map request response to original URI when printing debug output for http responses for `bundler/fetcher/downloader`.

Overview
--------
I have recently been debugging some bundler stalling issues and found this addition to the debug output helpful when ruling out if a particular URL was timing out with the `CompactIndex` fetcher as it does it's requests over 25 threads and returns them asynchronously.  Getting a bunch of `HTTP 304 Not Modified` isn't as helpful if you are trying to determine how a thread is locking up.

Incidentally, this didn't end up helping solving some issues (further PRs will address this), but it seems like a simple debugging addition that could help rule out specific endpoint issues without requiring more [advanced debugging setups](https://gist.github.com/NickLaMuro/e923fc4e55307437a8f0e97ee6429410).