### PR TITLE
Add more details on URI::InvalidComponentError

### DIFF
--- a/lib/bundler/source/rubygems/remote.rb
+++ b/lib/bundler/source/rubygems/remote.rb
@@ -39,9 +39,9 @@ module Bundler
           end
 
           uri
-        rescue URI::InvalidComponentError
+        rescue URI::InvalidComponentError => e
           error_message = "Please CGI escape your usernames and passwords before " \
-                          "setting them for authentication."
+                          "setting them for authentication. Original error: #{e}"
           raise HTTPError.new(error_message)
         end
 

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -481,8 +481,7 @@ describe "bundle install with gem sources" do
     it "should display a helpful messag explaining how to fix it" do
       bundle :install, :env => { "BUNDLE_RUBYGEMS__ORG" => "user:pass{word" }
       expect(exitstatus).to eq(17) if exitstatus
-      expect(out).to eq("Please CGI escape your usernames and passwords before " \
-                        "setting them for authentication.")
+      expect(out).to match(/Please CGI escape your usernames and passwords/)
     end
   end
 


### PR DESCRIPTION
This would have helped me when I had misunderstood the value of the `ENV['BUNDLE_GEM__FURY__IO']` variable used to provide details to private Rubygems sources. The job was running on Travis so it was hard to debug. (I had put the whole URL there, not just the username part)

Downside: it _will_ likely contain the secret text. Something like this: `bad component(expected user component): //<secret>@gem.fury.io/something-uber-cool/`

I will have total understanding if the PR is rejected for this exact reason. (What I did was to reproduce the problem locally, then add something like this in my local copy of bundler.)
