### PR TITLE
[Installer] Skip eval’ing a Gemfile twice when there’s a lockfile

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -169,6 +169,7 @@ module Bundler
 
     def missing_dependencies?
       missing = []
+      resolve.materialize(current_dependencies, missing)
       return false if missing.empty?
       Bundler.ui.debug "The definition is missing #{missing.map(&:full_name)}"
       true

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -167,10 +167,16 @@ module Bundler
       missing
     end
 
-    def missing_dependencies
+    def missing_dependencies?
       missing = []
-      resolve.materialize(current_dependencies, missing)
-      missing
+      return false if missing.empty?
+      Bundler.ui.debug "The definition is missing #{missing.map(&:full_name)}"
+      true
+    rescue BundlerError => e
+      Bundler.ui.debug "The definition is missing dependencies, failed to resolve & materialize locally (#{e})"
+      true
+    ensure
+      @specs = nil
     end
 
     def requested_specs

--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -68,7 +68,7 @@ module Bundler
         return
       end
 
-      resolve_if_need(options)
+      resolve_if_needed(options)
       install(options)
 
       lock unless Bundler.settings[:frozen]
@@ -181,7 +181,7 @@ module Bundler
         "because of an invalid symlink. Remove the symlink so the directory can be created."
     end
 
-    def resolve_if_need(options)
+    def resolve_if_needed(options)
       if Bundler.default_lockfile.exist? && !options["update"]
         if @definition.new_platform?
           Bundler.ui.debug "Resolving since there is a new platform in the definition"

--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -183,16 +183,16 @@ module Bundler
 
     def resolve_if_need(options)
       if Bundler.default_lockfile.exist? && !options["update"]
-        local = Bundler.ui.silence do
-          begin
-            tmpdef = Definition.build(Bundler.default_gemfile, Bundler.default_lockfile, nil)
-            true unless tmpdef.new_platform? || tmpdef.missing_dependencies.any?
-          rescue BundlerError
-          end
+        if @definition.new_platform?
+          Bundler.ui.debug "Resolving since there is a new platform in the definition"
+        elsif @definition.missing_dependencies?
+          nil
+        else
+          Bundler.ui.debug "No need to re-resolve! The info in the lockfile is sufficient"
+          return
         end
       end
 
-      return if local
       options["local"] ? @definition.resolve_with_cache! : @definition.resolve_remotely!
     end
   end

--- a/lib/bundler/source/path.rb
+++ b/lib/bundler/source/path.rb
@@ -33,10 +33,12 @@ module Bundler
       end
 
       def remote!
+        @local_specs  = nil
         @allow_remote = true
       end
 
       def cached!
+        @local_specs  = nil
         @allow_cached = true
       end
 

--- a/lib/bundler/source/rubygems.rb
+++ b/lib/bundler/source/rubygems.rb
@@ -27,10 +27,12 @@ module Bundler
       end
 
       def remote!
+        @specs        = nil
         @allow_remote = true
       end
 
       def cached!
+        @specs        = nil
         @allow_cached = true
       end
 

--- a/lib/bundler/source_list.rb
+++ b/lib/bundler/source_list.rb
@@ -54,6 +54,7 @@ module Bundler
     end
 
     def get(source)
+      return unless source
       source_list_for(source).find {|s| source == s }
     end
 

--- a/lib/bundler/spec_set.rb
+++ b/lib/bundler/spec_set.rb
@@ -108,6 +108,10 @@ module Bundler
       SpecSet.new(arr)
     end
 
+    def to_s
+      format("<%s:%p @specs=%s>", self.class, object_id, @specs.map(&:full_name))
+    end
+
   private
 
     def sorted

--- a/spec/install/gemfile/lockfile_spec.rb
+++ b/spec/install/gemfile/lockfile_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe "bundle install with a lockfile present" do
+  let(:gf) { <<-G }
+    source "file://#{gem_repo1}"
+
+    gem "rack", "1.0.0"
+  G
+
+  before do
+    install_gemfile(gf)
+  end
+
+  context "gemfile evaluation" do
+    let(:gf) { super() + "\n\n File.open('evals', 'a') {|f| f << %(1\n) }" }
+    it "does not evaluate the gemfile twice" do
+      bundle! :install
+
+      # The first eval is from the initial install, we're testing that the
+      # second install doesn't double-eval
+      expect(bundled_app("evals").read.lines.size).to eq(2)
+    end
+  end
+end

--- a/spec/install/gemfile/lockfile_spec.rb
+++ b/spec/install/gemfile/lockfile_spec.rb
@@ -13,13 +13,30 @@ describe "bundle install with a lockfile present" do
   end
 
   context "gemfile evaluation" do
-    let(:gf) { super() + "\n\n File.open('evals', 'a') {|f| f << %(1\n) }" }
+    let(:gf) { super() + "\n\n File.open('evals', 'a') {|f| f << %(1\n) } unless ENV['BUNDLER_SPEC_NO_APPEND']" }
+
     it "does not evaluate the gemfile twice" do
       bundle! :install
+
+      with_env_vars("BUNDLER_SPEC_NO_APPEND" => "1") { should_be_installed "rack 1.0.0" }
 
       # The first eval is from the initial install, we're testing that the
       # second install doesn't double-eval
       expect(bundled_app("evals").read.lines.size).to eq(2)
+    end
+
+    context "when the gem is not installed" do
+      before { FileUtils.rm_rf ".bundle" }
+
+      it "does not evaluate the gemfile twice" do
+        bundle! :install
+
+        with_env_vars("BUNDLER_SPEC_NO_APPEND" => "1") { should_be_installed "rack 1.0.0" }
+
+        # The first eval is from the initial install, we're testing that the
+        # second install doesn't double-eval
+        expect(bundled_app("evals").read.lines.size).to eq(2)
+      end
     end
   end
 end


### PR DESCRIPTION
Closes #3096. Closes #4417.

\c @indirect 