### PR TITLE
[LockfileParser] Stop requiring strscan

### DIFF
--- a/lib/bundler/lockfile_parser.rb
+++ b/lib/bundler/lockfile_parser.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "strscan"
 
 # Some versions of the Bundler 1.1 RC series introduced corrupted
 # lockfiles. There were two major problems:


### PR DESCRIPTION
Introduced and seemingly never used by https://github.com/bundler/bundler/commit/ba579f4a3e525fdd78d89531291450b26a009b07