### PR TITLE
[CLI] Dont override Kernel#gem for bundle gem

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -418,8 +418,19 @@ module Bundler
 
     commands["gem"].tap do |gem_command|
       def gem_command.run(instance, args = [])
+        arity = 1 # name
+
         require "bundler/cli/gem"
-        Gem.new(instance.options, *args, instance).run
+        cmd_args = args + [instance]
+        cmd_args.unshift(instance.options)
+
+        cmd = begin
+          Gem.new(*cmd_args)
+        rescue ArgumentError => e
+          instance.class.handle_argument_error(self, e, args, arity)
+        end
+
+        cmd.run
       end
     end
 

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -748,6 +748,14 @@ describe "bundle gem" do
       bundle "gem 'foo bar'"
       expect(out).to end_with("Invalid gem name foo bar -- `Foo bar` is an invalid constant name")
     end
+
+    it "fails gracefully when multiple names are passed" do
+      bundle "gem foo bar baz"
+      expect(out).to eq(<<-E.strip)
+ERROR: "bundle gem" was called with arguments ["foo", "bar", "baz"]
+Usage: "bundle gem GEM [OPTIONS]"
+      E
+    end
   end
 
   describe "#ensure_safe_gem_name" do


### PR DESCRIPTION
Should fix #5296 

Since `Kernel#require` calls into `Kernel#gem` as an instance method on `self`, overriding the `gem` method can lead to bad things happening