### PR TITLE
[Definition] Avoid re-resolving when a gemspec has dev deps

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -691,7 +691,8 @@ module Bundler
           dep.platforms.concat(@platforms.map {|p| Dependency::REVERSE_PLATFORM_MAP[p] }.flatten(1)).uniq!
         end
       end
-      Set.new(@dependencies) != Set.new(@locked_deps)
+      dependency_without_type = proc {|d| Gem::Dependency.new(d.name, *d.requirement.as_list) }
+      Set.new(@dependencies.map(&dependency_without_type)) != Set.new(@locked_deps.map(&dependency_without_type))
     end
 
     # Remove elements from the locked specs that are expired. This will most

--- a/spec/install/gemfile/gemspec_spec.rb
+++ b/spec/install/gemfile/gemspec_spec.rb
@@ -145,6 +145,23 @@ RSpec.describe "bundle install from an existing gemspec" do
     expect(out).to include("Found no changes, using resolution from the lockfile")
   end
 
+  it "should match a lockfile without needing to re-resolve with development dependencies" do
+    simulate_platform java
+
+    build_lib("foo", :path => tmp.join("foo")) do |s|
+      s.add_dependency "rack"
+      s.add_development_dependency "thin"
+    end
+
+    install_gemfile! <<-G
+      source "file://#{gem_repo1}"
+      gemspec :path => '#{tmp.join("foo")}'
+    G
+
+    bundle! "install", :verbose => true
+    expect(out).to include("Found no changes, using resolution from the lockfile")
+  end
+
   it "should evaluate the gemspec in its directory" do
     build_lib("foo", :path => tmp.join("foo"))
     File.open(tmp.join("foo/foo.gemspec"), "w") do |s|


### PR DESCRIPTION
Inspired by #5349.

Since dev deps are added with `type: :development`, they are `!=` to the deps retrieved from the lockfile, which have no type. This compares the deps ignoring type completely