### PR TITLE
Update gem_helper.rb --ci skip

### DIFF
--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -131,6 +131,7 @@ module Bundler
       clean? && committed? || raise("There are files that need to be committed first.")
     end
 
+    # Runs shell command and returns true if the program exits with no differences.
     def clean?
       sh_with_code("git diff --exit-code")[1] == 0
     end


### PR DESCRIPTION
Explanation for Bundler::GemHelper#clean?
[ci skip]