### PR TITLE
Fix URI parsing issue with fallback config for Ruby < 2.2

### DIFF
--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -83,6 +83,7 @@ module Bundler
       local_config_file || raise(GemfileNotFound, "Could not locate Gemfile")
       set_key(key, value, @local_config, local_config_file)
     end
+    alias_method :set_local, :[]=
 
     def temporary(update)
       existing = Hash[update.map {|k, _| [k, @temporary[k]] }]
@@ -94,8 +95,6 @@ module Bundler
         existing.each {|k, v| v.nil? ? @temporary.delete(k) : @temporary[k] = v }
       end
     end
-
-    alias_method :set_local, :[]=
 
     def delete(key)
       @local_config.delete(key_for(key))

--- a/spec/bundler/settings_spec.rb
+++ b/spec/bundler/settings_spec.rb
@@ -236,7 +236,7 @@ that would suck --ehhh=oh geez it looks like i might have broken bundler somehow
         "mirror.https://rubygems.org/.fallback_timeout/"
       )
 
-      expect(result).to eq ["Set for your local app (/Users/Juan/dev/bundler/tmp/bundled_app/.bundle/config): \"true\""]
+      expect(result).to eq ["Set for your local app (#{bundled_app(".bundle/config")}): \"true\""]
     end
 
     it "please work" do
@@ -246,7 +246,7 @@ that would suck --ehhh=oh geez it looks like i might have broken bundler somehow
         "mirror.https://rubygems.org.fallback_timeout/"
       )
 
-      expect(result).to eq ["Set for your local app (/Users/Juan/dev/bundler/tmp/bundled_app/.bundle/config): \"true\""]
+      expect(result).to eq ["Set for your local app (#{bundled_app(".bundle/config")}): \"true\""]
     end
   end
 end

--- a/spec/bundler/settings_spec.rb
+++ b/spec/bundler/settings_spec.rb
@@ -227,4 +227,26 @@ that would suck --ehhh=oh geez it looks like i might have broken bundler somehow
       expect(settings["mirror.https://rubygems.org/"]).to eq("http://rubygems-mirror.org")
     end
   end
+
+  describe "#pretty_values_for" do
+    it "works" do
+      config("BUNDLE_MIRROR__HTTPS://RUBYGEMS__ORG/__FALLBACK_TIMEOUT/" => "true")
+
+      result = Bundler.settings.pretty_values_for(
+        "mirror.https://rubygems.org/.fallback_timeout/"
+      )
+
+      expect(result).to eq ["Set for your local app (/Users/Juan/dev/bundler/tmp/bundled_app/.bundle/config): \"true\""]
+    end
+
+    it "please work" do
+      config("BUNDLE_MIRROR__HTTPS://RUBYGEMS__ORG__FALLBACK_TIMEOUT/" => "true")
+
+      result = Bundler.settings.pretty_values_for(
+        "mirror.https://rubygems.org.fallback_timeout/"
+      )
+
+      expect(result).to eq ["Set for your local app (/Users/Juan/dev/bundler/tmp/bundled_app/.bundle/config): \"true\""]
+    end
+  end
 end


### PR DESCRIPTION
Try to fix #4830.
- [x] spec
- [ ] Implementation

> Parse settings keys on "." first so keys are always accurate

@indirect Could you elaborate? :)

<details>
<summary>

Error Log w/ Ruby 2.1.9</summary>



```
$ dbundle config mirror.https://rubygems.org.fallback_timeout true

/Users/Juan/.rubies/ruby-2.1.9/lib/ruby/2.1.0/uri/generic.rb:214:in `initialize': the scheme mirror.https does not accept registry part: rubygems.org.fallback_timeout (or bad hostname?) (URI::InvalidURIError)
    from /Users/Juan/.rubies/ruby-2.1.9/lib/ruby/2.1.0/uri/common.rb:218:in `new'
    from /Users/Juan/.rubies/ruby-2.1.9/lib/ruby/2.1.0/uri/common.rb:218:in `parse'
    from /Users/Juan/.rubies/ruby-2.1.9/lib/ruby/2.1.0/uri/common.rb:747:in `parse'
    from /Users/Juan/.rubies/ruby-2.1.9/lib/ruby/2.1.0/uri/common.rb:1232:in `URI'
    from /Users/Juan/dev/bundler/lib/bundler/settings.rb:314:in `normalize_uri'
    from /Users/Juan/dev/bundler/lib/bundler/settings.rb:220:in `key_for'
    from /Users/Juan/dev/bundler/lib/bundler/settings.rb:153:in `pretty_values_for'
    from /Users/Juan/dev/bundler/lib/bundler/env.rb:32:in `block in report'
    from /Users/Juan/dev/bundler/lib/bundler/env.rb:30:in `each'
    from /Users/Juan/dev/bundler/lib/bundler/env.rb:30:in `report'
    from /Users/Juan/dev/bundler/lib/bundler/friendly_errors.rb:74:in `request_issue_report_for'
    from /Users/Juan/dev/bundler/lib/bundler/friendly_errors.rb:40:in `log_error'
    from /Users/Juan/dev/bundler/lib/bundler/friendly_errors.rb:102:in `rescue in with_friendly_errors'
    from /Users/Juan/dev/bundler/lib/bundler/friendly_errors.rb:100:in `with_friendly_errors'
    from /Users/Juan/dev/bundler/exe/bundle:24:in `<main>'
```

</details>
