### PR TITLE
[Definition] Print a helpful warning when a dependency is unused on a…

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -808,8 +808,16 @@ module Bundler
       deps = []
       dependencies.each do |dep|
         dep = Dependency.new(dep, ">= 0") unless dep.respond_to?(:name)
-        next unless remote || dep.current_platform?
-        dep.gem_platforms(@platforms).each do |p|
+        next if !remote && !dep.current_platform?
+        platforms = dep.gem_platforms(@platforms)
+        if platforms.empty?
+          Bundler.ui.warn \
+            "The dependency #{dep} will be unused by any of the platforms Bundler is installing for. " \
+            "Bundler is installing for #{@platforms.join ", "} but the dependency " \
+            "is only for #{dep.platforms.map {|p| Dependency::PLATFORM_MAP[p] }.join ", "}. " \
+            "To add those platforms to the bundle, run `bundle lock --add-platform #{dep.platforms.join ", "}`."
+        end
+        platforms.each do |p|
           deps << DepProxy.new(dep, p) if remote || p == generic_local_platform
         end
       end

--- a/spec/install/gemfile/platform_spec.rb
+++ b/spec/install/gemfile/platform_spec.rb
@@ -218,7 +218,7 @@ describe "bundle install with platform conditionals" do
     bundle! "install"
 
     expect(out).to include <<-O.strip
-The dependency rack (>= 0) will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for java. To add those platforms to the bundle, run `bundle lock --add-platform jruby`.
+The dependency #{Gem::Dependency.new("rack", ">= 0")} will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for java. To add those platforms to the bundle, run `bundle lock --add-platform jruby`.
     O
   end
 end

--- a/spec/install/gemfile/platform_spec.rb
+++ b/spec/install/gemfile/platform_spec.rb
@@ -184,7 +184,7 @@ describe "bundle install with platform conditionals" do
 
     gemfile <<-G
       source "file://#{gem_repo1}"
-      gem "some_gem", platform: :rbx
+      gem "some_gem", :platform => :rbx
     G
 
     bundle "install --local"
@@ -203,6 +203,23 @@ describe "bundle install with platform conditionals" do
 
     bundle "install --local"
     expect(out).not_to match(/Could not find gem 'some_gem/)
+  end
+
+  it "prints a helpful warning when a dependency is unused on any platform" do
+    simulate_platform "ruby"
+    simulate_ruby_engine "ruby"
+
+    gemfile <<-G
+      source "file://#{gem_repo1}"
+
+      gem "rack", :platform => :jruby
+    G
+
+    bundle! "install"
+
+    expect(out).to include <<-O.strip
+The dependency rack (>= 0) will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for java. To add those platforms to the bundle, run `bundle lock --add-platform jruby`.
+    O
   end
 end
 


### PR DESCRIPTION
…ny platform

Should help address the confusion caused by https://github.com/bundler/bundler/issues/5001