### PR TITLE
change checksum warning to debug print

### DIFF
--- a/lib/bundler/compact_index_client/updater.rb
+++ b/lib/bundler/compact_index_client/updater.rb
@@ -30,7 +30,7 @@ module Bundler
         Dir.mktmpdir("bundler-compact-index-") do |local_temp_dir|
           local_temp_path = Pathname.new(local_temp_dir).join(local_path.basename)
 
-          # download new file if retrying
+          # first try to fetch any new bytes on the existing file
           if retrying.nil? && local_path.file?
             FileUtils.cp local_path, local_temp_path
             headers["If-None-Match"] = etag_for(local_temp_path)
@@ -61,7 +61,7 @@ module Bundler
             return nil
           end
 
-          unless retrying.nil?
+          if retrying
             raise MisMatchedChecksumError.new(remote_path, response_etag, etag_for(local_temp_path))
           end
 

--- a/lib/bundler/fetcher/compact_index.rb
+++ b/lib/bundler/fetcher/compact_index.rb
@@ -78,7 +78,7 @@ module Bundler
     private
 
       def compact_index_client
-        @compact_index_client ||=
+        @compact_index_client ||= begin
           SharedHelpers.filesystem_access(cache_path) do
             CompactIndexClient.new(cache_path, compact_fetcher)
           end.tap do |client|
@@ -89,6 +89,7 @@ module Bundler
               inputs.map { worker.deq }
             end
           end
+        end
       end
 
       def bundle_worker(func = nil)

--- a/lib/bundler/fetcher/compact_index.rb
+++ b/lib/bundler/fetcher/compact_index.rb
@@ -80,6 +80,7 @@ module Bundler
       def compact_index_client
         @compact_index_client ||= begin
           SharedHelpers.filesystem_access(cache_path) do
+            compact_fetcher = Fetcher.new(downloader, fetch_url, Bundler.ui)
             CompactIndexClient.new(cache_path, compact_fetcher)
           end.tap do |client|
             client.in_parallel = lambda do |inputs, &blk|
@@ -106,15 +107,13 @@ module Bundler
         Bundler.user_cache.join("compact_index", remote.cache_slug)
       end
 
-      def compact_fetcher
-        lambda do |path, headers|
-          begin
-            downloader.fetch(fetch_uri + path, headers)
-          rescue NetworkDownError => e
-            raise unless Bundler.feature_flag.allow_offline_install? && headers["If-None-Match"]
-            Bundler.ui.warn "Using the cached data for the new index because of a network error: #{e}"
-            Net::HTTPNotModified.new(nil, nil, nil)
-          end
+      Fetcher = Struct.new(:downloader, :fetch_uri, :ui) do
+        def call(path, headers)
+          downloader.fetch(fetch_uri + path, headers)
+        rescue NetworkDownError => e
+          raise unless Bundler.feature_flag.allow_offline_install? && headers["If-None-Match"]
+          ui.warn "Using the cached data for the new index because of a network error: #{e}"
+          Net::HTTPNotModified.new(nil, nil, nil)
         end
       end
     end

--- a/lib/bundler/fetcher/compact_index.rb
+++ b/lib/bundler/fetcher/compact_index.rb
@@ -66,7 +66,7 @@ module Bundler
         # Read info file checksums out of /versions, so we can know if gems are up to date
         fetch_uri.scheme != "file" && compact_index_client.update_and_parse_checksums!
       rescue CompactIndexClient::Updater::MisMatchedChecksumError => e
-        Bundler.ui.warn(e.message)
+        Bundler.ui.debug(e.message)
         nil
       end
       compact_index_request :available?


### PR DESCRIPTION
This was super helpful when the server was continuously returning bad
checksums, but it’s a scary warning to see anytime we update the 
versions file. And we’re going to need to update the versions file at
least twice a year, so it seems like a good idea to head off users
worrying about a message that is actually things working as intended.