### PR TITLE
Remove expect_err from the specs & print all output on a spec failure

### DIFF
--- a/spec/bundler/friendly_errors_spec.rb
+++ b/spec/bundler/friendly_errors_spec.rb
@@ -37,7 +37,7 @@ describe Bundler, "friendly errors" do
         gem "rack"
       G
 
-      bundle :install, :env => { "DEBUG" => true }, :expect_err => true
+      bundle :install, :env => { "DEBUG" => true }
 
       expect(err).to include("Failed to load #{home(".gemrc")}")
       expect(exitstatus).to eq(0) if exitstatus

--- a/spec/bundler/gem_helper_spec.rb
+++ b/spec/bundler/gem_helper_spec.rb
@@ -237,7 +237,7 @@ describe Bundler::GemHelper do
           mock_confirm_message "Pushed git commits and tags."
           expect(subject).to receive(:rubygem_push).with(app_gem_path.to_s)
 
-          Dir.chdir(app_path) { sys_exec("git push -u origin master", true) }
+          Dir.chdir(app_path) { sys_exec("git push -u origin master") }
 
           Rake.application["release"].invoke
         end

--- a/spec/cache/git_spec.rb
+++ b/spec/cache/git_spec.rb
@@ -124,18 +124,18 @@ end
       end
 
       Dir.chdir(lib_path("has_submodule-1.0")) do
-        sys_exec "git submodule add #{lib_path("submodule-1.0")} submodule-1.0", :expect_err => true
+        sys_exec "git submodule add #{lib_path("submodule-1.0")} submodule-1.0"
         `git commit -m "submodulator"`
       end
 
-      install_gemfile <<-G, :expect_err => true
+      install_gemfile <<-G
         git "#{lib_path("has_submodule-1.0")}", :submodules => true do
           gem "has_submodule"
         end
       G
 
       ref = git.ref_for("master", 11)
-      bundle "#{cmd} --all", :expect_err => true
+      bundle "#{cmd} --all"
 
       expect(bundled_app("vendor/cache/has_submodule-1.0-#{ref}")).to exist
       expect(bundled_app("vendor/cache/has_submodule-1.0-#{ref}/submodule-1.0")).to exist

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -128,7 +128,7 @@ describe "bundle exec" do
       G
     end
 
-    bundle! "exec rackup", :expect_err => true
+    bundle! "exec rackup"
 
     expect(out).to eq("0.9.1")
 
@@ -425,11 +425,11 @@ describe "bundle exec" do
         G
       end
 
-      install_gemfile <<-G, :expect_err => true
+      install_gemfile <<-G
         gem "foo", :path => "#{lib_path("foo-1.0")}"
       G
 
-      bundle "exec irb", :expect_err => true
+      bundle "exec irb"
 
       expect(err).to match("The gemspec at #{lib_path("foo-1.0").join("foo.gemspec")} is not valid")
       expect(err).to match('"TODO" is not a summary')
@@ -480,7 +480,7 @@ describe "bundle exec" do
     let(:expected) { [exec, args, rack].join("\n") }
     let(:expected_err) { "" }
 
-    subject { bundle "exec #{path} arg1 arg2", :expect_err => true }
+    subject { bundle "exec #{path} arg1 arg2" }
 
     shared_examples_for "it runs" do
       it "like a normally executed executable" do

--- a/spec/commands/help_spec.rb
+++ b/spec/commands/help_spec.rb
@@ -7,7 +7,7 @@ describe "bundle help" do
   it "complains if older versions of bundler are installed", :if => rubygems_under_14 do
     system_gems "bundler-0.8.1"
 
-    bundle "help", :expect_err => true
+    bundle "help"
     expect(err).to include("older than 0.9")
     expect(err).to include("running `gem cleanup bundler`.")
   end
@@ -28,7 +28,7 @@ describe "bundle help" do
 
   it "simply outputs the txt file when there is no man on the path" do
     with_path_as("") do
-      bundle "help install", :expect_err => true
+      bundle "help install"
     end
     expect(out).to match(/BUNDLE-INSTALL/)
   end
@@ -81,7 +81,7 @@ describe "bundle help" do
 
   it "has helpful output when using --help flag for a non-existent command" do
     with_fake_man do
-      bundle "instill -h", :expect_err => true
+      bundle "instill -h"
     end
     expect(out).to include('Could not find command "instill".')
   end

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -13,7 +13,7 @@ describe "bundle install with gem sources" do
     end
 
     it "does not make a lockfile if the install fails" do
-      install_gemfile <<-G, :expect_err => true
+      install_gemfile <<-G
         raise StandardError, "FAIL"
       G
 
@@ -60,7 +60,7 @@ describe "bundle install with gem sources" do
 
       lockfile = File.read(bundled_app("Gemfile.lock"))
 
-      install_gemfile <<-G, :expect_err => true
+      install_gemfile <<-G
         raise StandardError, "FAIL"
       G
 
