### PR TITLE
Prefer require_relative to simplify loading

### DIFF
--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -1,7 +1,5 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require '<%=config[:namespaced_path]%>/version'
+require_relative 'lib/<%=config[:namespaced_path]%>/version'
 
 Gem::Specification.new do |spec|
   spec.name          = <%=config[:name].inspect%>


### PR DESCRIPTION
Using `require_relative` avoids modifying `$LOAD_PATH`. It's simpler and more robust.