### PR TITLE
`bundle inject` with source and group options

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -465,10 +465,14 @@ module Bundler
     end
 
     desc "inject GEM VERSION", "Add the named gem, with version requirements, to the resolved Gemfile"
+    method_option "source", :type => :string, :banner =>
+     "Use the specific source for the gem"
+    method_option "group", :type => :string, :banner =>
+     "Put the gem into specific group"
     def inject(name, version)
       SharedHelpers.major_deprecation "The `inject` command has been replaced by the `add` command"
       require "bundler/cli/inject"
-      Inject.new(options, name, version).run
+      Inject.new(options.dup, name, version).run
     end
 
     desc "lock", "Creates a lockfile without installing"

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -466,9 +466,9 @@ module Bundler
 
     desc "inject GEM VERSION", "Add the named gem, with version requirements, to the resolved Gemfile"
     method_option "source", :type => :string, :banner =>
-     "Use the specific source for the gem"
+     "Install gem from the given source"
     method_option "group", :type => :string, :banner =>
-     "Put the gem into specific group"
+     "Install gem into a bundler group"
     def inject(name, version)
       SharedHelpers.major_deprecation "The `inject` command has been replaced by the `add` command"
       require "bundler/cli/inject"

--- a/lib/bundler/cli/inject.rb
+++ b/lib/bundler/cli/inject.rb
@@ -31,7 +31,8 @@ module Bundler
 
       if added.any?
         Bundler.ui.confirm "Added to Gemfile:"
