### PR TITLE
Bundle info command

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -245,6 +245,14 @@ module Bundler
     # TODO: 2.0 remove `bundle list`
     map %w(list) => "show"
 
+    desc "info GEM [OPTIONS]", "Shows gem information"
+    method_option "path", :type => :boolean,
+                   :banner => "Show gem path"
+    def info(gem_name)
+      require "bundler/cli/info"
+      Info.new(options, gem_name).run
+    end
+
     desc "binstubs GEM [OPTIONS]", "Install the binstubs of the listed gem"
     long_desc <<-D
       Generate binstubs for executables in [GEM]. Binstubs are put into bin,

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -247,6 +247,7 @@ module Bundler
 
     desc "info GEM [OPTIONS]", "Shows gem information"
     method_option "path", :type => :boolean,
+                   :default => false,
                    :banner => "Show gem path"
     def info(gem_name)
       require "bundler/cli/info"

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -247,8 +247,8 @@ module Bundler
 
     desc "info GEM [OPTIONS]", "Shows gem information"
     method_option "path", :type => :boolean,
-                   :default => false,
-                   :banner => "Show gem path"
+                          :default => false,
+                          :banner => "Show gem path"
     def info(gem_name)
       require "bundler/cli/info"
       Info.new(options, gem_name).run

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -245,7 +245,8 @@ module Bundler
     # TODO: 2.0 remove `bundle list`
     map %w(list) => "show"
 
-    desc "info GEM [OPTIONS]", "Shows gem information"
+    desc "info GEM [OPTIONS]", "Show information for the given gem"
+    method_option "path", :type => :boolean, :banner => "Print full path to gem"
     def info(gem_name)
       require "bundler/cli/info"
       Info.new(options, gem_name).run

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -246,9 +246,6 @@ module Bundler
     map %w(list) => "show"
 
     desc "info GEM [OPTIONS]", "Shows gem information"
-    method_option "path", :type => :boolean,
-                          :default => false,
-                          :banner => "Show gem path"
     def info(gem_name)
       require "bundler/cli/info"
       Info.new(options, gem_name).run

--- a/lib/bundler/cli/info.rb
+++ b/lib/bundler/cli/info.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+require "bundler/cli/common"
+
+module Bundler
+  class CLI::Info
+    attr_reader :gem_name, :options, :latest_specs
+    def initialize(options, gem_name)
+      @options = options
+      @gem_name = gem_name
+      @latest_specs = fetch_latest_specs if not options[:path]
+    end
+
+    def run
+      Bundler.ui.silence do
+        Bundler.definition.validate_runtime!
+        Bundler.load.lock
+      end
+
+      spec = Bundler::CLI::Common.select_spec(gem_name, :regex_match)
+      return unless spec
+
+      path = spec.full_gem_path
+      if options[:path]
+        return Bundler.ui.info(path)
+      end
+
+      unless File.directory?(path)
+        Bundler.ui.warn("The gem #{gem_name} has been deleted. It was installed at:")
+      end
+
+      return print_gem_info spec
+    end
+
+    private
+
+    def print_gem_info spec
+      desc = "  * #{spec.name} (#{spec.version}#{spec.git_version})"
+      latest = latest_specs.find {|l| l.name == spec.name }
+      Bundler.ui.info <<-END.gsub(/^ +/, "")
+        #{desc}
+        \tSummary:  #{spec.summary || "No description available."}
+        \tHomepage: #{spec.homepage || "No website available."}
+        \tStatus:   #{outdated?(spec, latest) ? "Outdated - #{spec.version} < #{latest.version}" : "Up to date"}
+      END
+    end
+
+    def fetch_latest_specs
+      definition = Bundler.definition(true)
+      definition.resolve_remotely!
+      definition.specs
+    end
+
+    def outdated?(current, latest)
+      return false unless latest
+      Gem::Version.new(current.version) < Gem::Version.new(latest.version)
+    end
+
+  end
+end

--- a/lib/bundler/cli/info.rb
+++ b/lib/bundler/cli/info.rb
@@ -3,7 +3,7 @@ require "bundler/cli/common"
 
 module Bundler
   class CLI::Info
