### PR TITLE
Print a backtrace on SIGINT in debug mode

### DIFF
--- a/exe/bundle
+++ b/exe/bundle
@@ -2,7 +2,10 @@
 # frozen_string_literal: true
 
 # Exit cleanly from an early interrupt
-Signal.trap("INT") { exit 1 }
+Signal.trap("INT") do
+  Bundler.ui.debug("\n#{caller.join("\n")}") if defined?(Bundler)
+  exit 1
+end
 
 update = "update".start_with?(ARGV.first || " ") && ARGV.find {|a| a.start_with?("--bundler") }
 update &&= update =~ /--bundler(?:=(.+))?/ && $1 || "> 0.a"

--- a/lib/bundler/worker.rb
+++ b/lib/bundler/worker.rb
@@ -76,6 +76,7 @@ module Bundler
 
     def abort_threads
       return unless @threads
+      Bundler.ui.debug("\n#{caller.join("\n")}")
       @threads.each(&:exit)
       exit 1
     end


### PR DESCRIPTION
I found this helpful when trying to figure out why bundler was going so slowly