### PR TITLE
Bundle show --outdated shouldn't be updating versions 

### DIFF
--- a/lib/bundler/cli/show.rb
+++ b/lib/bundler/cli/show.rb
@@ -64,6 +64,7 @@ module Bundler
       else
         definition.resolve_with_cache!
       end
+      Bundler.reset!
       definition.specs
     end
 

--- a/spec/commands/show_spec.rb
+++ b/spec/commands/show_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe "bundle show" do
       expect(the_bundle).to include_gem("rails 2.3.2")
 
       update_repo2 do
-        build_gem "rails", '3.0.0' do |s|
+        build_gem "rails", "3.0.0" do |s|
           s.executables = "rails"
         end
       end

--- a/spec/commands/show_spec.rb
+++ b/spec/commands/show_spec.rb
@@ -169,10 +169,12 @@ RSpec.describe "bundle show" do
     end
 
     it "doesn't update gems to newer versions" do
-      install_gemfile <<-G
+      install_gemfile! <<-G
         source "file://#{gem_repo2}"
         gem "rails"
       G
+
+      expect(the_bundle).to include_gem("rails 2.3.2")
 
       update_repo2 do
         build_gem "rails", '3.0.0' do |s|
@@ -180,10 +182,10 @@ RSpec.describe "bundle show" do
         end
       end
 
-      bundle "show --outdated"
+      bundle! "show --outdated"
 
-      bundle "install"
-      expect(the_bundle).to include_gems("rails 2.3.2")
+      bundle! "install"
+      expect(the_bundle).to include_gem("rails 2.3.2")
     end
   end
 end

--- a/spec/commands/show_spec.rb
+++ b/spec/commands/show_spec.rb
@@ -174,8 +174,6 @@ RSpec.describe "bundle show" do
         gem "rails"
       G
 
-      bundle "install"
-
       update_repo2 do
         build_gem "rails", '3.0.0' do |s|
           s.executables = "rails"

--- a/spec/commands/show_spec.rb
+++ b/spec/commands/show_spec.rb
@@ -161,4 +161,31 @@ RSpec.describe "bundle show" do
       expect(out).to include("Could not find gem '#{invalid_regexp}'.")
     end
   end
+
+  context "--outdated option" do
+    # Regression test for https://github.com/bundler/bundler/issues/5375
+    before do
+      build_repo2
+    end
+
+    it "doesn't update gems to newer versions" do
+      install_gemfile <<-G
+        source "file://#{gem_repo2}"
+        gem "rails"
+      G
+
+      bundle "install"
+
+      update_repo2 do
+        build_gem "rails", '3.0.0' do |s|
+          s.executables = "rails"
+        end
+      end
+
+      bundle "show --outdated"
+
+      bundle "install"
+      expect(the_bundle).to include_gems("rails 2.3.2")
+    end
+  end
 end


### PR DESCRIPTION
This PR is for #5375. I have added a spec (currently failing) of the desired behavior for `bundle show --outdated`

I'm currently looking into a fix for this but welcome anyone else to come in as well.