### PR TITLE
bundle info command

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -245,6 +245,14 @@ module Bundler
     # TODO: 2.0 remove `bundle list`
     map %w(list) => "show"
 
+    desc "info GEM [OPTIONS]", "Shows gem information"
+    method_option "path", :type => :boolean,
+                   :banner => "Show gem path"
+    def info(gem_name)
+      require "bundler/cli/info"
+      Info.new(options, gem_name).run
+    end
+
     desc "binstubs GEM [OPTIONS]", "Install the binstubs of the listed gem"
     long_desc <<-D
       Generate binstubs for executables in [GEM]. Binstubs are put into bin,

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -247,6 +247,7 @@ module Bundler
 
     desc "info GEM [OPTIONS]", "Shows gem information"
     method_option "path", :type => :boolean,
+                   :default => false,
                    :banner => "Show gem path"
     def info(gem_name)
       require "bundler/cli/info"

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -247,8 +247,8 @@ module Bundler
 
     desc "info GEM [OPTIONS]", "Shows gem information"
     method_option "path", :type => :boolean,
-                   :default => false,
-                   :banner => "Show gem path"
+                          :default => false,
+                          :banner => "Show gem path"
     def info(gem_name)
       require "bundler/cli/info"
       Info.new(options, gem_name).run

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -246,9 +246,6 @@ module Bundler
     map %w(list) => "show"
 
     desc "info GEM [OPTIONS]", "Shows gem information"
-    method_option "path", :type => :boolean,
-                          :default => false,
-                          :banner => "Show gem path"
     def info(gem_name)
       require "bundler/cli/info"
       Info.new(options, gem_name).run

--- a/lib/bundler/cli/info.rb
+++ b/lib/bundler/cli/info.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+require "bundler/cli/common"
+
+module Bundler
+  class CLI::Info
+    attr_reader :gem_name, :options, :latest_specs
+    def initialize(options, gem_name)
+      @options = options
+      @gem_name = gem_name
+      @latest_specs = fetch_latest_specs if not options[:path]
+    end
+
+    def run
+      Bundler.ui.silence do
+        Bundler.definition.validate_runtime!
+        Bundler.load.lock
+      end
+
+      spec = Bundler::CLI::Common.select_spec(gem_name, :regex_match)
+      return unless spec
+
+      path = spec.full_gem_path
+      if options[:path]
+        return Bundler.ui.info(path)
+      end
+
+      unless File.directory?(path)
+        Bundler.ui.warn("The gem #{gem_name} has been deleted. It was installed at:")
+      end
+
+      return print_gem_info spec
+    end
+
+    private
+
+    def print_gem_info spec
+      desc = "  * #{spec.name} (#{spec.version}#{spec.git_version})"
+      latest = latest_specs.find {|l| l.name == spec.name }
+      Bundler.ui.info <<-END.gsub(/^ +/, "")
+        #{desc}
+        \tSummary:  #{spec.summary || "No description available."}
+        \tHomepage: #{spec.homepage || "No website available."}
+        \tStatus:   #{outdated?(spec, latest) ? "Outdated - #{spec.version} < #{latest.version}" : "Up to date"}
+      END
+    end
+
+    def fetch_latest_specs
+      definition = Bundler.definition(true)
+      definition.resolve_remotely!
+      definition.specs
+    end
+
+    def outdated?(current, latest)
+      return false unless latest
+      Gem::Version.new(current.version) < Gem::Version.new(latest.version)
+    end
+
+  end
+end

--- a/lib/bundler/cli/info.rb
+++ b/lib/bundler/cli/info.rb
@@ -3,7 +3,7 @@ require "bundler/cli/common"
 
 module Bundler
   class CLI::Info
-    attr_reader :gem_name, :options 
+    attr_reader :gem_name, :options
     def initialize(options, gem_name)
       @options = options
       @gem_name = gem_name
@@ -19,22 +19,20 @@ module Bundler
       return unless spec
 
       path = spec.full_gem_path
-      if options[:path]
-        return Bundler.ui.info(path)
-      end
+      return Bundler.ui.info(path) if options[:path]
 
       unless File.directory?(path)
         Bundler.ui.warn("The gem #{gem_name} has been deleted. It was installed at:")
       end
 
-      return print_gem_info spec
+      print_gem_info spec
     end
 
-    private
+  private
 
-    def print_gem_info spec
+    def print_gem_info(spec)
       desc = "  * #{spec.name} (#{spec.version}#{spec.git_version})"
-      latest = fetch_latest_specs().find {|l| l.name == spec.name }
+      latest = fetch_latest_specs.find {|l| l.name == spec.name }
       Bundler.ui.info <<-END.gsub(/^ +/, "")
         #{desc}
         \tSummary:  #{spec.summary || "No description available."}
@@ -53,6 +51,5 @@ module Bundler
       return false unless latest
       Gem::Version.new(current.version) < Gem::Version.new(latest.version)
     end
-
   end
 end

--- a/lib/bundler/cli/info.rb
+++ b/lib/bundler/cli/info.rb
@@ -3,11 +3,10 @@ require "bundler/cli/common"
 
 module Bundler
   class CLI::Info
-    attr_reader :gem_name, :options, :latest_specs
+    attr_reader :gem_name, :options 
     def initialize(options, gem_name)
       @options = options
       @gem_name = gem_name
-      @latest_specs = fetch_latest_specs if not options[:path]
     end
 
     def run
@@ -35,7 +34,7 @@ module Bundler
 
     def print_gem_info spec
       desc = "  * #{spec.name} (#{spec.version}#{spec.git_version})"
-      latest = latest_specs.find {|l| l.name == spec.name }
+      latest = fetch_latest_specs().find {|l| l.name == spec.name }
       Bundler.ui.info <<-END.gsub(/^ +/, "")
         #{desc}
         \tSummary:  #{spec.summary || "No description available."}

