### PR TITLE
Add --only argument to bundle install

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -197,6 +197,8 @@ module Bundler
       "Exclude gems that are part of the specified named group."
     deprecated_option "with", :type => :array, :banner =>
       "Include gems that are part of the specified named group."
+    method_option "only", :type => :array, :banner =>
+      "Include only the gems that are part of the specified named group."
     map "i" => "install"
     def install
       require "bundler/cli/install"

--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -151,6 +151,7 @@ module Bundler
     def normalize_groups
       options[:with] &&= options[:with].join(":").tr(" ", ":").split(":")
       options[:without] &&= options[:without].join(":").tr(" ", ":").split(":")
+      options[:only] &&= options[:only].join(":").tr(" ", ":").split(":")
 
       check_for_group_conflicts_in_cli_options
 
@@ -165,8 +166,12 @@ module Bundler
       without |= Bundler.settings[:without].map(&:to_s)
       without -= options[:with] if options[:with]
 
+      only = options.fetch("only", [])
+      only |= Bundler.settings.only.map(&:to_s)
+
       options[:with]    = with
       options[:without] = without
+      options[:only] = only
     end
 
     def normalize_settings
@@ -189,12 +194,13 @@ module Bundler
 
       Bundler.settings.set_command_option_if_given :clean, options["clean"]
 
-      unless Bundler.settings[:without] == options[:without] && Bundler.settings[:with] == options[:with]
+      unless Bundler.settings[:without] == options[:without] && Bundler.settings[:with] == options[:with] && Bundler.settings[:only] == options[:only]
         # need to nil them out first to get around validation for backwards compatibility
         Bundler.settings.set_command_option :without, nil
         Bundler.settings.set_command_option :with,    nil
         Bundler.settings.set_command_option :without, options[:without] - options[:with]
         Bundler.settings.set_command_option :with,    options[:with]
+        Bundler.settings.set_command_option :only,    options[:only]
       end
 
       options[:force] = options[:redownload]

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -920,6 +920,7 @@ module Bundler
     end
 
     def requested_groups
+      return Bundler.settings[:only] if Bundler.settings[:only].any?
       groups - Bundler.settings[:without] - @optional_groups + Bundler.settings[:with]
     end
 

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -61,6 +61,7 @@ module Bundler
     ARRAY_KEYS = %w[
       with
       without
+      only
     ].freeze
 
     DEFAULT_CONFIG = {

--- a/man/bundle-install.ronn
+++ b/man/bundle-install.ronn
@@ -23,6 +23,7 @@ bundle-install(1) -- Install the dependencies specified in your Gemfile
                  [--trust-policy=POLICY]
                  [--with=GROUP[ GROUP...]]
                  [--without=GROUP[ GROUP...]]
+                 [--only=GROUP[ GROUP...]]
 
 ## DESCRIPTION
 
@@ -150,6 +151,11 @@ time `bundle install` is run, use `bundle config` (see bundle-config(1)).
   A space-separated list of groups referencing gems to skip during installation.
   If a group is given that is in the remembered list of groups given
   to --with, it is removed from that list.
+
+* `--only=<list>`:
+  A space-separated list of groups referencing gems to install. If groups are
+  given, they are the only groups installed. This overrides --with and
+  --without.
 
 ## DEPLOYMENT MODE
 

--- a/spec/install/gemfile/groups_spec.rb
+++ b/spec/install/gemfile/groups_spec.rb
@@ -70,6 +70,58 @@ RSpec.describe "bundle install with groups" do
     end
   end
 
+  describe "installing --only" do
+    describe "with gems assigned to a single group" do
+      before :each do
+        gemfile <<-G
+          source "file://#{gem_repo1}"
+          gem "thin"
+          group :emo do
+            gem "activesupport", "2.3.5"
+          end
+          group :debugging, :optional => true do
+            gem "rack"
+          end
+        G
+      end
+
+      it "installs gems from only the given optional group when that group is in only" do
+        bundle :install, :only => "debugging"
+        expect(the_bundle).not_to include_gems "thin"
+        expect(the_bundle).not_to include_gems "activesupport"
+        expect(the_bundle).to include_gems "rack 1.0.0"
+      end
+
+      it "installs gems from only the given groups when those group are in only" do
+        bundle :install, :only => "debugging emo"
+        expect(the_bundle).to include_gems "rack 1.0.0"
+        expect(the_bundle).to include_gems "activesupport 2.3.5"
+        expect(the_bundle).not_to include_gems "thin"
+      end
+
+      it "installs gems from only the given group when that group is in only" do
+        bundle :install, :only => "emo"
+        expect(the_bundle).not_to include_gems "rack"
+        expect(the_bundle).to include_gems "activesupport 2.3.5"
+        expect(the_bundle).not_to include_gems "thin"
+      end
+
+      it "installs gems from only the given optional group overriding with" do
+        bundle :install, :only => "debugging", :with => "emo"
+        expect(the_bundle).to include_gems "rack 1.0.0"
+        expect(the_bundle).not_to include_gems "activesupport"
+        expect(the_bundle).not_to include_gems "thin"
+      end
+
+      it "installs gems from only the given optional group ignoring without" do
+        bundle :install, :only => "debugging", :without => "debugging"
+        expect(the_bundle).to include_gems "rack 1.0.0"
+        expect(the_bundle).not_to include_gems "activesupport"
+        expect(the_bundle).not_to include_gems "thin"
+      end
+    end
+  end
+
   describe "installing --without" do
     describe "with gems assigned to a single group" do
       before :each do


### PR DESCRIPTION
Implementation of an `--only` argument for `bundle install`.

https://github.com/bundler/bundler-features/issues/59

The reasoning here is that sometimes you want a single group or two, and not default. My particular use case is having a deployment group which contains everything needed for a CI server. To do this with existing functionality, I have to list all possible groups in `--without`, which can change and easily be forgotten.

Thanks for considering!
