### PR TITLE
Add documentation for mirror.fallback_timeout option.

### DIFF
--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -272,6 +272,18 @@ For example, to use a mirror of rubygems.org hosted at
 
     bundle config mirror.http://rubygems.org http://rubygems-mirror.org
 
+Bundler allows to set fallback timeout. When it pass Bundler will use original
+source instead of configured mirror.
+
+    bundle config mirror.SOURCE_URL.fallback_timeout TIMEOUT
+
+For example, to fallback mirror to original rubygems.org after 3 seconds
+
+    bundle config mirror.https://rubygems.org.fallback_timeout 3
+
+Default fallback timeout is 0.1 second. Bundler accepts only whole seconds as
+valid timeout values (1, 2, 3 ...).
+
 ## CREDENTIALS FOR GEM SOURCES
 
 Bundler allows you to configure credentials for any gem source, which allows

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -268,21 +268,22 @@ mirror to fetch gems.
 
     bundle config mirror.SOURCE_URL MIRROR_URL
 
-For example, to use a mirror of rubygems.org hosted at
+For example, to use a mirror of rubygems.org hosted at rubygems-mirror.org:
 
     bundle config mirror.http://rubygems.org http://rubygems-mirror.org
 
-Bundler allows to set fallback timeout. When it pass Bundler will use original
-source instead of configured mirror.
+Each mirror also provides a fallback timeout setting. If the mirror does not
+respond within the fallback timeout, Bundler will try to use the original
+server instead of the mirror.
 
     bundle config mirror.SOURCE_URL.fallback_timeout TIMEOUT
 
-For example, to fallback mirror to original rubygems.org after 3 seconds
+For example, to fall back to rubygems.org after 3 seconds:
 
     bundle config mirror.https://rubygems.org.fallback_timeout 3
 
-Default fallback timeout is 0.1 second. Bundler accepts only whole seconds as
-valid timeout values (1, 2, 3 ...).
+The default fallback timeout is 0.1 seconds, but the setting can currently
+only accept whole seconds (for example, 1, 15, or 30).
 
 ## CREDENTIALS FOR GEM SOURCES
 


### PR DESCRIPTION
As suggested in https://github.com/bundler/bundler/pull/5403#issuecomment-278384552 instead of changing parsing `mirror.fallback_timeout` I added documentation for it.
Pull request https://github.com/bundler/bundler/pull/5403 can be closed.