### PR TITLE
`bundle update` post install messages

### DIFF
--- a/lib/bundler/cli/common.rb
+++ b/lib/bundler/cli/common.rb
@@ -1,6 +1,23 @@
 # frozen_string_literal: true
 module Bundler
   module CLI::Common
+    def self.output_post_install_messages(messages)
+      return if Bundler.settings["ignore_messages"]
+      messages.to_a.each do |name, msg|
+        print_post_install_message(name, msg) unless Bundler.settings["ignore_messages.#{name}"]
+      end
+    end
+
+    def self.print_post_install_message(name, msg)
+      Bundler.ui.confirm "Post-install message from #{name}:"
+      Bundler.ui.info msg
+    end
+
+    def self.output_without_groups_message
+      return unless Bundler.settings.without.any?
+      Bundler.ui.confirm without_groups_message
+    end
+
     def self.without_groups_message
       groups = Bundler.settings.without
       group_list = [groups[0...-1].join(", "), groups[-1..-1]].

--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require "bundler/cli/common"
+
 module Bundler
   class CLI::Install
     attr_reader :options
@@ -69,7 +71,7 @@ module Bundler
       Bundler.load.cache if Bundler.app_cache.exist? && !options["no-cache"] && !Bundler.settings[:frozen]
 
       Bundler.ui.confirm "Bundle complete! #{dependencies_count_for(definition)}, #{gems_installed_for(definition)}."
-      confirm_without_groups
+      Bundler::CLI::Common.output_without_groups_message
 
       if Bundler.settings[:path]
         absolute_path = File.expand_path(Bundler.settings[:path])
@@ -79,11 +81,7 @@ module Bundler
         Bundler.ui.confirm "Use `bundle show [gemname]` to see where a bundled gem is installed."
       end
 
-      unless Bundler.settings["ignore_messages"]
-        installer.post_install_messages.to_a.each do |name, msg|
-          print_post_install_message(name, msg) unless Bundler.settings["ignore_messages.#{name}"]
-        end
-      end
+      Bundler::CLI::Common.output_post_install_messages installer.post_install_messages
 
       warn_ambiguous_gems
 
@@ -132,12 +130,6 @@ module Bundler
       end
     end
 
-    def confirm_without_groups
-      return unless Bundler.settings.without.any?
-      require "bundler/cli/common"
-      Bundler.ui.confirm Bundler::CLI::Common.without_groups_message
-    end
-
     def dependencies_count_for(definition)
       count = definition.dependencies.count
       "#{count} Gemfile #{count == 1 ? "dependency" : "dependencies"}"
@@ -146,11 +138,6 @@ module Bundler
     def gems_installed_for(definition)
       count = definition.specs.count
       "#{count} #{count == 1 ? "gem" : "gems"} now installed"
-    end
-
-    def print_post_install_message(name, msg)
-      Bundler.ui.confirm "Post-install message from #{name}:"
-      Bundler.ui.info msg
     end
 
     def check_for_group_conflicts

--- a/lib/bundler/cli/update.rb
+++ b/lib/bundler/cli/update.rb
@@ -61,15 +61,7 @@ module Bundler
       end
 
       Bundler.ui.confirm "Bundle updated!"
-      without_groups_messages
-    end
-
-  private
-
-    def without_groups_messages
-      return unless Bundler.settings.without.any?
-      require "bundler/cli/common"
-      Bundler.ui.confirm Bundler::CLI::Common.without_groups_message
+      Bundler::CLI::Common.output_without_groups_message
     end
   end
 end

--- a/lib/bundler/cli/update.rb
+++ b/lib/bundler/cli/update.rb
@@ -52,7 +52,7 @@ module Bundler
       Bundler.settings[:jobs] = opts["jobs"] if opts["jobs"]
 
       Bundler.definition.validate_runtime!
-      Installer.install Bundler.root, Bundler.definition, opts
+      installer = Installer.install Bundler.root, Bundler.definition, opts
       Bundler.load.cache if Bundler.app_cache.exist?
 
       if Bundler.settings[:clean] && Bundler.settings[:path]
@@ -62,6 +62,7 @@ module Bundler
 
       Bundler.ui.confirm "Bundle updated!"
       Bundler::CLI::Common.output_without_groups_message
+      Bundler::CLI::Common.output_post_install_messages installer.post_install_messages
     end
   end
 end

--- a/spec/update/gems/post_install_spec.rb
+++ b/spec/update/gems/post_install_spec.rb
@@ -11,9 +11,9 @@ describe "bundle update" do
       gem 'thin'
     G
 
-    bundle "config #{config}" if config
+    bundle! "config #{config}" if config
 
-    bundle :install
+    bundle! :install
   end
 
   shared_examples "a config observer" do
@@ -53,7 +53,7 @@ describe "bundle update" do
         gem 'thin'
       G
 
-      bundle :update
+      bundle! :update
     end
 
     it_behaves_like "a post-install message outputter"
@@ -68,7 +68,7 @@ describe "bundle update" do
         gem 'thin'
       G
 
-      bundle :update
+      bundle! :update
     end
 
     it_behaves_like "a post-install message outputter"

--- a/spec/update/gems/post_install_spec.rb
+++ b/spec/update/gems/post_install_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe "bundle update" do
+  let(:config) {}
+
+  before do
+    gemfile <<-G
+      source "file://#{gem_repo1}"
+      gem 'rack', "< 1.0"
+      gem 'thin'
+    G
+
+    bundle "config #{config}" if config
+
+    bundle :install
+  end
+
+  shared_examples "a config observer" do
+    context "when ignore post-install messages for gem is set" do
+      let(:config) { "ignore_messages.rack true" }
+
+      it "doesn't display gem's post-install message" do
+        expect(out).not_to include("Rack's post install message")
+      end
+    end
+
+    context "when ignore post-install messages for all gems" do
+      let(:config) { "ignore_messages true" }
+
+      it "doesn't display any post-install messages" do
+        expect(out).not_to include("Post-install message")
+      end
+    end
+  end
+
+  shared_examples "a post-install message outputter" do
+    it "should display post-install messages for updated gems" do
+      expect(out).to include("Post-install message from rack:")
+      expect(out).to include("Rack's post install message")
+    end
+
+    it "should not display the post-install message for non-updated gems" do
+      expect(out).not_to include("Thin's post install message")
+    end
+  end
+
+  context "when listed gem is updated" do
+    before do
+      gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem 'rack'
+        gem 'thin'
+      G
+
+      bundle :update
+    end
+
+    it_behaves_like "a post-install message outputter"
+    it_behaves_like "a config observer"
+  end
+
+  context "when dependency triggers update" do
+    before do
+      gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem 'rack-obama'
+        gem 'thin'
+      G
+
+      bundle :update
+    end
+
+    it_behaves_like "a post-install message outputter"
+    it_behaves_like "a config observer"
+  end
+end


### PR DESCRIPTION
Currently post install messages are only displayed for `bundle install` not for `bundle update`.  This PR fixes that so they're displayed for both, and includes a small refactor of some duplicated functionality between `install` and `update`