### PR TITLE
Rename all BUNDLE_ORIG_* env to BUNDLER_ORIG*

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -214,8 +214,8 @@ module Bundler
       Bundler::SharedHelpers.major_deprecation("`Bundler.clean_env` has weird edge cases, use `.original_env` instead")
       env = original_env
 
-      if env.key?("BUNDLE_ORIG_MANPATH")
-        env["MANPATH"] = env["BUNDLE_ORIG_MANPATH"]
+      if env.key?("BUNDLER_ORIG_MANPATH")
+        env["MANPATH"] = env["BUNDLER_ORIG_MANPATH"]
       end
 
       env.delete_if {|k, _| k[0, 7] == "BUNDLE_" }

--- a/lib/bundler/environment_preserver.rb
+++ b/lib/bundler/environment_preserver.rb
@@ -6,7 +6,7 @@ module Bundler
     def initialize(env, keys)
       @original = env.to_hash
       @keys = keys
-      @prefix = "BUNDLE_ORIG_"
+      @prefix = "BUNDLER_ORIG_"
     end
 
     # @return [Hash]

--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -270,7 +270,7 @@ module Bundler
 
     def setup_manpath
       # Store original MANPATH for restoration later in with_clean_env()
-      ENV["BUNDLE_ORIG_MANPATH"] = ENV["MANPATH"]
+      ENV["BUNDLER_ORIG_MANPATH"] = ENV["MANPATH"]
 
       # Add man/ subdirectories from activated bundles to MANPATH for man(1)
       manuals = $LOAD_PATH.map do |path|

--- a/spec/bundler/environment_preserver_spec.rb
+++ b/spec/bundler/environment_preserver_spec.rb
@@ -9,7 +9,7 @@ describe Bundler::EnvironmentPreserver do
     subject { preserver.backup }
 
     it "should create backup entries" do
-      expect(subject["BUNDLE_ORIG_foo"]).to eq("my-foo")
+      expect(subject["BUNDLER_ORIG_foo"]).to eq("my-foo")
     end
 
     it "should keep the original entry" do
@@ -17,7 +17,7 @@ describe Bundler::EnvironmentPreserver do
     end
 
     it "should not create backup entries for unspecified keys" do
-      expect(subject.key?("BUNDLE_ORIG_bar")).to eq(false)
+      expect(subject.key?("BUNDLER_ORIG_bar")).to eq(false)
     end
 
     it "should not affect the original env" do
@@ -29,15 +29,15 @@ describe Bundler::EnvironmentPreserver do
       let(:env) { { "foo" => "" } }
 
       it "should not create backup entries" do
-        expect(subject.key?("BUNDLE_ORIG_foo")).to eq(false)
+        expect(subject.key?("BUNDLER_ORIG_foo")).to eq(false)
       end
     end
 
     context "when an original key is set" do
-      let(:env) { { "foo" => "my-foo", "BUNDLE_ORIG_foo" => "orig-foo" } }
+      let(:env) { { "foo" => "my-foo", "BUNDLER_ORIG_foo" => "orig-foo" } }
 
-      it "should keep the original value in the BUNDLE_ORIG_ variable" do
-        expect(subject["BUNDLE_ORIG_foo"]).to eq("orig-foo")
+      it "should keep the original value in the BUNDLER_ORIG_ variable" do
+        expect(subject["BUNDLER_ORIG_foo"]).to eq("orig-foo")
       end
 
       it "should keep the variable" do
@@ -50,14 +50,14 @@ describe Bundler::EnvironmentPreserver do
     subject { preserver.restore }
 
     context "when an original key is set" do
-      let(:env) { { "foo" => "my-foo", "BUNDLE_ORIG_foo" => "orig-foo" } }
+      let(:env) { { "foo" => "my-foo", "BUNDLER_ORIG_foo" => "orig-foo" } }
 
       it "should restore the original value" do
         expect(subject["foo"]).to eq("orig-foo")
       end
 
       it "should delete the backup value" do
-        expect(subject.key?("BUNDLE_ORIG_foo")).to eq(false)
+        expect(subject.key?("BUNDLER_ORIG_foo")).to eq(false)
       end
     end
 
@@ -70,7 +70,7 @@ describe Bundler::EnvironmentPreserver do
     end
 
     context "when the original key is empty" do
-      let(:env) { { "foo" => "my-foo", "BUNDLE_ORIG_foo" => "" } }
+      let(:env) { { "foo" => "my-foo", "BUNDLER_ORIG_foo" => "" } }
 
       it "should keep the current value" do
         expect(subject["foo"]).to eq("my-foo")

--- a/spec/runtime/with_clean_env_spec.rb
+++ b/spec/runtime/with_clean_env_spec.rb
@@ -78,7 +78,7 @@ describe "Bundler.with_env helpers" do
     it "should restore the original MANPATH" do
       code = "print Bundler.clean_env['MANPATH']"
       ENV["MANPATH"] = "/foo"
-      ENV["BUNDLE_ORIG_MANPATH"] = "/foo-original"
+      ENV["BUNDLER_ORIG_MANPATH"] = "/foo-original"
       result = bundle("exec ruby -e #{code.inspect}")
       expect(result).to eq("/foo-original")
     end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -256,7 +256,7 @@ module Spec
       backup = ENV.to_hash
       ENV["GEM_HOME"] = path.to_s
       ENV["GEM_PATH"] = path.to_s
-      ENV["BUNDLE_ORIG_GEM_PATH"] = nil
+      ENV["BUNDLER_ORIG_GEM_PATH"] = nil
       yield
     ensure
       ENV.replace(backup)
@@ -265,7 +265,7 @@ module Spec
     def with_path_as(path)
       backup = ENV.to_hash
       ENV["PATH"] = path.to_s
-      ENV["BUNDLE_ORIG_PATH"] = nil
+      ENV["BUNDLER_ORIG_PATH"] = nil
       yield
     ensure
       ENV.replace(backup)
@@ -305,7 +305,7 @@ module Spec
       env_backup = ENV.to_hash
       ENV["GEM_HOME"] = system_gem_path.to_s
       ENV["GEM_PATH"] = system_gem_path.to_s
-      ENV["BUNDLE_ORIG_GEM_PATH"] = nil
+      ENV["BUNDLER_ORIG_GEM_PATH"] = nil
 
       install_gems(*gems)
       return unless block_given?


### PR DESCRIPTION
Any enviroment variable that starts with BUNDLE_ will be treated as a
configurationg setting, printed by `bundle config`, and made available
internally via `Bundler.settings`. The ORIG_* environment variables are
actually just internal housekeeping to enable us to provide clean
non-bundled environments, and so they shouldn't show up as settings.

This change to the environment variable names makes sure it is still
clear where they are coming from, but no longer surfaces them via
config/settings.