### PR TITLE
Adds *.gem to the default git ignore for a new gem.

### DIFF
--- a/lib/bundler/templates/newgem/gitignore.tt
+++ b/lib/bundler/templates/newgem/gitignore.tt
@@ -7,6 +7,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+*.gem
 <%- if config[:ext] -%>
 *.bundle
 *.so


### PR DESCRIPTION
Gemspecs by default use

     spec.files         = `git ls-files -z`.split("\x0").reject do |f|

So, if you create a gem file it will get sucked into spec.files.

Suppose you then try to use this development gem from another project in a Gemfile using path:

    gem 'thingy', path: /some/other/dir

`bundle install` then fails because the Gemfile itself is being included.