### PR TITLE
[SharedHelpers] Always print major deprecations on .99 versions

### DIFF
--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -224,7 +224,8 @@ module Bundler
 
     def prints_major_deprecations?
       require "bundler"
-      return false unless Bundler.settings[:major_deprecations]
+      deprecation_release = Bundler::VERSION.split(".").drop(1).include?("99")
+      return false if !deprecation_release && !Bundler.settings[:major_deprecations]
       require "bundler/deprecate"
       return false if Bundler::Deprecate.skip
       true

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -4,6 +4,22 @@ require "spec_helper"
 describe "major deprecations" do
   let(:warnings) { out } # change to err in 2.0
 
+  context "in a .99 version" do
+    before do
+      simulate_bundler_version "1.99.1"
+      bundle "config --delete major_deprecations"
+    end
+
+    it "prints major deprecations without being configured" do
+      ruby <<-R
+        require "bundler"
+        Bundler::SharedHelpers.major_deprecation(Bundler::VERSION)
+      R
+
+      expect(warnings).to have_major_deprecation("1.99.1")
+    end
+  end
+
   before do
     bundle "config major_deprecations true"
 


### PR DESCRIPTION
See #4855 

\c @indirect 