### PR TITLE
Better gem outdated list

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -269,6 +269,8 @@ module Bundler
       versions of the given gems. Prerelease gems are ignored by default. If your gems
       are up to date, Bundler will exit with a status of 0. Otherwise, it will exit 1.
     D
+    method_option "group", :aliases => "--group", :type => :string, :banner => "List gems from a specific group"
+    method_option "groups", :aliases => "--groups", :type => :boolean, :banner => "List gems organized by groups"
     method_option "local", :type => :boolean, :banner =>
       "Do not attempt to fetch gems remotely and use the gem cache instead"
     method_option "pre", :type => :boolean, :banner => "Check for newer pre-release gems"


### PR DESCRIPTION
Hi,

the current version of bundler is listing all gems with the group, I improve these list grouping the gems by group and not repeat the group every line.

Current:
```
Outdated gems included in the bundle:
  * aasm (newest 4.11.0, installed 3.4.0, requested = 3.4.0) in group "default"
  * activerecord-import (newest 0.15.0, installed 0.13.0) in group "default"
  * annotate (newest 2.7.1, installed 2.7.0) in group "development"
  * authority (newest 3.2.0, installed 3.0.0, requested ~> 3.0.0) in group "default"
  * awesome_print (newest 1.7.0, installed 1.2.0, requested ~> 1.2.0) in groups "development, test"
  * aws-sdk (newest 2.5.1, installed 1.60.2, requested ~> 1.60.2) in group "default"
  * bootstrap-sass (newest 3.3.7, installed 3.3.5.1, requested ~> 3.3.5.1) in group "default"
  * capybara (newest 2.7.1, installed 2.5.0, requested ~> 2.4) in group "test"
  * capybara-email (newest 2.5.0, installed 2.4.0) in group "test"
  * codeclimate-test-reporter (newest 0.6.0, installed 0.4.7) in group "test"
  * coffee-rails (newest 4.2.1, installed 4.0.1, requested ~> 4.0.0) in group "default"
  * countries (newest 1.2.5, installed 0.9.3, requested ~> 0.9.3) in group "default"
  * country_select (newest 2.5.2, installed 2.1.1) in group "default"
  * dalli (newest 2.7.6, installed 2.7.4) in group "default"

```

Better group:
```
$ bundle outdated

===== Group default =====
  * addressable (newest 2.4.0, installed 2.3.8)
  * puma (newest 3.6.0, installed 2.10.2, requested ~> 2.10.2)
  * rails-assets-Sortable (newest 1.4.2, installed 0.7.1, requested ~> 0.7.1)
  * rails-assets-jquery-file-upload (newest 9.12.5, installed 9.7.0, requested = 9.7.0)
  * rails-assets-jquery-ui (newest 1.12.0, installed 1.11.0, requested = 1.11.0)
  * rails-assets-superagent (newest 2.1.0, installed 0.21.0, requested ~> 0.21.0)
  * rollbar (newest 2.12.0, installed 2.7.1, requested ~> 2.0)
  * sidekiq-pro (newest 3.3.2, installed 3.3.1)
===== Group development =====
  * brakeman (newest 3.3.3, installed 3.1.0)
===== Group development, test =====
  * pry (newest 0.10.4, installed 0.10.3)
  * pry-doc (newest 0.9.0, installed 0.8.0)
  * rspec (newest 3.5.0, installed 3.3.0, requested ~> 3.0)
  * rspec-support (newest 3.5.0, installed 3.3.0)
  * rubocop-rspec (newest 1.4.0, installed 1.3.1)
===== Without group =====
  * babel-source (newest 5.8.35, installed 5.8.34)
  * execjs (newest 2.7.0, installed 2.6.0)
  * hashie (newest 3.4.4, installed 3.3.1)
  * ice_nine (newest 0.11.2, installed 0.11.1)
  * mini_portile2 (newest 2.1.0, installed 2.0.0)
  * minitest (newest 5.9.0, installed 5.8.4)
  * multi_json (newest 1.12.1, installed 1.11.2)
  * multipart-post (newest 2.0.0, installed 1.2.0)
  * rails-assets-blueimp-canvas-to-blob (newest 3.3.0, installed 2.1.1)
  * rails-assets-blueimp-load-image (newest 2.6.1, installed 1.13.0)
  * rails-assets-blueimp-tmpl (newest 3.4.0, installed 2.5.4)
  * rails-assets-jquery (newest 3.1.0, installed 2.1.4)
  * rake (newest 11.2.2, installed 10.5.0)
  * rdoc (newest 4.2.2, installed 4.2.0)
```

Regards