### PR TITLE
Add conservative update options to bundle lock

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -457,6 +457,14 @@ module Bundler
       "add a new platform to the lockfile"
     method_option "remove-platform", :type => :array, :default => [], :banner =>
       "remove a platform from the lockfile"
+    method_option "patch", :type => :boolean, :hide => true, :banner =>
+      "Prefer updating only to next patch version"
+    method_option "minor", :type => :boolean, :hide => true, :banner =>
+      "Prefer updating only to next minor version"
+    method_option "major", :type => :boolean, :hide => true, :banner =>
+      "Prefer updating to next major version (default)"
+    method_option "strict", :type => :boolean, :hide => true, :banner =>
+      "Do not allow any gem to be updated past latest --patch/--minor/--major"
     def lock
       require "bundler/cli/lock"
       Lock.new(options).run

--- a/lib/bundler/cli/common.rb
+++ b/lib/bundler/cli/common.rb
@@ -52,5 +52,14 @@ module Bundler
       message += "\nDid you mean #{suggestions}?" if suggestions
       message
     end
+
+    def self.config_gem_version_promoter(definition, opts)
+      patch_level = [:major, :minor, :patch].select {|v| opts.keys.include?(v.to_s) }
+      raise InvalidOption, "Provide only one of the following options: #{patch_level.join(", ")}" unless patch_level.length <= 1
+      definition.gem_version_promoter.tap do |gvp|
+        gvp.level = patch_level.first || :major
+        gvp.strict = opts[:strict]
+      end
+    end
   end
 end

--- a/lib/bundler/cli/lock.rb
+++ b/lib/bundler/cli/lock.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require "bundler/cli/common"
+
 module Bundler
   class CLI::Lock
     attr_reader :options
@@ -22,6 +24,8 @@ module Bundler
       update = options[:update]
       update = { :gems => update } if update.is_a?(Array)
       definition = Bundler.definition(update)
+
+      Bundler::CLI::Common.config_gem_version_promoter(Bundler.definition, options) if options[:update]
 
       options["remove-platform"].each do |platform|
         definition.remove_platform(platform)

--- a/lib/bundler/cli/update.rb
+++ b/lib/bundler/cli/update.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require "bundler/cli/common"
+
 module Bundler
   class CLI::Update
     attr_reader :options, :gems
@@ -27,7 +29,6 @@ module Bundler
         names = Bundler.locked_gems.specs.map(&:name)
         gems.each do |g|
           next if names.include?(g)
-          require "bundler/cli/common"
           raise GemNotFound, Bundler::CLI::Common.gem_not_found_message(g, names)
         end
 
@@ -39,12 +40,7 @@ module Bundler
         Bundler.definition(:gems => gems, :sources => sources, :ruby => options[:ruby])
       end
 
-      patch_level = [:major, :minor, :patch].select {|v| options.keys.include?(v.to_s) }
-      raise InvalidOption, "Provide only one of the following options: #{patch_level.join(", ")}" unless patch_level.length <= 1
-      Bundler.definition.gem_version_promoter.tap do |gvp|
-        gvp.level = patch_level.first || :major
-        gvp.strict = options[:strict]
-      end
+      Bundler::CLI::Common.config_gem_version_promoter(Bundler.definition, options)
 
       Bundler::Fetcher.disable_endpoint = options["full-index"]
 


### PR DESCRIPTION
Fix #4912.

The bundle lock command produces a lockfile same as bundle update but
won't install all the gems. If the `--update` option is fed to `bundle
lock` you can also specify the `--patch`, `--minor`, `--major` and
`--strict` options added to `bundle update` in 1.13.