-    attr_reader :gem_name, :options 
+    attr_reader :gem_name, :options
     def initialize(options, gem_name)
       @options = options
       @gem_name = gem_name
@@ -19,22 +19,20 @@ module Bundler
       return unless spec
 
       path = spec.full_gem_path
-      if options[:path]
-        return Bundler.ui.info(path)
-      end
+      return Bundler.ui.info(path) if options[:path]
 
       unless File.directory?(path)
         Bundler.ui.warn("The gem #{gem_name} has been deleted. It was installed at:")
       end
 
-      return print_gem_info spec
+      print_gem_info spec
     end
 
-    private
+  private
 
-    def print_gem_info spec
+    def print_gem_info(spec)
       desc = "  * #{spec.name} (#{spec.version}#{spec.git_version})"
-      latest = fetch_latest_specs().find {|l| l.name == spec.name }
+      latest = fetch_latest_specs.find {|l| l.name == spec.name }
       Bundler.ui.info <<-END.gsub(/^ +/, "")
         #{desc}
         \tSummary:  #{spec.summary || "No description available."}
@@ -53,6 +51,5 @@ module Bundler
       return false unless latest
       Gem::Version.new(current.version) < Gem::Version.new(latest.version)
     end
-
   end
 end

--- a/lib/bundler/cli/info.rb
+++ b/lib/bundler/cli/info.rb
@@ -3,11 +3,10 @@ require "bundler/cli/common"
 
 module Bundler
   class CLI::Info
-    attr_reader :gem_name, :options, :latest_specs
+    attr_reader :gem_name, :options 
     def initialize(options, gem_name)
       @options = options
       @gem_name = gem_name
-      @latest_specs = fetch_latest_specs if not options[:path]
     end
 
     def run
@@ -35,7 +34,7 @@ module Bundler
 
     def print_gem_info spec
       desc = "  * #{spec.name} (#{spec.version}#{spec.git_version})"
-      latest = latest_specs.find {|l| l.name == spec.name }
+      latest = fetch_latest_specs().find {|l| l.name == spec.name }
       Bundler.ui.info <<-END.gsub(/^ +/, "")
         #{desc}
         \tSummary:  #{spec.summary || "No description available."}

--- a/lib/bundler/cli/info.rb
+++ b/lib/bundler/cli/info.rb
@@ -14,6 +14,7 @@ module Bundler
         gem = Gem::Specification.find_by_name(gem_name)
         spec = gem if gem.default_gem?
       rescue Gem::MissingSpecError
+        nil
       end
 
       spec ||= Bundler::CLI::Common.select_spec(gem_name, :regex_match)

--- a/lib/bundler/cli/info.rb
+++ b/lib/bundler/cli/info.rb
@@ -15,7 +15,7 @@ module Bundler
       print_gem_info(spec)
     end
 
-    private
+  private
 
     def print_gem_path(spec)
       Bundler.ui.info spec.full_gem_path

--- a/lib/bundler/cli/info.rb
+++ b/lib/bundler/cli/info.rb
@@ -20,8 +20,8 @@ module Bundler
   private
 
     def spec_for_gem(gem_name)
-      spec = Bundler.definition.specs.find { |s| s.name == gem_name }
-      spec ||= default_gem_spec(gem_name)
+      spec = Bundler.definition.specs.find {|s| s.name == gem_name }
+      spec || default_gem_spec(gem_name)
     end
 
     def default_gem_spec(gem_name)

--- a/lib/bundler/cli/info.rb
+++ b/lib/bundler/cli/info.rb
@@ -10,38 +10,24 @@ module Bundler
     end
 
     def run
-      Bundler.ui.silence do
-        Bundler.definition.validate_runtime!
-        Bundler.load.lock
-      end
-
       spec = Bundler::CLI::Common.select_spec(gem_name, :regex_match)
-      return print_gem_info(spec) if spec
+      return print_gem_path(spec) if @options[:path]
+      print_gem_info(spec)
     end
 
-  private
+    private
+
+    def print_gem_path(spec)
+      Bundler.ui.info spec.full_gem_path
+    end
 
     def print_gem_info(spec)
