### PR TITLE
Fill in git username to the generated gem's contributing section of README.md

### DIFF
--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -44,7 +44,8 @@ module Bundler
         :test             => options[:test],
         :ext              => options[:ext],
         :exe              => options[:exe],
-        :bundler_version  => bundler_dependency_version
+        :bundler_version  => bundler_dependency_version,
+        :git_user_name    => git_user_name.empty? ? "[USERNAME]" : git_user_name
       }
       ensure_safe_gem_name(name, constant_array)
 

--- a/lib/bundler/templates/newgem/README.md.tt
+++ b/lib/bundler/templates/newgem/README.md.tt
@@ -32,7 +32,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/<%= config[:name] %>.<% if config[:coc] %> This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.<% end %>
+Bug reports and pull requests are welcome on GitHub at https://github.com/<%= config[:git_user_name] %>/<%= config[:name] %>.<% if config[:coc] %> This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.<% end %>
 <% if config[:mit] %>
 
 ## License

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -112,6 +112,35 @@ describe "bundle gem" do
     end
   end
 
+  context "README.md" do
+    let(:gem_name) { "test_gem" }
+    let(:generated_gem) { Bundler::GemHelper.new(bundled_app(gem_name).to_s) }
+
+    context "git config user.name present" do
+      before do
+        execute_bundle_gem(gem_name)
+      end
+
+      it "contribute URL set to git username" do
+        expect(bundled_app("test_gem/README.md").read).not_to include("[USERNAME]")
+      end
+    end
+
+    context "git config user.name is absent" do
+      before do
+        `git config --unset user.name`
+        reset!
+        in_app_root
+        bundle "gem #{gem_name}"
+        remove_push_guard(gem_name)
+      end
+
+      it "contribute URL set to [USERNAME]" do
+        expect(bundled_app("test_gem/README.md").read).to include("[USERNAME]")
+      end
+    end
+  end
+
   it "generates a valid gemspec" do
     system_gems ["rake-10.0.2"]
 


### PR DESCRIPTION
This Pull Request changes the GitHub URL in the Contributing section of README.md from generated gem (e.g. `bundle gem foo`).

Why:

I found myself change `[USERNAME]` to my git username so many times and I also help [some](https://github.com/suzuki86/rhymer/pull/1/files) [people](https://github.com/fastly/blockbuster/pull/12/files) [fix](https://github.com/abookyun/taiwan_validator/pull/2/files) [this](https://github.com/mkhairi/materialize-sass/pull/62/files).

So I think this should be filled when new gem is generated. When git username not set, falls back to `[USERNAME]`.

I don't really know how to make tests DRY, please advise, thank you.
