### PR TITLE
[Definition] Implicitly lock to running ruby version when there is no…

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -492,7 +492,11 @@ module Bundler
                 "Your Ruby patchlevel is #{actual}, but your #{specified} #{expected}"
               end
       end
-      msg += ". This may cause issues if there are any gems that were depending on that ruby version." if implicit_ruby_version
+      if implicit_ruby_version
+        msg += ". This may cause issues if there are any gems that were depending on that ruby version." \
+               "\nTo update the locked ruby version, run `bundle update --ruby`." \
+               "If that fails, run `bundle update` followed by `bundle update --ruby`."
+      end
 
       raise RubyVersionMismatch, msg if !implicit_ruby_version || Bundler.feature_flag.bundler_2_mode?
 

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -779,8 +779,8 @@ module Bundler
       @expanded_dependencies ||= begin
         ruby_versions = concat_ruby_version_requirements(@ruby_version)
         if ruby_versions.empty? || !@ruby_version.exact?
-          concat_ruby_version_requirements(RubyVersion.system)
-          concat_ruby_version_requirements(locked_ruby_version_object) unless @unlock[:ruby]
+          concat_ruby_version_requirements(RubyVersion.system, ruby_versions)
+          concat_ruby_version_requirements(locked_ruby_version_object, ruby_versions) unless @unlock[:ruby]
         end
 
         metadata_dependencies = [

--- a/spec/bundler/definition_spec.rb
+++ b/spec/bundler/definition_spec.rb
@@ -65,6 +65,9 @@ describe Bundler::Definition do
         DEPENDENCIES
           foo!
 
+        RUBY VERSION
+           #{Bundler::RubyVersion.system}
+
         BUNDLED WITH
            #{Bundler::VERSION}
       G
@@ -102,6 +105,9 @@ describe Bundler::Definition do
         DEPENDENCIES
           foo!
 
+        RUBY VERSION
+           #{Bundler::RubyVersion.system}
+
         BUNDLED WITH
            #{Bundler::VERSION}
       G
@@ -127,6 +133,9 @@ describe Bundler::Definition do
 
         DEPENDENCIES
           foo
+
+        RUBY VERSION
+           #{Bundler::RubyVersion.system}
 
         BUNDLED WITH
            #{Bundler::VERSION}

--- a/spec/commands/lock_spec.rb
+++ b/spec/commands/lock_spec.rb
@@ -51,6 +51,9 @@ describe "bundle lock" do
         rails
         with_license
 
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
+
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -59,7 +62,7 @@ describe "bundle lock" do
   it "prints a lockfile when there is no existing lockfile with --print" do
     bundle "lock --print"
 
-    expect(out).to include(@lockfile)
+    expect(out).to eq(@lockfile)
   end
 
   it "prints a lockfile when there is an existing lockfile with --print" do
@@ -241,6 +244,9 @@ describe "bundle lock" do
         gssapi
         mixlib-shellout
 
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
+
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -268,6 +274,9 @@ describe "bundle lock" do
       DEPENDENCIES
         gssapi
         mixlib-shellout
+
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
 
       BUNDLED WITH
          #{Bundler::VERSION}

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -387,7 +387,7 @@ describe "bundle update --ruby" do
           ::RUBY_PATCHLEVEL = 222
       G
     end
-    it "removes the Ruby from the Gemfile.lock" do
+    it "does not remove the Ruby from the Gemfile.lock" do
       bundle "update --ruby"
 
       lockfile_should_be <<-L
@@ -398,6 +398,9 @@ describe "bundle update --ruby" do
          ruby
 
        DEPENDENCIES
+
+       RUBY VERSION
+          ruby 2.1.4p222
 
        BUNDLED WITH
           #{Bundler::VERSION}

--- a/spec/install/gemfile/gemspec_spec.rb
+++ b/spec/install/gemfile/gemspec_spec.rb
@@ -336,6 +336,9 @@ describe "bundle install from an existing gemspec" do
               DEPENDENCIES
                 foo!
 
+              RUBY VERSION
+                 #{Bundler::RubyVersion.system}
+
               BUNDLED WITH
                  #{Bundler::VERSION}
             L
@@ -366,6 +369,9 @@ describe "bundle install from an existing gemspec" do
               DEPENDENCIES
                 foo!
                 platform_specific
+
+              RUBY VERSION
+                 #{Bundler::RubyVersion.system}
 
               BUNDLED WITH
                  #{Bundler::VERSION}
@@ -400,6 +406,9 @@ describe "bundle install from an existing gemspec" do
               DEPENDENCIES
                 foo!
                 indirect_platform_specific
+
+              RUBY VERSION
+                 #{Bundler::RubyVersion.system}
 
               BUNDLED WITH
                  #{Bundler::VERSION}

--- a/spec/install/gems/flex_spec.rb
+++ b/spec/install/gems/flex_spec.rb
@@ -272,6 +272,9 @@ describe "bundle flex_install" do
       DEPENDENCIES
         rack
 
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
+
       BUNDLED WITH
          #{Bundler::VERSION}
       L

--- a/spec/lock/lockfile_spec.rb
+++ b/spec/lock/lockfile_spec.rb
@@ -23,6 +23,9 @@ describe "the lockfile format" do
       DEPENDENCIES
         rack
 
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
+
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -47,6 +50,9 @@ describe "the lockfile format" do
         omg!
         rack
 
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
+
       BUNDLED WITH
          1.8.2
     L
@@ -69,6 +75,9 @@ describe "the lockfile format" do
       DEPENDENCIES
         rack
 
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
+
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -86,6 +95,9 @@ describe "the lockfile format" do
 
       DEPENDENCIES
         rack
+
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
 
       BUNDLED WITH
          1.10.0
@@ -108,6 +120,9 @@ describe "the lockfile format" do
 
       DEPENDENCIES
         rack
+
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
 
       BUNDLED WITH
          1.10.0
@@ -146,6 +161,9 @@ describe "the lockfile format" do
       DEPENDENCIES
         rack (> 0)
 
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
+
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -163,6 +181,9 @@ describe "the lockfile format" do
 
       DEPENDENCIES
         rack
+
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
 
       BUNDLED WITH
          9999999.1.0
@@ -192,6 +213,9 @@ describe "the lockfile format" do
       DEPENDENCIES
         rack
 
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
+
       BUNDLED WITH
          9999999.1.0
     G
@@ -209,6 +233,9 @@ describe "the lockfile format" do
 
       DEPENDENCIES
         rack
+
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
 
       BUNDLED WITH
          9999999.0.0
@@ -245,6 +272,9 @@ describe "the lockfile format" do
         rails-assets-bootstrap!
         rake
 
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
+
       BUNDLED WITH
          9999999.0.0
     L
@@ -275,6 +305,9 @@ describe "the lockfile format" do
       DEPENDENCIES
         rack
 
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
+
       BUNDLED WITH
          1.10.0
     L
@@ -302,6 +335,9 @@ describe "the lockfile format" do
       DEPENDENCIES
         rack
 
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
+
       BUNDLED WITH
          9999999.0.0
     G
@@ -328,6 +364,9 @@ describe "the lockfile format" do
       DEPENDENCIES
         rack-obama
 
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
+
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -353,6 +392,9 @@ describe "the lockfile format" do
 
       DEPENDENCIES
         rack-obama (>= 1.0)
+
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -384,6 +426,9 @@ describe "the lockfile format" do
       DEPENDENCIES
         rack-obama (>= 1.0)
 
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
+
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -408,6 +453,9 @@ describe "the lockfile format" do
 
       DEPENDENCIES
         net-sftp
+
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -438,6 +486,9 @@ describe "the lockfile format" do
 
       DEPENDENCIES
         foo!
+
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -475,6 +526,9 @@ describe "the lockfile format" do
         omg!
         rack
 
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
+
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -508,6 +562,9 @@ describe "the lockfile format" do
       DEPENDENCIES
         foo!
 
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
+
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -537,6 +594,9 @@ describe "the lockfile format" do
 
       DEPENDENCIES
         foo!
+
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -568,6 +628,9 @@ describe "the lockfile format" do
       DEPENDENCIES
         foo!
 
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
+
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -594,6 +657,9 @@ describe "the lockfile format" do
 
       DEPENDENCIES
         foo!
+
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -637,6 +703,9 @@ describe "the lockfile format" do
         foo!
         rack
 
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
+
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -671,6 +740,9 @@ describe "the lockfile format" do
         actionpack
         rack-obama
         thin
+
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -711,6 +783,9 @@ describe "the lockfile format" do
       DEPENDENCIES
         rails
 
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
+
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -736,6 +811,9 @@ describe "the lockfile format" do
 
       DEPENDENCIES
         double_deps
+
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -763,6 +841,9 @@ describe "the lockfile format" do
       DEPENDENCIES
         rack-obama (>= 1.0)
 
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
+
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -788,6 +869,9 @@ describe "the lockfile format" do
 
       DEPENDENCIES
         rack-obama (>= 1.0)
+
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -817,6 +901,9 @@ describe "the lockfile format" do
       DEPENDENCIES
         foo
 
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
+
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -844,6 +931,9 @@ describe "the lockfile format" do
 
       DEPENDENCIES
         foo
+
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -873,6 +963,9 @@ describe "the lockfile format" do
       DEPENDENCIES
         foo
 
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
+
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -900,6 +993,9 @@ describe "the lockfile format" do
       DEPENDENCIES
         foo!
 
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
+
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -917,6 +1013,9 @@ describe "the lockfile format" do
 
       DEPENDENCIES
         rack
+
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -942,6 +1041,9 @@ describe "the lockfile format" do
 
       DEPENDENCIES
         rack
+
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -971,6 +1073,9 @@ describe "the lockfile format" do
 
       DEPENDENCIES
         platform_specific
+
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -1003,6 +1108,9 @@ describe "the lockfile format" do
         activesupport
         rack
 
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
+
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -1026,6 +1134,9 @@ describe "the lockfile format" do
 
       DEPENDENCIES
         rack
+
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -1051,6 +1162,9 @@ describe "the lockfile format" do
       DEPENDENCIES
         rack (= 1.0)
 
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
+
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -1074,6 +1188,9 @@ describe "the lockfile format" do
 
       DEPENDENCIES
         rack (= 1.0)
+
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -1119,6 +1236,9 @@ describe "the lockfile format" do
 
       DEPENDENCIES
         rack (> 0.9, < 1.0)
+
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -1196,6 +1316,9 @@ describe "the lockfile format" do
       DEPENDENCIES
         omg!
 
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
+
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -1222,6 +1345,9 @@ describe "the lockfile format" do
 
       DEPENDENCIES
         omg!
+
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -1312,6 +1438,9 @@ describe "the lockfile format" do
 
       DEPENDENCIES
         rack
+
+      RUBY VERSION
+         #{Bundler::RubyVersion.system}
 
       BUNDLED WITH
          #{Bundler::VERSION}

--- a/spec/other/platform_spec.rb
+++ b/spec/other/platform_spec.rb
@@ -376,7 +376,7 @@ G
 
       bundle :check
       expect(exitstatus).to eq(0) if exitstatus
-      expect(out).to eq("Resolving dependencies...\nThe Gemfile's dependencies are satisfied")
+      expect(out).to eq("The Gemfile's dependencies are satisfied")
     end
 
     it "checks fine with any engine" do
@@ -395,7 +395,7 @@ G
 
         bundle :check
         expect(exitstatus).to eq(0) if exitstatus
-        expect(out).to eq("Resolving dependencies...\nThe Gemfile's dependencies are satisfied")
+        expect(out).to eq("The Gemfile's dependencies are satisfied")
       end
     end
 

--- a/spec/plugins/source/example_spec.rb
+++ b/spec/plugins/source/example_spec.rb
@@ -84,6 +84,9 @@ describe "real source plugins" do
         DEPENDENCIES
           a-path-gem!
 
+        RUBY VERSION
+           #{Bundler::RubyVersion.system}
+
         BUNDLED WITH
            #{Bundler::VERSION}
       G
@@ -348,6 +351,9 @@ describe "real source plugins" do
 
         DEPENDENCIES
           ma-gitp-gem!
+
+        RUBY VERSION
+           #{Bundler::RubyVersion.system}
 
         BUNDLED WITH
            #{Bundler::VERSION}

--- a/spec/update/git_spec.rb
+++ b/spec/update/git_spec.rb
@@ -325,6 +325,9 @@ describe "bundle update" do
           foo!
           rack
 
+        RUBY VERSION
+           #{Bundler::RubyVersion.system}
+
         BUNDLED WITH
            #{Bundler::VERSION}
       G


### PR DESCRIPTION
…ne in the gemfile

@indirect I think this does what you asked for in https://github.com/bundler/bundler/issues/4853?
