### PR TITLE
Defer requiring rubygems/spec_fetcher until it becomes necessary

### DIFF
--- a/lib/bundler/lazy_specification.rb
+++ b/lib/bundler/lazy_specification.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require "uri"
-require "rubygems/spec_fetcher"
 require "bundler/match_platform"
 
 module Bundler

--- a/lib/bundler/remote_specification.rb
+++ b/lib/bundler/remote_specification.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require "uri"
-require "rubygems/spec_fetcher"
 
 module Bundler
   # Represents a lazily loaded gem specification, where the full specification

--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -213,6 +213,7 @@ module Bundler
     end
 
     def fetch_specs(all, pre, &blk)
+      require "rubygems/spec_fetcher"
       specs = Gem::SpecFetcher.new.list(all, pre)
       specs.each { yield } if block_given?
       specs

--- a/lib/bundler/source/rubygems.rb
+++ b/lib/bundler/source/rubygems.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 require "uri"
 require "rubygems/user_interaction"
-require "rubygems/spec_fetcher"
 
 module Bundler
   class Source

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -1080,8 +1080,8 @@ RSpec.describe "Bundler.setup" do
     end
   end
 
-  describe "when Psych is not in the Gemfile", :ruby => "~> 2.2" do
-    it "does not load Psych" do
+  describe "with gemified standard libraries" do
+    it "does not load Psych", :ruby => "~> 2.2" do
       gemfile ""
       ruby <<-RUBY
         require 'bundler/setup'
@@ -1092,6 +1092,17 @@ RSpec.describe "Bundler.setup" do
       pre_bundler, post_bundler = out.split("\n")
       expect(pre_bundler).to eq("undefined")
       expect(post_bundler).to match(/\d+\.\d+\.\d+/)
+    end
+
+    it "does not load openssl" do
+      install_gemfile! ""
+      ruby! <<-RUBY
+        require "bundler/setup"
+        puts defined?(OpenSSL) || "undefined"
+        require "openssl"
+        puts defined?(OpenSSL) || "undefined"
+      RUBY
+      expect(out).to eq("undefined\nconstant")
     end
   end
 


### PR DESCRIPTION
Avoid conflict between two versions of openssl gem on 'bundle exec' if
a newer and non-default version of openssl gem is installed to the
system. rubygems/spec_fetcher loads openssl through resolv and
securerandom when running with Ruby <= 2.4.

This is not a proper fix for #5235 as other standard libraries that
Bundler currently loads will be gemified as well in Ruby >= 2.5,
however, this will fix openssl's case.

Reference: https://github.com/bundler/bundler/issues/5235
Fixes: https://github.com/ruby/openssl/issues/103

---

Reproduce:

1. Install Ruby 2.4.0 (comes with openssl 2.0.2)
2. Run `gem install openssl` to install openssl 2.0.3
3. Create a Gemfile and run `bundle install`
4. Run `bundle exec ruby -e'require "openssl"'