### PR TITLE
Add Code of Conduct content to README template

### DIFF
--- a/lib/bundler/templates/newgem/README.md.tt
+++ b/lib/bundler/templates/newgem/README.md.tt
@@ -39,3 +39,9 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/<%= co
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
 <% end %>
+
+<% if config[:coc] %>
+## Code of Conduct
+
+Everyone interacting in the <%= config[:constant_name] %> project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/<%= config[:github_username] %>/<%= config[:name] %>/blob/master/CODE_OF_CONDUCT.md).
+<% end %>

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -103,6 +103,13 @@ RSpec.describe "bundle gem" do
       gem_skeleton_assertions(gem_name)
       expect(bundled_app("test-gem/CODE_OF_CONDUCT.md")).to exist
     end
+
+    describe "README additions" do
+      it "generates the README with a section for the Code of Conduct" do
+        expect(bundled_app("test-gem/README.md").read).to include("## Code of Conduct")
+        expect(bundled_app("test-gem/README.md").read).to include("https://github.com/bundleuser/#{gem_name}/blob/master/CODE_OF_CONDUCT.md")
+      end
+    end
   end
 
   shared_examples_for "--no-coc flag" do
@@ -112,6 +119,13 @@ RSpec.describe "bundle gem" do
     it "generates a gem skeleton without Code of Conduct" do
       gem_skeleton_assertions(gem_name)
       expect(bundled_app("test-gem/CODE_OF_CONDUCT.md")).to_not exist
+    end
+
+    describe "README additions" do
+      it "generates the README without a section for the Code of Conduct" do
+        expect(bundled_app("test-gem/README.md").read).not_to include("## Code of Conduct")
+        expect(bundled_app("test-gem/README.md").read).not_to include("https://github.com/bundleuser/#{gem_name}/blob/master/CODE_OF_CONDUCT.md")
+      end
     end
   end
 


### PR DESCRIPTION
Adds feature discussed in #5512 

When the --coc flag is set or otherwise enabled when generating a new
gem, a Code of Conduct is generated. This adds an additional link to
that Code of Conduct in the README, and adds default text for the
Code of Conduct based on language used in other popular ruby open
source libraries (bundler, rails).