### PR TITLE
handle read only filesystem

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -176,7 +176,7 @@ module Bundler
         tmp_home_path.join(login).tap(&:mkpath)
       end
     rescue => e
-      raise "#{warning}\nBundler also failed to create a temporary home directory at `#{path}':\n#{e}"
+      Bundler.ui.warn "#{warning}\nBundler also failed to create a temporary home directory at `#{path}':\n#{e}"
     end
 
     def user_bundle_path

--- a/spec/bundler/bundler_spec.rb
+++ b/spec/bundler/bundler_spec.rb
@@ -208,5 +208,10 @@ EOF
       expect(File).to receive(:chmod).with(0o777, "/TMP/bundler/home")
       expect(Bundler.tmp_home_path("USER", "")).to eq(Pathname("/TMP/bundler/home/USER"))
     end
+
+    it "should warn on r/o filesystem" do
+      allow(SharedHelpers).to receive(:filesystem_access).and_raise(PermissionError.new('/tmp'))
+      expect(Bundler.ui).to receive(:warn).with("AAA\nBundler also failed to create a temporary home directory at `AAA':\nAAA")
+    end
   end
 end


### PR DESCRIPTION
Resolves the issue where bundler errors on startup on a read only filesystem. 

Resolves #5371 