### PR TITLE
enables BUNDLE_MIRROR__HOSTNAME environment variables

### DIFF
--- a/lib/bundler/mirror.rb
+++ b/lib/bundler/mirror.rb
@@ -121,7 +121,7 @@ module Bundler
         if uri == "all"
           @all = true
         else
-          @uri = /https?:/ =~ uri ? Settings.normalize_uri(uri) : uri
+          @uri = URI(uri).absolute? ? Settings.normalize_uri(uri) : uri
         end
         @value = value
       end

--- a/lib/bundler/mirror.rb
+++ b/lib/bundler/mirror.rb
@@ -43,8 +43,7 @@ module Bundler
     private
 
       def fetch_valid_mirror_for(uri)
-        host = Settings.normalize_uri(URI(uri.to_s).host)
-        mirror = (@mirrors[URI(uri.to_s.downcase)] || @mirrors[host] || Mirror.new(uri)).validate!(@prober)
+        mirror = (@mirrors[URI(uri.to_s.downcase)] || @mirrors[URI(uri.to_s).host] || Mirror.new(uri)).validate!(@prober)
         mirror = Mirror.new(uri) unless mirror.valid?
         mirror
       end
@@ -122,7 +121,7 @@ module Bundler
         if uri == "all"
           @all = true
         else
-          @uri = Settings.normalize_uri(uri)
+          @uri = /https?:/ =~ uri ? Settings.normalize_uri(uri) : uri
         end
         @value = value
       end

--- a/lib/bundler/mirror.rb
+++ b/lib/bundler/mirror.rb
@@ -43,7 +43,8 @@ module Bundler
     private
 
       def fetch_valid_mirror_for(uri)
-        mirror = (@mirrors[URI(uri.to_s.downcase)] || Mirror.new(uri)).validate!(@prober)
+        host = Settings.normalize_uri(URI(uri.to_s).host)
+        mirror = (@mirrors[URI(uri.to_s.downcase)] || @mirrors[host] || Mirror.new(uri)).validate!(@prober)
         mirror = Mirror.new(uri) unless mirror.valid?
         mirror
       end

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -289,11 +289,7 @@ module Bundler
     def self.normalize_uri(uri)
       uri = uri.to_s
       uri = "#{uri}/" unless uri =~ %r{/\Z}
-      uri = URI(uri)
-      unless uri.absolute?
-        raise ArgumentError, "Gem sources must be absolute. You provided '#{uri}'."
-      end
-      uri
+      URI(uri)
     end
   end
 end

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -289,7 +289,11 @@ module Bundler
     def self.normalize_uri(uri)
       uri = uri.to_s
       uri = "#{uri}/" unless uri =~ %r{/\Z}
-      URI(uri)
+      uri = URI(uri)
+      unless uri.absolute?
+        raise ArgumentError, format("Gem sources must be absolute. You provided '%s'.", uri)
+      end
+      uri
     end
   end
 end

--- a/spec/bundler/mirror_spec.rb
+++ b/spec/bundler/mirror_spec.rb
@@ -154,6 +154,11 @@ describe Bundler::Settings::Mirrors do
       expect(mirrors.for("http://rubygems.org/").uri).to eq(localhost_uri)
     end
 
+    it "parses a relative mirror key and returns a mirror for the parsed uri" do
+      mirrors.parse("mirror.rubygems.org", localhost_uri)
+      expect(mirrors.for("http://rubygems.org/").uri).to eq(localhost_uri)
+    end
+
     context "with a uri parsed already" do
       before { mirrors.parse("mirror.http://rubygems.org/", localhost_uri) }
 

--- a/spec/bundler/mirror_spec.rb
+++ b/spec/bundler/mirror_spec.rb
@@ -154,9 +154,14 @@ describe Bundler::Settings::Mirrors do
       expect(mirrors.for("http://rubygems.org/").uri).to eq(localhost_uri)
     end
 
-    it "parses a relative mirror key and returns a mirror for the parsed uri" do
+    it "parses a relative mirror key and returns a mirror for the parsed http uri" do
       mirrors.parse("mirror.rubygems.org", localhost_uri)
       expect(mirrors.for("http://rubygems.org/").uri).to eq(localhost_uri)
+    end
+
+    it "parses a relative mirror key and returns a mirror for the parsed https uri" do
+      mirrors.parse("mirror.rubygems.org", localhost_uri)
+      expect(mirrors.for("https://rubygems.org/").uri).to eq(localhost_uri)
     end
 
     context "with a uri parsed already" do

--- a/spec/bundler/settings_spec.rb
+++ b/spec/bundler/settings_spec.rb
@@ -207,6 +207,13 @@ that would suck --ehhh=oh geez it looks like i might have broken bundler somehow
         URI("http://rubygems-mirror.org/")
       )
     end
+
+    it "accepts keys using host names" do
+      settings["mirror.rubygems.org"] = "http://rubygems-mirror.org"
+      expect(settings.mirror_for("rubygems.org")).to eq(
+        URI("http://rubygems-mirror.org/")
+      )
+    end
   end
 
   describe "BUNDLE_ keys format" do

--- a/spec/bundler/settings_spec.rb
+++ b/spec/bundler/settings_spec.rb
@@ -207,13 +207,6 @@ that would suck --ehhh=oh geez it looks like i might have broken bundler somehow
         URI("http://rubygems-mirror.org/")
       )
     end
-
-    it "accepts keys using host names" do
-      settings["mirror.rubygems.org"] = "http://rubygems-mirror.org"
-      expect(settings.mirror_for("rubygems.org")).to eq(
-        URI("http://rubygems-mirror.org/")
-      )
-    end
   end
 
   describe "BUNDLE_ keys format" do


### PR DESCRIPTION
Proposed fix for issue #4843.

I would like to be able to do something like `BUNDLE_MIRROR__FOO__RUBYGEMS__ORG` and have it work the same way as `BUNDLE_MIRROR__HTTPS://FOO__RUBYGEMS__ORG/`

There was some discussion about it already [here](https://groups.google.com/forum/#!topic/ruby-bundler/QlhlTuxoDCc).

I'm sure there are currently some issues with my implementation as this was the first time I looked at the bundler code, but would you accept this change once they are resolved?