### PR TITLE
lock: make {add,remove}-platform default to the local platform

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -479,9 +479,9 @@ module Bundler
       "the path the lockfile should be written to"
     method_option "full-index", :type => :boolean, :default => false, :banner =>
       "Fall back to using the single-file index of all gems"
-    method_option "add-platform", :type => :array, :default => [], :banner =>
+    method_option "add-platform", :type => :array, :lazy_default => [Gem::Platform.local], :banner =>
       "Add a new platform to the lockfile"
-    method_option "remove-platform", :type => :array, :default => [], :banner =>
+    method_option "remove-platform", :type => :array, :lazy_default => [Gem::Platform.local], :banner =>
       "Remove a platform from the lockfile"
     method_option "patch", :type => :boolean, :banner =>
       "If updating, prefer updating only to next patch version"

--- a/lib/bundler/cli/lock.rb
+++ b/lib/bundler/cli/lock.rb
@@ -27,11 +27,11 @@ module Bundler
 
       Bundler::CLI::Common.configure_gem_version_promoter(Bundler.definition, options) if options[:update]
 
-      options["remove-platform"].each do |platform|
+      Array(options["remove-platform"]).each do |platform|
         definition.remove_platform(platform)
       end
 
-      options["add-platform"].each do |platform_string|
+      Array(options["add-platform"]).each do |platform_string|
         platform = Gem::Platform.new(platform_string)
         if platform.to_s == "unknown"
           Bundler.ui.warn "The platform `#{platform_string}` is unknown to RubyGems " \

--- a/man/bundle-lock.ronn
+++ b/man/bundle-lock.ronn
@@ -43,10 +43,10 @@ Lock the gems specified in Gemfile.
 
 * `--add-platform`:
   Add a new platform to the lockfile, re-resolving for the addition of that
-  platform.
+  platform. Defaults to the local platform.
 
 * `--remove-platform`:
-  Remove a platform from the lockfile.
+  Remove a platform from the lockfile. Defaults to the local platform.
 
 * `--patch`:
   If updating, prefer updating only to next patch version.


### PR DESCRIPTION
We need to use "lazy_default" instead of "default" as otherwise thor does
not properly return the default value for array types. Guard against the
options being "nil" by wrapping them in "Array()".