@@ -302,7 +302,7 @@ describe "bundle install with gem sources" do
         gem "rack"
       G
 
-      bundle :install, :expect_err => true
+      bundle :install
       expect(out).to include("Your Gemfile has no gem server sources")
     end
 
@@ -356,7 +356,7 @@ describe "bundle install with gem sources" do
 
     context "and using an unsupported Ruby version" do
       it "prints an error" do
-        install_gemfile <<-G, :expect_err => true
+        install_gemfile <<-G
           ::RUBY_VERSION = '1.8.7'
           ruby '~> 2.1'
         G
@@ -366,7 +366,7 @@ describe "bundle install with gem sources" do
 
     context "and using a supported Ruby version" do
       before do
-        install_gemfile <<-G, :expect_err => true
+        install_gemfile <<-G
           ::RUBY_VERSION = '2.1.3'
           ::RUBY_PATCHLEVEL = 100
           ruby '~> 2.1.0'
@@ -392,7 +392,7 @@ describe "bundle install with gem sources" do
       end
 
       it "updates Gemfile.lock with updated incompatible ruby version" do
-        install_gemfile <<-G, :expect_err => true
+        install_gemfile <<-G
           ::RUBY_VERSION = '2.2.3'
           ::RUBY_PATCHLEVEL = 100
           ruby '~> 2.2.0'

--- a/spec/commands/package_spec.rb
+++ b/spec/commands/package_spec.rb
@@ -165,7 +165,7 @@ describe "bundle package" do
 
       bundle "package --no-install"
 
-      expect(the_bundle).not_to include_gems "rack 1.0.0", :expect_err => true
+      expect(the_bundle).not_to include_gems "rack 1.0.0"
       expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
     end
 

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -55,11 +55,11 @@ describe "bundle update" do
 
   describe "with an unknown dependency" do
     it "should inform the user" do
-      bundle "update halting-problem-solver", :expect_err => true
+      bundle "update halting-problem-solver"
       expect(out).to include "Could not find gem 'halting-problem-solver'"
     end
     it "should suggest alternatives" do
-      bundle "update active-support", :expect_err => true
+      bundle "update active-support"
       expect(out).to include "Did you mean activesupport?"
     end
   end
@@ -336,23 +336,23 @@ end
 
 describe "bundle update --ruby" do
   before do
-    install_gemfile <<-G, :expect_err => true
+    install_gemfile <<-G
         ::RUBY_VERSION = '2.1.3'
         ::RUBY_PATCHLEVEL = 100
         ruby '~> 2.1.0'
     G
-    bundle "update --ruby", :expect_err => true
+    bundle "update --ruby"
   end
 
   context "when the Gemfile removes the ruby" do
     before do
-      install_gemfile <<-G, :expect_err => true
+      install_gemfile <<-G
           ::RUBY_VERSION = '2.1.4'
           ::RUBY_PATCHLEVEL = 222
       G
     end
     it "removes the Ruby from the Gemfile.lock" do
-      bundle "update --ruby", :expect_err => true
+      bundle "update --ruby"
 
       lockfile_should_be <<-L
        GEM
@@ -371,14 +371,14 @@ describe "bundle update --ruby" do
 
   context "when the Gemfile specified an updated Ruby version" do
     before do
-      install_gemfile <<-G, :expect_err => true
+      install_gemfile <<-G
           ::RUBY_VERSION = '2.1.4'
           ::RUBY_PATCHLEVEL = 222
           ruby '~> 2.1.0'
       G
     end
     it "updates the Gemfile.lock with the latest version" do
-      bundle "update --ruby", :expect_err => true
+      bundle "update --ruby"
 
       lockfile_should_be <<-L
        GEM
@@ -400,14 +400,14 @@ describe "bundle update --ruby" do
 
   context "when a different Ruby is being used than has been versioned" do
     before do
-      install_gemfile <<-G, :expect_err => true
+      install_gemfile <<-G
           ::RUBY_VERSION = '2.2.2'
           ::RUBY_PATCHLEVEL = 505
           ruby '~> 2.1.0'
       G
     end
     it "shows a helpful error message" do
-      bundle "update --ruby", :expect_err => true
+      bundle "update --ruby"
 
       expect(out).to include("Your Ruby version is 2.2.2, but your Gemfile specified ~> 2.1.0")
     end
@@ -415,14 +415,14 @@ describe "bundle update --ruby" do
 
   context "when updating Ruby version and Gemfile `ruby`" do
     before do
-      install_gemfile <<-G, :expect_err => true
+      install_gemfile <<-G
           ::RUBY_VERSION = '1.8.3'
           ::RUBY_PATCHLEVEL = 55
           ruby '~> 1.8.0'
       G
     end
     it "updates the Gemfile.lock with the latest version" do
