### PR TITLE
Re-work RSpec configuration to be more CI-friendly

### DIFF
--- a/lib/bundler/templates/newgem/spec/spec_helper.rb.tt
+++ b/lib/bundler/templates/newgem/spec/spec_helper.rb.tt
@@ -5,6 +5,9 @@ RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
 
+  # Disable RSpec exposing methods globally on `Module` and `main`
+  config.disable_monkey_patching!
+
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end

--- a/spec/bundler/bundler_spec.rb
+++ b/spec/bundler/bundler_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 require "bundler"
 
-describe Bundler do
+RSpec.describe Bundler do
   describe "#load_gemspec_uncached" do
     let(:app_gemspec_path) { tmp("test.gemspec") }
     subject { Bundler.load_gemspec_uncached(app_gemspec_path) }

--- a/spec/bundler/cli_spec.rb
+++ b/spec/bundler/cli_spec.rb
@@ -2,7 +2,7 @@
 require "spec_helper"
 require "bundler/cli"
 
-describe "bundle executable" do
+RSpec.describe "bundle executable" do
   it "returns non-zero exit status when passed unrecognized options" do
     bundle "--invalid_argument"
     expect(exitstatus).to_not be_zero if exitstatus
@@ -63,7 +63,7 @@ describe "bundle executable" do
   end
 end
 
-describe "bundler executable" do
+RSpec.describe "bundler executable" do
   it "shows the bundler version just as the `bundle` executable does" do
     bundler "--version"
     expect(out).to eq("Bundler version #{Bundler::VERSION}")

--- a/spec/bundler/definition_spec.rb
+++ b/spec/bundler/definition_spec.rb
@@ -2,7 +2,7 @@
 require "spec_helper"
 require "bundler/definition"
 
-describe Bundler::Definition do
+RSpec.describe Bundler::Definition do
   describe "#lock" do
     before do
       allow(Bundler).to receive(:settings) { Bundler::Settings.new(".") }

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe Bundler::Dsl do
+RSpec.describe Bundler::Dsl do
   before do
     @rubygems = double("rubygems")
     allow(Bundler::Source::Rubygems).to receive(:new) { @rubygems }

--- a/spec/bundler/endpoint_specification_spec.rb
+++ b/spec/bundler/endpoint_specification_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe Bundler::EndpointSpecification do
+RSpec.describe Bundler::EndpointSpecification do
   let(:name)         { "foo" }
   let(:version)      { "1.0.0" }
   let(:platform)     { Gem::Platform::RUBY }

--- a/spec/bundler/env_spec.rb
+++ b/spec/bundler/env_spec.rb
@@ -2,7 +2,7 @@
 require "spec_helper"
 require "bundler/settings"
 
-describe Bundler::Env do
+RSpec.describe Bundler::Env do
   let(:env)            { described_class.new }
   let(:git_proxy_stub) { Bundler::Source::Git::GitProxy.new(nil, nil, nil) }
 

--- a/spec/bundler/environment_preserver_spec.rb
+++ b/spec/bundler/environment_preserver_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe Bundler::EnvironmentPreserver do
+RSpec.describe Bundler::EnvironmentPreserver do
   let(:preserver) { described_class.new(env, ["foo"]) }
 
   describe "#backup" do

--- a/spec/bundler/fetcher/base_spec.rb
+++ b/spec/bundler/fetcher/base_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe Bundler::Fetcher::Base do
+RSpec.describe Bundler::Fetcher::Base do
   let(:downloader)  { double(:downloader) }
   let(:remote)      { double(:remote) }
   let(:display_uri) { "http://sample_uri.com" }

--- a/spec/bundler/fetcher/compact_index_spec.rb
+++ b/spec/bundler/fetcher/compact_index_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe Bundler::Fetcher::CompactIndex do
+RSpec.describe Bundler::Fetcher::CompactIndex do
   let(:downloader)  { double(:downloader) }
   let(:remote)      { double(:remote, :cache_slug => "lsjdf") }
   let(:display_uri) { URI("http://sampleuri.com") }

--- a/spec/bundler/fetcher/dependency_spec.rb
+++ b/spec/bundler/fetcher/dependency_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe Bundler::Fetcher::Dependency do
+RSpec.describe Bundler::Fetcher::Dependency do
   let(:downloader)  { double(:downloader) }
   let(:remote)      { double(:remote, :uri => URI("http://localhost:5000")) }
   let(:display_uri) { "http://sample_uri.com" }

--- a/spec/bundler/fetcher/downloader_spec.rb
+++ b/spec/bundler/fetcher/downloader_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe Bundler::Fetcher::Downloader do
+RSpec.describe Bundler::Fetcher::Downloader do
   let(:connection)     { double(:connection) }
   let(:redirect_limit) { 5 }
   let(:uri)            { URI("http://www.uri-to-fetch.com/api/v2/endpoint") }

--- a/spec/bundler/fetcher/index_spec.rb
+++ b/spec/bundler/fetcher/index_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe Bundler::Fetcher::Index do
+RSpec.describe Bundler::Fetcher::Index do
   let(:downloader)  { nil }
   let(:remote)      { nil }
   let(:display_uri) { "http://sample_uri.com" }

--- a/spec/bundler/fetcher_spec.rb
+++ b/spec/bundler/fetcher_spec.rb
@@ -2,7 +2,7 @@
 require "spec_helper"
 require "bundler/fetcher"
 
-describe Bundler::Fetcher do
+RSpec.describe Bundler::Fetcher do
   let(:uri) { URI("https://example.com") }
   let(:remote) { double("remote", :uri => uri, :original_uri => nil) }
 

--- a/spec/bundler/friendly_errors_spec.rb
+++ b/spec/bundler/friendly_errors_spec.rb
@@ -4,7 +4,7 @@ require "bundler"
 require "bundler/friendly_errors"
 require "cgi"
 
-describe Bundler, "friendly errors" do
+RSpec.describe Bundler, "friendly errors" do
   context "with invalid YAML in .gemrc" do
     before do
       File.open(Gem.configuration.config_file_name, "w") do |f|

--- a/spec/bundler/gem_helper_spec.rb
+++ b/spec/bundler/gem_helper_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 require "rake"
 require "bundler/gem_helper"
 
