### PR TITLE
Feature: Add parseable option to bundle config command

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -344,6 +344,7 @@ module Bundler
       will show the current value, as well as any superceded values and
       where they were specified.
     D
+    method_option "parseable", :aliases => "--porcelain", :type => :boolean, :banner => "Use minimal formatting for more parseable output"
     def config(*args)
       require "bundler/cli/config"
       Config.new(options, args, self).run

--- a/lib/bundler/cli/config.rb
+++ b/lib/bundler/cli/config.rb
@@ -21,6 +21,8 @@ module Bundler
         return
       end
 
+      return Bundler.ui.info(Bundler.settings[name]) if options[:parseable]
+
       unless valid_scope?(scope)
         Bundler.ui.error "Invalid scope --#{scope} given. Please use --local or --global."
         exit 1

--- a/spec/commands/config_spec.rb
+++ b/spec/commands/config_spec.rb
@@ -188,8 +188,32 @@ describe ".bundle/config" do
   end
 
   context "with --parseable option" do
-    it "returns value associated with the config" do
-      global_config "BUNDLE_GEM__COC" => "true"
+    it "returns empty when not set" do
+      bundle "config gem.coc", :parseable => true
+
+      expect(out).to eq ""
+    end
+
+    it "returns true when set" do
+      bundle "config gem.coc true"
+
+      bundle "config gem.coc", :parseable => true
+
+      expect(out).to eq "true"
+    end
+
+    it "returns empty string when unset" do
+      bundle "config gem.coc true"
+      bundle "config --delete gem.coc"
+
+      bundle "config gem.coc", :parseable => true
+
+      expect(out).to eq ""
+    end
+
+    it "returns default if global default presents when unset" do
+      bundle "config --delete gem.coc"
+      bundle "config --global gem.coc true"
 
       bundle "config gem.coc", :parseable => true
 

--- a/spec/commands/config_spec.rb
+++ b/spec/commands/config_spec.rb
@@ -187,6 +187,16 @@ describe ".bundle/config" do
     end
   end
 
+  context "with --parseable option" do
+    it "returns value associated with the config" do
+      global_config "BUNDLE_GEM__COC" => "true"
+
+      bundle "config gem.coc", :parseable => true
+
+      expect(out).to eq "true"
+    end
+  end
+
   describe "gem mirrors" do
     before(:each) { bundle :install }
 

--- a/spec/commands/config_spec.rb
+++ b/spec/commands/config_spec.rb
@@ -102,6 +102,12 @@ describe ".bundle/config" do
       run "puts Bundler.settings['local.foo']"
       expect(out).to eq(File.expand_path(Dir.pwd + "/.."))
     end
+
+    it "works with parseable option" do
+      bundle "config --global parseable value"
+      run "puts Bundler.settings['parseable']"
+      expect(out).to eq("value")
+    end
   end
 
   describe "local" do
@@ -146,6 +152,12 @@ describe ".bundle/config" do
       bundle "config --local local.foo .."
       run "puts Bundler.settings['local.foo']"
       expect(out).to eq(File.expand_path(Dir.pwd + "/.."))
+    end
+
+    it "works with parseable option" do
+      bundle "config --local parseable value"
+      run "puts Bundler.settings['parseable']"
+      expect(out).to eq("value")
     end
   end
 


### PR DESCRIPTION
This Pull Request implements #4913:

```
$ bundle config gem.coc --parseable
=> true
```
## 

Related: #4871

<details>
<summary>

Feedback for development of Bundler</summary>



Cannot use byebug / pry to dive into the code. 😢 
Cannot use puts / p to print something for debugging. 😢 
Currently use `Bundler.ui.info` to print something for debugging. 😅 
</details>
