### PR TITLE
[Install] Fetch all symbolic refs (not just branch heads)

### DIFF
--- a/lib/bundler/source/git/git_proxy.rb
+++ b/lib/bundler/source/git/git_proxy.rb
@@ -92,7 +92,7 @@ module Bundler
             return if has_revision_cached?
             Bundler.ui.info "Fetching #{URICredentialsFilter.credential_filtered_uri(uri)}"
             in_path do
-              git_retry %(fetch --force --quiet --tags #{uri_escaped_with_configured_credentials} "refs/heads/*:refs/heads/*")
+              git_retry %(fetch --force --quiet --tags #{uri_escaped_with_configured_credentials} "refs/*:refs/*")
             end
           else
             Bundler.ui.info "Fetching #{URICredentialsFilter.credential_filtered_uri(uri)}"


### PR DESCRIPTION
The intention here is to allow installing a gem from git using a
ref of the form "refs/zuul/<uuid>" (which are used by the zuul
continuous-integration system). There are likely other use cases for
arbitrary refs.

An example Gemfile that would take advantage of this functionality can
be seen at [1]; however, it currently fails to fetch the existing ref
with the error seen at [2].

[1] https://review.openstack.org/#/c/351437/1/Gemfile
[2] http://logs.openstack.org/37/351437/1/check/gate-puppet-log_processor-puppet-lint/7be9b6a/console.html#_2016-08-05_02_06_48_423939

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bundler/bundler/4845)
<!-- Reviewable:end -->
