### PR TITLE
[Resolver] Improve sorting of deps with 0 or 1 possibility

### DIFF
--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -329,6 +329,12 @@ module Bundler
 
   private
 
+    # returns an integer \in (-\infty, 0]
+    # a number closer to 0 means the dependency is less constraining
+    #
+    # dependencies w/ 0 or 1 possibilities (ignoring version requirements)
+    # are given very negative values, so they _always_ sort first,
+    # before dependencies that are unconstrained
     def amount_constrained(dependency)
       @amount_constrained ||= {}
       @amount_constrained[dependency.name] ||= begin
@@ -336,8 +342,9 @@ module Bundler
           dependency.requirement.satisfied_by?(base.first.version) ? 0 : 1
         else
           all = index_for(dependency).search(dependency.name).size
+
           if all <= 1
-            all
+            all - 1_000_000
           else
             search = search_for(dependency).size
             search - all

--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -230,11 +230,11 @@ module Bundler
 
     def debug?
       return @debug_mode if defined?(@debug_mode)
-      @debug_mode = ENV["DEBUG_RESOLVER"] || ENV["DEBUG_RESOLVER_TREE"]
+      @debug_mode = ENV["DEBUG_RESOLVER"] || ENV["DEBUG_RESOLVER_TREE"] || false
     end
 
     def before_resolution
-      Bundler.ui.info "Resolving dependencies...", false
+      Bundler.ui.info "Resolving dependencies...", debug?
     end
 
     def after_resolution
@@ -242,7 +242,7 @@ module Bundler
     end
 
     def indicate_progress
-      Bundler.ui.info ".", false
+      Bundler.ui.info ".", false unless debug?
     end
 
     include Molinillo::SpecificationProvider

--- a/spec/install/bundler_spec.rb
+++ b/spec/install/bundler_spec.rb
@@ -44,17 +44,14 @@ RSpec.describe "bundle install" do
           In Gemfile:
             bundler (= 0.9.2)
 
-            rails (= 3.0) was resolved to 3.0, which depends on
-              bundler (>= 0.9.0.pre)
-
           Current Bundler version:
             bundler (#{Bundler::VERSION})
         This Gemfile requires a different version of Bundler.
         Perhaps you need to update Bundler by running `gem install bundler`?
 
-        Could not find gem 'bundler (= 0.9.2)', which is required by gem 'rails (= 3.0)', in any of the sources.
+        Could not find gem 'bundler (= 0.9.2)' in any of the sources
         E
-      expect(out).to include(nice_error)
+      expect(out).to eq(nice_error)
     end
 
     it "works for gems with multiple versions in its dependencies" do


### PR DESCRIPTION
As the added comment says, this will force all dependencies where there are only 0 or 1 total specs with that name to be resolved first. Right now, they sort ~last, which leads to poor performance.

(This was one way of fixing some recent resolver issues, even though we've done the proper fixes in Molinillo for them)