### PR TITLE
Updater.rb: Avoid using String method on nil

### DIFF
--- a/lib/bundler/compact_index_client/updater.rb
+++ b/lib/bundler/compact_index_client/updater.rb
@@ -53,7 +53,7 @@ module Bundler
             local_temp_path.open(mode) {|f| f << content }
           end
 
-          response_etag = response["ETag"].gsub(%r{\AW/}, "")
+          response_etag = (response["ETag"] || "").gsub(%r{\AW/}, "")
           if etag_for(local_temp_path) == response_etag
             SharedHelpers.filesystem_access(local_path) do
               FileUtils.mv(local_temp_path, local_path)

--- a/spec/bundler/compact_index_client/updater_spec.rb
+++ b/spec/bundler/compact_index_client/updater_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+require "spec_helper"
+require "net/http"
+require "bundler/compact_index_client"
+require "bundler/compact_index_client/updater"
+
+RSpec.describe Bundler::CompactIndexClient::Updater do
+  subject(:updater) { described_class.new(fetcher) }
+
+  let(:fetcher) { double(:fetcher) }
+
+  context "when the ETag header is missing" do
+    # Regression test for https://github.com/bundler/bundler/issues/5463
+
+    let(:response) { double(:response, :body => "") }
+    let(:local_path) { Pathname("/tmp/localpath") }
+    let(:remote_path) { double(:remote_path) }
+
+    it "MisMatchedChecksumError is raised" do
+      # Twice: #update retries on failure
+      expect(response).to receive(:[]).with("Content-Encoding").twice { "" }
+      expect(response).to receive(:[]).with("ETag").twice { nil }
+      expect(fetcher).to receive(:call).twice { response }
+
+      expect do
+        updater.update(local_path, remote_path)
+      end.to raise_error(Bundler::CompactIndexClient::Updater::MisMatchedChecksumError)
+    end
+  end
+end


### PR DESCRIPTION
This code in Compact Index Client expected there to _be_ an ETag header in the response:

```ruby
response_etag = response["ETag"].gsub(%r{\AW/}, "")
```

This PR handles that case when an ETag header may not be available in the `response`. If so, we won't try to update any cache.

~**Questions**: Would it be better with a non-empty string default? Something along the lines of "No ETag header found in response"?~

Closes #5463 

---

Continuation of this work: Use artifice to imitate Net::HTTP interactions -
 see https://github.com/bundler/bundler/commit/fb8d40c3462751e5853f76e2cd342b8b9a4b4430 for details