### PR TITLE
Fix #4934. Make GVP _after_ eager unlock.

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -102,13 +102,13 @@ module Bundler
       end
       @unlocking ||= @unlock[:ruby] ||= (!@locked_ruby_version ^ !@ruby_version)
 
-      @gem_version_promoter = create_gem_version_promoter
-
       add_current_platform unless Bundler.settings[:frozen]
 
       @path_changes = converge_paths
       eager_unlock = expand_dependencies(@unlock[:gems])
       @unlock[:gems] = @locked_specs.for(eager_unlock).map(&:name)
+
+      @gem_version_promoter = create_gem_version_promoter
 
       @source_changes = converge_sources
       @dependency_changes = converge_dependencies


### PR DESCRIPTION
When Definition creates the GemVersionPromoter, it needs to do so
_after_ it's performed the eager_unlock so the GVP gets the correct list
of unlocked gems.

Prior to this fix, it had a stricter list of gems being updated with the
new `--patch` or `--minor` options used with `bundle update` and in some
cases would have inconsistent results when used without a conservative
switch or the `--major` option. See #4934 for details.