### PR TITLE
fix spacing between paragraphs in generated READMEs for new gems

### DIFF
--- a/lib/bundler/templates/newgem/README.md.tt
+++ b/lib/bundler/templates/newgem/README.md.tt
@@ -33,15 +33,15 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/<%= config[:github_username] %>/<%= config[:name] %>.<% if config[:coc] %> This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.<% end %>
-<% if config[:mit] %>
+<% if config[:mit] -%>
 
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-<% end %>
+<% end -%>
 
-<% if config[:coc] %>
+<% if config[:coc] -%>
 ## Code of Conduct
 
 Everyone interacting in the <%= config[:constant_name] %> project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/<%= config[:github_username] %>/<%= config[:name] %>/blob/master/CODE_OF_CONDUCT.md).
-<% end %>
+<% end -%>


### PR DESCRIPTION
This PR fixes a tiny cosmetic issue in the READMEs that are generated with the `bundle gem` command. Currently when ERB is parsing the `<% if ...` blocks the new lines are not being omitted so you end up with:

```
## Contributing

Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/testapp. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.


## License

The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).



## Code of Conduct

Everyone interacting in the Testapp project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/testapp/blob/master/CODE_OF_CONDUCT.md).
```

Where it should be:

```
## Contributing

Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/testapp. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.

## License

The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).

## Code of Conduct

Everyone interacting in the Testapp project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/testapp/blob/master/CODE_OF_CONDUCT.md).
```