### PR TITLE
clean up platform docs for versions

### DIFF
--- a/man/gemfile.5.ronn
+++ b/man/gemfile.5.ronn
@@ -173,78 +173,38 @@ There are a number of `Gemfile` platforms:
 
   * `ruby`:
     C Ruby (MRI) or Rubinius, but `NOT` Windows
-  * `ruby_18`:
-    _ruby_ `AND` version 1.8
-  * `ruby_19`:
-    _ruby_ `AND` version 1.9
-  * `ruby_20`:
-    _ruby_ `AND` version 2.0
-  * `ruby_21`:
-    _ruby_ `AND` version 2.1
-  * `ruby_22`:
-    _ruby_ `AND` version 2.2
-  * `ruby_23`:
-    _ruby_ `AND` version 2.3
-  * `ruby_24`:
-    _ruby_ `AND` version 2.4
-  * `ruby_25`:
-    _ruby_ `AND` version 2.5
   * `mri`:
     Same as _ruby_, but not Rubinius
-  * `mri_18`:
-    _mri_ `AND` version 1.8
-  * `mri_19`:
-    _mri_ `AND` version 1.9
-  * `mri_20`:
-    _mri_ `AND` version 2.0
-  * `mri_21`:
-    _mri_ `AND` version 2.1
-  * `mri_22`:
-    _mri_ `AND` version 2.2
-  * `mri_23`:
-    _mri_ `AND` version 2.3
-  * `mri_24`:
-    _mri_ `AND` version 2.4
-  * `mri_25`:
-    _mri_ `AND` version 2.5
+  * `mingw`:
+    Windows 32 bit 'mingw32' platform (aka RubyInstaller)
+  * `x64_mingw`:
+    Windows 64 bit 'mingw32' platform (aka RubyInstaller x64)
   * `rbx`:
     Same as _ruby_, but only Rubinius (not MRI)
   * `jruby`:
     JRuby
   * `mswin`:
     Windows
+
+You can restrict further by platform and version for all platforms *except* for
+`rbx`, `jruby`, and `mswin`.
+
+To specify a version in addition to a platform, append the version number without
+the delimiter to the platform. For example, to specify that a gem should only be
+used on platforms with Ruby 2.3, use:
+
+    ruby_23
+
+The full list of platforms and supported versions includes:
+
+  * `ruby`:
+    1.8, 1.9, 2.0, 2.1, 2.2, 2.3, 2.4, 2.5
+  * `mri`:
+    1.8, 1.9, 2.0, 2.1, 2.2, 2.3, 2.4, 2.5
   * `mingw`:
-    Windows 32 bit 'mingw32' platform (aka RubyInstaller)
-  * `mingw_18`:
-    _mingw_ `AND` version 1.8
-  * `mingw_19`:
-    _mingw_ `AND` version 1.9
-  * `mingw_20`:
-    _mingw_ `AND` version 2.0
-  * `mingw_21`:
-    _mingw_ `AND` version 2.1
-  * `mingw_22`:
-    _mingw_ `AND` version 2.2
-  * `mingw_23`:
-    _mingw_ `AND` version 2.3
-  * `mingw_24`:
-    _mingw_ `AND` version 2.4
-  * `mingw_25`:
-    _mingw_ `AND` version 2.5
+    1.8, 1.9, 2.0, 2.1, 2.2, 2.3, 2.4, 2.5
   * `x64_mingw`:
-    Windows 64 bit 'mingw32' platform (aka RubyInstaller x64)
-  * `x64_mingw_20`:
-    _x64_mingw_ `AND` version 2.0
-  * `x64_mingw_21`:
-    _x64_mingw_ `AND` version 2.1
-  * `x64_mingw_22`:
-    _x64_mingw_ `AND` version 2.2
-  * `x64_mingw_23`:
-    _x64_mingw_ `AND` version 2.3
-  * `x64_mingw_24`:
-    _x64_mingw_ `AND` version 2.4
-  * `x64_mingw_25`:
-    _x64_mingw_ `AND` version 2.5
+    2.0, 2.1, 2.2, 2.3, 2.4, 2.5
 
 As with groups, you can specify one or more platforms:
 


### PR DESCRIPTION
closes https://github.com/bundler/bundler-site/issues/260

Per @lynnco's suggestion, this cleans up the formatting for platform version specifications. I added the platform list first, then specified the platforms that don't have versions, and then provided the full version list.

I'm not sure how to check the formatting of man pages locally - if you let me know how to do this I can update `CONTRIBUTING` and add this to other guidelines 💯 