### PR TITLE
Update specs to use compact_index 0.11

### DIFF
--- a/spec/support/artifice/compact_index.rb
+++ b/spec/support/artifice/compact_index.rb
@@ -103,8 +103,8 @@ class CompactIndexAPI < Endpoint
       file = tmp("versions.list")
       file.delete if file.file?
       file = CompactIndex::VersionsFile.new(file.to_s)
-      file.update_with(gems)
-      CompactIndex.versions(file, nil, {})
+      file.create(gems)
+      file.contents
     end
   end
 

--- a/spec/support/artifice/compact_index_concurrent_download.rb
+++ b/spec/support/artifice/compact_index_concurrent_download.rb
@@ -22,8 +22,8 @@ class CompactIndexConcurrentDownload < CompactIndexAPI
       file = tmp("versions.list")
       file.delete if file.file?
       file = CompactIndex::VersionsFile.new(file.to_s)
-      file.update_with(gems)
-      CompactIndex.versions(file, nil, {})
+      file.create(gems)
+      file.contents
     end
   end
 end

--- a/spec/support/artifice/compact_index_extra_api.rb
+++ b/spec/support/artifice/compact_index_extra_api.rb
@@ -15,8 +15,8 @@ class CompactIndexExtraApi < CompactIndexAPI
       file = tmp("versions.list")
       file.delete if file.file?
       file = CompactIndex::VersionsFile.new(file.to_s)
-      file.update_with(gems(gem_repo4))
-      CompactIndex.versions(file, nil, {})
+      file.create(gems(gem_repo4))
+      file.contents
     end
   end
 

--- a/spec/support/rubygems_ext.rb
+++ b/spec/support/rubygems_ext.rb
@@ -37,7 +37,7 @@ module Spec
         FileUtils.rm_rf(Path.base_system_gems)
         FileUtils.mkdir_p(Path.base_system_gems)
         puts "installing gems for the tests to use..."
-        DEPS.sort {|a, _| a[1].nil? ? 1 : -1 }.each {|n, v| install_gem(n, v) }
+        install_gems(DEPS)
         File.open(manifest_path, "w") {|f| f << manifest.join }
       end
 
@@ -46,10 +46,14 @@ module Spec
       Gem::DefaultUserInteraction.ui = Gem::SilentUI.new
     end
 
-    def self.install_gem(name, version = nil)
-      cmd = "gem install #{name} --no-rdoc --no-ri"
-      cmd += " --version '#{version}'" if version
-      system(cmd) || raise("Installing gem #{name} for the tests to use failed!")
+    def self.install_gems(gems)
+      reqs, no_reqs = gems.partition {|_, req| !req.nil? && !req.split(" ").empty? }
+      no_reqs.map!(&:first)
+      reqs.map! {|name, req| "'#{name}:#{req}'" }
+      deps = reqs.concat(no_reqs).join(" ")
+      cmd = "gem install #{deps} --no-rdoc --no-ri"
+      puts cmd
+      system(cmd) || raise("Installing gems #{deps} for the tests to use failed!")
     end
   end
 end

--- a/spec/support/rubygems_ext.rb
+++ b/spec/support/rubygems_ext.rb
@@ -9,7 +9,8 @@ module Spec
         # rack 2.x requires Ruby version >= 2.2.2.
         # artifice doesn't support rack 2.x now.
         "rack" => "< 2",
-        "fakeweb artifice compact_index" => nil,
+        "fakeweb artifice" => nil,
+        "compact_index" => "~> 0.11.0",
         "sinatra" => "1.2.7",
         # Rake version has to be consistent for tests to pass
         "rake" => "10.0.2",


### PR DESCRIPTION
Also removed the penalty for adding requirements to dependencies!

\c @indirect 