### PR TITLE
Move man pages to man folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 
 # output from ronn
 /lib/bundler/man/
+man/*
+!man/*.ronn
 
 # rspec failure tracking
 .rspec_status

--- a/Rakefile
+++ b/Rakefile
@@ -238,14 +238,15 @@ begin
   require "ronn"
 
   namespace :man do
-    directory "lib/bundler/man"
+    directory "man"
 
     sources = Dir["man/*.ronn"].map {|f| File.basename(f, ".ronn") }
     sources.map do |basename|
       ronn = "man/#{basename}.ronn"
-      roff = "lib/bundler/man/#{basename}"
+      manual_section = ".1" unless basename =~ /.*(\d+)\Z/
+      roff = "man/#{basename}#{manual_section}"
 
-      file roff => ["lib/bundler/man", ronn] do
+      file roff => ["man", ronn] do
         sh "#{Gem.ruby} -S ronn --roff --pipe #{ronn} > #{roff}"
       end
 
@@ -257,9 +258,8 @@ begin
     end
 
     task :clean do
-      leftovers = Dir["lib/bundler/man/*"].reject do |f|
-        basename = File.basename(f).sub(/\.(txt|ronn)/, "")
-        sources.include?(basename)
+      leftovers = Dir["man/*"].reject do |f|
+        File.extname(f) == ".ronn" || f == "man/index.txt"
       end
       rm leftovers if leftovers.any?
     end

--- a/bundler.gemspec
+++ b/bundler.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.files = `git ls-files -z`.split("\x0").reject {|f| f.match(%r{^(test|spec|features)/}) }
   # we don't check in man pages, but we need to ship them because
   # we use them to generate the long-form help for each command.
-  s.files += Dir.glob("lib/bundler/man/**/*")
+  s.files += Dir.glob("man/**/*")
 
   s.bindir        = "exe"
   s.executables   = %w(bundle bundler)

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -61,30 +61,21 @@ module Bundler
 
     def help(cli = nil)
       case cli
-      when "gemfile" then command = "gemfile.5"
+      when "gemfile" then command = "gemfile"
       when nil       then command = "bundle"
       else command = "bundle-#{cli}"
       end
 
-      manpages = %w(
-        bundle
-        bundle-config
-        bundle-exec
-        bundle-gem
-        bundle-install
-        bundle-package
-        bundle-update
-        bundle-platform
-        gemfile.5
-      )
+      man_path  = File.expand_path("../../../man", __FILE__)
+      man_pages = Hash[Dir.glob(File.join(man_path, "*")).grep(/.*\.\d*\Z/).collect do |f|
+        [File.basename(f, ".*"), f]
+      end]
 
-      if manpages.include?(command)
-        root = File.expand_path("../man", __FILE__)
-
-        if Bundler.which("man") && root !~ %r{^file:/.+!/META-INF/jruby.home/.+}
-          Kernel.exec "man #{root}/#{command}"
+      if man_pages.include?(command)
+        if Bundler.which("man") && man_path !~ %r{^file:/.+!/META-INF/jruby.home/.+}
+          Kernel.exec "man #{man_pages[command]}"
         else
-          puts File.read("#{root}/#{command}.txt")
+          puts File.read("#{man_path}/#{File.basename(man_pages[command])}.txt")
         end
       elsif command_path = Bundler.which("bundler-#{cli}")
         Kernel.exec(command_path, "--help")

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -272,35 +272,35 @@ describe "bundle exec" do
           with_fake_man do
             bundle "#{exec} --help cat"
           end
-          expect(out).to include(%(["#{root}/lib/bundler/man/bundle-exec"]))
+          expect(out).to include(%(["#{root}/man/bundle-exec.1"]))
         end
 
         it "shows bundle-exec's man page when --help is before exec" do
           with_fake_man do
             bundle "--help #{exec}"
           end
