### PR TITLE
Gemfile docs: add note about ruby version marker

### DIFF
--- a/man/gemfile.5.ronn
+++ b/man/gemfile.5.ronn
@@ -64,6 +64,18 @@ the Ruby version that the engine is compatible with.
 
     ruby "1.9.3"
 
+If your application is a library which needs to be tested on more than one
+Ruby version, you can tell Bundler to use the current Ruby version as the
+required one:
+
+    ruby RUBY_VERSION
+
+This will add the Ruby version to the requirements list. Sub-dependencies
+will also be subject to this version requirement.
+
+(NB: The Bundler team is actively working on making Bundler able to handle
+ruby versions without having to put `ruby` in the Gemfile.)
+
 ### ENGINE
 
 Each application _may_ specify a Ruby engine. If an engine is specified, an

--- a/man/gemfile.5.ronn
+++ b/man/gemfile.5.ronn
@@ -71,10 +71,12 @@ required one:
     ruby RUBY_VERSION
 
 This will add the Ruby version to the requirements list. Sub-dependencies
-will also be subject to this version requirement.
+will also be subject to this version requirement. NB: This will overwrite your
+`Gemfile.lock` at every usage. People who use this technique ignore their
+`Gemfile.lock` from source control.
 
-(NB: The Bundler team is actively working on making Bundler able to handle
-ruby versions without having to put `ruby` in the Gemfile.)
+(NB: Upcoming versions of Bundler will be able to discover the Ruby version
+without needing a `ruby` annotation in the Gemfile.)
 
 ### ENGINE
 


### PR DESCRIPTION
This is a docs addition to the Gemfile man page, the `ruby` section.

  - try to explain the `ruby RUBY_VERSION` trick, useful to library authors
  - add NB about actively working on improving this
