### PR TITLE
Bundler version warning should not print when versions match

### DIFF
--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -125,6 +125,7 @@ module Bundler
       return if ENV["BUNDLE_POSTIT_TRAMPOLINING_VERSION"].nil?
       installed_version = Gem::Version.new(ENV["BUNDLE_POSTIT_TRAMPOLINING_VERSION"].dup)
       running_version = Gem::Version.new(Bundler::VERSION)
+      return if Gem::Requirement.new(installed_version).satisfied_by?(running_version)
       if Bundler.settings[:warned_version].nil? || running_version > Gem::Version.new(Bundler.settings[:warned_version])
         Bundler.settings[:warned_version] = running_version
         Bundler.ui.warn "You're running Bundler #{installed_version} but this " \

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -491,6 +491,7 @@ describe "bundle install with gem sources" do
       gemfile <<-G
         source "file://#{gem_repo1}"
       G
+
       bundle :install, :env => { "BUNDLE_POSTIT_TRAMPOLINING_VERSION" => "999" }
       expect(out).to include("You're running Bundler 999 but this project uses #{Bundler::VERSION}.")
 
@@ -500,7 +501,8 @@ describe "bundle install with gem sources" do
 
     it "should not print warning if versions match" do
       bundle :init
-      bundle :install, :env => { "BUNDLE_POSTIT_TRAMPOLINING_VERSION" => "#{Bundler::VERSION}" }
+      bundle :install, :env => { "BUNDLE_POSTIT_TRAMPOLINING_VERSION" => Bundler::VERSION }
+      expect(out).to start_with("Running `bundle install --no-color` with bundler #{Bundler::VERSION}\nThe Gemfile specifies no dependencies")
       expect(out).not_to include("You're running Bundler #{Bundler::VERSION} but this project uses #{Bundler::VERSION}.")
     end
   end

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -491,12 +491,17 @@ describe "bundle install with gem sources" do
       gemfile <<-G
         source "file://#{gem_repo1}"
       G
-
       bundle :install, :env => { "BUNDLE_POSTIT_TRAMPOLINING_VERSION" => "999" }
       expect(out).to include("You're running Bundler 999 but this project uses #{Bundler::VERSION}.")
 
       bundle :install, :env => { "BUNDLE_POSTIT_TRAMPOLINING_VERSION" => "999" }
       expect(out).not_to include("You're running Bundler 999 but this project uses #{Bundler::VERSION}.")
+    end
+
+    it "should not print warning if versions match" do
+      bundle :init
+      bundle :install, :env => { "BUNDLE_POSTIT_TRAMPOLINING_VERSION" => "#{Bundler::VERSION}" }
+      expect(out).not_to include("You're running Bundler #{Bundler::VERSION} but this project uses #{Bundler::VERSION}.")
     end
   end
 end


### PR DESCRIPTION
Closes #4752 

@RochesterinNYC @indirect 