### PR TITLE
Ensure Gem.loaded_specs["bundler"].version returns bundler's version

### DIFF
--- a/lib/bundler/version.rb
+++ b/lib/bundler/version.rb
@@ -8,4 +8,17 @@ module Bundler
   # with other versions of bundler and we are unsure how to
   # handle this better.
   VERSION = "1.14.6" unless defined?(::Bundler::VERSION)
+
+  def self.overwrite_loaded_gem_version
+    begin
+      require "rubygems"
+    rescue LoadError
+      return
+    end
+    return unless bundler_spec = Gem.loaded_specs["bundler"]
+    return if bundler_spec.version == VERSION
+    bundler_spec.version = Bundler::VERSION
+  end
+  private_class_method :overwrite_loaded_gem_version
+  overwrite_loaded_gem_version
 end


### PR DESCRIPTION
Once RubyGems ships with Bundler as a default spec, if using bundler via
-I, it will still be registered as an activated spec (even if the loaded
features are loaded from the load path and not the default gem). This
hack ensures the versions will always match.

This works around https://github.com/rubygems/rubygems/issues/1866, and is a substitute for https://github.com/rubygems/rubygems/pull/1868, allowing the bundler tests to pass if RubyGems master (which will be released as 2.7), which ships with bundler as a default gem, is installed (vs. just being used via `-I`)