### PR TITLE
Use new RSpec syntax in spec template

### DIFF
--- a/lib/bundler/templates/newgem/spec/newgem_spec.rb.tt
+++ b/lib/bundler/templates/newgem/spec/newgem_spec.rb.tt
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe <%= config[:constant_name] %> do
+RSpec.describe <%= config[:constant_name] %> do
   it "has a version number" do
     expect(<%= config[:constant_name] %>::VERSION).not_to be nil
   end


### PR DESCRIPTION
This little pull request, juste for use actual new syntax for begin an spec file.

```ruby
RSpec.describe "MyAwesomeSpec" do

end
```

instead

```ruby
describe "MyOldAwesomeSpec" do
end
```

link: https://github.com/rspec/rspec-rails/commit/ca0d249858903949052e06884e8e7f9d596cdc79