### PR TITLE
Support specify engine by symbol in Gemfile

### DIFF
--- a/lib/bundler/ruby_version.rb
+++ b/lib/bundler/ruby_version.rb
@@ -23,8 +23,8 @@ module Bundler
 
       @versions           = Array(versions)
       @gem_version        = Gem::Requirement.create(@versions.first).requirements.first.last
-      @input_engine       = engine
-      @engine             = engine || "ruby"
+      @input_engine       = engine && engine.to_s
+      @engine             = engine && engine.to_s || "ruby"
       @engine_versions    = (engine_version && Array(engine_version)) || @versions
       @engine_gem_version = Gem::Requirement.create(@engine_versions.first).requirements.first.last
       @patchlevel         = patchlevel

--- a/spec/bundler/ruby_version_spec.rb
+++ b/spec/bundler/ruby_version_spec.rb
@@ -35,6 +35,14 @@ describe "Bundler::RubyVersion and its subclasses" do
         end
       end
 
+      context "with engine in symbol" do
+        let(:engine) { :jruby }
+
+        it "should coerce engine to string" do
+          expect(subject.engine).to eq("jruby")
+        end
+      end
+
       context "is called with multiple requirements" do
         let(:version) { ["<= 2.0.0", "> 1.9.3"] }
         let(:engine_version) { nil }

--- a/spec/install/gemfile_spec.rb
+++ b/spec/install/gemfile_spec.rb
@@ -73,7 +73,7 @@ describe "bundle install" do
         simulate_ruby_engine "jruby", "9.1.2.0" do
           install_gemfile! <<-G
             source "https://rubygems.org"
-            ruby "2.3.0", :engine => :jruby, engine_version: "9.1.2.0"
+            ruby "2.3.0", :engine => :jruby, :engine_version => "9.1.2.0"
           G
 
           expect(out).to match(/Bundle complete!/)
@@ -86,7 +86,7 @@ describe "bundle install" do
         simulate_ruby_engine "jruby", "9.1.2.0" do
           install_gemfile! <<-G
             source "file://#{gem_repo1}"
-            ruby "2.3.0", :engine => :jruby, engine_version: "9.1.2.0"
+            ruby "2.3.0", :engine => :jruby, :engine_version => "9.1.2.0"
             gem "rack"
           G
 

--- a/spec/install/gemfile_spec.rb
+++ b/spec/install/gemfile_spec.rb
@@ -66,4 +66,33 @@ describe "bundle install" do
       expect(out).to match(/You passed :lib as an option for gem 'rack', but it is invalid/)
     end
   end
+
+  context "with engine specified in symbol" do
+    it "does not raise any error parsing Gemfile" do
+      simulate_ruby_version "2.3.0" do
+        simulate_ruby_engine "jruby", "9.1.2.0" do
+          install_gemfile! <<-G
+            source "https://rubygems.org"
+            ruby "2.3.0", :engine => :jruby, engine_version: "9.1.2.0"
+          G
+
+          expect(out).to match(/Bundle complete!/)
+        end
+      end
+    end
+
+    it "installation succeeds" do
+      simulate_ruby_version "2.3.0" do
+        simulate_ruby_engine "jruby", "9.1.2.0" do
+          install_gemfile! <<-G
+            source "file://#{gem_repo1}"
+            ruby "2.3.0", :engine => :jruby, engine_version: "9.1.2.0"
+            gem "rack"
+          G
+
+          expect(the_bundle).to include_gems "rack 1.0.0"
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This fixes #4914.

Our test suite did not run with jruby but I have manually verified this patch works. Details can be seen below.

<details>
<summary>View manual verification details</summary>

The spec I added in this PR works with jruby:

```
$ chruby jruby-9.1.2.0

$ ruby -v
jruby 9.1.2.0 (2.3.0) 2016-05-26 7357c8f Java HotSpot(TM) 64-Bit Server VM 25.25-b02 on 1.8.0_25-b17 +jit [darwin-x86_64]

$ rspec spec/install/gemfile_spec.rb
Run options: exclude {:rubygems_master=>true, :git=>"=< 2.8.1", :rubygems=>"=< 2.6.4", :ruby=>"=< 2.3.0", :realworld=>true, :sudo=>true}

bundle install
  with duplicated gems
    will display a warning
  with --gemfile
    finds the gemfile
  with gemfile set via config
    uses the gemfile to install
    uses the gemfile while in a subdirectory
  with deprecated features
    reports that lib is an invalid option
  with engine specified in symbol <--------------------- HERE
    should not report error <--------------------- HERE


Retried examples: 0

Finished in 43.89 seconds (files took 1.68 seconds to load)
6 examples, 0 failures
```

Real-world Gemfile also works after this patch:

```
$ ruby -v
jruby 9.1.2.0 (2.3.0) 2016-05-26 7357c8f Java HotSpot(TM) 64-Bit Server VM 25.25-b02 on 1.8.0_25-b17 +jit [darwin-x86_64]

$ cat Gemfile
source "https://rubygems.org"

ruby '2.3.0', :engine => :jruby, engine_version: '9.1.2.0'

$ dbundle
The Gemfile specifies no dependencies
Bundle complete! 0 Gemfile dependencies, 1 gem now installed.
Use `bundle show [gemname]` to see where a bundled gem is installed.
```

</details>