### PR TITLE
Fail fast in the specs when running from a path with special characters

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,10 @@ rescue LoadError
   abort "Run rake spec:deps to install development dependencies"
 end
 
+if File.expand_path(__FILE__) =~ %r{([^\w/\.])}
+  abort "The bundler specs cannot be run from a path that contains special characters (particularly #{$1.inspect})"
+end
+
 require "bundler"
 
 # Require the correct version of popen for the current platform


### PR DESCRIPTION
\c @indirect