### PR TITLE
[SandaloneInstaller] Warn if different ruby used

### DIFF
--- a/lib/bundler/installer/standalone.rb
+++ b/lib/bundler/installer/standalone.rb
@@ -14,6 +14,11 @@ module Bundler
         file.puts "# ruby 1.8.7 doesn't define RUBY_ENGINE"
         file.puts "ruby_engine = defined?(RUBY_ENGINE) ? RUBY_ENGINE : 'ruby'"
         file.puts "ruby_version = RbConfig::CONFIG[\"ruby_version\"]"
+        file.puts %(install_ruby_version = "#{RbConfig::CONFIG["ruby_version"]}")
+        file.puts "if ruby_version != install_ruby_version"
+        file.puts %(  puts "WARNING: \#{__FILE__} was generated with ruby \#{install_ruby_version} and you are using \#{ruby_version}")
+        file.puts %(  puts "WARNING: Some gems may not load properly.")
+        file.puts "end"
         file.puts "path = File.expand_path('..', __FILE__)"
         paths.each do |path|
           file.puts %($:.unshift "\#{path}/#{path}")


### PR DESCRIPTION
The goal is to avoid confusion when user is running
`bundle/bundler/setup.rb` with a different `ruby_version` than the one
used to install gems.

I just did a rough patch. I would like to discuss to get something cleaner since:

* the `setup.rb` file is currently version agnostic, maybe some users are installing gems with different ruby versions in `bundle/ruby/` so that their app can run with multiple ruby versions?
* a warning in the output might not be the cleanest solution, failure is a possibility.
* we could also test for the existence of directoris for all the paths in `setup.rb`, I am afraid that this might cause issues or unnecessary warnings.