### PR TITLE
Removes OSX/msysgit strings from Bundler::Source::Git::GitProxy#version

### DIFF
--- a/lib/bundler/env.rb
+++ b/lib/bundler/env.rb
@@ -75,7 +75,7 @@ module Bundler
     end
 
     def git_version
-      Bundler::Source::Git::GitProxy.new(nil, nil, nil).version
+      Bundler::Source::Git::GitProxy.new(nil, nil, nil).full_version
     rescue Bundler::Source::Git::GitNotInstalledError
       "not installed"
     end

--- a/lib/bundler/source/git/git_proxy.rb
+++ b/lib/bundler/source/git/git_proxy.rb
@@ -80,7 +80,7 @@ module Bundler
         end
 
         def version
-          git("--version").sub("git version", "").strip
+          git("--version").match(/(git version\s*)?((\.?\d+)+).*/)[2]
         end
 
         def checkout

--- a/lib/bundler/source/git/git_proxy.rb
+++ b/lib/bundler/source/git/git_proxy.rb
@@ -83,6 +83,10 @@ module Bundler
           git("--version").match(/(git version\s*)?((\.?\d+)+).*/)[2]
         end
 
+        def full_version
+          git("--version").sub("git version", "").strip
+        end
+
         def checkout
           if path.exist?
             return if has_revision_cached?

--- a/spec/bundler/env_spec.rb
+++ b/spec/bundler/env_spec.rb
@@ -3,7 +3,8 @@ require "spec_helper"
 require "bundler/settings"
 
 describe Bundler::Env do
-  let(:env) { described_class.new }
+  let(:env)            { described_class.new }
+  let(:git_proxy_stub) { Bundler::Source::Git::GitProxy.new(nil, nil, nil) }
 
   describe "#report" do
     it "prints the environment" do
@@ -70,6 +71,16 @@ describe Bundler::Env do
 
         expect(output).to include("foo.gemspec")
         expect(output).to include(gemspec)
+      end
+    end
+
+    context "when the git version is OS specific" do
+      it "includes OS specific information with the version number" do
+        expect(git_proxy_stub).to receive(:git).with("--version").
+          and_return("git version 1.2.3 (Apple Git-BS)")
+        expect(Bundler::Source::Git::GitProxy).to receive(:new).and_return(git_proxy_stub)
+
+        expect(env.report).to include("Git       1.2.3 (Apple Git-BS)")
       end
     end
   end

--- a/spec/bundler/source/git/git_proxy_spec.rb
+++ b/spec/bundler/source/git/git_proxy_spec.rb
@@ -32,4 +32,51 @@ describe Bundler::Source::Git::GitProxy do
       subject.checkout
     end
   end
+
+  describe "#version" do
+    context "with a normal version number" do
+      before do
+        expect(subject).to receive(:git).with("--version").
+          and_return("git version 1.2.3")
+      end
+
+      it "returns the git version number" do
+        expect(subject.version).to eq("1.2.3")
+      end
+
+      it "does not raise an error when passed into Gem::Version.create" do
+        expect { Gem::Version.create subject.version }.not_to raise_error
+      end
+    end
+
+    context "with a OSX version number" do
+      before do
+        expect(subject).to receive(:git).with("--version").
+          and_return("git version 1.2.3 (Apple Git-BS)")
+      end
+
+      it "strips out OSX specific additions in the version string" do
+        expect(subject.version).to eq("1.2.3")
+      end
+
+      it "does not raise an error when passed into Gem::Version.create" do
+        expect { Gem::Version.create subject.version }.not_to raise_error
+      end
+    end
+
+    context "with a msysgit version number" do
+      before do
+        expect(subject).to receive(:git).with("--version").
+          and_return("git version 1.2.3.msysgit.0")
+      end
+
+      it "strips out msysgit specific additions in the version string" do
+        expect(subject.version).to eq("1.2.3")
+      end
+
+      it "does not raise an error when passed into Gem::Version.create" do
+        expect { Gem::Version.create subject.version }.not_to raise_error
+      end
+    end
+  end
 end

--- a/spec/bundler/source/git/git_proxy_spec.rb
+++ b/spec/bundler/source/git/git_proxy_spec.rb
@@ -79,4 +79,39 @@ describe Bundler::Source::Git::GitProxy do
       end
     end
   end
+
+  describe "#full_version" do
+    context "with a normal version number" do
+      before do
+        expect(subject).to receive(:git).with("--version").
+          and_return("git version 1.2.3")
+      end
+
+      it "returns the git version number" do
+        expect(subject.full_version).to eq("1.2.3")
+      end
+    end
+
+    context "with a OSX version number" do
+      before do
+        expect(subject).to receive(:git).with("--version").
+          and_return("git version 1.2.3 (Apple Git-BS)")
+      end
+
+      it "does not strip out OSX specific additions in the version string" do
+        expect(subject.full_version).to eq("1.2.3 (Apple Git-BS)")
+      end
+    end
+
+    context "with a msysgit version number" do
+      before do
+        expect(subject).to receive(:git).with("--version").
+          and_return("git version 1.2.3.msysgit.0")
+      end
+
+      it "does not strip out msysgit specific additions in the version string" do
+        expect(subject.full_version).to eq("1.2.3.msysgit.0")
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -74,9 +74,11 @@ RSpec.configure do |config|
     config.filter_run_excluding :realworld => true
   end
 
+  git_version = Bundler::Source::Git::GitProxy.new(nil, nil, nil).version
+
   config.filter_run_excluding :ruby => LessThanProc.with(RUBY_VERSION)
   config.filter_run_excluding :rubygems => LessThanProc.with(Gem::VERSION)
-  config.filter_run_excluding :git => LessThanProc.with(`git --version`.gsub("git version", "").strip)
+  config.filter_run_excluding :git => LessThanProc.with(git_version)
   config.filter_run_excluding :rubygems_master => (ENV["RGV"] != "master")
 
   config.filter_run :focused => true unless ENV["CI"]


### PR DESCRIPTION
Overview
--------

When running the previous version of `Bundler::Source::Git::GitProxy#version` output through `Gem::Version.create` when the git version is something like

    $ git --version
    git version 1.2.3 (Apple Git-22)

Ruby blows up with the error:

    ArgumentError:  Malformed version number string 1.2.3 (Apple Git-22)

The '(Apple Git-22)' and any additions that are added by `msysgit` (ex: `1.8.3.msysgit.0`) can be safely ignored as they are additions to the git version string for those specific versions, but should still line up with the core git version.


This regression was added in https://github.com/bundler/bundler/pull/4717, so this is not in a release of the gem yet, only in `1.13.0.rc1` installation.  This prevented:

* running tests on OSX or on any OS with a non-core git installation
* running `bundle install/update` with any git gem dependencies  in the Gemfile on OSX or any OS with a non-core git installation

This change simply regexps those version additions out, in addition to removing the `git version`, so only the version number (containing numbers or `.`s) will be parsed by this regexp.

Also, another method, `full_version` has been added to allow the `Bundler::Env` to report on the specific version of git being used, which is useful  when error reports are submitted.


Note about tests
----------------
The tests stub out any shell cmd and mocks a return value, which was easier to test the functionality of the regexp and requiring different git executable versions.  I also didn't add integration tests to address the regression caused by #4717, but simply tested that the versions parsed would work when sent through `Gem::Version.create`

This does mean I only tested a sample of git version types, so there might be something that I missed.  Also, the test for `full_version` working in reports was kinda jank, but it was the best I could do...