### PR TITLE
[SharedHelpers] Handle generic SystemCallErrors in #filesystem_access

### DIFF
--- a/lib/bundler/errors.rb
+++ b/lib/bundler/errors.rb
@@ -132,4 +132,24 @@ module Bundler
 
     status_code(28)
   end
+
+  class NoSpaceOnDeviceError < PermissionError
+    def message
+      "There was an error while trying to #{action} `#{@path}`. " \
+      "There was insufficent space remaining on the device."
+    end
+
+    status_code(31)
+  end
+
+  class GenericSystemCallError < BundlerError
+    attr_reader :underlying_error
+
+    def initialize(underlying_error, message)
+      @underlying_error = underlying_error
+      super("#{message}\nThe underlying system error is #{@underlying_error.class}: #{@underlying_error}")
+    end
+
+    status_code(32)
+  end
 end

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -115,6 +115,8 @@ module Bundler
       raise NoSpaceOnDeviceError.new(path, action)
     rescue *[const_get_safely(:ENOTSUP, Errno)].compact
       raise OperationNotSupportedError.new(path, action)
+    rescue Errno::EEXIST, Errno::ENOENT
+      raise
     rescue SystemCallError => e
       raise GenericSystemCallError.new(e, "There was an error accessing `#{path}`.")
     end

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -111,8 +111,12 @@ module Bundler
       raise TemporaryResourceError.new(path, action)
     rescue Errno::EPROTO
       raise VirtualProtocolError.new
+    rescue Errno::ENOSPC
+      raise NoSpaceOnDeviceError.new(path, action)
     rescue *[const_get_safely(:ENOTSUP, Errno)].compact
       raise OperationNotSupportedError.new(path, action)
+    rescue SystemCallError => e
+      raise GenericSystemCallError.new(e, "There was an error accessing `#{path}`.")
     end
 
     def const_get_safely(constant_name, namespace)

--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -388,6 +388,27 @@ describe Bundler::SharedHelpers do
         )
       end
     end
+
+    context "system throws Errno::ENOSPC" do
+      let(:file_op_block) { proc {|_path| raise Errno::ENOSPC } }
+
+      it "raises a NoSpaceOnDeviceError" do
+        expect { subject.filesystem_access("/path", &file_op_block) }.to raise_error(
+          Bundler::NoSpaceOnDeviceError
+        )
+      end
+    end
+
+    context "system throws an unhandled SystemCallError" do
+      let(:error) { SystemCallError.new("Shields down", 1337) }
+      let(:file_op_block) { proc {|_path| raise error } }
+
+      it "raises a GenericSystemCallError" do
+        expect { subject.filesystem_access("/path", &file_op_block) }.to raise_error(
+          Bundler::GenericSystemCallError, /error accessing.+underlying.+Shields down/m
+        )
+      end
+    end
   end
 
   describe "#const_get_safely" do


### PR DESCRIPTION
Closes #5134 