### PR TITLE
Use correct hook name in comment

### DIFF
--- a/lib/bundler/plugin/api/source.rb
+++ b/lib/bundler/plugin/api/source.rb
@@ -93,7 +93,7 @@ module Bundler
         # It should be called in `install` after the plugin is done placing the
         # gem at correct install location.
         #
-        # It also runs Gem hooks `post_install`, `post_build` and `post_install`
+        # It also runs Gem hooks `pre_install`, `post_build` and `post_install`
         #
         # Note: Do not override if you don't know what you are doing.
         def post_install(spec, disable_exts = false)


### PR DESCRIPTION
I checked `Bundler::Source::Path::Installer#post_install` - it's definitely `pre_install` and not `post_install` twice though I wasn't sure given the method name 😄 