-        Bundler.ui.confirm added.map {|g| "  #{g}" }.join("\n")
+        Bundler.ui.confirm added.map {|g| "  #{g}, group => #{g.groups.inspect},
+         :source => '#{g.source}'" }.join("\n")
       else
         Bundler.ui.confirm "All gems were already present in the Gemfile"
       end

--- a/lib/bundler/cli/inject.rb
+++ b/lib/bundler/cli/inject.rb
@@ -31,8 +31,7 @@ module Bundler
 
       if added.any?
         Bundler.ui.confirm "Added to Gemfile:"
-        Bundler.ui.confirm added.map {|g| "  #{g}, group => #{g.groups.inspect},
-         :source => '#{g.source}'" }.join("\n")
+        Bundler.ui.confirm added.map {|g| "  #{g}, group => #{g.groups.inspect}, :source => '#{g.source}'" }.join("\n")
       else
         Bundler.ui.confirm "All gems were already present in the Gemfile"
       end

--- a/lib/bundler/cli/inject.rb
+++ b/lib/bundler/cli/inject.rb
@@ -31,7 +31,7 @@ module Bundler
 
       if added.any?
         Bundler.ui.confirm "Added to Gemfile:"
-        Bundler.ui.confirm added.map {|g| "  #{g}, group => #{g.groups.inspect}, :source => '#{g.source}'" }.join("\n")
+        Bundler.ui.confirm added.map {|g| "  #{g}, group => #{g.groups.inspect}, :source => '#{g.source.dump}'" }.join("\n")
       else
         Bundler.ui.confirm "All gems were already present in the Gemfile"
       end

--- a/lib/bundler/cli/inject.rb
+++ b/lib/bundler/cli/inject.rb
@@ -6,7 +6,7 @@ module Bundler
       @options = options
       @name = name
       @version = version || last_version_number
-      @group = options[:group]
+      @group = options[:group].split(",") unless options[:group].nil?
       @source = options[:source]
       @gems = []
     end
@@ -31,7 +31,13 @@ module Bundler
 
       if added.any?
         Bundler.ui.confirm "Added to Gemfile:"
-        Bundler.ui.confirm added.map {|g| "  #{g}, group => #{g.groups.inspect}, :source => '#{g.source.dump}'" }.join("\n")
+        Bundler.ui.confirm(added.map do |d|
+          name = "'#{d.name}'"
+          requirement = ", '#{d.requirement}'"
+          group = ", :group => #{d.groups.inspect}" if d.groups != Array(:default)
+          source = ", :source => '#{d.source}'" unless d.source.nil?
+          %(gem #{name}#{requirement}#{group}#{source})
+        end.join("\n"))
       else
         Bundler.ui.confirm "All gems were already present in the Gemfile"
       end

--- a/lib/bundler/injector.rb
+++ b/lib/bundler/injector.rb
@@ -51,7 +51,14 @@ module Bundler
       @new_deps.map do |d|
         name = "'#{d.name}'"
         requirement = ", '#{d.requirement}'"
-        group = ", :group => #{d.groups.inspect}" if d.groups != Array(:default)
+        if d.groups != Array(:default)
+          group =
+            if d.groups.size == 1
+              ", :group => #{d.groups.inspect}"
+            else
+              ", :groups => #{d.groups.inspect}"
+            end
+        end
         source = ", :source => '#{d.source}'" unless d.source.nil?
         %(gem #{name}#{requirement}#{group}#{source})
       end.join("\n")

--- a/spec/commands/inject_spec.rb
+++ b/spec/commands/inject_spec.rb
@@ -52,6 +52,29 @@ Usage: "bundle inject GEM VERSION"
     end
   end
 
+  context "use source and group options" do
+    it "add gem with source in gemfile" do
+      bundle "inject 'bootstrap' '>0' --source=https://rubygems.org"
+      gemfile = bundled_app("Gemfile").read
+      str = "gem 'bootstrap', '> 0', :source => 'https://rubygems.org'"
+      expect(gemfile).to match(/str/)
+    end
+
+    it "add gem with group in gemfile" do
+      bundle "inject 'rack-obama' '>0' --group=development"
+      gemfile = bundled_app("Gemfile").read
+      str = "gem 'rack-obama', '> 0', :group => [:development]"
+      expect(gemfile).to match(/str/)
+    end
+
+    it "add gem with source and group in gemfile" do
+      bundle "inject 'rails' '>0' --source=https://rubygems.org --group=development"
+      gemfile = bundled_app("Gemfile").read
+      str = "gem 'rails', '> 0', :group => [:development], :source => 'https://rubygems.org'"
+      expect(gemfile).to match(/str/)
+    end
+  end
+
   context "when frozen" do
     before do
       bundle "install"

--- a/spec/commands/inject_spec.rb
+++ b/spec/commands/inject_spec.rb
@@ -52,26 +52,21 @@ Usage: "bundle inject GEM VERSION"
     end
   end
 
-  context "use source and group options" do
-    it "add gem with source in gemfile" do
-      bundle "inject 'bootstrap' '>0' --source=https://rubygems.org"
+  context "with source option" do
+    it "add gem with source option in gemfile" do
+      bundle "inject 'bootstrap' '>0' --source=https://ruby.taobao.org/"
       gemfile = bundled_app("Gemfile").read
-      str = "gem 'bootstrap', '> 0', :source => 'https://rubygems.org'"
-      expect(gemfile).to match(/str/)
+      str = "gem 'bootstrap', '> 0', :source => 'https://ruby.taobao.org/'"
+      expect(gemfile).to include str
     end
+  end
 
-    it "add gem with group in gemfile" do
+  context "with group option" do
+    it "add gem with group option in gemfile" do
       bundle "inject 'rack-obama' '>0' --group=development"
       gemfile = bundled_app("Gemfile").read
       str = "gem 'rack-obama', '> 0', :group => [:development]"
-      expect(gemfile).to match(/str/)
-    end
-
-    it "add gem with source and group in gemfile" do
-      bundle "inject 'rails' '>0' --source=https://rubygems.org --group=development"
-      gemfile = bundled_app("Gemfile").read
-      str = "gem 'rails', '> 0', :group => [:development], :source => 'https://rubygems.org'"
-      expect(gemfile).to match(/str/)
+      expect(gemfile).to include str
     end
   end
 

--- a/spec/commands/inject_spec.rb
+++ b/spec/commands/inject_spec.rb
@@ -68,6 +68,13 @@ Usage: "bundle inject GEM VERSION"
       str = "gem 'rack-obama', '> 0', :group => [:development]"
       expect(gemfile).to include str
     end
+
+    it "add gem with multiple group in gemfile" do
+      bundle "inject 'rack-obama' '>0' --group=development,test"
+      gemfile = bundled_app("Gemfile").read
+      str = "gem 'rack-obama', '> 0', :group => [:development, :test]"
+      expect(gemfile).to include str
+    end
   end
 
   context "when frozen" do

--- a/spec/commands/inject_spec.rb
+++ b/spec/commands/inject_spec.rb
@@ -54,9 +54,9 @@ Usage: "bundle inject GEM VERSION"
 
   context "with source option" do
     it "add gem with source option in gemfile" do
-      bundle "inject 'bootstrap' '>0' --source=https://ruby.taobao.org/"
+      bundle "inject 'foo' '>0' --source file://#{gem_repo1}"
       gemfile = bundled_app("Gemfile").read
-      str = "gem 'bootstrap', '> 0', :source => 'https://ruby.taobao.org/'"
+      str = "gem 'foo', '> 0', :source => 'file://#{gem_repo1}'"
       expect(gemfile).to include str
     end
   end

--- a/spec/commands/inject_spec.rb
+++ b/spec/commands/inject_spec.rb
@@ -69,7 +69,7 @@ Usage: "bundle inject GEM VERSION"
       expect(gemfile).to include str
     end
 
-    it "add gem with multiple group in gemfile" do
+    it "add gem with multiple groups in gemfile" do
       bundle "inject 'rack-obama' '>0' --group=development,test"
       gemfile = bundled_app("Gemfile").read
       str = "gem 'rack-obama', '> 0', :group => [:development, :test]"

--- a/spec/commands/inject_spec.rb
+++ b/spec/commands/inject_spec.rb
@@ -72,7 +72,7 @@ Usage: "bundle inject GEM VERSION"
     it "add gem with multiple groups in gemfile" do
       bundle "inject 'rack-obama' '>0' --group=development,test"
       gemfile = bundled_app("Gemfile").read
-      str = "gem 'rack-obama', '> 0', :group => [:development, :test]"
+      str = "gem 'rack-obama', '> 0', :groups => [:development, :test]"
       expect(gemfile).to include str
     end
   end


### PR DESCRIPTION
Fixes https://github.com/bundler/bundler/issues/5452

Eg

```
$ bundle inject "bootstrap" ">0" --source=https://rubygems.org --group=development
Fetching gem metadata from https://rubygems.org/............
Fetching version metadata from https://rubygems.org/..
Fetching dependency metadata from https://rubygems.org/.
Fetching gem metadata from https://rubygems.org/.............
Fetching version metadata from https://rubygems.org/..
Fetching dependency metadata from https://rubygems.org/.
Added to Gemfile:
  bootstrap (> 0), group => [:development], :source => 'https://rubygems.org'
```

In GemFile 

```
gem 'bootstrap', '> 0', :group => [:development], :source => 'https://rubygems.org'
```

### Multiple group : 

```
$ dbundle inject "bootstrap" ">0" --source=https://rubygems.org --group=development,production
Fetching gem metadata from https://rubygems.org/............

Added to Gemfile:
gem 'bootstrap', '> 0', :group => [:development, :production], :source => 'https://rubygems.org'

```
In gemfile

```
# Added at 2017-03-24 11:40:51 +0530 by shekharrajak:
gem 'bootstrap', '> 0', :group => [:development, :production], :source => 'https://rubygems.org'
```