-      desc = "  * #{spec.name} (#{spec.version}#{spec.git_version})"
-      latest = fetch_latest_specs.find {|l| l.name == spec.name }
-      Bundler.ui.info <<-END.gsub(/^ +/, "")
-        #{desc}
-        \tSummary:  #{spec.summary || "No description available."}
-        \tHomepage: #{spec.homepage || "No website available."}
-        \tStatus:   #{outdated?(spec, latest) ? "Outdated - #{spec.version} < #{latest.version}" : "Up to date"}
-        \tPath:     #{spec.full_gem_path}
-      END
-    end
-
-    def fetch_latest_specs
-      definition = Bundler.definition(true)
-      definition.resolve_remotely!
-      definition.specs
-    end
-
-    def outdated?(current, latest)
-      return false unless latest
-      Gem::Version.new(current.version) < Gem::Version.new(latest.version)
+      gem_info = String.new
+      gem_info << "  * #{spec.name} (#{spec.version}#{spec.git_version})\n"
+      gem_info << "\tSummary: #{spec.summary}\n" if spec.summary
+      gem_info << "\tHomepage: #{spec.homepage}\n" if spec.homepage
+      gem_info << "\tPath: #{spec.full_gem_path}\n"
+      Bundler.ui.info gem_info
     end
   end
 end

--- a/lib/bundler/cli/info.rb
+++ b/lib/bundler/cli/info.rb
@@ -10,7 +10,14 @@ module Bundler
     end
 
     def run
-      spec = Bundler::CLI::Common.select_spec(gem_name, :regex_match)
+      begin
+        gem = Gem::Specification.find_by_name(gem_name)
+        spec = gem if gem.default_gem?
+      rescue Gem::MissingSpecError
+      end
+
+      spec ||= Bundler::CLI::Common.select_spec(gem_name, :regex_match)
+      return unless spec
       return print_gem_path(spec) if @options[:path]
       print_gem_info(spec)
     end

--- a/lib/bundler/cli/info.rb
+++ b/lib/bundler/cli/info.rb
@@ -10,20 +10,29 @@ module Bundler
     end
 
     def run
-      begin
-        gem = Gem::Specification.find_by_name(gem_name)
-        spec = gem if gem.default_gem?
-      rescue Gem::MissingSpecError
-        nil
-      end
+      spec = spec_for_gem(gem_name)
 
-      spec ||= Bundler::CLI::Common.select_spec(gem_name, :regex_match)
-      return unless spec
+      spec_not_found(gem_name) unless spec
       return print_gem_path(spec) if @options[:path]
       print_gem_info(spec)
     end
 
   private
+
+    def spec_for_gem(gem_name)
+      spec = Bundler.definition.specs.find { |s| s.name == gem_name }
+      spec ||= default_gem_spec(gem_name)
+    end
+
+    def default_gem_spec(gem_name)
+      return nil unless Gem::Specification.respond_to?(:find_all_by_name)
+      gem_spec = Gem::Specification.find_all_by_name(gem_name).last
+      return gem_spec if gem_spec && gem_spec.default_gem?
+    end
+
+    def spec_not_found(gem_name)
+      raise GemNotFound, Bundler::CLI::Common.gem_not_found_message(gem_name, Bundler.definition.dependencies)
+    end
 
     def print_gem_path(spec)
       Bundler.ui.info spec.full_gem_path
@@ -35,6 +44,7 @@ module Bundler
       gem_info << "\tSummary: #{spec.summary}\n" if spec.summary
       gem_info << "\tHomepage: #{spec.homepage}\n" if spec.homepage
       gem_info << "\tPath: #{spec.full_gem_path}\n"
+      gem_info << "\tDefault Gem: yes" if spec.respond_to?(:default_gem?) && spec.default_gem?
       Bundler.ui.info gem_info
     end
   end

--- a/lib/bundler/cli/info.rb
+++ b/lib/bundler/cli/info.rb
@@ -16,16 +16,7 @@ module Bundler
       end
 
       spec = Bundler::CLI::Common.select_spec(gem_name, :regex_match)
-      return unless spec
-
-      path = spec.full_gem_path
-      return Bundler.ui.info(path) if options[:path]
-
-      unless File.directory?(path)
-        Bundler.ui.warn("The gem #{gem_name} has been deleted. It was installed at:")
-      end
-
-      print_gem_info spec
+      return print_gem_info(spec) if spec
     end
 
   private
