### PR TITLE
Changed the behavior of 'bundle clean --dry-run' to output the list regardless of path set or force option

### DIFF
--- a/lib/bundler/cli/clean.rb
+++ b/lib/bundler/cli/clean.rb
@@ -8,7 +8,7 @@ module Bundler
     end
 
     def run
-      require_path_or_force
+      require_path_or_force unless options[:"dry-run"]
       Bundler.load.clean(options[:"dry-run"])
     end
 

--- a/spec/commands/clean_spec.rb
+++ b/spec/commands/clean_spec.rb
@@ -567,7 +567,7 @@ describe "bundle clean" do
     expect(exitstatus).to eq(0) if exitstatus
   end
 
-  it "doesn't remove gems in dry-run mode" do
+  it "doesn't remove gems in dry-run mode with path set" do
     gemfile <<-G
       source "file://#{gem_repo1}"
 
@@ -584,6 +584,36 @@ describe "bundle clean" do
     G
 
     bundle :install
+
+    bundle "clean --dry-run"
+
+    expect(out).not_to include("Removing foo (1.0)")
+    expect(out).to include("Would have removed foo (1.0)")
+
+    should_have_gems "thin-1.0", "rack-1.0.0", "foo-1.0"
+
+    expect(vendored_gems("bin/rackup")).to exist
+  end
+
+  it "doesn't remove gems in dry-run mode with no path set" do
+    gemfile <<-G
+      source "file://#{gem_repo1}"
+
+      gem "thin"
+      gem "foo"
+    G
+
+    bundle "install --path vendor/bundle --no-clean"
+
+    gemfile <<-G
+      source "file://#{gem_repo1}"
+
+      gem "thin"
+    G
+
+    bundle :install
+
+    bundle "configuration --delete path"
 
     bundle "clean --dry-run"
 


### PR DESCRIPTION
Changed the behavior of 'bundle clean --dry-run' to output the list of gems bundle without having the local path set or providing the '--force' option. This change does not affect the actual behavior of 'bundle clean' which requires either the path being set or use of '--force'.

Closes #5027.