### PR TITLE
Use empty array when `spec_settings` returns `nil`

### DIFF
--- a/lib/bundler/installer/gem_installer.rb
+++ b/lib/bundler/installer/gem_installer.rb
@@ -52,7 +52,7 @@ module Bundler
     end
 
     def install
-      spec.source.install(spec, :force => force, :ensure_builtin_gems_cached => standalone, :build_args => [spec_settings])
+      spec.source.install(spec, :force => force, :ensure_builtin_gems_cached => standalone, :build_args => Array(spec_settings))
     end
 
     def install_with_settings

--- a/spec/bundler/installer/gem_installer_spec.rb
+++ b/spec/bundler/installer/gem_installer_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+require "spec_helper"
+require "bundler/installer/gem_installer"
+
+RSpec.describe Bundler::GemInstaller do
+  let(:installer) { instance_double("Installer") }
+  let(:spec_source) { instance_double("SpecSource") }
+  let(:spec) { instance_double("Specification", :name => "dummy", :version => "0.0.1", :loaded_from => "dummy", :source => spec_source) }
+
+  subject { described_class.new(spec, installer) }
+
+  context "spec_settings is nil" do
+    it "invokes install method with empty build_args" do
+      allow(spec_source).to receive(:install).with(spec, :force => false, :ensure_builtin_gems_cached => false, :build_args => [])
+      subject.install_from_spec
+    end
+  end
+
+  context "spec_settings is build option" do
+    it "invokes install method with build_args" do
+      allow(Bundler.settings).to receive(:[]).with(:bin)
+      allow(Bundler.settings).to receive(:[]).with("build.dummy").and_return("--with-dummy-config=dummy")
+      allow(spec_source).to receive(:install).with(spec, :force => false, :ensure_builtin_gems_cached => false, :build_args => ["--with-dummy-config=dummy"])
+      subject.install_from_spec
+    end
+  end
+end

--- a/spec/bundler/installer/gem_installer_spec.rb
+++ b/spec/bundler/installer/gem_installer_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe Bundler::GemInstaller do
   subject { described_class.new(spec, installer) }
 
   context "spec_settings is nil" do
-    it "invokes install method with empty build_args" do
+    it "invokes install method with empty build_args", :rubygems => ">= 2" do
       allow(spec_source).to receive(:install).with(spec, :force => false, :ensure_builtin_gems_cached => false, :build_args => [])
       subject.install_from_spec
     end
   end
 
   context "spec_settings is build option" do
-    it "invokes install method with build_args" do
+    it "invokes install method with build_args", :rubygems => ">= 2" do
       allow(Bundler.settings).to receive(:[]).with(:bin)
       allow(Bundler.settings).to receive(:[]).with("build.dummy").and_return("--with-dummy-config=dummy")
       allow(spec_source).to receive(:install).with(spec, :force => false, :ensure_builtin_gems_cached => false, :build_args => ["--with-dummy-config=dummy"])


### PR DESCRIPTION
If use bundler 1.14.4 with rubygems 2.6.8 and
`Bundler.settings["build.#{spec.name}"]` returns `nil` then we get
error "can't modify frozen literal string" from [rubygems](https://github.com/rubygems/rubygems/blob/v2.6.8/lib/rubygems/ext/rake_builder.rb#L13).
RubyGems 2.6.8 is the default version for Ruby2.4.0.

See also https://github.com/sickill/rainbow/issues/48