### PR TITLE
Allow to set float number as mirror timeout.

### DIFF
--- a/lib/bundler/mirror.rb
+++ b/lib/bundler/mirror.rb
@@ -81,7 +81,7 @@ module Bundler
         when false, "false"
           @fallback_timeout = 0
         else
-          @fallback_timeout = timeout.to_i
+          @fallback_timeout = timeout.to_f
         end
         @valid = nil
       end

--- a/spec/bundler/mirror_spec.rb
+++ b/spec/bundler/mirror_spec.rb
@@ -34,6 +34,11 @@ RSpec.describe Bundler::Settings::Mirror do
     expect(mirror.fallback_timeout).to eq(0)
   end
 
+  it "takes a float number as a fallback_timeout" do
+    mirror.fallback_timeout = 0.5
+    expect(mirror.fallback_timeout).to eq(0.5)
+  end
+
   it "takes a string for the uri but returns an uri object" do
     mirror.uri = "http://localhost:9292"
     expect(mirror.uri).to eq(URI("http://localhost:9292"))


### PR DESCRIPTION
I noticed some inconsistency in mirror timeout setting during playing
with gemstash. Default value is `0.1`, but when I set timeout value to
`0.5` it behaved as with `0` value. It set proper timeout only when I
set `1` as timeout value. I think it is also not proper behaviour with
`0.1` default and while setting cast it to Fixnum.