### PR TITLE
Add `bundle issue` command that prints instructions for reporting issues

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -528,6 +528,12 @@ module Bundler
       Doctor.new(options).run
     end
 
+    desc "issue", "Learn how to report an issue in Bundler"
+    def issue
+      require "bundler/cli/issue"
+      Issue.new.run
+    end
+
     if Bundler.feature_flag.plugins?
       require "bundler/cli/plugin"
       desc "plugin SUBCOMMAND ...ARGS", "manage the bundler plugins"

--- a/lib/bundler/cli/issue.rb
+++ b/lib/bundler/cli/issue.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rbconfig"
+
+module Bundler
+  class CLI::Issue
+    def run
+      Bundler.ui.info <<-EOS.gsub(/^ {8}/, "")
+        Did you find an issue with Bundler? Before filing a new issue,
+        be sure to check out these resources:
+
+        1. Check out our troubleshooting guide for quick fixes to common issues:
+        https://github.com/bundler/bundler/blob/master/doc/TROUBLESHOOTING.md
+
+        2. Instructions for common Bundler uses can be found on the documentation
+        site: http://bundler.io/
+
+        3. Information about each Bundler command can be found in the Bundler
+        man pages: http://bundler.io/man/bundle.1.html
+
+        Hopefully the trouble shooting steps above resolved your problem!  If things
+        still aren't working the way you expect them to, please let us know so
+        that we can diagnose and hopefully fix the problem you're having. Please
+        view the Filing Issues guide for more information:
+        https://github.com/bundler/bundler/blob/master/doc/contributing/ISSUES.md
+
+      EOS
+
+      Bundler.ui.info Bundler::Env.new.report
+
+      Bundler.ui.info "\n## Bundle Doctor"
+      doctor
+    end
+
+    def doctor
+      require "bundler/cli/doctor"
+      Bundler::CLI::Doctor.new({}).run
+    end
+  end
+end

--- a/lib/bundler/cli/issue.rb
+++ b/lib/bundler/cli/issue.rb
@@ -26,7 +26,7 @@ module Bundler
 
       EOS
 
-      Bundler.ui.info Bundler::Env.new.report(print_gemfile: true)
+      Bundler.ui.info Bundler::Env.new.report(:print_gemfile => true)
 
       Bundler.ui.info "\n## Bundle Doctor"
       doctor

--- a/lib/bundler/cli/issue.rb
+++ b/lib/bundler/cli/issue.rb
@@ -18,9 +18,9 @@ module Bundler
         3. Information about each Bundler command can be found in the Bundler
         man pages: http://bundler.io/man/bundle.1.html
 
-        Hopefully the trouble shooting steps above resolved your problem!  If things
+        Hopefully the troubleshooting steps above resolved your problem!  If things
         still aren't working the way you expect them to, please let us know so
-        that we can diagnose and hopefully fix the problem you're having. Please
+        that we can diagnose and help fix the problem you're having. Please
         view the Filing Issues guide for more information:
         https://github.com/bundler/bundler/blob/master/doc/contributing/ISSUES.md
 

--- a/lib/bundler/cli/issue.rb
+++ b/lib/bundler/cli/issue.rb
@@ -26,7 +26,7 @@ module Bundler
 
       EOS
 
-      Bundler.ui.info Bundler::Env.new.report
+      Bundler.ui.info Bundler::Env.new.report(print_gemfile: true)
 
       Bundler.ui.info "\n## Bundle Doctor"
       doctor

--- a/spec/commands/issue_spec.rb
+++ b/spec/commands/issue_spec.rb
@@ -3,9 +3,15 @@ require "spec_helper"
 
 RSpec.describe "bundle issue" do
   it "exits with a message" do
+    install_gemfile <<-G
+      source "file://#{gem_repo1}"
+      gem "rails"
+    G
+
     bundle "issue"
     expect(out).to include "Did you find an issue with Bundler?"
     expect(out).to include "## Environment"
+    expect(out).to include "## Gemfile"
     expect(out).to include "## Bundle Doctor"
   end
 end

--- a/spec/commands/issue_spec.rb
+++ b/spec/commands/issue_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+RSpec.describe "bundle issue" do
+  it "exits with a message" do
+    bundle "issue"
+    expect(out).to include "Did you find an issue with Bundler?"
+    expect(out).to include "## Environment"
+    expect(out).to include "## Bundle Doctor"
+  end
+end


### PR DESCRIPTION
This is my stab at adding a `bundle issue` command, as listed in the list of tasks anyone can claim (#4871).  This is also my first contribution (of what I hope will be many) to Bundler!  

I hope that this is useful, and please let me know how to improve it! 