### PR TITLE
Fix Github username for README.md contrib URL

### DIFF
--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -29,7 +29,8 @@ module Bundler
       constant_name = name.gsub(/-[_-]*(?![_-]|$)/) { "::" }.gsub(/([_-]+|(::)|^)(.|$)/) { $2.to_s + $3.upcase }
       constant_array = constant_name.split("::")
 
-      git_user_name = `git config user.name`.chomp
+      git_author_name = `git config user.name`.chomp
+      github_username = `git config github.user`.chomp
       git_user_email = `git config user.email`.chomp
 
       config = {
@@ -39,13 +40,13 @@ module Bundler
         :makefile_path    => "#{underscored_name}/#{underscored_name}",
         :constant_name    => constant_name,
         :constant_array   => constant_array,
-        :author           => git_user_name.empty? ? "TODO: Write your name" : git_user_name,
+        :author           => git_author_name.empty? ? "TODO: Write your name" : git_author_name,
         :email            => git_user_email.empty? ? "TODO: Write your email address" : git_user_email,
         :test             => options[:test],
         :ext              => options[:ext],
         :exe              => options[:exe],
         :bundler_version  => bundler_dependency_version,
-        :git_user_name    => git_user_name.empty? ? "[USERNAME]" : git_user_name
+        :github_username  => github_username.empty? ? "[USERNAME]" : github_username
       }
       ensure_safe_gem_name(name, constant_array)
 

--- a/lib/bundler/templates/newgem/README.md.tt
+++ b/lib/bundler/templates/newgem/README.md.tt
@@ -32,7 +32,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/<%= config[:git_user_name] %>/<%= config[:name] %>.<% if config[:coc] %> This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.<% end %>
+Bug reports and pull requests are welcome on GitHub at https://github.com/<%= config[:github_username] %>/<%= config[:name] %>.<% if config[:coc] %> This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.<% end %>
 <% if config[:mit] %>
 
 ## License

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe "bundle gem" do
 
   def gem_skeleton_assertions(gem_name)
     expect(bundled_app("#{gem_name}/#{gem_name}.gemspec")).to exist
+    expect(bundled_app("#{gem_name}/README.md")).to exist
     expect(bundled_app("#{gem_name}/Gemfile")).to exist
     expect(bundled_app("#{gem_name}/Rakefile")).to exist
     expect(bundled_app("#{gem_name}/lib/test/gem.rb")).to exist
@@ -36,6 +37,8 @@ RSpec.describe "bundle gem" do
     [user]
       name = "Bundler User"
       email = user@example.com
+    [github]
+      user = bundleuser
     EOF
     @git_config_location = ENV["GIT_CONFIG"]
     path = "#{File.expand_path("../../tmp", File.dirname(__FILE__))}/test_git_config.txt"
@@ -116,19 +119,20 @@ RSpec.describe "bundle gem" do
     let(:gem_name) { "test_gem" }
     let(:generated_gem) { Bundler::GemHelper.new(bundled_app(gem_name).to_s) }
 
-    context "git config user.name present" do
+    context "git config github.user present" do
       before do
         execute_bundle_gem(gem_name)
       end
 
       it "contribute URL set to git username" do
         expect(bundled_app("test_gem/README.md").read).not_to include("[USERNAME]")
+        expect(bundled_app("test_gem/README.md").read).to include("github.com/bundleuser")
       end
     end
 
-    context "git config user.name is absent" do
+    context "git config github.user is absent" do
       before do
-        `git config --unset user.name`
+        sys_exec("git config --unset github.user")
         reset!
         in_app_root
         bundle "gem #{gem_name}"
@@ -137,6 +141,7 @@ RSpec.describe "bundle gem" do
 
       it "contribute URL set to [USERNAME]" do
         expect(bundled_app("test_gem/README.md").read).to include("[USERNAME]")
+        expect(bundled_app("test_gem/README.md").read).not_to include("github.com/bundleuser")
       end
     end
   end


### PR DESCRIPTION
This fixes #5438 where the wrong git config variable was being
retrieved.

This was using `git config user.name` rather than `git config github.user` in URL in `README.md`