@@ -38,6 +29,7 @@ module Bundler
         \tSummary:  #{spec.summary || "No description available."}
         \tHomepage: #{spec.homepage || "No website available."}
         \tStatus:   #{outdated?(spec, latest) ? "Outdated - #{spec.version} < #{latest.version}" : "Up to date"}
+        \tPath:     #{spec.full_gem_path}
       END
     end
 

--- a/lib/bundler/cli/info.rb
+++ b/lib/bundler/cli/info.rb
@@ -25,9 +25,9 @@ module Bundler
     end
 
     def default_gem_spec(gem_name)
-      return nil unless Gem::Specification.respond_to?(:find_all_by_name)
+      return unless Gem::Specification.respond_to?(:find_all_by_name)
       gem_spec = Gem::Specification.find_all_by_name(gem_name).last
-      return gem_spec if gem_spec && gem_spec.default_gem?
+      return gem_spec if gem_spec && gem_spec.respond_to?(:default_gem?) && gem_spec.default_gem?
     end
 
     def spec_not_found(gem_name)

--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -76,7 +76,7 @@ module Bundler
         relative_path = absolute_path.sub(File.expand_path(".") + File::SEPARATOR, "." + File::SEPARATOR)
         Bundler.ui.confirm "Bundled gems are installed into #{relative_path}."
       else
-        Bundler.ui.confirm "Use `bundle show [gemname]` to see where a bundled gem is installed."
+        Bundler.ui.confirm "Use `bundle info [gemname]` to see where a bundled gem is installed."
       end
 
       unless Bundler.settings["ignore_messages"]

--- a/lib/bundler/cli/show.rb
+++ b/lib/bundler/cli/show.rb
@@ -17,6 +17,10 @@ module Bundler
         Bundler.load.lock
       end
 
+      if options[:outdated]
+        Bundler.ui.warn("Deprecated: use `bundle info GEM` or `bundle outdated` instead of `bundle show --outdated`")
+      end
+
       if gem_name
         if gem_name == "bundler"
           path = File.expand_path("../../../..", __FILE__)

--- a/lib/bundler/cli/show.rb
+++ b/lib/bundler/cli/show.rb
@@ -17,10 +17,6 @@ module Bundler
         Bundler.load.lock
       end
 
-      if options[:outdated]
-        SharedHelpers.major_deprecation("Deprecated: use `bundle info GEM` or `bundle outdated` instead of `bundle show --outdated`")
-      end
-
       if gem_name
         if gem_name == "bundler"
           path = File.expand_path("../../../..", __FILE__)

--- a/lib/bundler/cli/show.rb
+++ b/lib/bundler/cli/show.rb
@@ -18,7 +18,7 @@ module Bundler
       end
 
       if options[:outdated]
-        Bundler.ui.warn("Deprecated: use `bundle info GEM` or `bundle outdated` instead of `bundle show --outdated`")
+        SharedHelpers.major_deprecation("Deprecated: use `bundle info GEM` or `bundle outdated` instead of `bundle show --outdated`")
       end
 
       if gem_name

--- a/man/bundle-info.ronn
+++ b/man/bundle-info.ronn
@@ -1,4 +1,4 @@
-bundle-show(1) -- Show information for the given gem in your bundle
+bundle-info(1) -- Show information for the given gem in your bundle
 =========================================================================
 
 ## SYNOPSIS

--- a/man/bundle-info.ronn
+++ b/man/bundle-info.ronn
@@ -1,0 +1,17 @@
+bundle-show(1) -- Show information for the given gem in your bundle
+=========================================================================
+
+## SYNOPSIS
+
+`bundle info` [GEM]
+              [--path]
+
+## DESCRIPTION
+
+Print the basic information about the provided GEM such as homepage, version,
+path and summary.
+
+## OPTIONS
+
+* `--path`:
+Print the path of the given gem

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -2,7 +2,6 @@
 require "spec_helper"
 
 describe "bunlde info" do
-
   context "info from specific gem in gemfile" do
     before :each do
       install_gemfile <<-G
@@ -32,7 +31,7 @@ describe "bunlde info" do
 
       expect(bundled_app("Gemfile.lock")).to exist
     end
