### PR TITLE
Show inject usage when args are passed incorrectly

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -461,7 +461,7 @@ module Bundler
       Platform.new(options).run
     end
 
-    desc "inject GEM VERSION" "Add the named gem, with version requirements, to the resolved Gemfile"
+    desc "inject GEM VERSION", "Add the named gem, with version requirements, to the resolved Gemfile"
     def inject(name, version)
       SharedHelpers.major_deprecation "The `inject` command has been replaced by the `add` command"
       require "bundler/cli/inject"

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -461,11 +461,11 @@ module Bundler
       Platform.new(options).run
     end
 
-    desc "inject GEM VERSION ...", "Add the named gem(s), with version requirements, to the resolved Gemfile"
-    def inject(name, version, *gems)
+    desc "inject GEM VERSION" "Add the named gem, with version requirements, to the resolved Gemfile"
+    def inject(name, version)
       SharedHelpers.major_deprecation "The `inject` command has been replaced by the `add` command"
       require "bundler/cli/inject"
-      Inject.new(options, name, version, gems).run
+      Inject.new(options, name, version).run
     end
 
     desc "lock", "Creates a lockfile without installing"

--- a/lib/bundler/cli/inject.rb
+++ b/lib/bundler/cli/inject.rb
@@ -2,13 +2,13 @@
 module Bundler
   class CLI::Inject
     attr_reader :options, :name, :version, :group, :source, :gems
-    def initialize(options, name, version, gems)
+    def initialize(options, name, version)
       @options = options
       @name = name
       @version = version || last_version_number
       @group = options[:group]
       @source = options[:source]
-      @gems = gems
+      @gems = []
     end
 
     def run
@@ -18,6 +18,7 @@ module Bundler
 
       # Build an array of Dependency objects out of the arguments
       deps = []
+      # when `inject` will support addition of multiple gem, then this loop will help.
       gems.each_slice(4) do |gem_name, gem_version, gem_group, gem_source|
         ops = Gem::Requirement::OPS.map {|key, _val| key }
         has_op = ops.any? {|op| gem_version.start_with? op }

--- a/lib/bundler/cli/inject.rb
+++ b/lib/bundler/cli/inject.rb
@@ -18,7 +18,8 @@ module Bundler
 
       # Build an array of Dependency objects out of the arguments
       deps = []
-      # when `inject` will support addition of multiple gem, then this loop will help.
+      # when `inject` support addition of more than one gem, then this loop will
+      # help. Currently this loop is running once.
       gems.each_slice(4) do |gem_name, gem_version, gem_group, gem_source|
         ops = Gem::Requirement::OPS.map {|key, _val| key }
         has_op = ops.any? {|op| gem_version.start_with? op }

--- a/spec/commands/inject_spec.rb
+++ b/spec/commands/inject_spec.rb
@@ -42,6 +42,16 @@ RSpec.describe "bundle inject" do
     end
   end
 
+  context "incorrect arguments" do
+    it "fails when more than 2 arguments are passed" do
+      bundle "inject gem_name 1 v"
+      expect(out).to eq(<<-E.strip)
+ERROR: "bundle inject" was called with arguments ["gem_name", "1", "v"]
+Usage: "bundle inject GEM VERSION"
+      E
+    end
+  end
+
   context "when frozen" do
     before do
       bundle "install"


### PR DESCRIPTION
Closes #5384

Now it shows the error : 

```
$ bundle inject "gem_name" 1 "v"
ERROR: "bundle inject" was called with arguments ["gem_name", "1", "v"]
Usage: "bundle inject GEM VERSION"
$ bundle inject "gem_name" "v" 1
ERROR: "bundle inject" was called with arguments ["gem_name", "v", "1"]
Usage: "bundle inject GEM VERSION"

```
