### PR TITLE
Block resolving to older versions during an update

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -119,6 +119,9 @@ Metrics/AbcSize:
 Metrics/CyclomaticComplexity:
   Enabled: false
 
+Metrics/ParameterLists:
+  Enabled: false
+
 # It will be obvious which code is complex, Rubocop should only lint simple
 # rules for us.
 Metrics/PerceivedComplexity:

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -249,7 +249,7 @@ module Bundler
         else
           # Run a resolve against the locally available gems
           Bundler.ui.debug("Found changes from the lockfile, re-resolving dependencies because #{change_reason}")
-          last_resolve.merge Resolver.resolve(expanded_dependencies, index, source_requirements, last_resolve, ruby_version, gem_version_promoter)
+          last_resolve.merge Resolver.resolve(expanded_dependencies, index, source_requirements, last_resolve, ruby_version, gem_version_promoter, additional_base_requirements_for_resolve)
         end
       end
     end
@@ -811,6 +811,14 @@ module Bundler
         end
         requires
       end
+    end
+
+    def additional_base_requirements_for_resolve
+      return [] unless @locked_gems && Bundler.settings[:only_update_to_newer_versions]
+      @locked_gems.specs.reduce({}) do |requirements, locked_spec|
+        requirements[locked_spec.name] = Gem::Dependency.new(locked_spec.name, ">= #{locked_spec.version}")
+        requirements
+      end.values
     end
   end
 end

--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -175,14 +175,14 @@ module Bundler
     # ==== Returns
     # <GemBundle>,nil:: If the list of dependencies can be resolved, a
     #   collection of gemspecs is returned. Otherwise, nil is returned.
-    def self.resolve(requirements, index, source_requirements = {}, base = [], ruby_version = nil, gem_version_promoter = GemVersionPromoter.new)
+    def self.resolve(requirements, index, source_requirements = {}, base = [], ruby_version = nil, gem_version_promoter = GemVersionPromoter.new, additional_base_requirements = [])
       base = SpecSet.new(base) unless base.is_a?(SpecSet)
-      resolver = new(index, source_requirements, base, ruby_version, gem_version_promoter)
+      resolver = new(index, source_requirements, base, ruby_version, gem_version_promoter, additional_base_requirements)
       result = resolver.start(requirements)
       SpecSet.new(result)
     end
 
-    def initialize(index, source_requirements, base, ruby_version, gem_version_promoter)
+    def initialize(index, source_requirements, base, ruby_version, gem_version_promoter, additional_base_requirements)
       @index = index
       @source_requirements = source_requirements
       @base = base
@@ -190,6 +190,7 @@ module Bundler
       @search_for = {}
       @base_dg = Molinillo::DependencyGraph.new
       @base.each {|ls| @base_dg.add_vertex(ls.name, Dependency.new(ls.name, ls.version), true) }
+      additional_base_requirements.each {|d| @base_dg.add_vertex(d.name, d) }
       @ruby_version = ruby_version
       @gem_version_promoter = gem_version_promoter
     end

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -16,6 +16,7 @@ module Bundler
       major_deprecations
       no_install
       no_prune
+      only_update_to_newer_versions
       plugins
       silence_root_warning
     ).freeze


### PR DESCRIPTION
This is currently behind the only_update_to_newer_versions setting

Closes https://github.com/bundler/bundler/issues/4511.

See https://github.com/bundler/bundler/issues/4856 and https://github.com/bundler/bundler/issues/4871