### PR TITLE
[Lock] Fix --add-platform ruby

### DIFF
--- a/lib/bundler/cli/lock.rb
+++ b/lib/bundler/cli/lock.rb
@@ -33,7 +33,7 @@ module Bundler
 
       options["add-platform"].each do |platform_string|
         platform = Gem::Platform.new(platform_string)
-        if platform.to_a.compact == %w(unknown)
+        if platform.to_s == "unknown"
           Bundler.ui.warn "The platform `#{platform_string}` is unknown to RubyGems " \
             "and adding it will likely lead to resolution errors"
         end

--- a/spec/commands/lock_spec.rb
+++ b/spec/commands/lock_spec.rb
@@ -161,6 +161,12 @@ describe "bundle lock" do
     expect(lockfile.platforms).to eq([java, local, mingw])
   end
 
+  it "supports adding the `ruby` platform" do
+    bundle! "lock --add-platform ruby"
+    lockfile = Bundler::LockfileParser.new(read_lockfile)
+    expect(lockfile.platforms).to eq([local, "ruby"].uniq)
+  end
+
   it "warns when adding an unknown platform" do
     bundle "lock --add-platform foobarbaz"
     expect(out).to include("The platform `foobarbaz` is unknown to RubyGems and adding it will likely lead to resolution errors")


### PR DESCRIPTION
Necessary since the ruby platform is a string instead of a platform object

Closes #5230 