### PR TITLE
Add an open_timeout to the fetcher connection

### DIFF
--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -255,6 +255,7 @@ module Bundler
         end
 
         con.read_timeout = Fetcher.api_timeout
+        con.open_timeout = Fetcher.api_timeout
         con.override_headers["User-Agent"] = user_agent
         con.override_headers["X-Gemfile-Source"] = @remote.original_uri.to_s if @remote.original_uri
         con


### PR DESCRIPTION
Overview
--------
When ruby makes an HTTP connection with the `Net::HTTP` library, by default, it has no timeout to setup that connection.

```ruby
# excerpts from net/http stdlib
def initialize(address, port = nil)
  @address = address
  @port    = (port || HTTP.default_port)
  @local_host = nil
  @local_port = nil
  @curr_http_version = HTTPVersion
  @keep_alive_timeout = 2
  @last_communicated = nil
  @close_on_empty_response = false
  @socket  = nil
  @started = false
  @open_timeout = nil
  @read_timeout = 60
  # ...

end


def connect
  if proxy? then
    conn_address = proxy_address
    conn_port    = proxy_port
  else
    conn_address = address
    conn_port    = port
  end

  D "opening connection to #{conn_address}:#{conn_port}..."
  s = Timeout.timeout(@open_timeout, Net::OpenTimeout) {
    TCPSocket.open(conn_address, conn_port, @local_host, @local_port)
  }
  # ...

  if use_ssl?
    # ...
    Timeout.timeout(@open_timeout, Net::OpenTimeout) { s.connect }
  end
end
```

It can be set by changing the `open_timeout` variable on the connection object, but beyond that, it will attempt a connection unless an error is returned from the server.  The Net::HTTP::Persistent library included with bundler also maintains this same interface when dealing with threads, and eventually passes that same value down to the Net::HTTP lib.

It is possible to get into a state where bundler is currently attempting to establish a connection indefinitely to rubygems because this timeout is not in place.  Using the `Fetcher.api_timeout`, which is just pulled from the `Bundler.settings[:timeout]` value (defaults to 10 sec), we can also provide an `open_timeout` value and prevent this.  In most cases, and HTTP connection should be established in less than a second (if not, there is probably a bigger problem), and most uses of the Fecther's connection are also wrapped in a Bundler::Retry, so if it fails do to a network hiccup, it will be attempted again.

I was having this happen to me on a pretty consistent basis, and while it is probably more likely my ISP or something fishy with my home network, this seems like a relatively harmless fix.  In the code excerpts above from the STDLIB `net/http`, I would consistently have one or two Threads from the `CompactIndex` stall on the `s.connect`, which was while it was attempting to make an https connection.


Unfortunately, I can't think of a good way to test or reproduce this consistently (and of course, now I can't even reproduce it locally at all), so this PR is more of posing a question of "Do we want to do this, and why or why not?"