### PR TITLE
Allow signed tags on rake release

### DIFF
--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -140,7 +140,7 @@ module Bundler
     end
 
     def tag_version
-      sh "git tag -a -m \"Version #{version}\" #{version_tag}"
+      sh "git tag -m \"Version #{version}\" #{version_tag}"
       Bundler.ui.confirm "Tagged #{version_tag}."
       yield if block_given?
     rescue


### PR DESCRIPTION
Removing `--annotate` option does not change default behaviour

Since git 2.9.0 its possible to configure signed tag with
`tag.forceSignAnnotated` to true

Cheers