### PR TITLE
Adding the --key option for releasing private gems with gemstash

### DIFF
--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -94,6 +94,7 @@ module Bundler
     def rubygem_push(path)
       allowed_push_host = nil
       gem_command = "gem push '#{path}'"
+      gem_command += " --key #{gem_key}" if gem_key
       if @gemspec.respond_to?(:metadata)
         allowed_push_host = @gemspec.metadata["allowed_push_host"]
         gem_command += " --host #{allowed_push_host}" if allowed_push_host
@@ -179,6 +180,10 @@ module Bundler
         block.call(outbuf) if status.zero? && block
         [outbuf, status]
       end
+    end
+
+    def gem_key
+      ENV["gem_key"].to_s.downcase if ENV["gem_key"]
     end
 
     def gem_push?

--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -183,7 +183,7 @@ module Bundler
     end
 
     def gem_key
-      Bundler.settings['gem.push_key'].to_s.downcase if Bundler.settings['gem.push_key']
+      Bundler.settings["gem.push_key"].to_s.downcase if Bundler.settings["gem.push_key"]
     end
 
     def gem_push?

--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -183,7 +183,7 @@ module Bundler
     end
 
     def gem_key
-      ENV["gem_key"].to_s.downcase if ENV["gem_key"]
+      ENV["GEM_KEY"].to_s.downcase if ENV["GEM_KEY"]
     end
 
     def gem_push?

--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -183,7 +183,7 @@ module Bundler
     end
 
     def gem_key
-      ENV["GEM_KEY"].to_s.downcase if ENV["GEM_KEY"]
+      Bundler.settings['gem.push_key'].to_s.downcase if Bundler.settings['gem.push_key']
     end
 
     def gem_push?

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -300,3 +300,10 @@ This is especially useful for private repositories on hosts such as Github,
 where you can use personal OAuth tokens:
 
     export BUNDLE_GITHUB__COM=abcd0123generatedtoken:x-oauth-basic
+
+## RELEASING A GEM TO A PRIVATE SERVER
+
+In order to use the `rake release` command with a private gemstash server,
+you can configure the key for the `--key` parameter via:
+
+    bundle config gem.push_key GEMSTASH_KEY

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -219,6 +219,9 @@ learn more about their operation in [bundle install(1)][bundle-install].
    The location where RubyGems installs binstubs. Defaults to `Gem.bindir`.
 * `user_agent` (`BUNDLE_USER_AGENT`):
    The custom user agent fragment Bundler includes in API requests.
+* `gem.push_key` (`BUNDLE_GEM__PUSH_KEY`):
+   Sets the `--key` paramter for `gem push` when using the `rake release`
+   command with a private gemstash server.
 
 In general, you should set these settings per-application by using the applicable
 flag to the [bundle install(1)][bundle-install] or [bundle package(1)][bundle-package] command.
@@ -300,10 +303,3 @@ This is especially useful for private repositories on hosts such as Github,
 where you can use personal OAuth tokens:
 
     export BUNDLE_GITHUB__COM=abcd0123generatedtoken:x-oauth-basic
-
-## RELEASING A GEM TO A PRIVATE SERVER
-
-In order to use the `rake release` command with a private gemstash server,
-you can configure the key for the `--key` parameter via:
-
-    bundle config gem.push_key GEMSTASH_KEY


### PR DESCRIPTION
In order to use the `rake release` command with a private gemstash server, I'd need the `--key` option described here:
https://github.com/bundler/gemstash/blob/master/docs/gemstash-private-gems.7.md#pushing

I added a quite unobtrusive method to check for an ENV variable and - if it's present - add the `--key` param.

Final command would be:
`GEM_KEY=test_key bundle exec rake release`