### PR TITLE
Bypass recursive RubyGems require

### DIFF
--- a/lib/bundler/plugin/api/source.rb
+++ b/lib/bundler/plugin/api/source.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
-require "uri"
-require "digest/sha1"
 
 module Bundler
   module Plugin
@@ -41,6 +39,8 @@ module Bundler
       #     is present to be compatible with `Definition` and is used by
       #     rubygems source.
       module Source
+        require "uri"
+        require "digest/sha1"
         attr_reader :uri, :options, :name
         attr_accessor :dependency_names
 


### PR DESCRIPTION
I fixed a bug that [I reported for Rake test problem](https://github.com/ruby/rake/pull/161#issuecomment-246211119).

First, `Bundler::Plugin` uses cascading `autoload` for `Bundler::Plugin::API` and `Bundler::Plugin::API::Source`.

Secondly, Bundler uses monkey patch for RubyGems loading logic, thus [`Gem::Specification#full_gem_path`](https://github.com/bundler/bundler/blob/34404bb32945429ffedd484f8f3447529b3b33f4/lib/bundler/rubygems_ext.rb#L44-L50) is overridden.

Next, if a module is loaded by `require` in RubyGems with Bundler's monkey patch, the `Gem::Specification#full_gem_path` that uses `Bundler::Plugin::API::Source` is called in it. But [`bundler/plugin/api/source` uses `require` before `Bundler::Plugin::API::Source` is defined](https://github.com/bundler/bundler/blob/695db9a169294ec0c6fef3c14ef0f0ac1f6cc65c/lib/bundler/plugin/api/source.rb#L2). RubyGems loading logic runs again by the `require`. `Bundler::Plugin::API::Source` is not defined yet. `Gem::Specification#full_gem_path` is called again, and it uses `Bundler::Plugin::API::Source`. The `autoload` is skipped after 2nd call. So exception is occurred.

> NameError: uninitialized constant Bundler::Plugin::API::Source

This Pull Request bypasses the recursive RubyGems require.