### PR TITLE
[Definition] Remove no-op code in expanded_deps

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -789,10 +789,10 @@ module Bundler
     def expanded_dependencies
       @expanded_dependencies ||= begin
         ruby_versions = concat_ruby_version_requirements(@ruby_version)
-        if ruby_versions.empty? || !@ruby_version.exact?
-          concat_ruby_version_requirements(RubyVersion.system)
-          concat_ruby_version_requirements(locked_ruby_version_object) unless @unlock[:ruby]
-        end
+        # if ruby_versions.empty? || !@ruby_version.exact?
+        #   concat_ruby_version_requirements(RubyVersion.system)
+        #   concat_ruby_version_requirements(locked_ruby_version_object) unless @unlock[:ruby]
+        # end
 
         metadata_dependencies = [
           Dependency.new("ruby\0", ruby_versions),


### PR DESCRIPTION
While troubleshooting my bundler-fixture gem, which hacks up a
Definition class with a fake Index, and needed updating for 1.14
support for ruby and RubyGems version in the Definition index, I
noticed this block of code appears to not do anything, since a 2nd
argument is not being passed into `concat_ruby_version_requirements`
method.

The specs that were altered in the same commit that added these lines
pass with or without the lines of code, so I'm committing this up to do
a full Travis run to see if there are any other consequences. If not,
then we either can remove these lines, or need to hook them up properly
and add proper failing specs.