### PR TITLE
[SharedHelpers] Use block.call instead of yield to avoid a stack cons…

### DIFF
--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -102,8 +102,10 @@ module Bundler
     #   end
     #
     # @see {Bundler::PermissionError}
-    def filesystem_access(path, action = :write)
-      yield path.dup.untaint
+    def filesystem_access(path, action = :write, &block)
+      # Use block.call instead of yield because of a bug in Ruby 2.2.2
+      # See https://github.com/bundler/bundler/issues/5341 for details
+      block.call(path.dup.untaint)
     rescue Errno::EACCES
       raise PermissionError.new(path, action)
     rescue Errno::EAGAIN


### PR DESCRIPTION
…istency error on Ruby 2.2.2

Using `yield` would cause a crash in the ruby VM due to calls sharing state
and leading to a count mismatch. Using block.call avoids that issue

Fixes https://github.com/bundler/bundler/issues/5341
Manually tested on Ruby 2.2.2 and 2.2.3, since they're not in the test matrix (only the latest 2.2.x is)