### PR TITLE
use Bundler.which to check for otool and ldd

### DIFF
--- a/lib/bundler/cli/doctor.rb
+++ b/lib/bundler/cli/doctor.rb
@@ -14,11 +14,11 @@ module Bundler
     end
 
     def otool_available?
-      system("otool --version 2>#{Bundler::NULL} >#{Bundler::NULL}")
+      system("command -v otool >#{Bundler::NULL}")
     end
 
     def ldd_available?
-      !system("ldd --help 2>#{Bundler::NULL} >#{Bundler::NULL}").nil?
+      system("command -v ldd >#{Bundler::NULL}")
     end
 
     def dylibs_darwin(path)

--- a/lib/bundler/cli/doctor.rb
+++ b/lib/bundler/cli/doctor.rb
@@ -14,11 +14,11 @@ module Bundler
     end
 
     def otool_available?
-      system("command -v otool >#{Bundler::NULL}")
+      Bundler.which("otool")
     end
 
     def ldd_available?
-      system("command -v ldd >#{Bundler::NULL}")
+      Bundler.which("ldd")
     end
 
     def dylibs_darwin(path)


### PR DESCRIPTION
Hi, there is some weird behaviour in `bundler doctor`. Bundler is checking for the existence of the `ldd` and `otool` commands but is not correctly redirecting the output of `otool`. Example being on the latest version of bundler:

```
› bundle doctor
llvm-otool(1): Apple Inc. version cctools-895
llvm-otool(1): Apple Inc. version cctools-895
llvm-otool(1): Apple Inc. version cctools-895
llvm-otool(1): Apple Inc. version cctools-895
llvm-otool(1): Apple Inc. version cctools-895
llvm-otool(1): Apple Inc. version cctools-895
```
 This is happening on Mac OS (10.12). I have refactored the check of these tool using the built in `command` function, this lets us check for the existence of these commands without actually having to execute them.

Thanks.