-describe Bundler::GemHelper do
+RSpec.describe Bundler::GemHelper do
   let(:app_name) { "lorem__ipsum" }
   let(:app_path) { bundled_app app_name }
   let(:app_gemspec_path) { app_path.join("#{app_name}.gemspec") }

--- a/spec/bundler/gem_version_promoter_spec.rb
+++ b/spec/bundler/gem_version_promoter_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe Bundler::GemVersionPromoter do
+RSpec.describe Bundler::GemVersionPromoter do
   context "conservative resolver" do
     def versions(result)
       result.flatten.map(&:version).map(&:to_s)

--- a/spec/bundler/index_spec.rb
+++ b/spec/bundler/index_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe Bundler::Index do
+RSpec.describe Bundler::Index do
   let(:specs) { [] }
   subject { described_class.build {|i| i.use(specs) } }
 

--- a/spec/bundler/installer/parallel_installer_spec.rb
+++ b/spec/bundler/installer/parallel_installer_spec.rb
@@ -2,7 +2,7 @@
 require "spec_helper"
 require "bundler/installer/parallel_installer"
 
-describe Bundler::ParallelInstaller do
+RSpec.describe Bundler::ParallelInstaller do
   let(:installer) { instance_double("Installer") }
   let(:all_specs) { [] }
   let(:size) { 1 }

--- a/spec/bundler/installer/spec_installation_spec.rb
+++ b/spec/bundler/installer/spec_installation_spec.rb
@@ -2,7 +2,7 @@
 require "spec_helper"
 require "bundler/installer/parallel_installer"
 
-describe Bundler::ParallelInstaller::SpecInstallation do
+RSpec.describe Bundler::ParallelInstaller::SpecInstallation do
   let!(:dep) do
     a_spec = Object.new
     def a_spec.name

--- a/spec/bundler/lockfile_parser_spec.rb
+++ b/spec/bundler/lockfile_parser_spec.rb
@@ -2,7 +2,7 @@
 require "spec_helper"
 require "bundler/lockfile_parser"
 
-describe Bundler::LockfileParser do
+RSpec.describe Bundler::LockfileParser do
   let(:lockfile_contents) { strip_whitespace(<<-L) }
     GIT
       remote: https://github.com/alloy/peiji-san.git

--- a/spec/bundler/mirror_spec.rb
+++ b/spec/bundler/mirror_spec.rb
@@ -2,7 +2,7 @@
 require "spec_helper"
 require "bundler/mirror"
 
-describe Bundler::Settings::Mirror do
+RSpec.describe Bundler::Settings::Mirror do
   let(:mirror) { Bundler::Settings::Mirror.new }
 
   it "returns zero when fallback_timeout is not set" do
@@ -144,7 +144,7 @@ describe Bundler::Settings::Mirror do
   end
 end
 
-describe Bundler::Settings::Mirrors do
+RSpec.describe Bundler::Settings::Mirrors do
   let(:localhost_uri) { URI("http://localhost:9292") }
 
   context "with a just created mirror" do
@@ -293,7 +293,7 @@ describe Bundler::Settings::Mirrors do
   end
 end
 
-describe Bundler::Settings::TCPSocketProbe do
+RSpec.describe Bundler::Settings::TCPSocketProbe do
   let(:probe) { Bundler::Settings::TCPSocketProbe.new }
 
   context "with a listening TCP Server" do

--- a/spec/bundler/plugin/api/source_spec.rb
+++ b/spec/bundler/plugin/api/source_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe Bundler::Plugin::API::Source do
+RSpec.describe Bundler::Plugin::API::Source do
   let(:uri) { "uri://to/test" }
   let(:type) { "spec_type" }
 

--- a/spec/bundler/plugin/api_spec.rb
+++ b/spec/bundler/plugin/api_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe Bundler::Plugin::API do
+RSpec.describe Bundler::Plugin::API do
   context "plugin declarations" do
     before do
       stub_const "UserPluginClass", Class.new(Bundler::Plugin::API)

--- a/spec/bundler/plugin/dsl_spec.rb
+++ b/spec/bundler/plugin/dsl_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe Bundler::Plugin::DSL do
+RSpec.describe Bundler::Plugin::DSL do
   DSL = Bundler::Plugin::DSL
 
   subject(:dsl) { Bundler::Plugin::DSL.new }

--- a/spec/bundler/plugin/index_spec.rb
+++ b/spec/bundler/plugin/index_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe Bundler::Plugin::Index do
+RSpec.describe Bundler::Plugin::Index do
   Index = Bundler::Plugin::Index
 
   before do

--- a/spec/bundler/plugin/installer_spec.rb
+++ b/spec/bundler/plugin/installer_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe Bundler::Plugin::Installer do
+RSpec.describe Bundler::Plugin::Installer do
   subject(:installer) { Bundler::Plugin::Installer.new }
 
   describe "cli install" do

--- a/spec/bundler/plugin/source_list_spec.rb
+++ b/spec/bundler/plugin/source_list_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe Bundler::Plugin::SourceList do
+RSpec.describe Bundler::Plugin::SourceList do
   SourceList = Bundler::Plugin::SourceList
 
   before do

--- a/spec/bundler/plugin_spec.rb
+++ b/spec/bundler/plugin_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe Bundler::Plugin do
+RSpec.describe Bundler::Plugin do
   Plugin = Bundler::Plugin
 
   let(:installer) { double(:installer) }

--- a/spec/bundler/psyched_yaml_spec.rb
+++ b/spec/bundler/psyched_yaml_spec.rb
@@ -2,7 +2,7 @@
 require "spec_helper"
 require "bundler/psyched_yaml"
 
-describe "Bundler::YamlLibrarySyntaxError" do
+RSpec.describe "Bundler::YamlLibrarySyntaxError" do
   it "is raised on YAML parse errors" do
     expect { YAML.parse "{foo" }.to raise_error(Bundler::YamlLibrarySyntaxError)
   end

--- a/spec/bundler/remote_specification_spec.rb
+++ b/spec/bundler/remote_specification_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe Bundler::RemoteSpecification do
+RSpec.describe Bundler::RemoteSpecification do
   let(:name)         { "foo" }
   let(:version)      { Gem::Version.new("1.0.0") }
   let(:platform)     { Gem::Platform::RUBY }

