### PR TITLE
Fix links in READMEs causing 404 errors in Github

### DIFF
--- a/doc/contributing/README.md
+++ b/doc/contributing/README.md
@@ -10,29 +10,29 @@ Welcome to Bundler! We are so happy that you're here. We know it can be daunting
 - *If you're interested in helping with code:*
   - Get a quick overview of our [development process](../development/README.md)
   - [Setup your machine for development](../development/SETUP.md)
-  - Checkout [How you can help: your first contributions!](contributing/HOW_YOU_CAN_HELP.md) for a list of suggestions to get started
+  - Checkout [How you can help: your first contributions!](HOW_YOU_CAN_HELP.md) for a list of suggestions to get started
 - *If you're interested in helping with documentation:*
   - Read up on [how documentation works for Bundler](../documentation/README.md)
   - Learn about our [documentation vision](../documentation/VISION.md)
 
 You can start learning about Bundler by reading [the documentation](http://bundler.io). If you want, you can also read a (lengthy) explanation of [why Bundler exists and what it does](http://bundler.io/rationale.html).
 
-##[How you can help: your first contributions!](contributing/HOW_YOU_CAN_HELP.md)
+##[How you can help: your first contributions!](HOW_YOU_CAN_HELP.md)
 
 A detailed overview of how to get started contributing to Bundler, including a long list of suggestions for your first project.
 
-##[Bug triage](contributing/BUG_TRIAGE.md)
+##[Bug triage](BUG_TRIAGE.md)
 
 Want to take a stab at processing issues? Start here.
 
-##[Getting help](contributing/GETTING_HELP.md)
+##[Getting help](GETTING_HELP.md)
 
 How to get in touch with folks who can help when you're stuck. Don't worry! This happens to all of us. We're really nice, we promise.
 
-##[Filing issues](contributing/ISSUES.md)
+##[Filing issues](ISSUES.md)
 
 We see a lot of issues in the Bundler repo! Use this guide to file informative, actionable issues.
 
-##[Community](contributing/COMMUNITY.md)
+##[Community](COMMUNITY.md)
 
 Learn more about our goals for the Bundler community and the ways you can help us build better together.

--- a/doc/development/README.md
+++ b/doc/development/README.md
@@ -2,18 +2,18 @@
 
 So, you're ready to start contributing to Bundler! You've come to the right place. Here you'll find an overview of how to work on Bundler locally and a description of the process from code to release.
 
-##[Development setup](development/SETUP.md)
+##[Development setup](SETUP.md)
 
 Guidelines for setting up your local development environment.
 
-##[Submitting pull requests](development/PULL_REQUESTS.md)
+##[Submitting pull requests](PULL_REQUESTS.md)
 
 An overview of our preferred PR process, including how to run the test suite and what to expect when you submit code for review.
 
-##[Adding new features](development/NEW_FEATURES.md)
+##[Adding new features](NEW_FEATURES.md)
 
 Guidelines for proposing and writing new features for Bundler.
 
-##[Releasing Bundler](development/RELEASING.md)
+##[Releasing Bundler](RELEASING.md)
 
 A broad-strokes overview of the release process adhered to by the Bundler core team.

--- a/doc/documentation/README.md
+++ b/doc/documentation/README.md
@@ -16,11 +16,11 @@ Not sure where to write documentation? In general, follow these guidelines:
 
 If you are unsure where to begin, ping [@feministy](https://github.com/feministy) or [@indirect](https://github.com/indirect) in the Bundler Slack ([get an invite here](../contributing/GETTING_HELP.md)).
 
-## [Writing docs for man pages)](documentation/WRITING.md)
+## [Writing docs for man pages)](WRITING.md)
 
 If you’d like to submit a patch to the man pages, you're in the right place! Details on editing and previewing changes to man pages can be found here.
 
-## [Documentation vision](documentation/VISION.md)
+## [Documentation vision](VISION.md)
 
 Just like Bundler, we have a grand plan (really, a wish list of sorts) for Bundler documentation. Preview our hopes and dreams for our documentation here.
 


### PR DESCRIPTION
In doc/contributing/README.md, doc/documentation/README.md, and
doc/development/README.md, there were links that referenced files in the
same doc directory but prepended the directory name. This lead to urls
that were broken due to having the directory name stated twice.

I didn't want to clog the issues section with this since it isn't actually an issue with bundler. But I can create an issue of that would be better. Just noticed as I was trying to figure out how to get started. This will be my first OS contribution, so even though it is minor, please let me know if I did anything wrong. Thanks.