### PR TITLE
[RubygemsExt] Add missing require rubygems/source

### DIFF
--- a/lib/bundler/rubygems_ext.rb
+++ b/lib/bundler/rubygems_ext.rb
@@ -8,6 +8,7 @@ end
 
 require "rubygems"
 require "rubygems/specification"
+require "rubygems/source"
 require "bundler/match_platform"
 
 module Gem

--- a/lib/bundler/rubygems_ext.rb
+++ b/lib/bundler/rubygems_ext.rb
@@ -8,7 +8,15 @@ end
 
 require "rubygems"
 require "rubygems/specification"
-require "rubygems/source"
+
+begin
+  # Possible use in Gem::Specification#source below and require
+  # shouldn't be deferred.
+  require "rubygems/source"
+rescue LoadError
+  # Not available before Rubygems 2.0.0, ignore
+end
+
 require "bundler/match_platform"
 
 module Gem

--- a/lib/bundler/rubygems_ext.rb
+++ b/lib/bundler/rubygems_ext.rb
@@ -13,8 +13,9 @@ begin
   # Possible use in Gem::Specification#source below and require
   # shouldn't be deferred.
   require "rubygems/source"
-rescue LoadError
+rescue LoadError => e
   # Not available before Rubygems 2.0.0, ignore
+  nil
 end
 
 require "bundler/match_platform"

--- a/lib/bundler/rubygems_ext.rb
+++ b/lib/bundler/rubygems_ext.rb
@@ -13,7 +13,7 @@ begin
   # Possible use in Gem::Specification#source below and require
   # shouldn't be deferred.
   require "rubygems/source"
-rescue LoadError => e
+rescue LoadError
   # Not available before Rubygems 2.0.0, ignore
   nil
 end


### PR DESCRIPTION
The change referenced below as released in 1.13.0.rc.2, may attempt to reference Gem::Source without it being loaded, resulting in:

~~~
  [!] There was an error parsing `Gemfile`:
  [!] There was an error while loading `elided.gemspec`: uninitialized constant Gem::Source. Bundler cannot continue.
~~~

Observed this on ruby 2.2.5 with stock rubygems 2.4.5 as well as upgraded rubygems 2.6.6. Add this require.

f9de70ee931ca4a8500916fa9480f6df6c062626  by @segiddins:
> [RubygemsExt] return Source::Installed from #source when appropriate