### PR TITLE
Add a new line for before priring BundlerError errors

### DIFF
--- a/lib/bundler/retry.rb
+++ b/lib/bundler/retry.rb
@@ -43,7 +43,10 @@ module Bundler
 
     def fail_attempt(e)
       @failed = true
-      raise e if last_attempt? || @exceptions.any? {|k| e.is_a?(k) }
+      if last_attempt? || @exceptions.any? {|k| e.is_a?(k) }
+        Bundler.ui.info "" unless Bundler.ui.debug?
+        raise e
+      end
       return true unless name
       Bundler.ui.info "" unless Bundler.ui.debug? # Add new line incase dots preceded this
       Bundler.ui.warn "Retrying #{name} due to error (#{current_run.next}/#{total_runs}): #{e.class} #{e.message}", Bundler.ui.debug?

--- a/spec/bundler/retry_spec.rb
+++ b/spec/bundler/retry_spec.rb
@@ -65,10 +65,10 @@ describe Bundler::Retry do
       end
     end
 
-    context "with debugging on" do
+    context "with debugging off" do
       it "print error message with newlines" do
         allow(Bundler.ui).to  receive(:debug?).and_return(false)
-        expect(Bundler.ui).to receive(:info).with("")
+        expect(Bundler.ui).to receive(:info).with("").twice
         expect(Bundler.ui).to receive(:warn).with(failure_message, false)
 
         expect do

--- a/spec/realworld/mirror_probe_spec.rb
+++ b/spec/realworld/mirror_probe_spec.rb
@@ -79,6 +79,24 @@ describe "fetching dependencies with a not available mirror", :realworld => true
       expect(out).to include("Retrying fetcher due to error (4/4): Bundler::HTTPError Could not fetch specs from #{mirror}")
       expect(out).to include("Could not fetch specs from #{mirror}")
     end
+
+    it "prints each error and warning on a new line" do
+
+      gemfile <<-G
+        source "#{original}"
+        gem 'weakling'
+      G
+
+      bundle :install
+
+      expect(out).to eq "Fetching source index from #{mirror}/
+
+Retrying fetcher due to error (2/4): Bundler::HTTPError Could not fetch specs from #{mirror}/
+Retrying fetcher due to error (3/4): Bundler::HTTPError Could not fetch specs from #{mirror}/
+Retrying fetcher due to error (4/4): Bundler::HTTPError Could not fetch specs from #{mirror}/
+Could not fetch specs from #{mirror}"
+      R
+    end
   end
 
   context "with a global mirror without a fallback timeout" do

--- a/spec/realworld/mirror_probe_spec.rb
+++ b/spec/realworld/mirror_probe_spec.rb
@@ -95,7 +95,6 @@ Retrying fetcher due to error (2/4): Bundler::HTTPError Could not fetch specs fr
 Retrying fetcher due to error (3/4): Bundler::HTTPError Could not fetch specs from #{mirror}/
 Retrying fetcher due to error (4/4): Bundler::HTTPError Could not fetch specs from #{mirror}/
 Could not fetch specs from #{mirror}/"
-      R
     end
   end
 

--- a/spec/realworld/mirror_probe_spec.rb
+++ b/spec/realworld/mirror_probe_spec.rb
@@ -94,7 +94,7 @@ describe "fetching dependencies with a not available mirror", :realworld => true
 Retrying fetcher due to error (2/4): Bundler::HTTPError Could not fetch specs from #{mirror}/
 Retrying fetcher due to error (3/4): Bundler::HTTPError Could not fetch specs from #{mirror}/
 Retrying fetcher due to error (4/4): Bundler::HTTPError Could not fetch specs from #{mirror}/
-Could not fetch specs from #{mirror}"
+Could not fetch specs from #{mirror}/"
       R
     end
   end

--- a/spec/realworld/mirror_probe_spec.rb
+++ b/spec/realworld/mirror_probe_spec.rb
@@ -81,7 +81,6 @@ describe "fetching dependencies with a not available mirror", :realworld => true
     end
 
     it "prints each error and warning on a new line" do
-
       gemfile <<-G
         source "#{original}"
         gem 'weakling'


### PR DESCRIPTION
This PR is fixing a problem where the warnings and errors on a `bundle install` using an invalid source are not being put on a newline correctly.
```
› bundle install
Fetching source index from https://www.google.com/

Retrying fetcher due to error (2/4): Bundler::HTTPError Could not fetch specs from https://www.google.com/
Retrying fetcher due to error (3/4): Bundler::HTTPError Could not fetch specs from https://www.google.com/
Retrying fetcher due to error (4/4): Bundler::HTTPError Could not fetch specs from https://www.google.com/Could not fetch specs from https://www.google.com/
``` 

This is happening because the new lines for the warnings are being printed before the error itself. This behaviour is happening due to another UI problem, see https://github.com/bundler/bundler/commit/2ac26bc88ba30b28aba6e11c9b2d04cdb0276a25. 

Maybe a better way of fixing this problem is to add a new line to the exception message itself rather then what i have submitted. Its a bit of a weird one.

Let me know.