### PR TITLE
add missing highlights to bundler's bundle man page

### DIFF
--- a/man/bundle.ronn
+++ b/man/bundle.ronn
@@ -27,20 +27,20 @@ We divide `bundle` subcommands into primary commands and utilities.
 
 ## PRIMARY COMMANDS
 
-* [bundle install(1)][bundle-install]:
+* [`bundle install(1)`][bundle-install]:
   Install the gems specified by the `Gemfile` or `Gemfile.lock`
 
-* [bundle update(1)][bundle-update]:
+* [`bundle update(1)`][bundle-update]:
   Update dependencies to their latest versions
 
-* [bundle package(1)][bundle-package]:
+* [`bundle package(1)`][bundle-package]:
   Package the .gem files required by your application into the
   `vendor/cache` directory
 
-* [bundle exec(1)][bundle-exec]:
+* [`bundle exec(1)`][bundle-exec]:
   Execute a script in the context of the current bundle
 
-* [bundle config(1)][bundle-config]:
+* [`bundle config(1)`][bundle-config]:
   Specify and read configuration options for bundler
 
 * `bundle help(1)`:


### PR DESCRIPTION
Hi, I noticed on the main man page for bundler that some of the listed categories where not being formatted correctly with the rest of the document. This change adds some backticks to add the highlights. The before image is on the right and the after image is on the left.

I'm not sure if those categories were missing their highlights on purpose but let me know if they were.

<img width="1280" alt="screen shot 2016-10-24 at 10 09 22 pm" src="https://cloud.githubusercontent.com/assets/996377/19643530/88d651f0-9a36-11e6-92e3-a05a9a71f147.png">

Thanks!