### PR TITLE
[Resolver] Restrict activated platforms to those in the Gemfile

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -249,7 +249,7 @@ module Bundler
         else
           # Run a resolve against the locally available gems
           Bundler.ui.debug("Found changes from the lockfile, re-resolving dependencies because #{change_reason}")
-          last_resolve.merge Resolver.resolve(expanded_dependencies, index, source_requirements, last_resolve, gem_version_promoter, additional_base_requirements_for_resolve)
+          last_resolve.merge Resolver.resolve(expanded_dependencies, index, source_requirements, last_resolve, gem_version_promoter, additional_base_requirements_for_resolve, platforms)
         end
       end
     end

--- a/spec/install/gemfile/gemspec_spec.rb
+++ b/spec/install/gemfile/gemspec_spec.rb
@@ -162,6 +162,24 @@ RSpec.describe "bundle install from an existing gemspec" do
     expect(out).to include("Found no changes, using resolution from the lockfile")
   end
 
+  it "should match a lockfile on non-ruby platforms with a transitive platform dependency" do
+    simulate_platform java
+    simulate_ruby_engine "jruby"
+
+    build_lib("foo", :path => tmp.join("foo")) do |s|
+      s.add_dependency "platform_specific"
+    end
+
+    install_gem "platform_specific-1.0-java"
+
+    install_gemfile! <<-G
+      gemspec :path => '#{tmp.join("foo")}'
+    G
+
+    bundle! "update --bundler", :verbose => true
+    expect(the_bundle).to include_gems "foo 1.0", "platform_specific 1.0 JAVA"
+  end
+
   it "should evaluate the gemspec in its directory" do
     build_lib("foo", :path => tmp.join("foo"))
     File.open(tmp.join("foo/foo.gemspec"), "w") do |s|


### PR DESCRIPTION
This ensures that deps that come from the lockfile, which might only have the "ruby" platform, dont cause us to attempt to activate/resolve all "ruby" platform gems

Closes #5349 