### PR TITLE
Dont build defintion with Gemfile.lock (if present) when resolving gems via inline gemfile

### DIFF
--- a/lib/bundler/inline.rb
+++ b/lib/bundler/inline.rb
@@ -60,7 +60,7 @@ def gemfile(install = false, options = {}, &gemfile)
 
   Bundler.ui = ui if install
   if install || missing_specs.call
-    installer = Bundler::Installer.install(Bundler.root, definition, :system => true)
+    installer = Bundler::Installer.install(Bundler.root, definition, :system => true, :inline => true)
     installer.post_install_messages.each do |name, message|
       Bundler.ui.info "Post-install message from #{name}:\n#{message}"
     end

--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -212,7 +212,7 @@ module Bundler
     end
 
     def resolve_if_need(options)
-      if Bundler.default_lockfile.exist? && !options["update"]
+      if Bundler.default_lockfile.exist? && !options["update"] && !options[:inline]
         local = Bundler.ui.silence do
           begin
             tmpdef = Definition.build(Bundler.default_gemfile, Bundler.default_lockfile, nil)

--- a/spec/runtime/inline_spec.rb
+++ b/spec/runtime/inline_spec.rb
@@ -216,13 +216,16 @@ describe "bundler/inline#gemfile" do
          1.13.6
     G
 
-    script <<-RUBY
-      gemfile do
-        source "https://rubygems.org"
-        gem "json", "~> 1.8.3"
-      end
-      puts JSON::VERSION
-    RUBY
+    in_app_root do
+      script <<-RUBY
+        gemfile do
+          source "file://#{gem_repo1}"
+          gem "rack"
+        end
+
+        puts RACK
+      RUBY
+    end
 
     expect(err).to be_empty
     expect(exitstatus).to be_zero if exitstatus

--- a/spec/runtime/inline_spec.rb
+++ b/spec/runtime/inline_spec.rb
@@ -193,4 +193,37 @@ describe "bundler/inline#gemfile" do
     expect(err).to be_empty
     expect(exitstatus).to be_zero if exitstatus
   end
+
+  it "installs inline gems when a Gemfile.lock is present" do
+    gemfile <<-G
+      source "https://rubygems.org"
+      gem "rake"
+    G
+
+    gemfile <<-G
+      GEM
+        remote: https://rubygems.org/
+        specs:
+          rake (11.3.0)
+
+      PLATFORMS
+        ruby
+
+      DEPENDENCIES
+        rake
+
+      BUNDLED WITH
+         1.13.6
+    G
+
+    script <<-RUBY
+      gemfile do
+        source "https://rubygems.org"
+        gem "whirly"
+      end
+    RUBY
+
+    expect(err).to be_empty
+    expet(existstatus).to be_zero if existstatus
+  end
 end

--- a/spec/runtime/inline_spec.rb
+++ b/spec/runtime/inline_spec.rb
@@ -200,7 +200,7 @@ describe "bundler/inline#gemfile" do
       gem "rake"
     G
 
-    gemfile <<-G
+    lockfile <<-G
       GEM
         remote: https://rubygems.org/
         specs:
@@ -225,6 +225,6 @@ describe "bundler/inline#gemfile" do
     RUBY
 
     expect(err).to be_empty
-    expet(exitstatus).to be_zero if exitstatus
+    expect(exitstatus).to be_zero if exitstatus
   end
 end

--- a/spec/runtime/inline_spec.rb
+++ b/spec/runtime/inline_spec.rb
@@ -219,11 +219,12 @@ describe "bundler/inline#gemfile" do
     script <<-RUBY
       gemfile do
         source "https://rubygems.org"
-        gem "whirly"
+        gem "json", "~> 2.0.2"
       end
+      puts JSON::VERSION
     RUBY
 
     expect(err).to be_empty
-    expet(existstatus).to be_zero if existstatus
+    expet(exitstatus).to be_zero if exitstatus
   end
 end

--- a/spec/runtime/inline_spec.rb
+++ b/spec/runtime/inline_spec.rb
@@ -219,7 +219,7 @@ describe "bundler/inline#gemfile" do
     script <<-RUBY
       gemfile do
         source "https://rubygems.org"
-        gem "json", "~> 2.0.2"
+        gem "json", "~> 1.8.3"
       end
       puts JSON::VERSION
     RUBY


### PR DESCRIPTION
This fixes #5117 

I am passing an option to `Installer` to not build a definition when resolving gems via inline gemfile.

Also, i notice: `Bundler.default_lockfile.exist? && !options["update"]...`. Is "update" suppose to be a string? I ask because i noticed that other options are being passed as symbols, so I'm not which i'm suppose to be using.

Thanks.

PS. Hopefully i have the bundler terminology correct 😄 