### PR TITLE
[merged] Add documentation around git HTTP(S) credentials configuration.

### DIFF
--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -223,3 +223,17 @@ For example, to save the credentials of user `claudette` for the gem source at
 Or you can set the credentials as an environment variable like this:
 
     export BUNDLE_GEMS__LONGEROUS__COM="claudette:s00pers3krit"
+
+For gems with a git source with HTTP(S) URL you can specify credentials like so:
+
+    bundle config https://github.com/bundler/bundler.git username:password
+
+Or you can set the credentials as an environment variable like so:
+
+    export BUNDLE_GITHUB__COM=username:password
+
+This is especially useful for private repositories on hosts such as Github,
+where you can use personal OAuth tokens:
+
+    export BUNDLE_GITHUB__COM=abcd0123generatedtoken:x-oauth-basic
+


### PR DESCRIPTION
This adds documentation around setting credential configurations for HTTP(S) git repos of gems.

This is especially useful when you want to use a private gem on Github, but do not wish to either:
- commit or push a `Gemfile.lock` with exposed credentials.
- Add credentials to `~/.git-credentials`.

Credit to @frsyuki https://github.com/bundler/bundler/pull/3898 for the implementation, and documentation in his PR.

Closes #5172.