-      bundle "update --ruby", :expect_err => true
+      bundle "update --ruby"
 
       lockfile_should_be <<-L
        GEM

--- a/spec/install/gemfile/gemspec_spec.rb
+++ b/spec/install/gemfile/gemspec_spec.rb
@@ -58,7 +58,7 @@ describe "bundle install from an existing gemspec" do
   it "should raise if there are no gemspecs available" do
     build_lib("foo", :path => tmp.join("foo"), :gemspec => false)
 
-    error = install_gemfile(<<-G, :expect_err => true)
+    error = install_gemfile(<<-G)
       source "file://#{gem_repo2}"
       gemspec :path => '#{tmp.join("foo")}'
     G
@@ -70,7 +70,7 @@ describe "bundle install from an existing gemspec" do
       s.write("foo2.gemspec", build_spec("foo", "4.0").first.to_ruby)
     end
 
-    error = install_gemfile(<<-G, :expect_err => true)
+    error = install_gemfile(<<-G)
       source "file://#{gem_repo2}"
       gemspec :path => '#{tmp.join("foo")}'
     G
@@ -84,7 +84,7 @@ describe "bundle install from an existing gemspec" do
       s.add_development_dependency "bar-dev", "=1.0.0"
     end
 
-    install_gemfile(<<-G, :expect_err => true)
+    install_gemfile(<<-G)
       source "file://#{gem_repo2}"
       gemspec :path => '#{tmp.join("foo")}', :name => 'foo'
     G
@@ -100,7 +100,7 @@ describe "bundle install from an existing gemspec" do
       s.add_development_dependency "bar-dev", "=1.0.0"
     end
 
-    install_gemfile(<<-G, :expect_err => true)
+    install_gemfile(<<-G)
       source "file://#{gem_repo2}"
       gemspec :path => '#{tmp.join("foo")}', :name => 'foo', :development_group => :dev
     G
@@ -137,7 +137,7 @@ describe "bundle install from an existing gemspec" do
       s.write "raise 'ahh' unless Dir.pwd == '#{tmp.join("foo")}'"
     end
 
-    install_gemfile <<-G, :expect_err => true
+    install_gemfile <<-G
       gemspec :path => '#{tmp.join("foo")}'
     G
     expect(@err).not_to match(/ahh/)

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -381,7 +381,7 @@ describe "bundle install with git sources" do
     #     gem "thingy", :git => "git@notthere.fallingsnow.net:somebody/thingy.git"
     #   G
     #
-    #   bundle :install, :expect_err => true
+    #   bundle :install
     #
     #   # p out
     #   # p err
@@ -564,7 +564,7 @@ describe "bundle install with git sources" do
       gem "foo", "1.0", :git => "omgomg"
     G
 
-    bundle :install, :expect_err => true
+    bundle :install
 
     expect(out).to include("Git error:")
     expect(err).to include("fatal")
@@ -612,18 +612,18 @@ describe "bundle install with git sources" do
       s.add_dependency "submodule"
     end
     Dir.chdir(lib_path("has_submodule-1.0")) do
-      sys_exec "git submodule add #{lib_path("submodule-1.0")} submodule-1.0", :expect_err => true
+      sys_exec "git submodule add #{lib_path("submodule-1.0")} submodule-1.0"
       `git commit -m "submodulator"`
     end
 