--- a/spec/bundler/retry_spec.rb
+++ b/spec/bundler/retry_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe Bundler::Retry do
+RSpec.describe Bundler::Retry do
   it "return successful result if no errors" do
     attempts = 0
     result = Bundler::Retry.new(nil, nil, 3).attempt do

--- a/spec/bundler/ruby_dsl_spec.rb
+++ b/spec/bundler/ruby_dsl_spec.rb
@@ -2,7 +2,7 @@
 require "spec_helper"
 require "bundler/ruby_dsl"
 
-describe Bundler::RubyDsl do
+RSpec.describe Bundler::RubyDsl do
   class MockDSL
     include Bundler::RubyDsl
 

--- a/spec/bundler/ruby_version_spec.rb
+++ b/spec/bundler/ruby_version_spec.rb
@@ -2,7 +2,7 @@
 require "spec_helper"
 require "bundler/ruby_version"
 
-describe "Bundler::RubyVersion and its subclasses" do
+RSpec.describe "Bundler::RubyVersion and its subclasses" do
   let(:version)              { "2.0.0" }
   let(:patchlevel)           { "645" }
   let(:engine)               { "jruby" }

--- a/spec/bundler/rubygems_integration_spec.rb
+++ b/spec/bundler/rubygems_integration_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe Bundler::RubygemsIntegration do
+RSpec.describe Bundler::RubygemsIntegration do
   it "uses the same chdir lock as rubygems", :rubygems => "2.1" do
     expect(Bundler.rubygems.ext_lock).to eq(Gem::Ext::Builder::CHDIR_MONITOR)
   end

--- a/spec/bundler/settings_spec.rb
+++ b/spec/bundler/settings_spec.rb
@@ -2,7 +2,7 @@
 require "spec_helper"
 require "bundler/settings"
 
-describe Bundler::Settings do
+RSpec.describe Bundler::Settings do
   subject(:settings) { described_class.new(bundled_app) }
 
   describe "#set_local" do

--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe Bundler::SharedHelpers do
+RSpec.describe Bundler::SharedHelpers do
   let(:ext_lock_double) { double(:ext_lock) }
 
   before do

--- a/spec/bundler/source/git/git_proxy_spec.rb
+++ b/spec/bundler/source/git/git_proxy_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe Bundler::Source::Git::GitProxy do
+RSpec.describe Bundler::Source::Git::GitProxy do
   let(:uri) { "https://github.com/bundler/bundler.git" }
   subject { described_class.new(Pathname("path"), uri, "HEAD") }
 

--- a/spec/bundler/source/rubygems/remote_spec.rb
+++ b/spec/bundler/source/rubygems/remote_spec.rb
@@ -2,7 +2,7 @@
 require "spec_helper"
 require "bundler/source/rubygems/remote"
 
-describe Bundler::Source::Rubygems::Remote do
+RSpec.describe Bundler::Source::Rubygems::Remote do
   def remote(uri)
     Bundler::Source::Rubygems::Remote.new(uri)
   end

--- a/spec/bundler/source/rubygems_spec.rb
+++ b/spec/bundler/source/rubygems_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe Bundler::Source::Rubygems do
+RSpec.describe Bundler::Source::Rubygems do
   before do
     allow(Bundler).to receive(:root) { Pathname.new("root") }
   end

--- a/spec/bundler/source_list_spec.rb
+++ b/spec/bundler/source_list_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe Bundler::SourceList do
+RSpec.describe Bundler::SourceList do
   before do
     allow(Bundler).to receive(:root) { Pathname.new "./tmp/bundled_app" }
 

--- a/spec/bundler/source_spec.rb
+++ b/spec/bundler/source_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe Bundler::Source do
+RSpec.describe Bundler::Source do
   class ExampleSource < Bundler::Source
   end
 

