### PR TITLE
Remove build that always fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,9 +95,6 @@ matrix:
       env: RGV=v1.3.7
     - rvm: 1.8.7
       env: RGV=v1.3.6
-    # For no apparent reason, this often goes over the Travis limit
-    - rvm: 1.8.7
-      env: RGV=v2.1.11
     # Ruby-head (we want to know how we're doing, but not fail the build)
     - rvm: ruby-head
       env: RGV=master
@@ -119,6 +116,5 @@ matrix:
       env: RGV=v1.3.7
     - rvm: 1.8.7
       env: RGV=v1.3.6
-    - rvm: 1.8.7
-      env: RGV=v2.1.11
     - rvm: ruby-head
+      env: RGV=master


### PR DESCRIPTION
In retrospect, once this build started always failing, we should have just removed it rather than moved it to allowed failures. I guess I was hoping it would get better. :/