### PR TITLE
Fix misleading warning message when a dependency is unused on any platform

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -829,7 +829,8 @@ module Bundler
             "The dependency #{dep} will be unused by any of the platforms Bundler is installing for. " \
             "Bundler is installing for #{@platforms.join ", "} but the dependency " \
             "is only for #{dep.platforms.map {|p| Dependency::PLATFORM_MAP[p] }.join ", "}. " \
-            "To add those platforms to the bundle, run `bundle lock --add-platform #{dep.platforms.join ", "}`."
+            "To add those platforms to the bundle, " \
+            "run `bundle lock --add-platform #{dep.platforms.map {|p| Dependency::PLATFORM_MAP[p] }.join " "}`."
         end
         platforms.each do |p|
           deps << DepProxy.new(dep, p) if remote || p == generic_local_platform

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -825,12 +825,13 @@ module Bundler
         next if !remote && !dep.current_platform?
         platforms = dep.gem_platforms(@platforms)
         if platforms.empty?
+          mapped_platforms = dep.platforms.map {|p| Dependency::PLATFORM_MAP[p] }
           Bundler.ui.warn \
             "The dependency #{dep} will be unused by any of the platforms Bundler is installing for. " \
             "Bundler is installing for #{@platforms.join ", "} but the dependency " \
-            "is only for #{dep.platforms.map {|p| Dependency::PLATFORM_MAP[p] }.join ", "}. " \
+            "is only for #{mapped_platforms.join ", "}. " \
             "To add those platforms to the bundle, " \
-            "run `bundle lock --add-platform #{dep.platforms.map {|p| Dependency::PLATFORM_MAP[p] }.join " "}`."
+            "run `bundle lock --add-platform #{mapped_platforms.join " "}`."
         end
         platforms.each do |p|
           deps << DepProxy.new(dep, p) if remote || p == generic_local_platform

--- a/spec/install/gemfile/platform_spec.rb
+++ b/spec/install/gemfile/platform_spec.rb
@@ -212,13 +212,13 @@ RSpec.describe "bundle install with platform conditionals" do
     gemfile <<-G
       source "file://#{gem_repo1}"
 
-      gem "rack", :platform => :jruby
+      gem "rack", :platform => [:mingw, :mswin, :x64_mingw, :jruby]
     G
 
     bundle! "install"
 
     expect(out).to include <<-O.strip
-The dependency #{Gem::Dependency.new("rack", ">= 0")} will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for java. To add those platforms to the bundle, run `bundle lock --add-platform jruby`.
+The dependency #{Gem::Dependency.new("rack", ">= 0")} will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for x86-mingw32, x86-mswin32, x64-mingw32, java. To add those platforms to the bundle, run `bundle lock --add-platform x86-mingw32 x86-mswin32 x64-mingw32 java`.
     O
   end
 end


### PR DESCRIPTION
The current warning message for a dep with empty platform is misleading/confusing. You see a sort of the below warning when you `bundle install`,

```
The dependency tzinfo-data (>= 0) will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for x86-mingw32, x86-mswin32, x64-mingw32, java. To add those platforms to the bundle, run `bundle lock --add-platform mingw, mswin, x64_mingw, jruby`.
```

However, there two issues exist in this message "run `bundle lock --add-platform mingw, mswin, x64_mingw, jruby`":

- You must not have comma (,) for separators
  - these commas will be considered as comma itself. see [here](https://github.com/bundler/bundler/blob/242fcbcb2d15d39c63e3441756b77fbfcc1b73b2/lib/bundler/cli/lock.rb#L34-L41)
- mingw, mswin, x64_mingw, jruby are not valid platforms
  - platforms must be specified as the formats that rubygems can understand, like (x86-mingw32, x86-mswin32, x64-mingw32, java)

This fixes these issues.
