### PR TITLE
Change standalone flag of binstubs cmd to boolean

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -255,7 +255,7 @@ module Bundler
       "Overwrite existing binstubs if they exist"
     method_option "path", :type => :string, :lazy_default => "bin", :banner =>
       "Binstub destination directory (default bin)"
-    method_option "standalone", :type => :array, :lazy_default => [], :banner =>
+    method_option "standalone", :type => :boolean, :banner =>
       "Make binstubs that can work without the Bundler runtime"
     def binstubs(*gems)
       require "bundler/cli/binstubs"


### PR DESCRIPTION
This flag was introduced in #4610, declared with the same code as the flag found in the `install` command.

In the case of the `install` command, it makes sense to be an `Array` option, since
one can specify groups.

This doesn't hold true for the `binstubs` cmd where `--standalone` just stands to signify
whether the generated stubs will require the Bundler runtime or not.

In the current implementation even passing groups with the flag doesn't have any affect.