### PR TITLE
Improve IRB behavior in generated bin/console

### DIFF
--- a/lib/bundler/templates/newgem/bin/console.tt
+++ b/lib/bundler/templates/newgem/bin/console.tt
@@ -11,4 +11,4 @@ require "<%= config[:namespaced_path] %>"
 # Pry.start
 
 require "irb"
-IRB.start
+IRB.start(__FILE__)


### PR DESCRIPTION
`IRB.start` expects an argument with the name of the script being executed. When this argument is omitted, IRB does not search the filesystem for `.irbrc` files. That means that developers who have customized their IRB settings with an `~/.irbrc` will not benefit from those customizations when using Bundler's default `bin/console` script.

Fix this by editing the `bin/console` template to pass `__FILE__` to `IRB.start`.

This makes `bin/console` consistent with Ruby's builtin `bin/irb` command.
https://github.com/ruby/ruby/blob/9f9add3eb5006473dfabac3e994e904b5c1979fe/bin/irb#L11