-  
+
     it "should show error message if gem not found" do
       bundle "info anything"
 

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe "bunlde info" do
+
+  context "info from specific gem in gemfile" do
+    before :each do
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem "rails"
+      G
+    end
+
+    it "should print summary of rake gem" do
+      bundle "info rails"
+
+      expect(out).to include("rails")
+      expect(out).to include("\tSummary:")
+      expect(out).to include("\tHomepage:")
+      expect(out).to include("\tStatus:")
+    end
+
+    it "should print gem path" do
+      bundle "info rails --path"
+      expect(out).to eq(default_bundle_path("gems", "rails-2.3.2").to_s)
+    end
+
+    it "should create a Gemfile.lock if not existing" do
+      FileUtils.rm("Gemfile.lock")
+
+      bundle "info rails"
+
+      expect(bundled_app("Gemfile.lock")).to exist
+    end
+
+  end
+end

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -32,6 +32,11 @@ describe "bunlde info" do
 
       expect(bundled_app("Gemfile.lock")).to exist
     end
+  
+    it "should show error message if gem not found" do
+      bundle "info anything"
 
+      expect(out).to eql("Could not find gem 'anything'.")
+    end
   end
 end

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -3,35 +3,48 @@ require "spec_helper"
 
 describe "bundle info" do
   context "info from specific gem in gemfile" do
-    before :each do
+    before do
       install_gemfile <<-G
         source "file://#{gem_repo1}"
         gem "rails"
       G
     end
 
-    it "should print summary of rake gem" do
+    it "prints information about the current gem" do
       bundle "info rails"
-
-      expect(out).to include("rails")
-      expect(out).to include("\tSummary:")
-      expect(out).to include("\tHomepage:")
-      expect(out).to include("\tStatus:")
-      expect(out).to include("\tPath:")
+      expect(out).to include "* rails (2.3.2)
+\tSummary: This is just a fake gem for testing
+\tHomepage: http://example.com"
+      expect(out).to match(/Path\: .*\/rails\-2\.3\.2/)
     end
 
-    it "should create a Gemfile.lock if not existing" do
-      FileUtils.rm("Gemfile.lock")
-
-      bundle "info rails"
-
-      expect(bundled_app("Gemfile.lock")).to exist
+    context "given a gem that is not installed" do
+      it "prints missing gem error" do
+        bundle "info foo"
+        expect(out).to eq "Could not find gem 'foo'."
+      end
     end
 
-    it "should show error message if gem not found" do
-      bundle "info anything"
+    context 'when gem does not have homepage' do
+      before do
+        build_repo1 do
+          build_gem "rails", "2.3.2" do |s|
+            s.executables = "rails"
+            s.summary = "Just another test gem"
+          end
+        end
+      end
 
-      expect(out).to eql("Could not find gem 'anything'.")
+      it 'excludes the homepage field from the output' do
+        expect(out).to_not include("Homepage:")
+      end
+    end
+
+    context 'given --path option' do
+      it "prints the path to the gem" do
+        bundle "info rails"
+        expect(out).to match(/.*\/rails\-2\.3\.2/)
+      end
     end
   end
 end

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bunlde info" do
+describe "bundle info" do
   context "info from specific gem in gemfile" do
     before :each do
       install_gemfile <<-G

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -26,10 +26,10 @@ RSpec.describe "bundle info" do
     end
 
     context "given a default gem shippped in ruby" do
-      it "prints information about the default gem" do
+      it "prints information about the default gem", :if => (RUBY_VERSION >= "1.9") do
         bundle "info rdoc"
         expect(out).to include("* rdoc")
-        expect(out).to match(%r{gems\/rdoc\-})
+        expect(out).to include("Default Gem: yes")
       end
     end
 

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -17,11 +17,7 @@ describe "bundle info" do
       expect(out).to include("\tSummary:")
       expect(out).to include("\tHomepage:")
       expect(out).to include("\tStatus:")
-    end
-
-    it "should print gem path" do
-      bundle "info rails --path"
-      expect(out).to eq(default_bundle_path("gems", "rails-2.3.2").to_s)
+      expect(out).to include("\tPath:")
     end
 
     it "should create a Gemfile.lock if not existing" do

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -15,7 +15,7 @@ describe "bundle info" do
       expect(out).to include "* rails (2.3.2)
 \tSummary: This is just a fake gem for testing
 \tHomepage: http://example.com"
