### PR TITLE
Fix NameError for Bundler::Plugin::API::Source

### DIFF
--- a/lib/bundler/rubygems_ext.rb
+++ b/lib/bundler/rubygems_ext.rb
@@ -19,6 +19,7 @@ rescue LoadError
 end
 
 require "bundler/match_platform"
+require "bundler/plugin/api/source"
 
 module Gem
   @loaded_stacks = Hash.new {|h, k| h[k] = [] }


### PR DESCRIPTION
There is a missing require statement for the API source under some
circumstances. I noticed it when I was starting Foreman after updating
to Bundler 1.14.1. Here's the stack track:

```
↪ foreman start -f Procfile.pow
~/.rvm/gems/ruby-2.2.3/gems/bundler-1.14.3/lib/bundler/rubygems_ext.rb:45:in `full_gem_path': uninitialized constant Bundler::Plugin::API::Source (NameError)
  from ~/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/basic_specification.rb:145:in `block in full_require_paths'
  from ~/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/basic_specification.rb:144:in `map'
  from ~/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/basic_specification.rb:144:in `full_require_paths'
  from ~/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/basic_specification.rb:77:in `contains_requirable_file?'
  from ~/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/specification.rb:949:in `block in find_in_unresolved'
  from ~/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/specification.rb:949:in `each'
  from ~/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/specification.rb:949:in `find_all'
  from ~/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/specification.rb:949:in `find_in_unresolved'
  from ~/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:74:in `require'
  from ~/.rvm/gems/ruby-2.2.3/gems/bundler-1.14.3/lib/bundler/plugin/api/source.rb:2:in `<top (required)>'
  from ~/.rvm/gems/ruby-2.2.3/gems/bundler-1.14.3/lib/bundler/rubygems_ext.rb:45:in `full_gem_path'
  from ~/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/basic_specification.rb:145:in `block in full_require_paths'
  from ~/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/basic_specification.rb:144:in `map'
  from ~/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/basic_specification.rb:144:in `full_require_paths'
  from ~/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/specification.rb:1370:in `add_self_to_load_path'
  from ~/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/specification.rb:1283:in `activate'
  from ~/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/core_ext/kernel_gem.rb:67:in `block in gem'
  from ~/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/core_ext/kernel_gem.rb:66:in `synchronize'
  from ~/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/core_ext/kernel_gem.rb:66:in `gem'
  from ~/.rvm/gems/ruby-2.2.3/bin/foreman:22:in `<main>'
  from ~/.rvm/gems/ruby-2.2.3/bin/ruby_executable_hooks:15:in `eval'
  from ~/.rvm/gems/ruby-2.2.3/bin/ruby_executable_hooks:15:in `<main>'
```

The line in question is:

```ruby
load Gem.activate_bin_path('foreman', 'foreman', version)
```

So it appears that the `Gem.activate_bin_path` method is the entrypoint
where this fails without the proper require.