### PR TITLE
Specs for multiple platform bug fix in outdated.

### DIFF
--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -427,6 +427,33 @@ describe "bundle outdated" do
     end
   end
 
+  context "update available for a gem on the same platform while multiple platforms used for gem" do
+    it "reports that updates are available if the Ruby platform is used" do
+      install_gemfile <<-G
+        source "file://#{gem_repo2}"
+        gem "laduradura", '= 5.15.2', :platforms => [:ruby, :jruby]
+      G
+
+      bundle "outdated"
+      expect(out).to include("Bundle up to date!")
+    end
+
+    it "reports that updates are available if the JRuby platform is used" do
+      simulate_ruby_engine "jruby", "1.6.7" do
+        simulate_platform "jruby" do
+          install_gemfile <<-G
+            source "file://#{gem_repo2}"
+            gem "laduradura", '= 5.15.2', :platforms => [:ruby, :jruby]
+          G
+
+          bundle "outdated"
+          expect(out).to include("Outdated gems included in the bundle:")
+          expect(out).to include("laduradura (newest 5.15.3, installed 5.15.2, requested = 5.15.2)")
+        end
+      end
+    end
+  end
+
   shared_examples_for "version update is detected" do
     it "reports that a gem has a newer version" do
       subject


### PR DESCRIPTION
This supersedes PR #4734, which fixed a bug but didn't have proper spec
coverage. Since that PR was submitted, a different commit (291a807c in
PR #5176) fixed a similar bug at the same time. That caused a merge
conflict in #4734. It was unknown if the same fix fixed both bugs,
since there were no successfully implemented specs. These specs show
that the bug was properly fixed.

These specs were mostly already implemented by @b-ggs, just needed a
little additional guidance.