### PR TITLE
[StubSpecification] Avoid loading all installed gemspecs

### DIFF
--- a/lib/bundler/stub_specification.rb
+++ b/lib/bundler/stub_specification.rb
@@ -15,6 +15,13 @@ module Bundler
       _remote_specification.to_yaml
     end
 
+    if Bundler.rubygems.provides?(">= 2.3")
+      # This is defined directly to avoid having to load every installed spec
+      def missing_extensions?
+        stub.missing_extensions?
+      end
+    end
+
   private
 
     def _remote_specification

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -673,6 +673,34 @@ RSpec.describe "Bundler.setup" do
     expect(out).to be_empty
   end
 
+  it "does not load all gemspecs", :rubygems => ">= 2.3" do
+    install_gemfile! <<-G
+      source "file://#{gem_repo1}"
+      gem "rack"
+    G
+
+    run! <<-R
+      File.open(File.join(Gem.dir, "specifications", "broken.gemspec"), "w") do |f|
+        f.write <<-RUBY
+# -*- encoding: utf-8 -*-
+# stub: broken 1.0.0 ruby lib
+
+Gem::Specification.new do |s|
+  s.name = "broken"
+  s.version = "1.0.0"
+  raise "BROKEN GEMSPEC"
+end
+        RUBY
+      end
+    R
+
+    run! <<-R
+      puts "WIN"
+    R
+
+    expect(out).to eq("WIN")
+  end
+
   it "ignores empty gem paths" do
     install_gemfile <<-G
       source "file://#{gem_repo1}"


### PR DESCRIPTION
Call through to the stub instead of materializing the full remote_spec since all gems added to the local index are asked whether they are missing extensions or not