### PR TITLE
[Definition] Converge sources before anything else

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -636,6 +636,9 @@ module Bundler
       @locked_specs.each do |spec|
         spec.source &&= converge_path_source_to_gemspec_source(spec.source)
       end
+      @locked_deps.each do |dep|
+        dep.source &&= converge_path_source_to_gemspec_source(dep.source)
+      end
 
       # Get the Rubygems sources from the Gemfile.lock
       locked_gem_sources = @locked_sources.select {|s| s.is_a?(Source::Rubygems) }

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -104,8 +104,9 @@ module Bundler
 
       add_current_platform unless Bundler.settings[:frozen]
 
-      @source_changes = converge_sources
+      converge_gemspec_sources
       @path_changes = converge_paths
+      @source_changes = converge_sources
 
       unless @unlock[:lock_shared_dependencies]
         eager_unlock = expand_dependencies(@unlock[:gems])
@@ -627,9 +628,7 @@ module Bundler
       gemspec_source || source
     end
 
-    def converge_sources
-      changes = false
-
+    def converge_gemspec_sources
       @locked_sources.map! do |source|
         converge_path_source_to_gemspec_source(source)
       end
@@ -639,6 +638,10 @@ module Bundler
       @locked_deps.each do |dep|
         dep.source &&= converge_path_source_to_gemspec_source(dep.source)
       end
+    end
+
+    def converge_sources
+      changes = false
 
       # Get the Rubygems sources from the Gemfile.lock
       locked_gem_sources = @locked_sources.select {|s| s.is_a?(Source::Rubygems) }

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -104,6 +104,7 @@ module Bundler
 
       add_current_platform unless Bundler.settings[:frozen]
 
+      @source_changes = converge_sources
       @path_changes = converge_paths
 
       unless @unlock[:lock_shared_dependencies]
@@ -113,7 +114,6 @@ module Bundler
 
       @gem_version_promoter = create_gem_version_promoter
 
-      @source_changes = converge_sources
       @dependency_changes = converge_dependencies
       @local_changes = converge_locals
 

--- a/lib/bundler/installer/parallel_installer.rb
+++ b/lib/bundler/installer/parallel_installer.rb
@@ -67,6 +67,10 @@ module Bundler
       def all_dependencies
         @spec.dependencies
       end
+
+      def to_s
+        "#<#{self.class} #{@spec.full_name} (#{state})>"
+      end
     end
 
     def self.call(*args)

--- a/spec/install/deploy_spec.rb
+++ b/spec/install/deploy_spec.rb
@@ -267,22 +267,21 @@ RSpec.describe "install with --deployment or --frozen" do
   context "with path in Gemfile and packed" do
     it "works fine after bundle package and bundle install --local" do
       build_lib "foo", :path => lib_path("foo")
-      install_gemfile <<-G
-      gem "foo", :path => "#{lib_path("foo")}"
+      install_gemfile! <<-G
+        gem "foo", :path => "#{lib_path("foo")}"
       G
 
-      bundle :install
+      bundle! :install
       expect(the_bundle).to include_gems "foo 1.0"
-      bundle "package --all"
+      bundle! "package --all"
       expect(bundled_app("vendor/cache/foo")).to be_directory
 
-      bundle "install --local"
+      bundle! "install --local"
       expect(out).to include("Using foo 1.0 from source at")
       expect(out).to include("vendor/cache/foo")
-      expect(exitstatus).to eq(0) if exitstatus
 
       simulate_new_machine
-      bundle "install --deployment"
+      bundle! "install --deployment --verbose"
       expect(out).not_to include("You are trying to install in deployment mode after changing your Gemfile")
       expect(out).not_to include("You have added to the Gemfile")
       expect(out).not_to include("You have deleted from the Gemfile")

--- a/spec/install/gemfile/gemspec_spec.rb
+++ b/spec/install/gemfile/gemspec_spec.rb
@@ -131,6 +131,20 @@ RSpec.describe "bundle install from an existing gemspec" do
     end
   end
 
+  it "should match a lockfile without needing to re-resolve" do
+    build_lib("foo", :path => tmp.join("foo")) do |s|
+      s.add_dependency "rack"
+    end
+
+    install_gemfile! <<-G
+      source "file://#{gem_repo1}"
+      gemspec :path => '#{tmp.join("foo")}'
+    G
+
+    bundle! "install", :verbose => true
+    expect(out).to include("Found no changes, using resolution from the lockfile")
+  end
+
   it "should evaluate the gemspec in its directory" do
     build_lib("foo", :path => tmp.join("foo"))
     File.open(tmp.join("foo/foo.gemspec"), "w") do |s|


### PR DESCRIPTION
Fixes #5340 

Improves handling of gemspec sources by ensuring they're converged before anything else, and also converging the locked dependency sources so that `dependencies_for_source_changed?` doesn't get tripped up

- [x] test coverage