### PR TITLE
CI against Ruby 2.1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ rvm:
   - 2.4.0
   - 2.3.3
   - 2.2.6
-  - 2.1.9
+  - 2.1.10
   - 2.0.0
   - 1.9.3
   - 1.8.7
@@ -51,7 +51,7 @@ matrix:
     - rvm: 2.2.6
       env: RGV=v2.4.8
     # Ruby 2.1, Rubygems 2.2.2 and up
-    - rvm: 2.1.9
+    - rvm: 2.1.10
       env: RGV=v2.2.5
     # Ruby 2.0.0, Rubygems 2.0.0 and up
     - rvm: 2.0.0


### PR DESCRIPTION
Ruby 2.1.10 was released.

https://www.ruby-lang.org/en/news/2016/04/01/ruby-2-1-10-released