### PR TITLE
Permissive temporary home directory

### DIFF
--- a/spec/bundler/bundler_spec.rb
+++ b/spec/bundler/bundler_spec.rb
@@ -170,4 +170,43 @@ EOF
       end
     end
   end
+
+  describe "#user_home" do
+    context "home directory is set" do
+      it "should return the user home" do
+        path = "/home/oggy"
+        allow(Bundler.rubygems).to receive(:user_home).and_return(path)
+        allow(File).to receive(:directory?).with(path).and_return true
+        allow(File).to receive(:writable?).with(path).and_return true
+        expect(Bundler.user_home).to eq(Pathname(path))
+      end
+    end
+
+    context "home directory is not set" do
+      it "should issue warning and return a temporary user home" do
+        allow(Bundler.rubygems).to receive(:user_home).and_return(nil)
+        allow(Etc).to receive(:getlogin).and_return("USER")
+        allow(Dir).to receive(:tmpdir).and_return("/TMP")
+        allow(FileTest).to receive(:exist?).with("/TMP/bundler/home").and_return(true)
+        expect(FileUtils).to receive(:mkpath).with("/TMP/bundler/home/USER")
+        message = <<EOF
+Your home directory is not set.
+Bundler will use `/TMP/bundler/home/USER' as your home directory temporarily.
+EOF
+        expect(Bundler.ui).to receive(:warn).with(message)
+        expect(Bundler.user_home).to eq(Pathname("/TMP/bundler/home/USER"))
+      end
+    end
+  end
+
+  describe "#tmp_home_path" do
+    it "should create temporary user home" do
+      allow(Dir).to receive(:tmpdir).and_return("/TMP")
+      allow(FileTest).to receive(:exist?).with("/TMP/bundler/home").and_return(false)
+      expect(FileUtils).to receive(:mkpath).once.ordered.with("/TMP/bundler/home")
+      expect(FileUtils).to receive(:mkpath).once.ordered.with("/TMP/bundler/home/USER")
+      expect(File).to receive(:chmod).with(0o777, "/TMP/bundler/home")
+      expect(Bundler.tmp_home_path("USER", "")).to eq(Pathname("/TMP/bundler/home/USER"))
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -103,6 +103,14 @@ RSpec.configure do |config|
 
   config.before :all do
     build_repo1
+    # HACK: necessary until rspec-mocks > 3.5.0 is used
+    # see https://github.com/bundler/bundler/pull/5363#issuecomment-278089256
+    if RUBY_VERSION < "1.9"
+      FileUtils.module_eval do
+        alias_method :mkpath, :mkdir_p
+        module_function :mkpath
+      end
+    end
   end
 
   config.before :each do


### PR DESCRIPTION
We're deploying to a server with several Ruby applications each with it's own user. However, the home directory of these users is *not* writable by the users.

Since Bundler 1.14.x, a temporary home directoy in the `tmpdir` is used as a fallback. This works well for only one user, but will fail with more than one:

1. user1 execs `bundle`
2. `/tmp/bundler/home/user1` is created usually with 0755 modes
3. user2 execs `bundle`
4. `/tmp/bundler/home/user2` cannot be created since user2 can't write to `home`

This PR adds a `chmod` to apply mode 0777 to `home`. It rescues to nil in order to silently fail on step 4 (user2 cannot chmod `home` since it's owned by user1) as well as in case of any other problem performing chmod. Since we're in a fallback here, I guess it's okay to do this. However, if this is too much code smell, a `unless File.exist?` will do the trick as well.