### PR TITLE
[workaround] Use `require` instead of `autoload` for bundler/plugin/api

### DIFF
--- a/lib/bundler/plugin.rb
+++ b/lib/bundler/plugin.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
+require "bundler/plugin/api"
 
 module Bundler
   module Plugin
-    autoload :API,        "bundler/plugin/api"
     autoload :DSL,        "bundler/plugin/dsl"
     autoload :Index,      "bundler/plugin/index"
     autoload :Installer,  "bundler/plugin/installer"

--- a/lib/bundler/plugin/api.rb
+++ b/lib/bundler/plugin/api.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require "bundler/plugin/api/source"
 
 module Bundler
   # This is the interfacing class represents the API that we intend to provide
@@ -23,7 +24,6 @@ module Bundler
   # and hooks).
   module Plugin
     class API
-      autoload :Source, "bundler/plugin/api/source"
       # The plugins should declare that they handle a command through this helper.
       #
       # @param [String] command being handled by them


### PR DESCRIPTION
Please read https://github.com/bundler/bundler/pull/4981#issuecomment-248674155.

> But it's elusive reproduction (and lack of test case) makes me think that the problem is a bit deeper and may recur.

I think so. This Pull Request is just *workaround*.