### PR TITLE
include version numbers involved with warn_for_outdated_bundler_version

### DIFF
--- a/lib/bundler/lockfile_parser.rb
+++ b/lib/bundler/lockfile_parser.rb
@@ -109,8 +109,8 @@ module Bundler
         raise LockfileError, "You must use Bundler #{bundler_version.segments.first} or greater with this lockfile."
       when 0
         if current_version < bundler_version
-          Bundler.ui.warn "Warning: the running version of Bundler is older " \
-               "than the version that created the lockfile. We suggest you " \
+          Bundler.ui.warn "Warning: the running version of Bundler (#{current_version}) is older " \
+               "than the version that created the lockfile (#{bundler_version}). We suggest you " \
                "upgrade to the latest version of Bundler by running `gem " \
                "install bundler#{prerelease_text}`.\n"
         end

--- a/spec/commands/check_spec.rb
+++ b/spec/commands/check_spec.rb
@@ -331,7 +331,7 @@ describe "bundle check" do
       it "does not change the lock but warns" do
         lockfile lock_with(Bundler::VERSION.succ)
         bundle :check
-        expect(out).to include("Bundler is older than the version that created the lockfile")
+        expect(out).to include("the running version of Bundler (#{Bundler::VERSION}) is older than the version that created the lockfile (#{Bundler::VERSION.succ})")
         expect(err).to lack_errors
         lockfile_should_be lock_with(Bundler::VERSION.succ)
       end

--- a/spec/lock/lockfile_spec.rb
+++ b/spec/lock/lockfile_spec.rb
@@ -176,8 +176,8 @@ describe "the lockfile format" do
       G
     end
 
-    warning_message = "Warning: the running version of Bundler is " \
-                           "older than the version that created the lockfile"
+    warning_message = "the running version of Bundler (9999999.0.0) is older " \
+                      "than the version that created the lockfile (9999999.1.0)"
     expect(out.scan(warning_message).size).to eq(1)
 
     lockfile_should_be <<-G


### PR DESCRIPTION
Can make it easier to understand what's going on.