### PR TITLE
Duplicate existing definition in Installer

### DIFF
--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -215,7 +215,7 @@ module Bundler
       if Bundler.default_lockfile.exist? && !options["update"] && !options[:inline]
         local = Bundler.ui.silence do
           begin
-            tmpdef = Definition.build(Bundler.default_gemfile, Bundler.default_lockfile, nil)
+            tmpdef = @definition.dup
             true unless tmpdef.new_platform? || tmpdef.missing_dependencies.any?
           rescue BundlerError
           end


### PR DESCRIPTION
When i `bundle install`, Bundler is creating 2 Definitions (which means it's parsing the Gemfile + Gemfile.lock multiple times) which we can see this by having `puts "Parsing Gemfile` in the `Gemfile`

```
$ ruby -I ../bundler/lib ../bundler/exe/bundle install
parsing gemfile...
parsing gemfile...
Using rack 2.0.1
Using bundler 1.13.6
Bundle complete! 1 Gemfile dependency, 2 gems now installed.
Use `bundle show [gemname]` to see where a bundled gem is installed.
```

Looking at the implementation of Installer and Definition, this seems rather unnecessary. This change makes a small optimisation by duplicating the definition that exists already inside Installer.

I can't use `true unless @definition.new_platform? || @definition.missing_dependencies.any?` because there appears to be some internals state in `Installer` that is preventing me from doing so but maybe this is something to look at in the future.