### PR TITLE
Switch autoload to require `source` in plugin/api

### DIFF
--- a/lib/bundler/plugin/api.rb
+++ b/lib/bundler/plugin/api.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+# Should not use `autoload :Source, "bundler/plugin/api/source"` as this breaks sdoc, fastlane with this error:
+# 
+require "bundler/plugin/api/source"
 
 module Bundler
   # This is the interfacing class represents the API that we intend to provide
@@ -23,7 +26,6 @@ module Bundler
   # and hooks).
   module Plugin
     class API
-      autoload :Source, "bundler/plugin/api/source"
 
       # The plugins should declare that they handle a command through this helper.
       #

--- a/lib/bundler/plugin/api.rb
+++ b/lib/bundler/plugin/api.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-# Should not use `autoload :Source, "bundler/plugin/api/source"` as this breaks sdoc, fastlane with this error:
-# 
+# Note for others: should not use `autoload :Source, "bundler/plugin/api/source"` as this breaks sdoc, fastlane with this error:
+# gems/bundler-1.14.3/lib/bundler/rubygems_ext.rb:45:in `full_gem_path': uninitialized constant Bundler::Plugin::API::Source (NameError)
 require "bundler/plugin/api/source"
 
 module Bundler


### PR DESCRIPTION
Should not use `autoload :Source, "bundler/plugin/api/source"` in plugin/api as this breaks sdoc, fastlane with this error:
```
# gems/bundler-1.14.3/lib/bundler/rubygems_ext.rb:45:in `full_gem_path': uninitialized constant Bundler::Plugin::API::Source (NameError)
```
Thank you for merging in and putting out new gem!