### PR TITLE
fix message parenthesis color

### DIFF
--- a/lib/bundler/source.rb
+++ b/lib/bundler/source.rb
@@ -20,7 +20,7 @@ module Bundler
         locked_spec = Bundler.locked_gems.specs.find {|s| s.name == spec.name }
         locked_spec_version = locked_spec.version if locked_spec
         if locked_spec_version && spec.version != locked_spec_version
-          message += " (#{Bundler.ui.add_color("was #{locked_spec_version}", :green)})"
+          message += Bundler.ui.add_color(" (was #{locked_spec_version})", :green)
         end
       end
 

--- a/spec/bundler/source_spec.rb
+++ b/spec/bundler/source_spec.rb
@@ -61,7 +61,7 @@ describe Bundler::Source do
             before { Bundler.ui = Bundler::UI::Shell.new }
 
             it "should return a string with the spec name and version and locked spec version" do
-              expect(subject.version_message(spec)).to eq("nokogiri >= 1.6 (\e[32mwas < 1.5\e[0m)")
+              expect(subject.version_message(spec)).to eq("nokogiri >= 1.6\e[32m (was < 1.5)\e[0m")
             end
           end
 


### PR DESCRIPTION
Hello!
Using Bundler version 1.13.1 i noticed a small graphic inconsistency on parentheses color:

<img width="349" alt="screen shot 2016-09-19 at 16 16 10" src="https://cloud.githubusercontent.com/assets/557414/18635257/b41a0366-7e84-11e6-9664-174c90a0863f.png">

This commit resets the opening parenthesis color:

<img width="287" alt="screen shot 2016-09-19 at 16 27 08" src="https://cloud.githubusercontent.com/assets/557414/18635630/f7081b94-7e85-11e6-963c-8c2b869a9443.png">

Is this the expected behaviour? The spec was only checking the closing parenthesis color.

p.s:
Imho green parentheses look better here.
 