### PR TITLE
Enable compact index when OpenSSL FIPS mode is enabled but not active

### DIFF
--- a/lib/bundler/fetcher/compact_index.rb
+++ b/lib/bundler/fetcher/compact_index.rb
@@ -122,24 +122,13 @@ module Bundler
       end
 
       def md5_available?
-        return true unless fips_enabled? && Process.respond_to?(:fork)
-        pid = fork do
-          $stderr.reopen(File.new("/dev/null", "w"))
-          require "digest/md5"
-          Digest::MD5.new
-          exit
-        end
-        Process.wait pid
-        $?.success?
-      end
-
-      def fips_enabled?
-        begin
-          require "openssl"
-        rescue LoadError
-          nil
-        end
-        defined?(OpenSSL::OPENSSL_FIPS) && OpenSSL::OPENSSL_FIPS
+        require "openssl"
+        OpenSSL::Digest::MD5.digest("")
+        true
+      rescue LoadError
+        true
+      rescue OpenSSL::Digest::DigestError
+        false
       end
     end
   end

--- a/spec/bundler/fetcher/compact_index_spec.rb
+++ b/spec/bundler/fetcher/compact_index_spec.rb
@@ -52,12 +52,6 @@ RSpec.describe Bundler::Fetcher::CompactIndex do
           before do
             allow(OpenSSL::Digest::MD5).to receive(:digest).
               and_raise(OpenSSL::Digest::DigestError)
-            allow(Digest::MD5).to receive(:new) do
-              # OpenSSL writes to STDERR and kills the current process with SIGABRT
-              # when FIPS mode prevents MD5 from being used.
-              $stderr.write "Digest MD5 forbidden in FIPS mode!"
-              Process.kill("ABRT", Process.pid)
-            end
           end
 
           it "returns false" do


### PR DESCRIPTION
Fixes #5433. Since there is no easy accessor in Ruby to detect whether or not FIPS mode is currently active, the best approach I could come up with is to `fork` a separate process and attempt to generate a build MD5 object as a test of whether MD5 module is currently available.

Because `fork` approach won't work on some platforms (JRuby, Windows etc), `md5_supported?` returns `false` on any platforms where FIPS mode is enabled and `Process.respond_to?(:fork)` is `false`.

I've added a spec that simulates behavior when OpenSSL FIPS mode is active - an error message is output to STDERR and the process is killed with the `ABRT` signal.