### PR TITLE
change license specification in gemspec

### DIFF
--- a/bundler.gemspec
+++ b/bundler.gemspec
@@ -7,7 +7,7 @@ require "bundler/version"
 Gem::Specification.new do |s|
   s.name        = "bundler"
   s.version     = Bundler::VERSION
-  s.licenses    = ["MIT"]
+  s.license     = "MIT"
   s.authors     = ["André Arko", "Samuel Giddins"]
   s.email       = ["team@bundler.io"]
   s.homepage    = "http://bundler.io"


### PR DESCRIPTION
for compatibility with license_finder gem, allowing automatic license checks.

Bundler already proposes the same format in it's newgem.gemspec template:
https://github.com/bundler/bundler/blob/master/lib/bundler/templates/newgem/newgem.gemspec.tt#L16
Let use it for bundler itself too.