### PR TITLE
[FriendlyErrors] Update ISSUES.md URL

### DIFF
--- a/lib/bundler/friendly_errors.rb
+++ b/lib/bundler/friendly_errors.rb
@@ -81,7 +81,7 @@ module Bundler
 
           I tried...
 
-        - **Have you read our issues document, https://github.com/bundler/bundler/blob/master/ISSUES.md?**
+        - **Have you read our issues document, https://github.com/bundler/bundler/blob/master/doc/contributing/ISSUES.md?**
 
           ...
 


### PR DESCRIPTION
This URL no longer exists after the docs reorganization

\c @feministy 

I'd like to release this as 1.14.x so people aren't frustrated when opening new issues