### PR TITLE
fixing NoMethodError on settings

### DIFF
--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -296,7 +296,7 @@ module Bundler
     }xo
 
     def load_config(config_file)
-      return unless config_file
+      return {} unless config_file
       SharedHelpers.filesystem_access(config_file, :read) do |file|
         valid_file = file.exist? && !file.size.zero?
         return {} if ignore_config? || !valid_file

--- a/spec/bundler/settings_spec.rb
+++ b/spec/bundler/settings_spec.rb
@@ -54,6 +54,16 @@ that would suck --ehhh=oh geez it looks like i might have broken bundler somehow
   end
 
   describe "#[]" do
+    context "when the local config file is not found" do
+      subject(:settings) { described_class.new }
+
+      it "does not raise" do
+        expect {
+          subject['foo']
+        }.not_to raise_error
+      end
+    end
+
     context "when not set" do
       context "when default value present" do
         it "retrieves value" do

--- a/spec/bundler/settings_spec.rb
+++ b/spec/bundler/settings_spec.rb
@@ -58,9 +58,9 @@ that would suck --ehhh=oh geez it looks like i might have broken bundler somehow
       subject(:settings) { described_class.new }
 
       it "does not raise" do
-        expect {
-          subject['foo']
-        }.not_to raise_error
+        expect do
+          subject["foo"]
+        end.not_to raise_error
       end
     end
 


### PR DESCRIPTION
When the Settings object is initialized with no root directory it cannot read the local_config. This used to not be a problem due to the fact that the `#load_config` method did not try to exit early. Since now it does it returns nil when the config is not present setting the @local_config instance variable to nil. The fix is to return an empty hash the same way the `#load_config` method would return if it encountered a problem later on.

The attached test proves that there is a problem and the fix makes the problem go away.