### PR TITLE
[CurrentRuby] Ensure the local platform isnt ruby before checking os/cpu

### DIFF
--- a/lib/bundler/current_ruby.rb
+++ b/lib/bundler/current_ruby.rb
@@ -58,15 +58,15 @@ module Bundler
     end
 
     def mswin64?
-      Bundler::WINDOWS && Bundler.local_platform.os == "mswin64" && Bundler.local_platform.cpu == "x64"
+      Bundler::WINDOWS && Bundler.local_platform != Gem::Platform::RUBY && Bundler.local_platform.os == "mswin64" && Bundler.local_platform.cpu == "x64"
     end
 
     def mingw?
-      Bundler::WINDOWS && Bundler.local_platform.os == "mingw32" && Bundler.local_platform.cpu != "x64"
+      Bundler::WINDOWS && Bundler.local_platform != Gem::Platform::RUBY && Bundler.local_platform.os == "mingw32" && Bundler.local_platform.cpu != "x64"
     end
 
     def x64_mingw?
-      Bundler::WINDOWS && Bundler.local_platform.os == "mingw32" && Bundler.local_platform.cpu == "x64"
+      Bundler::WINDOWS && Bundler.local_platform != Gem::Platform::RUBY && Bundler.local_platform.os == "mingw32" && Bundler.local_platform.cpu == "x64"
     end
 
     (KNOWN_MINOR_VERSIONS + KNOWN_MAJOR_VERSIONS).each do |version|

--- a/spec/runtime/platform_spec.rb
+++ b/spec/runtime/platform_spec.rb
@@ -104,4 +104,20 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
 
     expect(the_bundle).to include_gems "nokogiri 1.4.2", "platform_specific 1.0 RUBY"
   end
+
+  it "allows specifying only-ruby-platform on windows with dependency platforms" do
+    simulate_windows do
+      install_gemfile! <<-G
+        source "file://#{gem_repo1}"
+        gem "nokogiri", :platforms => [:mingw, :mswin, :x64_mingw, :jruby]
+        gem "platform_specific"
+      G
+
+      bundle! "config force_ruby_platform true"
+
+      bundle! "install"
+
+      expect(the_bundle).to include_gems "platform_specific 1.0 RUBY"
+    end
+  end
 end


### PR DESCRIPTION
Closes #5344 

fixes the problem since `Bundler.local_platform` can now be `"ruby"` on Windows, instead of a full-blown `Gem::Platform` object, when `force_ruby_platform` is set