### PR TITLE
Fixed missing constant with rubygems integration

### DIFF
--- a/lib/bundler/rubygems_ext.rb
+++ b/lib/bundler/rubygems_ext.rb
@@ -19,6 +19,7 @@ rescue LoadError
 end
 
 require "bundler/match_platform"
+require "bundler/plugin/api/source"
 
 module Gem
   @loaded_stacks = Hash.new {|h, k| h[k] = [] }


### PR DESCRIPTION
Fixes #5000.

I got uninitialized constant error with bundler-1.13.1 on travis. see https://travis-ci.org/ruby/rake/jobs/159734476

It's reproduce my local box with ruby/rake testing. I simply fixed this error.

Thank you.