### PR TITLE
Add a spec for not activating any gems during Bundler.setup

### DIFF
--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -746,7 +746,13 @@ module Bundler
       end
 
       def backport_ext_builder_monitor
-        require "rubygems/ext"
+        # So we can avoid requiring "rubygems/ext" in its entirety
+        Gem.module_eval <<-RB, __FILE__, __LINE__ + 1
+          module Ext
+          end
+        RB
+
+        require "rubygems/ext/builder"
 
         Gem::Ext::Builder.class_eval do
           unless const_defined?(:CHDIR_MONITOR)

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -1144,16 +1144,20 @@ end
 
       let(:code) { strip_whitespace(<<-RUBY) }
         require "rubygems"
-        Gem::Specification.send(:alias_method, :bundler_spec_activate, :activate)
-        Gem::Specification.send(:define_method, :activate) do
-          unless #{exemptions.inspect}.include?(name)
-            warn '-' * 80
-            warn "activating \#{full_name}"
-            warn *caller
-            warn '*' * 80
+
+        if Gem::Specification.instance_methods.map(&:to_sym).include?(:activate)
+          Gem::Specification.send(:alias_method, :bundler_spec_activate, :activate)
+          Gem::Specification.send(:define_method, :activate) do
+            unless #{exemptions.inspect}.include?(name)
+              warn '-' * 80
+              warn "activating \#{full_name}"
+              warn *caller
+              warn '*' * 80
+            end
+            bundler_spec_activate
           end
-          bundler_spec_activate
         end
+
         require "bundler/setup"
         require "pp"
         loaded_specs = Gem.loaded_specs.dup


### PR DESCRIPTION
This is failing on ruby 2.5, since more of the stdlib is being gemified (fileutils in particular)

We can wait to merge until it passes if you'd like, @indirect, but this will likely also require changes in RubyGems