### PR TITLE
added documentation for gem install bundler permission denied

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -19,11 +19,11 @@ Certain operating systems such as MacOS and Ubuntu have versions of Ruby that re
 
 There are multiple ways to solve this issue. You can install bundler with elevated privilges using `sudo` or `su`.
 
-  sudo gem install bundler
+    sudo gem install bundler
 
 If you cannot elevated your privileges or do not want to globally install Bundler, you can use the `--user-install` option.
 
-  gem install bundler --user-install
+    gem install bundler --user-install
 
 This will install Bundler into your home directory. Note that you will need to append `~/.gem/ruby/<ruby version>/bin` to your `$PATH` variable to use `bundle`.
 

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -14,17 +14,17 @@ Detailed information about each Bundler command, including help with common prob
 
 Certain operating systems such as MacOS and Ubuntu have versions of Ruby that require evelated privileges to install gems.
 
-	ERROR:  While executing gem ... (Gem::FilePermissionError)
-	    You don't have write permissions for the /Library/Ruby/Gems/2.0.0 directory.
+    ERROR:  While executing gem ... (Gem::FilePermissionError)
+      You don't have write permissions for the /Library/Ruby/Gems/2.0.0 directory.
 
 There are multiple ways to solve this issue. You can install bundler with elevated privilges using `sudo` or `su`.
 
-	sudo gem install bundler
-	
+  sudo gem install bundler
+
 If you cannot elevated your privileges or do not want to globally install Bundler, you can use the `--user-install` option.
 
-	gem install bundler --user-install
-	
+  gem install bundler --user-install
+
 This will install Bundler into your home directory. Note that you will need to append `~/.gem/ruby/<ruby version>/bin` to your `$PATH` variable to use `bundle`.
 
 ### Heroku errors

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -10,6 +10,20 @@ Detailed information about each Bundler command, including help with common prob
 
 ## Troubleshooting
 
+### Permission denied when installing bundler
+Certain operating systems such as MacOS and Ubuntu have versions of Ruby that requires evelated privileges to install gems.
+
+```
+ERROR:  While executing gem ... (Gem::FilePermissionError)
+    You don't have write permissions for the /Library/Ruby/Gems/2.0.0 directory.
+```
+
+This is typically solved by prepending the command with `sudo`.
+
+```
+sudo gem install bundler
+```
+
 ### Heroku errors
 
 Please open a ticket with [Heroku](https://www.heroku.com) if you're having trouble deploying. They have a professional support team who can help you resolve Heroku issues far better than the Bundler team can. If the problem that you are having turns out to be a bug in Bundler itself, [Heroku support](https://www.heroku.com/support) can get the exact details to us.

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -11,18 +11,15 @@ Detailed information about each Bundler command, including help with common prob
 ## Troubleshooting
 
 ### Permission denied when installing bundler
+
 Certain operating systems such as MacOS and Ubuntu have versions of Ruby that requires evelated privileges to install gems.
 
-```
-ERROR:  While executing gem ... (Gem::FilePermissionError)
-    You don't have write permissions for the /Library/Ruby/Gems/2.0.0 directory.
-```
+	ERROR:  While executing gem ... (Gem::FilePermissionError)
+	    You don't have write permissions for the /Library/Ruby/Gems/2.0.0 directory.
 
 This is typically solved by prepending the command with `sudo`.
 
-```
-sudo gem install bundler
-```
+	sudo gem install bundler
 
 ### Heroku errors
 

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -12,14 +12,20 @@ Detailed information about each Bundler command, including help with common prob
 
 ### Permission denied when installing bundler
 
-Certain operating systems such as MacOS and Ubuntu have versions of Ruby that requires evelated privileges to install gems.
+Certain operating systems such as MacOS and Ubuntu have versions of Ruby that require evelated privileges to install gems.
 
 	ERROR:  While executing gem ... (Gem::FilePermissionError)
 	    You don't have write permissions for the /Library/Ruby/Gems/2.0.0 directory.
 
-This is typically solved by prepending the command with `sudo`.
+There are multiple ways to solve this issue. You can install bundler with elevated privilges using `sudo` or `su`.
 
 	sudo gem install bundler
+	
+If you cannot elevated your privileges or do not want to globally install Bundler, you can use the `--user-install` option.
+
+	gem install bundler --user-install
+	
+This will install Bundler into your home directory. Note that you will need to append `~/.gem/ruby/<ruby version>/bin` to your `$PATH` variable to use `bundle`.
 
 ### Heroku errors
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ echo 'gem "rspec"' >> Gemfile
 bundle install
 bundle exec rspec
 ```
+
 For help with installation issues, see [ISSUES](https://github.com/bundler/bundler/blob/master/ISSUES.md)
 
 See [bundler.io](http://bundler.io) for the full documentation.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ echo 'gem "rspec"' >> Gemfile
 bundle install
 bundle exec rspec
 ```
+For help with installation issues, see [ISSUES](https://github.com/bundler/bundler/blob/master/ISSUES.md)
 
 See [bundler.io](http://bundler.io) for the full documentation.
 


### PR DESCRIPTION
This PR is for #4986. It adds documentation into ISSUES for when the user gets permission denied when installing bundler and a typical solution.

This will benefit users who are unfamiliar with unix and how to handle installing a system gem with elevated privileges.