### PR TITLE
Add missing definition of `respond_to_missing?`

### DIFF
--- a/lib/bundler/remote_specification.rb
+++ b/lib/bundler/remote_specification.rb
@@ -81,5 +81,9 @@ module Bundler
     def method_missing(method, *args, &blk)
       _remote_specification.send(method, *args, &blk)
     end
+
+    def respond_to_missing?(method, include_all)
+      _remote_specification.respond_to?(method, include_all)
+    end
   end
 end

--- a/spec/bundler/remote_specification_spec.rb
+++ b/spec/bundler/remote_specification_spec.rb
@@ -171,4 +171,20 @@ describe Bundler::RemoteSpecification do
       end
     end
   end
+
+  describe "respond to missing?" do
+    context "and is present in Gem::Specification" do
+      let(:remote_spec) { double(:remote_spec) }
+
+      before do
+        allow_any_instance_of(Gem::Specification).to receive(:respond_to?).and_return(false)
+        allow(subject).to receive(:_remote_specification).and_return(remote_spec)
+      end
+
+      it "should send through to Gem::Specification" do
+        expect(remote_spec).to receive(:respond_to?).with(:missing_method_call, false).once
+        subject.respond_to?(:missing_method_call)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Because we should overwrite this method when we overwrite
`method_missing`.

See http://ruby-doc.org/core-2.3.1/BasicObject.html#method-i-method_missing