### PR TITLE
Revert "::Rake::CommandFailedError doesn't exist."

### DIFF
--- a/lib/bundler/deployment.rb
+++ b/lib/bundler/deployment.rb
@@ -15,7 +15,7 @@ module Bundler
       else
         context_name = "vlad"
         role_default = "[:app]"
-        error_type = ::Vlad::CommandFailedError
+        error_type = ::Rake::CommandFailedError
       end
 
       roles = context.fetch(:bundle_roles, false)


### PR DESCRIPTION
This reverts commit c5a889ce865cc0314597e9de11e2bee366e797ac.