-          expect(out).to include(%(["#{root}/lib/bundler/man/bundle-exec"]))
+          expect(out).to include(%(["#{root}/man/bundle-exec.1"]))
         end
 
         it "shows bundle-exec's man page when -h is before exec" do
           with_fake_man do
             bundle "-h #{exec}"
           end
-          expect(out).to include(%(["#{root}/lib/bundler/man/bundle-exec"]))
+          expect(out).to include(%(["#{root}/man/bundle-exec.1"]))
         end
 
         it "shows bundle-exec's man page when --help is after exec" do
           with_fake_man do
             bundle "#{exec} --help"
           end
-          expect(out).to include(%(["#{root}/lib/bundler/man/bundle-exec"]))
+          expect(out).to include(%(["#{root}/man/bundle-exec.1"]))
         end
 
         it "shows bundle-exec's man page when -h is after exec" do
           with_fake_man do
             bundle "#{exec} -h"
           end
-          expect(out).to include(%(["#{root}/lib/bundler/man/bundle-exec"]))
+          expect(out).to include(%(["#{root}/man/bundle-exec.1"]))
         end
       end
     end

--- a/spec/commands/help_spec.rb
+++ b/spec/commands/help_spec.rb
@@ -16,14 +16,14 @@ describe "bundle help" do
     with_fake_man do
       bundle "help gemfile"
     end
-    expect(out).to eq(%(["#{root}/lib/bundler/man/gemfile.5"]))
+    expect(out).to eq(%(["#{root}/man/gemfile.5"]))
   end
 
   it "prefixes bundle commands with bundle- when finding the groff files" do
     with_fake_man do
       bundle "help install"
     end
-    expect(out).to eq(%(["#{root}/lib/bundler/man/bundle-install"]))
+    expect(out).to eq(%(["#{root}/man/bundle-install.1"]))
   end
 
   it "simply outputs the txt file when there is no man on the path" do
@@ -55,28 +55,28 @@ describe "bundle help" do
     with_fake_man do
       bundle "install --help"
     end
-    expect(out).to eq(%(["#{root}/lib/bundler/man/bundle-install"]))
+    expect(out).to eq(%(["#{root}/man/bundle-install.1"]))
   end
 
   it "is called when the --help flag is used before the command" do
     with_fake_man do
       bundle "--help install"
     end
-    expect(out).to eq(%(["#{root}/lib/bundler/man/bundle-install"]))
+    expect(out).to eq(%(["#{root}/man/bundle-install.1"]))
   end
 
   it "is called when the -h flag is used before the command" do
     with_fake_man do
       bundle "-h install"
     end
-    expect(out).to eq(%(["#{root}/lib/bundler/man/bundle-install"]))
+    expect(out).to eq(%(["#{root}/man/bundle-install.1"]))
   end
 
   it "is called when the -h flag is used after the command" do
     with_fake_man do
       bundle "install -h"
     end
-    expect(out).to eq(%(["#{root}/lib/bundler/man/bundle-install"]))
+    expect(out).to eq(%(["#{root}/man/bundle-install.1"]))
   end
 
   it "has helpful output when using --help flag for a non-existent command" do
@@ -90,11 +90,11 @@ describe "bundle help" do
     with_fake_man do
       bundle "--help"
     end
-    expect(out).to eq(%(["#{root}/lib/bundler/man/bundle"]))
+    expect(out).to eq(%(["#{root}/man/bundle.1"]))
 
     with_fake_man do
       bundle "-h"
     end
-    expect(out).to eq(%(["#{root}/lib/bundler/man/bundle"]))
+    expect(out).to eq(%(["#{root}/man/bundle.1"]))
   end
 end


### PR DESCRIPTION
The [gem-man](https://github.com/defunkt/gem-man) gem searches for the man pages in the man folder. Sadly bundler right now uses `lib/bundler/man` for the man pages.

This pr fixes this and also creates correct names for the man pages. A man page always needs the section number in the filename.

After this is merged, I will create a PR that changes the [bundler-site](https://github.com/bundler/bundler-site) repo to search in this new folder for the documentation.
