### PR TITLE
[Fix #5358] Handle files conflicts when using `bundle gem`

### DIFF
--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -122,7 +122,10 @@ module Bundler
       end
 
       templates.each do |src, dst|
-        thor.template("newgem/#{src}", target.join(dst), config)
+        destination = target.join(dst)
+        SharedHelpers.filesystem_access(destination) do
+          thor.template("newgem/#{src}", destination, config)
+        end
       end
 
       executables.each do |file|
@@ -139,6 +142,8 @@ module Bundler
 
       # Open gemspec in editor
       open_editor(options["edit"], target.join("#{name}.gemspec")) if options[:edit]
+    rescue Errno::EEXIST => e
+      raise GenericSystemCallError.new(e, "There was a conflict while creating the new gem.")
     end
 
   private

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -835,4 +835,26 @@ Usage: "bundle gem GEM [OPTIONS]"
       expect(bundled_app("foobar/CODE_OF_CONDUCT.md")).to exist
     end
   end
+
+  context "on conflicts with a previously created file" do
+    it "should fail gracefully" do
+      in_app_root do
+        FileUtils.touch("conflict-foobar")
+      end
+      output = bundle "gem conflict-foobar"
+      expect(output).to include("Errno::EEXIST")
+      expect(exitstatus).to eql(32) if exitstatus
+    end
+  end
+
+  context "on conflicts with a previously created directory" do
+    it "should fail gracefully" do
+      in_app_root do
+        FileUtils.mkdir_p("conflict-foobar/Gemfile")
+      end
+      output = bundle "gem conflict-foobar"
+      expect(output).to include("Errno::EISDIR")
+      expect(exitstatus).to eql(32) if exitstatus
+    end
+  end
 end


### PR DESCRIPTION
`bundle gem` command fails with an exception when creating a gem having
the same name of a file in the specified path.

For instance:
> touch hello
> bundle gem hello

This bug is due to Thor gem. At the moment, Thor does not handle
conflicts between files and directories. This commit mitigates the
problem by rescuing the exception from Thor and gracefully exit with an
error message.

Fixes https://github.com/bundler/bundler/issues/5358