### PR TITLE
* fix execution with another active directory

### DIFF
--- a/lib/bundler/templates/newgem/bin/console.tt
+++ b/lib/bundler/templates/newgem/bin/console.tt
@@ -1,5 +1,9 @@
 #!/usr/bin/env ruby
 
+# help script to find ../lib/ if a shell executes it with another directory
+# set as active (like Mac OS Finder does)
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+
 require "bundler/setup"
 require "<%= config[:namespaced_path] %>"
 

--- a/lib/bundler/templates/newgem/bin/setup.tt
+++ b/lib/bundler/templates/newgem/bin/setup.tt
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+cd -
 IFS=$'\n\t'
 set -vx
 

--- a/lib/bundler/templates/newgem/bin/setup.tt
+++ b/lib/bundler/templates/newgem/bin/setup.tt
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
-cd -
+cd -P -- "$(dirname -- "$0")"
 IFS=$'\n\t'
 set -vx
 


### PR DESCRIPTION
Fix for the following issue: https://github.com/bundler/bundler/issues/5030

MacOS Finder (and I sure, that some other shells well) run the script setting ~ as his active directory. Running **bin/console** or **bin/setup** from it, you'll receive the following error, because they are unable to find /lib/:

_/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file --_

This fix helps them to find /lib/ and execute well.
