### PR TITLE
[Source::RubyGems] Print that we are fetching a gem

### DIFF
--- a/lib/bundler/source/rubygems.rb
+++ b/lib/bundler/source/rubygems.rb
@@ -410,6 +410,7 @@ module Bundler
         return false unless spec.remote
         uri = spec.remote.uri
         spec.fetch_platform
+        Bundler.ui.confirm("Fetching #{version_message(spec)}")
 
         download_path = requires_sudo? ? Bundler.tmp(spec.full_name) : rubygems_dir
         gem_path = "#{rubygems_dir}/cache/#{spec.full_name}.gem"

--- a/spec/runtime/inline_spec.rb
+++ b/spec/runtime/inline_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe "bundler/inline#gemfile" do
       end
     RUBY
 
-    expect(out).to eq("CONFIRMED!")
+    expect(out).to eq("CONFIRMED!\nCONFIRMED!")
     expect(exitstatus).to be_zero if exitstatus
   end
 


### PR DESCRIPTION
This is super helpful when you're on slow cafe wifi and downloading an 8MB gem such as nokogiri