### PR TITLE
remove post-install on account of confusion

### DIFF
--- a/bundler.gemspec
+++ b/bundler.gemspec
@@ -32,11 +32,4 @@ Gem::Specification.new do |s|
   s.bindir        = "exe"
   s.executables   = %w(bundle bundler)
   s.require_paths = ["lib"]
-
-  s.post_install_message = <<-END.lines.map(&:strip).join(" ")
-    Did you know that maintaining and improving Bundler and RubyGems.org costs
-    more than $25,000 USD every month? Help us keep the gem ecosystem free for
-    everyone by joining the hundreds of companies and individuals who help
-    cover these costs: https://ruby.to/support-bundler
-  END
 end


### PR DESCRIPTION
as demonstrated on twitter[1], this message was unfortunately convincing people that Ruby Together pays for the rubygems.org servers. let's remove it and come up with something clearer later.

[1]: https://twitter.com/MelissaKaulfuss/status/829504864229023744