### PR TITLE
[EndpointSpecification] Raise a helpful error when parsing metadata fails

### DIFF
--- a/lib/bundler/endpoint_specification.rb
+++ b/lib/bundler/endpoint_specification.rb
@@ -113,6 +113,8 @@ module Bundler
           @required_ruby_version = Gem::Requirement.new(v)
         end
       end
+    rescue => e
+      raise GemspecError, "There was an error parsing the metadata for the gem #{name} (#{version}): #{e.class}\n#{e}\nThe metadata was #{data.inspect}"
     end
 
     def build_dependency(name, requirements)

--- a/spec/bundler/endpoint_specification_spec.rb
+++ b/spec/bundler/endpoint_specification_spec.rb
@@ -50,4 +50,17 @@ describe Bundler::EndpointSpecification do
       end
     end
   end
+
+  describe "#parse_metadata" do
+    context "when the metadata has malformed requirements" do
+      let(:metadata) { { "rubygems" => ">\n" } }
+      it "raises a helpful error message" do
+        expect { subject }.to raise_error(
+          Bundler::GemspecError,
+          a_string_including("There was an error parsing the metadata for the gem foo (1.0.0)").
+            and(a_string_including('The metadata was {"rubygems"=>">\n"}'))
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
Would make diagnosing a recent issue around this easier

\c @indirect  would love to get this into 1.13.1