-    install_gemfile <<-G, :expect_err => true
+    install_gemfile <<-G
       git "#{lib_path("has_submodule-1.0")}" do
         gem "has_submodule"
       end
     G
     expect(out).to match(/could not find gem 'submodule/i)
 
-    expect(the_bundle).not_to include_gems "has_submodule 1.0", :expect_err => true
+    expect(the_bundle).not_to include_gems "has_submodule 1.0"
   end
 
   it "handles repos with submodules" do
@@ -632,11 +632,11 @@ describe "bundle install with git sources" do
       s.add_dependency "submodule"
     end
     Dir.chdir(lib_path("has_submodule-1.0")) do
-      sys_exec "git submodule add #{lib_path("submodule-1.0")} submodule-1.0", :expect_err => true
+      sys_exec "git submodule add #{lib_path("submodule-1.0")} submodule-1.0"
       `git commit -m "submodulator"`
     end
 
-    install_gemfile <<-G, :expect_err => true
+    install_gemfile <<-G
       git "#{lib_path("has_submodule-1.0")}", :submodules => true do
         gem "has_submodule"
       end
@@ -809,10 +809,10 @@ describe "bundle install with git sources" do
       bundle "install"
       expect(out).to_not match(/Revision.*does not exist/)
 
-      install_gemfile <<-G, :expect_err => true
+      install_gemfile <<-G
         gem "foo", :git => "file://#{lib_path("foo-1.0")}", :ref => "deadbeef"
       G
-      bundle "install", :expect_err => true
+      bundle "install"
       expect(out).to include("Revision deadbeef does not exist in the repository")
     end
   end
@@ -849,8 +849,8 @@ describe "bundle install with git sources" do
         H
       end
 
-      bundle :install, :expect_err => true,
-                       :requires => [lib_path("install_hooks.rb")]
+      bundle :install,
+        :requires => [lib_path("install_hooks.rb")]
       expect(err).to eq_err("Ran pre-install hook: foo-1.0")
     end
 
@@ -869,8 +869,8 @@ describe "bundle install with git sources" do
         H
       end
 
-      bundle :install, :expect_err => true,
-                       :requires => [lib_path("install_hooks.rb")]
+      bundle :install,
+        :requires => [lib_path("install_hooks.rb")]
       expect(err).to eq_err("Ran post-install hook: foo-1.0")
     end
 
@@ -889,8 +889,8 @@ describe "bundle install with git sources" do
         H
       end
 
-      bundle :install, :expect_err => true,
-                       :requires => [lib_path("install_hooks.rb")]
+      bundle :install,
+        :requires => [lib_path("install_hooks.rb")]
       expect(out).to include("failed for foo-1.0")
     end
   end
@@ -1107,13 +1107,13 @@ describe "bundle install with git sources" do
       let(:credentials) { "user1:password1" }
 
       it "does not display the password" do
-        install_gemfile <<-G, :expect_err => true
+        install_gemfile <<-G
           git "https://#{credentials}@github.com/company/private-repo" do
             gem "foo"
           end
         G
 
-        bundle :install, :expect_err => true
+        bundle :install
         expect(out).to_not include("password1")
         expect(out).to include("Fetching https://user1@github.com/company/private-repo")
       end
@@ -1123,13 +1123,13 @@ describe "bundle install with git sources" do
       let(:credentials) { "oauth_token" }
 
       it "displays the oauth scheme but not the oauth token" do
-        install_gemfile <<-G, :expect_err => true
+        install_gemfile <<-G
           git "https://#{credentials}:x-oauth-basic@github.com/company/private-repo" do
             gem "foo"
           end
         G
 
-        bundle :install, :expect_err => true
+        bundle :install
         expect(out).to_not include("oauth_token")
         expect(out).to include("Fetching https://x-oauth-basic@github.com/company/private-repo")
       end

--- a/spec/install/gemfile/path_spec.rb
+++ b/spec/install/gemfile/path_spec.rb
@@ -154,7 +154,7 @@ describe "bundle install with explicit source paths" do
       G
     end
 
-    install_gemfile <<-G, :expect_err => true
+    install_gemfile <<-G
       gem "foo", :path => "#{lib_path("foo-1.0")}"
     G
 
@@ -547,8 +547,8 @@ describe "bundle install with explicit source paths" do
         H
       end
 
-      bundle :install, :expect_err => true,
-                       :requires => [lib_path("install_hooks.rb")]
+      bundle :install,
+        :requires => [lib_path("install_hooks.rb")]
       expect(err).to eq_err("Ran pre-install hook: foo-1.0")
     end
 
@@ -567,8 +567,8 @@ describe "bundle install with explicit source paths" do
         H
       end
 
-      bundle :install, :expect_err => true,
-                       :requires => [lib_path("install_hooks.rb")]
+      bundle :install,
+        :requires => [lib_path("install_hooks.rb")]
       expect(err).to eq_err("Ran post-install hook: foo-1.0")
     end
 
@@ -587,8 +587,8 @@ describe "bundle install with explicit source paths" do
         H
       end
 
-      bundle :install, :expect_err => true,
-                       :requires => [lib_path("install_hooks.rb")]
+      bundle :install,
+        :requires => [lib_path("install_hooks.rb")]
       expect(out).to include("failed for foo-1.0")
     end
   end

--- a/spec/install/gems/flex_spec.rb
+++ b/spec/install/gems/flex_spec.rb
@@ -186,7 +186,7 @@ describe "bundle flex_install" do
 
     it "does not install gems whose dependencies are not met" do
       bundle :install
-      ruby <<-RUBY, :expect_err => true
+      ruby <<-RUBY
         require 'bundler/setup'
       RUBY
       expect(err).to match(/could not find gem 'rack-obama/i)

--- a/spec/install/gems/resolving_spec.rb
+++ b/spec/install/gems/resolving_spec.rb
@@ -76,11 +76,9 @@ describe "bundle install with install-time dependencies" do
           gem "net_e"
         G
 
-        resolve_output = capture(:stdout) do
-          bundle :install, :env => { "DEBUG_RESOLVER" => "1" }
-        end
+        bundle :install, :env => { "DEBUG_RESOLVER" => "1" }
 
-        expect(resolve_output).to include("Creating possibility state for net_c")
+        expect(err).to include("Creating possibility state for net_c")
       end
     end
 
@@ -92,12 +90,10 @@ describe "bundle install with install-time dependencies" do
           gem "net_e"
         G
 
-        resolve_output = capture(:stdout) do
-          bundle :install, :env => { "DEBUG_RESOLVER_TREE" => "1" }
-        end
+        bundle :install, :env => { "DEBUG_RESOLVER_TREE" => "1" }
 
-        expect(resolve_output).to include(" net_b")
-        expect(resolve_output).to include(" net_build_extensions (1.0)")
+        expect(err).to include(" net_b")
+        expect(err).to include(" net_build_extensions (1.0)")
       end
     end
   end

--- a/spec/install/gems/standalone_spec.rb
+++ b/spec/install/gems/standalone_spec.rb
@@ -198,7 +198,7 @@ shared_examples "bundle install --standalone" do
       bundle "install --standalone --path path/to/bundle"
 
       Dir.chdir(bundled_app) do
-        ruby <<-RUBY, :no_lib => true, :expect_err => false
+        ruby <<-RUBY, :no_lib => true
           $:.unshift File.expand_path("path/to/bundle")
           require "bundler/setup"
 

--- a/spec/lock/lockfile_spec.rb
+++ b/spec/lock/lockfile_spec.rb
@@ -1317,7 +1317,7 @@ describe "the lockfile format" do
          #{Bundler::VERSION}
     L
 
-    error = install_gemfile(<<-G, :expect_err => true)
+    error = install_gemfile(<<-G)
       source "file://#{gem_repo1}"
       gem "rack"
     G

--- a/spec/other/bundle_ruby_spec.rb
+++ b/spec/other/bundle_ruby_spec.rb
@@ -11,7 +11,7 @@ describe "bundle_ruby" do
         gem "foo"
       G
 
-      bundle_ruby :expect_err => true
+      bundle_ruby
 
       expect(out).to include("ruby 1.9.3")
     end
@@ -24,7 +24,7 @@ describe "bundle_ruby" do
         gem "foo"
       G
 
-      bundle_ruby :expect_err => true
+      bundle_ruby
 
       expect(out).to include("ruby 1.9.3")
     end
@@ -37,7 +37,7 @@ describe "bundle_ruby" do
         gem "foo"
       G
 
-      bundle_ruby :expect_err => true
+      bundle_ruby
 
       expect(out).to include("ruby 1.8.7 (jruby 1.6.5)")
     end
@@ -50,7 +50,7 @@ describe "bundle_ruby" do
         gem "foo"
       G
 
-      bundle_ruby :expect_err => true
+      bundle_ruby
 
       expect(out).to include("ruby 1.8.7 (rbx 1.2.4)")
     end
@@ -63,10 +63,10 @@ describe "bundle_ruby" do
         gem "foo"
       G
 
-      bundle_ruby :expect_err => true, :exitstatus => true
+      bundle_ruby
       expect(exitstatus).not_to eq(0) if exitstatus
 
-      bundle_ruby :expect_err => true
+      bundle_ruby
       expect(out).to include("Please define :engine_version")
     end
 
@@ -78,10 +78,10 @@ describe "bundle_ruby" do
         gem "foo"
       G
 
-      bundle_ruby :expect_err => true, :exitstatus => true
+      bundle_ruby
       expect(exitstatus).not_to eq(0) if exitstatus
 
-      bundle_ruby :expect_err => true
+      bundle_ruby
       expect(out).to include("Please define :engine")
     end
 
@@ -93,10 +93,10 @@ describe "bundle_ruby" do
         gem "foo"
       G
 
-      bundle_ruby :expect_err => true, :exitstatus => true
+      bundle_ruby
       expect(exitstatus).not_to eq(0) if exitstatus
 
-      bundle_ruby :expect_err => true
+      bundle_ruby
       expect(out).to include("ruby_version must match the :engine_version for MRI")
     end
 
@@ -107,7 +107,7 @@ describe "bundle_ruby" do
         gem "foo"
       G
 
-      bundle_ruby :expect_err => true
+      bundle_ruby
 
       expect(out).to include("No ruby version specified")
     end
@@ -122,7 +122,7 @@ describe "bundle_ruby" do
         gem "foo"
       G
 
-      bundle_ruby :expect_err => true
+      bundle_ruby
 
       expect(out).to include("ruby 1.9.3p429")
     end
@@ -135,7 +135,7 @@ describe "bundle_ruby" do
         gem "foo"
       G
 
-      bundle_ruby :expect_err => true
+      bundle_ruby
 
       expect(out).to include("ruby 1.9.3p392 (jruby 1.7.4)")
     end

--- a/spec/other/ext_spec.rb
+++ b/spec/other/ext_spec.rb
@@ -58,12 +58,12 @@ describe "Gem::SourceIndex#refresh!" do
   end
 
   it "does not explode when called", :if => rubygems_1_7 do
-    run "Gem.source_index.refresh!", :expect_err => true
-    run "Gem::SourceIndex.new([]).refresh!", :expect_err => true
+    run "Gem.source_index.refresh!"
+    run "Gem::SourceIndex.new([]).refresh!"
   end
 
   it "does not explode when called", :unless => rubygems_1_7 do
-    run "Gem.source_index.refresh!", :expect_err => true
-    run "Gem::SourceIndex.from_gems_in([]).refresh!", :expect_err => true
+    run "Gem.source_index.refresh!"
+    run "Gem::SourceIndex.from_gems_in([]).refresh!"
   end
 end

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -16,7 +16,7 @@ describe "major deprecations" do
 
   describe "bundle_ruby" do
     it "prints a deprecation" do
-      bundle_ruby :expect_err => true
+      bundle_ruby
       out.gsub! "\nruby #{RUBY_VERSION}", ""
       expect(warnings).to have_major_deprecation "the bundle_ruby executable has been removed in favor of `bundle platform --ruby`"
     end
@@ -136,7 +136,7 @@ describe "major deprecations" do
 
   context "when `bundler/deployment` is required in a ruby script" do
     it "should print a capistrano deprecation warning" do
-      ruby(<<-RUBY, :expect_err => true)
+      ruby(<<-RUBY)
         require 'bundler/deployment'
       RUBY
 

--- a/spec/other/trampoline_spec.rb
+++ b/spec/other/trampoline_spec.rb
@@ -82,7 +82,7 @@ describe "bundler version trampolining" do
 
     it "fails gracefully when installing the bundler fails" do
       ENV["BUNDLER_VERSION"] = "9999"
-      bundle "--version", :expect_err => true
+      bundle "--version"
       expect(err).to start_with(<<-E.strip)
 Installing locked Bundler version 9999...
 Installing the inferred bundler version (= 9999) failed.
@@ -115,7 +115,7 @@ The error was:
 
     it "updates to the specified version" do
       # HACK: since no released bundler version actually supports this feature!
-      bundle "update --bundler=1.12.0", :expect_err => true
+      bundle "update --bundler=1.12.0"
       expect(out).to include("Unknown switches '--bundler=1.12.0'")
     end
 

--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -208,7 +208,7 @@ describe "The library itself" do
       lib_files = `git ls-files -z`.split("\x0").grep(/\.rb$/) - exclusions
       lib_files.reject! {|f| f.start_with?("bundler/vendor") }
       lib_files.map! {|f| f.chomp(".rb") }
-      sys_exec("ruby -w -I. ", :expect_err) do |input, _, _|
+      sys_exec!("ruby -w -I.") do |input, _, _|
         lib_files.each do |f|
           input.puts "require '#{f}'"
         end

--- a/spec/realworld/edgecases_spec.rb
+++ b/spec/realworld/edgecases_spec.rb
@@ -89,7 +89,7 @@ describe "real world edgecases", :realworld => true, :sometimes => true do
       gem 'rack', '1.0.1'
     G
 
-    bundle "install --path vendor/bundle", :expect_err => true
+    bundle "install --path vendor/bundle"
     expect(err).not_to include("Could not find rake")
     expect(err).to lack_errors
   end

--- a/spec/runtime/inline_spec.rb
+++ b/spec/runtime/inline_spec.rb
@@ -61,7 +61,7 @@ describe "bundler/inline#gemfile" do
     expect(out).to eq("two")
     expect(exitstatus).to be_zero if exitstatus
 
-    script <<-RUBY, :expect_err => true
+    script <<-RUBY
       gemfile do
         path "#{lib_path}"
         gem "eleven"
@@ -114,7 +114,7 @@ describe "bundler/inline#gemfile" do
   end
 
   it "raises an exception if passed unknown arguments" do
-    script <<-RUBY, :expect_err => true
+    script <<-RUBY
       gemfile(true, :arglebargle => true) do
         path "#{lib_path}"
         gem "two"

--- a/spec/runtime/require_spec.rb
+++ b/spec/runtime/require_spec.rb
@@ -133,7 +133,7 @@ describe "Bundler.require" do
       gem "faulty"
     G
 
-    run "Bundler.require", :expect_err => true
+    run "Bundler.require"
     expect(err).to match("error while trying to load the gem 'faulty'")
     expect(err).to match("Gem Internal Error Message")
   end
@@ -155,7 +155,7 @@ describe "Bundler.require" do
         $stderr.puts "ZOMG LOAD ERROR: \#{e.message}"
       end
     RUBY
-    run(cmd, :expect_err => true)
+    run(cmd)
 
     expect(err).to eq_err("ZOMG LOAD ERROR: cannot load such file -- load-bar")
   end
@@ -191,7 +191,7 @@ describe "Bundler.require" do
         require 'bundler'
         Bundler.require
       RUBY
-      ruby(cmd, :expect_err => true)
+      ruby(cmd)
 
       expect(err).to lack_errors
     end
@@ -225,7 +225,7 @@ describe "Bundler.require" do
           $stderr.puts "ZOMG LOAD ERROR" if e.message.include?("Could not open library 'libfuuu-1.0'")
         end
       RUBY
-      run(cmd, :expect_err => true)
+      run(cmd)
 
       expect(err).to eq_err("ZOMG LOAD ERROR")
     end
@@ -248,7 +248,7 @@ describe "Bundler.require" do
           $stderr.puts "ZOMG LOAD ERROR: \#{e.message}"
         end
       RUBY
-      run(cmd, :expect_err => true)
+      run(cmd)
 
       expect(err).to eq_err("ZOMG LOAD ERROR: cannot load such file -- load-bar")
     end
@@ -374,7 +374,7 @@ describe "Bundler.require with platform specific dependencies" do
       gem "rack", "1.0.0"
     G
 
-    run "Bundler.require", :expect_err => true
+    run "Bundler.require"
     expect(err).to lack_errors
   end
 
@@ -387,7 +387,7 @@ describe "Bundler.require with platform specific dependencies" do
       end
     G
 
-    run "Bundler.require; puts RACK", :expect_err => true
+    run "Bundler.require; puts RACK"
 
     expect(out).to eq("1.0.0")
     expect(err).to lack_errors

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -93,7 +93,7 @@ describe "Bundler.setup" do
     end
 
     it "handles multiple non-additive invocations" do
-      ruby <<-RUBY, :expect_err => true
+      ruby <<-RUBY
         require 'bundler'
         Bundler.setup(:default, :test)
         Bundler.setup(:default)
@@ -194,7 +194,7 @@ describe "Bundler.setup" do
       gem "rack"
     G
 
-    ruby <<-R, :expect_err => true
+    ruby <<-R
       require 'rubygems'
       require 'bundler'
 
@@ -218,7 +218,7 @@ describe "Bundler.setup" do
       gem "nosuchgem", "10.0"
     G
 
-    ruby <<-R, :expect_err => true
+    ruby <<-R
       require 'rubygems'
       require 'bundler'
 
@@ -296,7 +296,7 @@ describe "Bundler.setup" do
       end
 
       it "version_requirement is now deprecated in rubygems 1.4.0+ when gem is missing" do
-        run <<-R, :expect_err => true
+        run <<-R
           begin
             gem "activesupport"
             puts "FAIL"
@@ -322,7 +322,7 @@ describe "Bundler.setup" do
       end
 
       it "version_requirement is now deprecated in rubygems 1.4.0+ when the version is wrong" do
-        run <<-R, :expect_err => true
+        run <<-R
           begin
             gem "rack", "1.0.0"
             puts "FAIL"
@@ -388,7 +388,7 @@ describe "Bundler.setup" do
     end
 
     it "provides a useful exception when the git repo is not checked out yet" do
-      run "1", :expect_err => true
+      run "1"
       expect(err).to match(/the git source #{lib_path('rack-1.0.0')} is not yet checked out. Please run `bundle install`/i)
     end
 
@@ -431,7 +431,7 @@ describe "Bundler.setup" do
         end
       R
 
-      run "puts 'FAIL'", :expect_err => true
+      run "puts 'FAIL'"
 
       expect(err).not_to include "This is not the git you are looking for"
     end
@@ -475,7 +475,7 @@ describe "Bundler.setup" do
       expect(out).to match(/at #{lib_path('local-rack')}/)
 
       FileUtils.rm_rf(lib_path("local-rack"))
-      run "require 'rack'", :expect_err => true
+      run "require 'rack'"
       expect(err).to match(/Cannot use local override for rack-0.8 because #{Regexp.escape(lib_path('local-rack').to_s)} does not exist/)
     end
 
@@ -498,7 +498,7 @@ describe "Bundler.setup" do
         gem "rack", :git => "#{lib_path("rack-0.8")}"
       G
 
-      run "require 'rack'", :expect_err => true
+      run "require 'rack'"
       expect(err).to match(/because :branch is not specified in Gemfile/)
     end
 
@@ -521,7 +521,7 @@ describe "Bundler.setup" do
         gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "changed"
       G
 
-      run "require 'rack'", :expect_err => true
+      run "require 'rack'"
       expect(err).to match(/is using branch master but Gemfile specifies changed/)
     end
 
@@ -541,7 +541,7 @@ describe "Bundler.setup" do
       G
 
       bundle %(config local.rack #{lib_path("local-rack")})
-      run "require 'rack'", :expect_err => true
+      run "require 'rack'"
       expect(err).to match(/is using branch master but Gemfile specifies nonexistant/)
     end
   end
@@ -635,7 +635,7 @@ describe "Bundler.setup" do
           gem "thin", "1.0"
         G
 
-        ruby <<-R, :expect_err => true
+        ruby <<-R
           require 'rubygems'
           gem "thin"
           require 'bundler'

--- a/spec/runtime/with_clean_env_spec.rb
+++ b/spec/runtime/with_clean_env_spec.rb
@@ -38,7 +38,7 @@ describe "Bundler.with_env helpers" do
       RB
       path = `getconf PATH`.strip + File::PATH_SEPARATOR + File.dirname(Gem.ruby)
       with_path_as(path) do
-        bundle!("exec ruby #{bundled_app("exe.rb")} 2", :expect_err => true)
+        bundle!("exec ruby #{bundled_app("exe.rb")} 2")
       end
       expect(err).to eq <<-EOS.strip
 2 false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,8 +34,7 @@ Dir["#{File.expand_path("../support", __FILE__)}/*.rb"].each do |file|
   require file unless file =~ %r{fakeweb/.*\.rb}
 end
 
-$debug    = false
-$show_err = true
+$debug = false
 
 Spec::Rubygems.setup
 FileUtils.rm_rf(Spec::Path.gem_repo1)
@@ -98,10 +97,12 @@ RSpec.configure do |config|
     reset!
     system_gems []
     in_app_root
+    @all_output = String.new
   end
 
   config.after :each do |example|
-    puts @out if defined?(@out) && example.exception
+    @all_output.strip!
+    warn @all_output if example.exception && !@all_output.empty?
 
     Dir.chdir(original_wd)
     ENV.replace(original_env)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -102,7 +102,13 @@ RSpec.configure do |config|
 
   config.after :each do |example|
     @all_output.strip!
-    warn @all_output if example.exception && !@all_output.empty?
+    if example.exception && !@all_output.empty?
+      warn @all_output
+      message = example.exception.message + "\n\nCommands:\n#{@all_output}"
+      (class << example.exception; self; end).send(:define_method, :message) do
+        message
+      end
+    end
 
     Dir.chdir(original_wd)
     ENV.replace(original_env)

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -158,7 +158,7 @@ module Spec
         args = args.gsub(/(?=")/, "\\")
         args = %("#{args}")
       end
-      sys_exec("#{Gem.ruby} -rubygems -S gem --backtrace #{command} #{args}", options[:expect_err])
+      sys_exec("#{Gem.ruby} -rubygems -S gem --backtrace #{command} #{args}")
     end
     bang :gem_command
 
@@ -172,7 +172,7 @@ module Spec
         @err = Thread.new { stderr.read }.value.strip
       end
 
-      @all_output << [
+      (@all_output ||= String.new) << [
         "$ #{cmd.to_s.strip}",
         out,
         err,

--- a/spec/update/git_spec.rb
+++ b/spec/update/git_spec.rb
@@ -132,7 +132,7 @@ describe "bundle update" do
         end
 
         Dir.chdir(lib_path("has_submodule-1.0")) do
-          sys_exec "git submodule add #{lib_path("submodule-1.0")} submodule-1.0", :expect_err => true
+          sys_exec "git submodule add #{lib_path("submodule-1.0")} submodule-1.0"
           `git commit -m "submodulator"`
         end
       end
@@ -147,7 +147,7 @@ describe "bundle update" do
         run "require 'submodule'"
         expect(out).to eq("GEM")
 
-        install_gemfile <<-G, :expect_err => true
+        install_gemfile <<-G
           git "#{lib_path("has_submodule-1.0")}", :submodules => true do
             gem "has_submodule"
           end
@@ -158,7 +158,7 @@ describe "bundle update" do
       end
 
       it "unlocks the source when submodules are removed from git source", :git => ">= 2.9.0" do
-        install_gemfile <<-G, :expect_err => true
+        install_gemfile <<-G
           git "#{lib_path("has_submodule-1.0")}", :submodules => true do
             gem "has_submodule"
           end
@@ -187,7 +187,7 @@ describe "bundle update" do
 
       lib_path("foo-1.0").join(".git").rmtree
 
-      bundle :update, :expect_err => true
+      bundle :update
       expect(out).to include(lib_path("foo-1.0").to_s)
     end
 


### PR DESCRIPTION
This now also appends all executed commands to failed examples, meaning we don't have to scroll up to see the output from a failing test:

```
Failures:

  1) The library itself does not contain any warnings
     Failure/Error:
       sys_exec!("ruby -w -I.") do |input, _, _|
         lib_files.each do |f|
           input.puts "require '#{f}'"
         end
         input.puts "abort 'fdsfds'"
       end

     RuntimeError:
       Invoking sys_exec!("ruby -w -I.") failed:
       fdsfds

       Commands:
       $ ruby -w -I.
       fdsfds
       # $? => 1
     # ./spec/quality_spec.rb:205:in `block (3 levels) in <top (required)>'
     # ./spec/quality_spec.rb:196:in `chdir'
     # ./spec/quality_spec.rb:196:in `block (2 levels) in <top (required)>'
```