--- a/lib/bundler/cli/info.rb
+++ b/lib/bundler/cli/info.rb
@@ -16,16 +16,7 @@ module Bundler
       end
 
       spec = Bundler::CLI::Common.select_spec(gem_name, :regex_match)
-      return unless spec
-
-      path = spec.full_gem_path
-      return Bundler.ui.info(path) if options[:path]
-
-      unless File.directory?(path)
-        Bundler.ui.warn("The gem #{gem_name} has been deleted. It was installed at:")
-      end
-
-      print_gem_info spec
+      return print_gem_info(spec) if spec
     end
 
   private
@@ -38,6 +29,7 @@ module Bundler
         \tSummary:  #{spec.summary || "No description available."}
         \tHomepage: #{spec.homepage || "No website available."}
         \tStatus:   #{outdated?(spec, latest) ? "Outdated - #{spec.version} < #{latest.version}" : "Up to date"}
+        \tPath:     #{spec.full_gem_path}
       END
     end
 

--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -76,7 +76,7 @@ module Bundler
         relative_path = absolute_path.sub(File.expand_path(".") + File::SEPARATOR, "." + File::SEPARATOR)
         Bundler.ui.confirm "Bundled gems are installed into #{relative_path}."
       else
-        Bundler.ui.confirm "Use `bundle show [gemname]` to see where a bundled gem is installed."
+        Bundler.ui.confirm "Use `bundle info [gemname]` to see where a bundled gem is installed."
       end
 
       unless Bundler.settings["ignore_messages"]

--- a/lib/bundler/cli/show.rb
+++ b/lib/bundler/cli/show.rb
@@ -17,6 +17,10 @@ module Bundler
         Bundler.load.lock
       end
 
+      if options[:outdated]
+        Bundler.ui.warn("Deprecated: use `bundle info GEM` or `bundle outdated` instead of `bundle show --outdated`")
+      end
+
       if gem_name
         if gem_name == "bundler"
           path = File.expand_path("../../../..", __FILE__)

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -2,7 +2,6 @@
 require "spec_helper"
 
 describe "bunlde info" do
-
   context "info from specific gem in gemfile" do
     before :each do
       install_gemfile <<-G
@@ -32,7 +31,7 @@ describe "bunlde info" do
 
       expect(bundled_app("Gemfile.lock")).to exist
     end
-  
+
     it "should show error message if gem not found" do
       bundle "info anything"
 

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe "bunlde info" do
+
+  context "info from specific gem in gemfile" do
+    before :each do
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem "rails"
+      G
+    end
+
+    it "should print summary of rake gem" do
+      bundle "info rails"
+
+      expect(out).to include("rails")
+      expect(out).to include("\tSummary:")
+      expect(out).to include("\tHomepage:")
+      expect(out).to include("\tStatus:")
+    end
+
+    it "should print gem path" do
+      bundle "info rails --path"
+      expect(out).to eq(default_bundle_path("gems", "rails-2.3.2").to_s)
+    end
+
+    it "should create a Gemfile.lock if not existing" do
+      FileUtils.rm("Gemfile.lock")
+
+      bundle "info rails"
+
+      expect(bundled_app("Gemfile.lock")).to exist
+    end
+
+  end
+end

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -32,6 +32,11 @@ describe "bunlde info" do
 
       expect(bundled_app("Gemfile.lock")).to exist
     end
+  
+    it "should show error message if gem not found" do
+      bundle "info anything"
 
+      expect(out).to eql("Could not find gem 'anything'.")
+    end
   end
 end

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bunlde info" do
+describe "bundle info" do
   context "info from specific gem in gemfile" do
     before :each do
       install_gemfile <<-G

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -17,11 +17,7 @@ describe "bundle info" do
       expect(out).to include("\tSummary:")
       expect(out).to include("\tHomepage:")
       expect(out).to include("\tStatus:")
-    end
-
-    it "should print gem path" do
-      bundle "info rails --path"
-      expect(out).to eq(default_bundle_path("gems", "rails-2.3.2").to_s)
+      expect(out).to include("\tPath:")
     end
 
     it "should create a Gemfile.lock if not existing" do

--- a/spec/install/post_bundle_message_spec.rb
+++ b/spec/install/post_bundle_message_spec.rb
@@ -14,7 +14,7 @@ describe "post bundle message" do
     G
   end
 
-  let(:bundle_show_message)       { "Use `bundle show [gemname]` to see where a bundled gem is installed." }
+  let(:bundle_show_message)       { "Use `bundle info [gemname]` to see where a bundled gem is installed." }
   let(:bundle_deployment_message) { "Bundled gems are installed into ./vendor" }
   let(:bundle_complete_message)   { "Bundle complete!" }
   let(:bundle_updated_message)    { "Bundle updated!" }


### PR DESCRIPTION
This PR refers to #4754. 

It introduces the command `bundle info GEM` that takes some responsabilities out of `bundle show`. 
### Example

`bundle info rake` will output information of a single gem, different from `bundle show --outdated` that outputs informataion of all gems:

```
* rake (11.3.0)
    Summary:  Rake is a Make-like program implemented in Ruby
    Homepage: https://github.com/ruby/rake
    Status:   Up to date
```

**Options:**
`--path` will output only gem's installation path:

```
$ bundle info rake --path 
/home/fredrb/.rvm/gems/ruby-2.3.1/gems/rake-11.3.0
```

---

As for now, the `GEM` parameter is not optional. I think this makes sense if there will be a `bundle list` command (or something similar) that will output the full list of gems. What do you guys think?

I also added a _deprecated warning_ in `bundle show --outdated` if that's fine. 