--- a/spec/bundler/spec_set_spec.rb
+++ b/spec/bundler/spec_set_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe Bundler::SpecSet do
+RSpec.describe Bundler::SpecSet do
   let(:specs) do
     [
       build_spec("a", "1.0"),

--- a/spec/bundler/ssl_certs/certificate_manager_spec.rb
+++ b/spec/bundler/ssl_certs/certificate_manager_spec.rb
@@ -2,7 +2,7 @@
 require "spec_helper"
 require "bundler/ssl_certs/certificate_manager"
 
-describe Bundler::SSLCerts::CertificateManager do
+RSpec.describe Bundler::SSLCerts::CertificateManager do
   let(:rubygems_path)      { root }
   let(:stub_cert)          { File.join(root.to_s, "lib", "rubygems", "ssl_certs", "rubygems.org", "ssl-cert.pem") }
   let(:rubygems_certs_dir) { File.join(root.to_s, "lib", "rubygems", "ssl_certs", "rubygems.org") }

--- a/spec/bundler/uri_credentials_filter_spec.rb
+++ b/spec/bundler/uri_credentials_filter_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe Bundler::URICredentialsFilter do
+RSpec.describe Bundler::URICredentialsFilter do
   subject { described_class }
 
   describe "#credential_filtered_uri" do

--- a/spec/bundler/worker_spec.rb
+++ b/spec/bundler/worker_spec.rb
@@ -2,7 +2,7 @@
 require "spec_helper"
 require "bundler/worker"
 
-describe Bundler::Worker do
+RSpec.describe Bundler::Worker do
   let(:size) { 5 }
   let(:name) { "Spec Worker" }
   let(:function) { proc {|object, worker_number| [object, worker_number] } }

--- a/spec/bundler/yaml_serializer_spec.rb
+++ b/spec/bundler/yaml_serializer_spec.rb
@@ -2,7 +2,7 @@
 require "spec_helper"
 require "bundler/yaml_serializer"
 
-describe Bundler::YAMLSerializer do
+RSpec.describe Bundler::YAMLSerializer do
   subject(:serializer) { Bundler::YAMLSerializer }
 
   describe "#dump" do

--- a/spec/cache/cache_path_spec.rb
+++ b/spec/cache/cache_path_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle package" do
+RSpec.describe "bundle package" do
   before do
     gemfile <<-G
       source "file://#{gem_repo1}"

--- a/spec/cache/gems_spec.rb
+++ b/spec/cache/gems_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle cache" do
+RSpec.describe "bundle cache" do
   describe "when there are only gemsources" do
     before :each do
       gemfile <<-G

--- a/spec/cache/git_spec.rb
+++ b/spec/cache/git_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "git base name" do
+RSpec.describe "git base name" do
   it "base_name should strip private repo uris" do
     source = Bundler::Source::Git.new("uri" => "git@github.com:bundler.git")
     expect(source.send(:base_name)).to eq("bundler")
@@ -14,7 +14,7 @@ describe "git base name" do
 end
 
 %w(cache package).each do |cmd|
-  describe "bundle #{cmd} with git" do
+  RSpec.describe "bundle #{cmd} with git" do
     it "copies repository to vendor cache and uses it" do
       git = build_git "foo"
       ref = git.ref_for("master", 11)

--- a/spec/cache/path_spec.rb
+++ b/spec/cache/path_spec.rb
@@ -2,7 +2,7 @@
 require "spec_helper"
 
 %w(cache package).each do |cmd|
-  describe "bundle #{cmd} with path" do
+  RSpec.describe "bundle #{cmd} with path" do
     it "is no-op when the path is within the bundle" do
       build_lib "foo", :path => bundled_app("lib/foo")
 

--- a/spec/cache/platform_spec.rb
+++ b/spec/cache/platform_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle cache with multiple platforms" do
+RSpec.describe "bundle cache with multiple platforms" do
   before :each do
     gemfile <<-G
       source "file://#{gem_repo1}"

--- a/spec/commands/binstubs_spec.rb
+++ b/spec/commands/binstubs_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle binstubs <gem>" do
+RSpec.describe "bundle binstubs <gem>" do
   context "when the gem exists in the lockfile" do
     it "sets up the binstub" do
       install_gemfile <<-G

--- a/spec/commands/check_spec.rb
+++ b/spec/commands/check_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle check" do
+RSpec.describe "bundle check" do
   it "returns success when the Gemfile is satisfied" do
     install_gemfile <<-G
       source "file://#{gem_repo1}"

--- a/spec/commands/clean_spec.rb
+++ b/spec/commands/clean_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle clean" do
+RSpec.describe "bundle clean" do
   def should_have_gems(*gems)
     gems.each do |g|
       expect(vendored_gems("gems/#{g}")).to exist

--- a/spec/commands/config_spec.rb
+++ b/spec/commands/config_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe ".bundle/config" do
+RSpec.describe ".bundle/config" do
   before :each do
     gemfile <<-G
       source "file://#{gem_repo1}"
@@ -276,7 +276,7 @@ E
   end
 end
 
-describe "setting gemfile via config" do
+RSpec.describe "setting gemfile via config" do
   context "when only the non-default Gemfile exists" do
     it "persists the gemfile location to .bundle/config" do
       File.open(bundled_app("NotGemfile"), "w") do |f|

--- a/spec/commands/console_spec.rb
+++ b/spec/commands/console_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle console" do
+RSpec.describe "bundle console" do
   before :each do
     install_gemfile <<-G
       source "file://#{gem_repo1}"

--- a/spec/commands/doctor_spec.rb
+++ b/spec/commands/doctor_spec.rb
@@ -4,7 +4,7 @@ require "stringio"
 require "bundler/cli"
 require "bundler/cli/doctor"
 
-describe "bundle doctor" do
+RSpec.describe "bundle doctor" do
   before(:each) do
     @stdout = StringIO.new
 

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle exec" do
+RSpec.describe "bundle exec" do
   let(:system_gems_to_install) { %w(rack-1.0.0 rack-0.9.1) }
   before :each do
     system_gems(system_gems_to_install)

--- a/spec/commands/help_spec.rb
+++ b/spec/commands/help_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle help" do
+RSpec.describe "bundle help" do
   # Rubygems 1.4+ no longer load gem plugins so this test is no longer needed
   rubygems_under_14 = Gem::Requirement.new("< 1.4").satisfied_by?(Gem::Version.new(Gem::VERSION))
   it "complains if older versions of bundler are installed", :if => rubygems_under_14 do

--- a/spec/commands/init_spec.rb
+++ b/spec/commands/init_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle init" do
+RSpec.describe "bundle init" do
   it "generates a Gemfile" do
     bundle :init
     expect(bundled_app("Gemfile")).to exist

--- a/spec/commands/inject_spec.rb
+++ b/spec/commands/inject_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle inject" do
+RSpec.describe "bundle inject" do
   before :each do
     gemfile <<-G
       source "file://#{gem_repo1}"

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle install with gem sources" do
+RSpec.describe "bundle install with gem sources" do
   describe "the simple case" do
     it "prints output and returns if no dependencies are specified" do
       gemfile <<-G

--- a/spec/commands/licenses_spec.rb
+++ b/spec/commands/licenses_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle licenses" do
+RSpec.describe "bundle licenses" do
   before :each do
     install_gemfile <<-G
       source "file://#{gem_repo1}"

--- a/spec/commands/lock_spec.rb
+++ b/spec/commands/lock_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle lock" do
+RSpec.describe "bundle lock" do
   def strip_lockfile(lockfile)
     strip_whitespace(lockfile).sub(/\n\Z/, "")
   end

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle gem" do
+RSpec.describe "bundle gem" do
   def reset!
     super
     global_config "BUNDLE_GEM__MIT" => "false", "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__COC" => "false"

--- a/spec/commands/open_spec.rb
+++ b/spec/commands/open_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle open" do
+RSpec.describe "bundle open" do
   before :each do
     install_gemfile <<-G
       source "file://#{gem_repo1}"

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle outdated" do
+RSpec.describe "bundle outdated" do
   before :each do
     build_repo2 do
       build_git "foo", :path => lib_path("foo")

--- a/spec/commands/package_spec.rb
+++ b/spec/commands/package_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle package" do
+RSpec.describe "bundle package" do
   context "with --gemfile" do
     it "finds the gemfile" do
       gemfile bundled_app("NotGemfile"), <<-G
@@ -222,7 +222,7 @@ describe "bundle package" do
   end
 end
 
-describe "bundle install with gem sources" do
+RSpec.describe "bundle install with gem sources" do
   describe "when cached and locked" do
     it "does not hit the remote at all" do
       build_repo2

--- a/spec/commands/show_spec.rb
+++ b/spec/commands/show_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle show" do
+RSpec.describe "bundle show" do
   context "with a standard Gemfile" do
     before :each do
       install_gemfile <<-G

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle update" do
+RSpec.describe "bundle update" do
   before :each do
     build_repo2
 
@@ -254,7 +254,7 @@ describe "bundle update" do
   end
 end
 
-describe "bundle update in more complicated situations" do
+RSpec.describe "bundle update in more complicated situations" do
   before :each do
     build_repo2
   end
@@ -295,7 +295,7 @@ describe "bundle update in more complicated situations" do
   end
 end
 
-describe "bundle update without a Gemfile.lock" do
+RSpec.describe "bundle update without a Gemfile.lock" do
   it "should not explode" do
     build_repo2
 
@@ -311,7 +311,7 @@ describe "bundle update without a Gemfile.lock" do
   end
 end
 
-describe "bundle update when a gem depends on a newer version of bundler" do
+RSpec.describe "bundle update when a gem depends on a newer version of bundler" do
   before(:each) do
     build_repo2 do
       build_gem "rails", "3.0.1" do |s|
@@ -338,7 +338,7 @@ describe "bundle update when a gem depends on a newer version of bundler" do
   end
 end
 
-describe "bundle update" do
+RSpec.describe "bundle update" do
   it "shows the previous version of the gem when updated from rubygems source" do
     build_repo2
 
@@ -370,7 +370,7 @@ describe "bundle update" do
   end
 end
 
-describe "bundle update --ruby" do
+RSpec.describe "bundle update --ruby" do
   before do
     install_gemfile <<-G
         ::RUBY_VERSION = '2.1.3'
@@ -480,7 +480,7 @@ describe "bundle update --ruby" do
 end
 
 # these specs are slow and focus on integration and therefore are not exhaustive. unit specs elsewhere handle that.
-describe "bundle update conservative" do
+RSpec.describe "bundle update conservative" do
   context "patch and minor options" do
     before do
       build_repo4 do

--- a/spec/commands/viz_spec.rb
+++ b/spec/commands/viz_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle viz", :ruby => "1.9.3", :if => Bundler.which("dot") do
+RSpec.describe "bundle viz", :ruby => "1.9.3", :if => Bundler.which("dot") do
   let(:graphviz_lib) do
     graphviz_glob = base_system_gems.join("gems/ruby-graphviz*/lib")
     Dir[graphviz_glob].first

--- a/spec/install/allow_offline_install_spec.rb
+++ b/spec/install/allow_offline_install_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle install with :allow_offline_install" do
+RSpec.describe "bundle install with :allow_offline_install" do
   before do
     bundle "config allow_offline_install true"
   end

--- a/spec/install/binstubs_spec.rb
+++ b/spec/install/binstubs_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle install" do
+RSpec.describe "bundle install" do
   describe "when system_bindir is set" do
     # On OS X, Gem.bindir defaults to /usr/bin, so system_bindir is useful if
     # you want to avoid sudo installs for system gems with OS X's default ruby

--- a/spec/install/bundler_spec.rb
+++ b/spec/install/bundler_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle install" do
+RSpec.describe "bundle install" do
   describe "with bundler dependencies" do
     before(:each) do
       build_repo2 do

--- a/spec/install/deploy_spec.rb
+++ b/spec/install/deploy_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "install with --deployment or --frozen" do
+RSpec.describe "install with --deployment or --frozen" do
   before do
     gemfile <<-G
       source "file://#{gem_repo1}"

--- a/spec/install/force_spec.rb
+++ b/spec/install/force_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle install" do
+RSpec.describe "bundle install" do
   describe "with --force" do
     before :each do
       gemfile <<-G

--- a/spec/install/gemfile/eval_gemfile_spec.rb
+++ b/spec/install/gemfile/eval_gemfile_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle install with gemfile that uses eval_gemfile" do
+RSpec.describe "bundle install with gemfile that uses eval_gemfile" do
   before do
     build_lib("gunks", :path => bundled_app.join("gems/gunks")) do |s|
       s.name    = "gunks"

--- a/spec/install/gemfile/gemspec_spec.rb
+++ b/spec/install/gemfile/gemspec_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle install from an existing gemspec" do
+RSpec.describe "bundle install from an existing gemspec" do
   before(:each) do
     build_gem "bar", :to_system => true
     build_gem "bar-dev", :to_system => true

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle install with git sources" do
+RSpec.describe "bundle install with git sources" do
   describe "when floating on master" do
     before :each do
       build_git "foo" do |s|

--- a/spec/install/gemfile/groups_spec.rb
+++ b/spec/install/gemfile/groups_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle install with groups" do
+RSpec.describe "bundle install with groups" do
   describe "installing with no options" do
     before :each do
       install_gemfile <<-G

--- a/spec/install/gemfile/path_spec.rb
+++ b/spec/install/gemfile/path_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle install with explicit source paths" do
+RSpec.describe "bundle install with explicit source paths" do
   it "fetches gems" do
     build_lib "foo"
 

--- a/spec/install/gemfile/platform_spec.rb
+++ b/spec/install/gemfile/platform_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle install across platforms" do
+RSpec.describe "bundle install across platforms" do
   it "maintains the same lockfile if all gems are compatible across platforms" do
     lockfile <<-G
       GEM
@@ -105,7 +105,7 @@ describe "bundle install across platforms" do
   end
 end
 
-describe "bundle install with platform conditionals" do
+RSpec.describe "bundle install with platform conditionals" do
   it "installs gems tagged w/ the current platforms" do
     install_gemfile <<-G
       source "file://#{gem_repo1}"
@@ -223,7 +223,7 @@ The dependency #{Gem::Dependency.new("rack", ">= 0")} will be unused by any of t
   end
 end
 
-describe "when a gem has no architecture" do
+RSpec.describe "when a gem has no architecture" do
   it "still installs correctly" do
     simulate_platform mswin
 

--- a/spec/install/gemfile/ruby_spec.rb
+++ b/spec/install/gemfile/ruby_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "ruby requirement" do
+RSpec.describe "ruby requirement" do
   def locked_ruby_version
     Bundler::RubyVersion.from_string(Bundler::LockfileParser.new(lockfile).ruby_version)
   end

--- a/spec/install/gemfile/sources_spec.rb
+++ b/spec/install/gemfile/sources_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle install with gems on multiple sources" do
+RSpec.describe "bundle install with gems on multiple sources" do
   # repo1 is built automatically before all of the specs run
   # it contains rack-obama 1.0.0 and rack 0.9.1 & 1.0.0 amongst other gems
 

--- a/spec/install/gemfile/specific_platform_spec.rb
+++ b/spec/install/gemfile/specific_platform_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle install with specific_platform enabled" do
+RSpec.describe "bundle install with specific_platform enabled" do
   before do
     bundle "config specific_platform true"
 

--- a/spec/install/gemfile_spec.rb
+++ b/spec/install/gemfile_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle install" do
+RSpec.describe "bundle install" do
   context "with duplicated gems" do
     it "will display a warning" do
       install_gemfile <<-G

--- a/spec/install/gems/compact_index_spec.rb
+++ b/spec/install/gems/compact_index_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "compact index api" do
+RSpec.describe "compact index api" do
   let(:source_hostname) { "localgemserver.test" }
   let(:source_uri) { "http://#{source_hostname}" }
 

--- a/spec/install/gems/dependency_api_spec.rb
+++ b/spec/install/gems/dependency_api_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "gemcutter's dependency API" do
+RSpec.describe "gemcutter's dependency API" do
   let(:source_hostname) { "localgemserver.test" }
   let(:source_uri) { "http://#{source_hostname}" }
 

--- a/spec/install/gems/env_spec.rb
+++ b/spec/install/gems/env_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle install with ENV conditionals" do
+RSpec.describe "bundle install with ENV conditionals" do
   describe "when just setting an ENV key as a string" do
     before :each do
       gemfile <<-G

--- a/spec/install/gems/flex_spec.rb
+++ b/spec/install/gems/flex_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle flex_install" do
+RSpec.describe "bundle flex_install" do
   it "installs the gems as expected" do
     install_gemfile <<-G
       source "file://#{gem_repo1}"

--- a/spec/install/gems/mirror_spec.rb
+++ b/spec/install/gems/mirror_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle install with a mirror configured" do
+RSpec.describe "bundle install with a mirror configured" do
   describe "when the mirror does not match the gem source" do
     before :each do
       gemfile <<-G

--- a/spec/install/gems/native_extensions_spec.rb
+++ b/spec/install/gems/native_extensions_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "installing a gem with native extensions" do
+RSpec.describe "installing a gem with native extensions" do
   it "installs" do
     build_repo2 do
       build_gem "c_extension" do |s|

--- a/spec/install/gems/post_install_spec.rb
+++ b/spec/install/gems/post_install_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle install" do
+RSpec.describe "bundle install" do
   context "with gem sources" do
     context "when gems include post install messages" do
       it "should display the post-install messages after installing" do

--- a/spec/install/gems/resolving_spec.rb
+++ b/spec/install/gems/resolving_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle install with install-time dependencies" do
+RSpec.describe "bundle install with install-time dependencies" do
   it "installs gems with implicit rake dependencies" do
     install_gemfile <<-G
       source "file://#{gem_repo1}"

--- a/spec/install/gems/standalone_spec.rb
+++ b/spec/install/gems/standalone_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-shared_examples "bundle install --standalone" do
+RSpec.shared_examples "bundle install --standalone" do
   shared_examples "common functionality" do
     it "still makes the gems available to normal bundler" do
       args = expected_gems.map {|k, v| "#{k} #{v}" }
@@ -303,11 +303,11 @@ shared_examples "bundle install --standalone" do
   end
 end
 
-describe "bundle install --standalone" do
+RSpec.describe "bundle install --standalone" do
   include_examples("bundle install --standalone")
 end
 
-describe "bundle install --standalone run in a subdirectory" do
+RSpec.describe "bundle install --standalone run in a subdirectory" do
   before do
     subdir = bundled_app("bob")
     FileUtils.mkdir_p(subdir)

--- a/spec/install/gems/sudo_spec.rb
+++ b/spec/install/gems/sudo_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "when using sudo", :sudo => true do
+RSpec.describe "when using sudo", :sudo => true do
   describe "and BUNDLE_PATH is writable" do
     context "but BUNDLE_PATH/build_info is not writable" do
       before do

--- a/spec/install/gems/win32_spec.rb
+++ b/spec/install/gems/win32_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle install with win32-generated lockfile" do
+RSpec.describe "bundle install with win32-generated lockfile" do
   it "should read lockfile" do
     File.open(bundled_app("Gemfile.lock"), "wb") do |f|
       f << "GEM\r\n"

--- a/spec/install/gemspecs_spec.rb
+++ b/spec/install/gemspecs_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle install" do
+RSpec.describe "bundle install" do
   describe "when a gem has a YAML gemspec" do
     before :each do
       build_repo2 do

--- a/spec/install/git_spec.rb
+++ b/spec/install/git_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle install" do
+RSpec.describe "bundle install" do
   context "git sources" do
     it "displays the revision hash of the gem repository" do
       build_git "foo", "1.0", :path => lib_path("foo")

--- a/spec/install/path_spec.rb
+++ b/spec/install/path_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle install" do
+RSpec.describe "bundle install" do
   describe "with --path" do
     before :each do
       build_gem "rack", "1.0.0", :to_system => true do |s|

--- a/spec/install/post_bundle_message_spec.rb
+++ b/spec/install/post_bundle_message_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "post bundle message" do
+RSpec.describe "post bundle message" do
   before :each do
     gemfile <<-G
       source "file://#{gem_repo1}"

--- a/spec/install/prereleases_spec.rb
+++ b/spec/install/prereleases_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle install" do
+RSpec.describe "bundle install" do
   describe "when prerelease gems are available" do
     it "finds prereleases" do
       install_gemfile <<-G

--- a/spec/install/security_policy_spec.rb
+++ b/spec/install/security_policy_spec.rb
@@ -5,7 +5,7 @@ require "rubygems/security"
 # unfortunately, testing signed gems with a provided CA is extremely difficult
 # as 'gem cert' is currently the only way to add CAs to the system.
 
-describe "policies with unsigned gems" do
+RSpec.describe "policies with unsigned gems" do
   before do
     build_security_repo
     gemfile <<-G
@@ -44,7 +44,7 @@ describe "policies with unsigned gems" do
   end
 end
 
-describe "policies with signed gems and no CA" do
+RSpec.describe "policies with signed gems and no CA" do
   before do
     build_security_repo
     gemfile <<-G

--- a/spec/install/yanked_spec.rb
+++ b/spec/install/yanked_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-context "when installing a bundle that includes yanked gems" do
+RSpec.context "when installing a bundle that includes yanked gems" do
   before(:each) do
     build_repo4 do
       build_gem "foo", "9.0.0"
@@ -42,7 +42,7 @@ context "when installing a bundle that includes yanked gems" do
   end
 end
 
-context "when using gem before installing" do
+RSpec.context "when using gem before installing" do
   it "does not suggest the author has yanked the gem" do
     gemfile <<-G
         source "file://#{gem_repo1}"

--- a/spec/lock/git_spec.rb
+++ b/spec/lock/git_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle lock with git gems" do
+RSpec.describe "bundle lock with git gems" do
   before :each do
     build_git "foo"
 

--- a/spec/lock/lockfile_spec.rb
+++ b/spec/lock/lockfile_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "the lockfile format" do
+RSpec.describe "the lockfile format" do
   include Bundler::GemHelpers
 
   it "generates a simple lockfile for a single source, gem" do

--- a/spec/other/bundle_ruby_spec.rb
+++ b/spec/other/bundle_ruby_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle_ruby" do
+RSpec.describe "bundle_ruby" do
   context "without patchlevel" do
     it "returns the ruby version" do
       gemfile <<-G

--- a/spec/other/cli_dispatch_spec.rb
+++ b/spec/other/cli_dispatch_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle command names" do
+RSpec.describe "bundle command names" do
   it "work when given fully" do
     bundle "install"
     expect(err).to lack_errors

--- a/spec/other/ext_spec.rb
+++ b/spec/other/ext_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "Gem::Specification#match_platform" do
+RSpec.describe "Gem::Specification#match_platform" do
   it "does not match platforms other than the gem platform" do
     darwin = gem "lol", "1.0", "platform_specific-1.0-x86-darwin-10"
     expect(darwin.match_platform(pl("java"))).to eq(false)
@@ -16,7 +16,7 @@ describe "Gem::Specification#match_platform" do
   end
 end
 
-describe "Bundler::GemHelpers#generic" do
+RSpec.describe "Bundler::GemHelpers#generic" do
   include Bundler::GemHelpers
 
   it "converts non-windows platforms into ruby" do
@@ -47,7 +47,7 @@ describe "Bundler::GemHelpers#generic" do
   end
 end
 
-describe "Gem::SourceIndex#refresh!" do
+RSpec.describe "Gem::SourceIndex#refresh!" do
   rubygems_1_7 = Gem::Version.new(Gem::VERSION) >= Gem::Version.new("1.7.0")
 
   before do

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "major deprecations" do
+RSpec.describe "major deprecations" do
   let(:warnings) { out } # change to err in 2.0
 
   context "in a .99 version" do

--- a/spec/other/platform_spec.rb
+++ b/spec/other/platform_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle platform" do
+RSpec.describe "bundle platform" do
   context "without flags" do
     it "returns all the output" do
       gemfile <<-G

--- a/spec/other/ssl_cert_spec.rb
+++ b/spec/other/ssl_cert_spec.rb
@@ -2,7 +2,7 @@
 require "spec_helper"
 require "bundler/ssl_certs/certificate_manager"
 
-describe "SSL Certificates", :rubygems_master do
+RSpec.describe "SSL Certificates", :rubygems_master do
   hosts = %w(
     rubygems.org
     index.rubygems.org

--- a/spec/other/trampoline_spec.rb
+++ b/spec/other/trampoline_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundler version trampolining" do
+RSpec.describe "bundler version trampolining" do
   before do
     ENV["BUNDLE_TRAMPOLINE_DISABLE"] = nil
     ENV["BUNDLE_TRAMPOLINE_FORCE"] = "true"

--- a/spec/plugins/command_spec.rb
+++ b/spec/plugins/command_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "command plugins" do
+RSpec.describe "command plugins" do
   before do
     build_repo2 do
       build_plugin "command-mah" do |s|

--- a/spec/plugins/hook_spec.rb
+++ b/spec/plugins/hook_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "hook plugins" do
+RSpec.describe "hook plugins" do
   before do
     build_repo2 do
       build_plugin "before-install-plugin" do |s|

--- a/spec/plugins/install_spec.rb
+++ b/spec/plugins/install_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundler plugin install" do
+RSpec.describe "bundler plugin install" do
   before do
     build_repo2 do
       build_plugin "foo"

--- a/spec/plugins/source/example_spec.rb
+++ b/spec/plugins/source/example_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "real source plugins" do
+RSpec.describe "real source plugins" do
   context "with a minimal source plugin" do
     before do
       build_repo2 do

--- a/spec/plugins/source_spec.rb
+++ b/spec/plugins/source_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundler source plugin" do
+RSpec.describe "bundler source plugin" do
   describe "plugins dsl eval for #source with :type option" do
     before do
       update_repo2 do

--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -6,7 +6,7 @@ if defined?(Encoding) && Encoding.default_external.name != "UTF-8"
   Encoding.default_external = Encoding.find("UTF-8")
 end
 
-describe "The library itself" do
+RSpec.describe "The library itself" do
   def check_for_spec_defs_with_single_quotes(filename)
     failing_lines = []
 

--- a/spec/realworld/dependency_api_spec.rb
+++ b/spec/realworld/dependency_api_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "gemcutter's dependency API", :realworld => true do
+RSpec.describe "gemcutter's dependency API", :realworld => true do
   context "when Gemcutter API takes too long to respond" do
     before do
       require_rack

--- a/spec/realworld/edgecases_spec.rb
+++ b/spec/realworld/edgecases_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "real world edgecases", :realworld => true, :sometimes => true do
+RSpec.describe "real world edgecases", :realworld => true, :sometimes => true do
   def rubygems_version(name, requirement)
     require "bundler/source/rubygems/remote"
     require "bundler/fetcher"

--- a/spec/realworld/gemfile_source_header_spec.rb
+++ b/spec/realworld/gemfile_source_header_spec.rb
@@ -2,7 +2,7 @@
 require "spec_helper"
 require "thread"
 
-describe "fetching dependencies with a mirrored source", :realworld => true, :rubygems => ">= 2.0" do
+RSpec.describe "fetching dependencies with a mirrored source", :realworld => true, :rubygems => ">= 2.0" do
   let(:mirror) { "https://server.example.org" }
   let(:original) { "http://127.0.0.1:#{@port}" }
 

--- a/spec/realworld/mirror_probe_spec.rb
+++ b/spec/realworld/mirror_probe_spec.rb
@@ -2,7 +2,7 @@
 require "spec_helper"
 require "thread"
 
-describe "fetching dependencies with a not available mirror", :realworld => true do
+RSpec.describe "fetching dependencies with a not available mirror", :realworld => true do
   let(:mirror) { @mirror_uri }
   let(:original) { @server_uri }
   let(:server_port) { @server_port }

--- a/spec/realworld/parallel_spec.rb
+++ b/spec/realworld/parallel_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "parallel", :realworld => true, :sometimes => true do
+RSpec.describe "parallel", :realworld => true, :sometimes => true do
   it "installs" do
     gemfile <<-G
       source "https://rubygems.org"

--- a/spec/resolver/basic_spec.rb
+++ b/spec/resolver/basic_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "Resolving" do
+RSpec.describe "Resolving" do
   before :each do
     @index = an_awesome_index
   end

--- a/spec/resolver/platform_spec.rb
+++ b/spec/resolver/platform_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "Resolving platform craziness" do
+RSpec.describe "Resolving platform craziness" do
   describe "with cross-platform gems" do
     before :each do
       @index = an_awesome_index

--- a/spec/runtime/executable_spec.rb
+++ b/spec/runtime/executable_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "Running bin/* commands" do
+RSpec.describe "Running bin/* commands" do
   before :each do
     gemfile <<-G
       source "file://#{gem_repo1}"

--- a/spec/runtime/gem_tasks_spec.rb
+++ b/spec/runtime/gem_tasks_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "require 'bundler/gem_tasks'" do
+RSpec.describe "require 'bundler/gem_tasks'" do
   before :each do
     bundled_app("foo.gemspec").open("w") do |f|
       f.write <<-GEMSPEC

--- a/spec/runtime/inline_spec.rb
+++ b/spec/runtime/inline_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundler/inline#gemfile" do
+RSpec.describe "bundler/inline#gemfile" do
   def script(code, options = {})
     requires = ["bundler/inline"]
     requires.unshift File.expand_path("../../support/artifice/" + options.delete(:artifice) + ".rb", __FILE__) if options.key?(:artifice)

--- a/spec/runtime/load_spec.rb
+++ b/spec/runtime/load_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "Bundler.load" do
+RSpec.describe "Bundler.load" do
   before :each do
     system_gems "rack-1.0.0"
   end

--- a/spec/runtime/platform_spec.rb
+++ b/spec/runtime/platform_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "Bundler.setup with multi platform stuff" do
+RSpec.describe "Bundler.setup with multi platform stuff" do
   it "raises a friendly error when gems are missing locally" do
     gemfile <<-G
       source "file://#{gem_repo1}"

--- a/spec/runtime/require_spec.rb
+++ b/spec/runtime/require_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "Bundler.require" do
+RSpec.describe "Bundler.require" do
   before :each do
     build_lib "one", "1.0.0" do |s|
       s.write "lib/baz.rb", "puts 'baz'"
@@ -362,7 +362,7 @@ describe "Bundler.require" do
   end
 end
 
-describe "Bundler.require with platform specific dependencies" do
+RSpec.describe "Bundler.require with platform specific dependencies" do
   it "does not require the gems that are pinned to other platforms" do
     install_gemfile <<-G
       source "file://#{gem_repo1}"

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "Bundler.setup" do
+RSpec.describe "Bundler.setup" do
   describe "with no arguments" do
     it "makes all groups available" do
       install_gemfile <<-G

--- a/spec/runtime/with_clean_env_spec.rb
+++ b/spec/runtime/with_clean_env_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "Bundler.with_env helpers" do
+RSpec.describe "Bundler.with_env helpers" do
   describe "Bundler.original_env" do
     before do
       gemfile ""

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,6 +65,12 @@ RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
 
+  # Since failures cause us to keep a bunch of long strings in memory, stop
+  # once we have a large number of failures (indicative of core pieces of
+  # bundler being broken) so that running the full test suite doesn't take
+  # forever due to memory constraints
+  config.fail_fast ||= 25
+
   if ENV["BUNDLER_SUDO_TESTS"] && Spec::Sudo.present?
     config.filter_run :sudo => true
   else

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,6 +65,8 @@ RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
 
+  config.disable_monkey_patching!
+
   # Since failures cause us to keep a bunch of long strings in memory, stop
   # once we have a large number of failures (indicative of core pieces of
   # bundler being broken) so that running the full test suite doesn't take

--- a/spec/update/gems/post_install_spec.rb
+++ b/spec/update/gems/post_install_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle update" do
+RSpec.describe "bundle update" do
   let(:config) {}
 
   before do

--- a/spec/update/git_spec.rb
+++ b/spec/update/git_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle update" do
+RSpec.describe "bundle update" do
   describe "git sources" do
     it "floats on a branch when :branch is used" do
       build_git "foo", "1.0"

--- a/spec/update/path_spec.rb
+++ b/spec/update/path_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "path sources" do
+RSpec.describe "path sources" do
   describe "bundle update --source" do
     it "shows the previous version of the gem when updated from path source" do
       build_lib "activesupport", "2.3.5", :path => lib_path("rails/activesupport")


### PR DESCRIPTION
- Fail fast when there are a bunch of failures. Especially since holding all of the failure output in memory makes the tests hella slow
- Disable RSpec monkey patching
- Disable the same by default when generating new gems