### PR TITLE
Fix `outdated` listing regression from cc355865

### DIFF
--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -54,9 +54,9 @@ module Bundler
         dependency = current_dependencies[current_spec.name]
 
         if strict
-          active_spec = definition.specs.detect {|spec| spec.name == current_spec.name && spec.platform == current_spec.platform }
+          active_spec = definition.specs.detect {|spec| spec.name == current_spec.name && spec.match_platform(current_spec.platform) }
         else
-          active_specs = definition.index[current_spec.name].select {|spec| spec.platform == current_spec.platform }.sort_by(&:version)
+          active_specs = definition.index[current_spec.name].select {|spec| spec.match_platform(current_spec.platform) }.sort_by(&:version)
           if !current_spec.version.prerelease? && !options[:pre] && active_specs.size > 1
             active_spec = active_specs.delete_if {|b| b.respond_to?(:version) && b.version.prerelease? }
           end


### PR DESCRIPTION
Fixes #4979, by using [`match_platform`](https://github.com/bundler/bundler/blob/b3cb9516aaf83cf865c9ed76c52ec4d0d182015f/lib/bundler/match_platform.rb) over comparing `platform` values directly, as suggested by @segiddins on the original thread.

I couldn't figure out how to test this, as the `outdated` tests are end to end tests that don't replicate this issue, as it seems the the `EndpointSpecification` objects are only present when reaching rubygems.org API.

/cc @chrismo
