### PR TITLE
Improve gem checksum mismatch error message

### DIFF
--- a/lib/bundler/rubygems_gem_installer.rb
+++ b/lib/bundler/rubygems_gem_installer.rb
@@ -31,20 +31,24 @@ module Bundler
         send(checksum_type(checksum), digest)
       end
       unless digest == checksum
-        raise SecurityError,
-          "Bundler cannot continue installing #{spec.name} (#{spec.version}).\n" \
-          "The checksum for the downloaded `#{spec.full_name}.gem` does not match " \
-          "the checksum given by the server. This means the contents of the downloaded " \
-          "gem is different from what was uploaded to the server, and could be a potential security issue.\n\n" \
-          "To resolve this issue:\n" \
-          "1. delete the downloaded gem located at: `#{spec.gem_dir}/#{spec.full_name}.gem`\n" \
-          "2. run `bundle install`\n\n" \
-          "If you wish to continue installing the downloaded gem, and are certain it does not pose a " \
-          "security issue despite the mismatching checksum, do the following:\n" \
-          "1. run `bundle config disable.checksum_validaiton true` to turn off checksum verification\n" \
-          "2. run `bundle install`\n\n" \
-          "(More info: The expected SHA256 checksum was #{checksum.inspect}, but the " \
-          "checksum for the downloaded gem was #{digest.inspect}.)\n" \
+        raise SecurityError, <<-MESSAGE
+          Bundler cannot continue installing #{spec.name} (#{spec.version}).
+          The checksum for the downloaded `#{spec.full_name}.gem` does not match \
+          the checksum given by the server. This means the contents of the downloaded \
+          gem is different from what was uploaded to the server, and could be a potential security issue.
+
+          To resolve this issue:
+          1. delete the downloaded gem located at: `#{spec.gem_dir}/#{spec.full_name}.gem`
+          2. run `bundle install`
+
+          If you wish to continue installing the downloaded gem, and are certain it does not pose a \
+          security issue despite the mismatching checksum, do the following:
+          1. run `bundle config disable.checksum_validaiton true` to turn off checksum verification
+          2. run `bundle install`
+
+          (More info: The expected SHA256 checksum was #{checksum.inspect}, but the \
+          checksum for the downloaded gem was #{digest.inspect}.)
+          MESSAGE
       end
       true
     end

--- a/lib/bundler/rubygems_gem_installer.rb
+++ b/lib/bundler/rubygems_gem_installer.rb
@@ -43,7 +43,7 @@ module Bundler
 
           If you wish to continue installing the downloaded gem, and are certain it does not pose a \
           security issue despite the mismatching checksum, do the following:
-          1. run `bundle config disable.checksum_validaiton true` to turn off checksum verification
+          1. run `bundle config disable.checksum_validation true` to turn off checksum verification
           2. run `bundle install`
 
           (More info: The expected SHA256 checksum was #{checksum.inspect}, but the \

--- a/lib/bundler/rubygems_gem_installer.rb
+++ b/lib/bundler/rubygems_gem_installer.rb
@@ -32,11 +32,19 @@ module Bundler
       end
       unless digest == checksum
         raise SecurityError,
-          "The checksum for the downloaded `#{spec.full_name}.gem` did not match " \
-          "the checksum given by the API. This means that the contents of the " \
-          "gem appear to be different from what was uploaded, and could be an indicator of a security issue.\n" \
-          "(The expected SHA256 checksum was #{checksum.inspect}, but the checksum for the downloaded gem was #{digest.inspect}.)\n" \
-          "Bundler cannot continue installing #{spec.name} (#{spec.version})."
+          "Bundler cannot continue installing #{spec.name} (#{spec.version}).\n" \
+          "The checksum for the downloaded `#{spec.full_name}.gem` does not match " \
+          "the checksum given by the server. This means the contents of the downloaded " \
+          "gem is different from what was uploaded to the server, and could be a potential security issue.\n\n" \
+          "To resolve this issue:\n" \
+          "1. delete the downloaded gem located at: `#{spec.gem_dir}/#{spec.full_name}.gem`\n" \
+          "2. run `bundle install`\n\n" \
+          "If you wish to continue installing the downloaded gem, and are certain it does not pose a " \
+          "security issue despite the mismatching checksum, do the following:\n" \
+          "1. run `bundle config disable.checksum_validaiton true` to turn off checksum verification\n" \
+          "2. run `bundle install`\n\n" \
+          "(More info: The expected SHA256 checksum was #{checksum.inspect}, but the " \
+          "checksum for the downloaded gem was #{digest.inspect}.)\n" \
       end
       true
     end

--- a/spec/install/gems/compact_index_spec.rb
+++ b/spec/install/gems/compact_index_spec.rb
@@ -713,12 +713,19 @@ The checksum of /versions does not match the checksum provided by the server! So
         source "#{source_uri}"
         gem "rack"
       G
+
       expect(exitstatus).to eq(19) if exitstatus
       expect(out).
-        to  include("The checksum for the downloaded `rack-1.0.0.gem` did not match the checksum given by the API.").
-        and include("This means that the contents of the gem appear to be different from what was uploaded, and could be an indicator of a security issue.").
-        and match(/\(The expected SHA256 checksum was "#{"ab" * 22}", but the checksum for the downloaded gem was ".+?"\.\)/).
-        and include("Bundler cannot continue installing rack (1.0.0).")
+        to  include("Bundler cannot continue installing rack (1.0.0).\n").
+        and include("The checksum for the downloaded `rack-1.0.0.gem` does not match the checksum given by the server.").
+        and include("This means the contents of the downloaded gem is different from what was uploaded to the server, and could be a potential security issue.").
+        and include("To resolve this issue:").
+        and include("1. delete the downloaded gem located at: `#{system_gem_path}/gems/rack-1.0.0/rack-1.0.0.gem`").
+        and include("2. run `bundle install`").
+        and include("If you wish to continue installing the downloaded gem, and are certain it does not pose a security issue despite the mismatching checksum, do the following:").
+        and include("1. run `bundle config disable.checksum_validaiton true` to turn off checksum verification").
+        and include("2. run `bundle install`").
+        and match(/\(More info: The expected SHA256 checksum was "#{"ab" * 22}", but the checksum for the downloaded gem was ".+?"\.\)/)
     end
 
     it "raises when the checksum is the wrong length" do

--- a/spec/install/gems/compact_index_spec.rb
+++ b/spec/install/gems/compact_index_spec.rb
@@ -716,7 +716,7 @@ The checksum of /versions does not match the checksum provided by the server! So
 
       expect(exitstatus).to eq(19) if exitstatus
       expect(out).
-        to  include("Bundler cannot continue installing rack (1.0.0).\n").
+        to  include("Bundler cannot continue installing rack (1.0.0).").
         and include("The checksum for the downloaded `rack-1.0.0.gem` does not match the checksum given by the server.").
         and include("This means the contents of the downloaded gem is different from what was uploaded to the server, and could be a potential security issue.").
         and include("To resolve this issue:").

--- a/spec/install/gems/compact_index_spec.rb
+++ b/spec/install/gems/compact_index_spec.rb
@@ -723,7 +723,7 @@ The checksum of /versions does not match the checksum provided by the server! So
         and include("1. delete the downloaded gem located at: `#{system_gem_path}/gems/rack-1.0.0/rack-1.0.0.gem`").
         and include("2. run `bundle install`").
         and include("If you wish to continue installing the downloaded gem, and are certain it does not pose a security issue despite the mismatching checksum, do the following:").
-        and include("1. run `bundle config disable.checksum_validaiton true` to turn off checksum verification").
+        and include("1. run `bundle config disable.checksum_validation true` to turn off checksum verification").
         and include("2. run `bundle install`").
         and match(/\(More info: The expected SHA256 checksum was "#{"ab" * 22}", but the checksum for the downloaded gem was ".+?"\.\)/)
     end


### PR DESCRIPTION
Improve gem checksum mismatch error message by telling users how to resolve it.

Old message:

```
The checksum for the downloaded `rack-1.0.0.gem` did not match the checksum given by the API. This means that the contents of the gem appear to be different from what was uploaded, and could be an indicator of a security issue.
(The expected SHA256 checksum was "abababababababababababababababababababababab", but the checksum for the downloaded gem was "BR6Oc6Gqnq93u1aIVX4m6DvTHaFgFxdYaLUfa4ekJKI=".)
Bundler cannot continue installing rack (1.0.0).
```

New message:

```
Bundler cannot continue installing rack (1.0.0).
The checksum for the downloaded `rack-1.0.0.gem` does not match the checksum given by the server. This means the contents of the downloaded gem is different from what was uploaded to the server, and could be a potential security issue.

To resolve this issue:
1. delete the downloaded gem located at: `full-path/gems/rack-1.0.0/rack-1.0.0.gem`
2. run `bundle install`

If you wish to continue installing the downloaded gem, and are certain it does not pose a security issue despite the mismatching checksum, do the following:
1. run `bundle config disable.checksum_validaiton true` to turn off checksum verification
2. run `bundle install`

(More info: The expected SHA256 checksum was "abababababababababababababababababababababab", but the checksum for the downloaded gem was "PbfaoemSetv76QdcxuoP0ggZ0TZhMELlMMWURJoX+dw=".)
```

Closes #5075