-      expect(out).to match(/Path\: .*\/rails\-2\.3\.2/)
+      expect(out).to match(%r{Path\: .*\/rails\-2\.3\.2})
     end
 
     context "given a gem that is not installed" do
@@ -25,7 +25,7 @@ describe "bundle info" do
       end
     end
 
-    context 'when gem does not have homepage' do
+    context "when gem does not have homepage" do
       before do
         build_repo1 do
           build_gem "rails", "2.3.2" do |s|
@@ -35,15 +35,15 @@ describe "bundle info" do
         end
       end
 
-      it 'excludes the homepage field from the output' do
+      it "excludes the homepage field from the output" do
         expect(out).to_not include("Homepage:")
       end
     end
 
-    context 'given --path option' do
+    context "given --path option" do
       it "prints the path to the gem" do
         bundle "info rails"
-        expect(out).to match(/.*\/rails\-2\.3\.2/)
+        expect(out).to match(%r{.*\/rails\-2\.3\.2})
       end
     end
   end

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -25,6 +25,14 @@ describe "bundle info" do
       end
     end
 
+    context "given a default gem shippped in ruby" do
+      it "prints information about the default gem" do
+        bundle "info rdoc"
+        expect(out).to include("* rdoc (5.0.0)")
+        expect(out).to match(%r{gems\/rdoc\-5\.0\.0})
+      end
+    end
+
     context "when gem does not have homepage" do
       before do
         build_repo1 do

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "bundle info" do
     end
 
     context "given a default gem shippped in ruby" do
-      it "prints information about the default gem", :if => (RUBY_VERSION >= "1.9") do
+      it "prints information about the default gem", :if => (RUBY_VERSION >= "2.0") do
         bundle "info rdoc"
         expect(out).to include("* rdoc")
         expect(out).to include("Default Gem: yes")

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe "bundle info" do
+RSpec.describe "bundle info" do
   context "info from specific gem in gemfile" do
     before do
       install_gemfile <<-G

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe "bundle info" do
     context "given a default gem shippped in ruby" do
       it "prints information about the default gem" do
         bundle "info rdoc"
-        expect(out).to include("* rdoc (5.0.0)")
-        expect(out).to match(%r{gems\/rdoc\-5\.0\.0})
+        expect(out).to include("* rdoc")
+        expect(out).to match(%r{gems\/rdoc\-})
       end
     end
 

--- a/spec/install/post_bundle_message_spec.rb
+++ b/spec/install/post_bundle_message_spec.rb
@@ -14,7 +14,7 @@ describe "post bundle message" do
     G
   end
 
-  let(:bundle_show_message)       { "Use `bundle show [gemname]` to see where a bundled gem is installed." }
+  let(:bundle_show_message)       { "Use `bundle info [gemname]` to see where a bundled gem is installed." }
   let(:bundle_deployment_message) { "Bundled gems are installed into ./vendor" }
   let(:bundle_complete_message)   { "Bundle complete!" }
   let(:bundle_updated_message)    { "Bundle updated!" }


### PR DESCRIPTION
This is a continuation of #5093 

This PR adds a new command called `info` that is nearly identical to the `show` command, specifically `show <gem> --verbose`.

Example:
```
› dbundler info rack
  * rack (2.0.1)
	Summary: a modular Ruby webserver interface
	Homepage: http://rack.github.io/
	Path: /Users/colby/.gem/ruby/2.4.0/gems/rack-2.0.1
```

There is also a option called `--path` that only prints the path to the gem
```
› dbundler info rack --path
/Users/colby/.gem/ruby/2.4.0/gems/rack-2.0.1
```

One noticeable difference between `info` and `show --verbose` is that i have removed the `outdated` functionality. This was made for several reasons:
* There are currently problems with that functionality which have been raised in #5375
* We have a dedicated command called `outdated` for the user to get information about the outdated status of gems.
* The outdated status requires an active internet connection and time to download the necessary information. I think not having to download anything and limiting `info` to just read information it already has would make for a more responsive and better user experience.