### PR TITLE
Set build args properly for Rubygems >=2.0

### DIFF
--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -724,10 +724,6 @@ module Bundler
       def repository_subdirectories
         Gem::REPOSITORY_SUBDIRECTORIES
       end
-
-      def install_with_build_args(args)
-        yield
-      end
     end
 
     # RubyGems 2.1.0


### PR DESCRIPTION
There is an issue with applying 'build' args that were set through 'bundler config' for Rubygems >=2.0. The default 'install_with_build_args' set them properly https://github.com/bundler/bundler/blob/master/lib/bundler/rubygems_integration.rb#L256 but existing one doesn't set at all.