### PR TITLE
Fix `bundle gem` command without having git

### DIFF
--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -54,7 +54,6 @@ module Bundler
 
       templates = {
         "Gemfile.tt" => "Gemfile",
-        "gitignore.tt" => ".gitignore",
         "lib/newgem.rb.tt" => "lib/#{namespaced_path}.rb",
         "lib/newgem/version.rb.tt" => "lib/#{namespaced_path}/version.rb",
         "newgem.gemspec.tt" => "#{name}.gemspec",
@@ -68,6 +67,8 @@ module Bundler
         bin/console
         bin/setup
       )
+
+      templates.merge!("gitignore.tt" => ".gitignore") if Bundler.git_present?
 
       if test_framework = ask_and_set_test_framework
         config[:test] = test_framework

--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -137,10 +137,12 @@ module Bundler
         path.chmod(executable)
       end
 
-      Bundler.ui.info "Initializing git repo in #{target}"
-      Dir.chdir(target) do
-        `git init`
-        `git add .`
+      if Bundler.git_present?
+        Bundler.ui.info "Initializing git repo in #{target}"
+        Dir.chdir(target) do
+          `git init`
+          `git add .`
+        end
       end
 
       # Open gemspec in editor

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -169,9 +169,13 @@ RSpec.describe "bundle gem" do
   context "when git is not avaiable" do
     let(:gem_name) { "test_gem" }
 
+    # This spec cannot have `git` avaiable in the test env
     before do
-      allow(Bundler).to receive(:git_present?).and_return(false)
-      bundle "gem #{gem_name}"
+      bundle_bin = File.expand_path("../../../exe/bundle", __FILE__)
+      load_paths = [lib, spec]
+      load_path_str = "-I#{load_paths.join(File::PATH_SEPARATOR)}"
+
+      sys_exec "PATH= #{Gem.ruby} #{load_path_str} #{bundle_bin} gem #{gem_name}"
     end
 
     it "creates the gem without the need for git" do

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe "bundle gem" do
       load_paths = [lib, spec]
       load_path_str = "-I#{load_paths.join(File::PATH_SEPARATOR)}"
 
-      sys_exec "PATH="" #{Gem.ruby} #{load_path_str} #{bundle_bin} gem #{gem_name}"
+      sys_exec "PATH=\"\" #{Gem.ruby} #{load_path_str} #{bundle_bin} gem #{gem_name}"
     end
 
     it "creates the gem without the need for git" do

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe "bundle gem" do
       load_paths = [lib, spec]
       load_path_str = "-I#{load_paths.join(File::PATH_SEPARATOR)}"
 
-      sys_exec "PATH= #{Gem.ruby} #{load_path_str} #{bundle_bin} gem #{gem_name}"
+      sys_exec "PATH="" #{Gem.ruby} #{load_path_str} #{bundle_bin} gem #{gem_name}"
     end
 
     it "creates the gem without the need for git" do

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -160,6 +160,33 @@ RSpec.describe "bundle gem" do
     end
   end
 
+  it "creates a new git repository" do
+    in_app_root
+    bundle "gem test_gem"
+    expect(bundled_app("test_gem/.git")).to exist
+  end
+
+  context "when git is not avaiable" do
+    let(:gem_name) { "test_gem" }
+
+    before do
+      allow(Bundler).to receive(:git_present?).and_return(false)
+      bundle "gem #{gem_name}"
+    end
+
+    it "creates the gem without the need for git" do
+      expect(bundled_app("#{gem_name}/README.md")).to exist
+    end
+
+    it "doesn't create a git repo" do
+      expect(bundled_app("#{gem_name}/.git")).to_not exist
+    end
+
+    it "doesn't create a .gitignore file" do
+      expect(bundled_app("#{gem_name}/.gitignore")).to_not exist
+    end
+  end
+
   it "generates a valid gemspec" do
     system_gems ["rake-10.0.2"]
 

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -158,23 +158,6 @@ RSpec.describe "bundle gem" do
         expect(bundled_app("test_gem/README.md").read).not_to include("github.com/bundleuser")
       end
     end
-
-    context "git is not installed in the system" do
-      before do
-        FileUtils.rm ENV["GIT_CONFIG"].to_s if File.exist?(ENV["GIT_CONFIG"])
-        reset!
-        in_app_root
-        bundle "gem #{gem_name}"
-        remove_push_guard(gem_name)
-      end
-
-      it "contribute URL set to [USERNAME]" do
-        expect(bundled_app("test_gem/README.md").read).to include("[USERNAME]")
-        expect(bundled_app("test_gem/README.md").read).not_to include("github.com/bundleuser")
-      end
-
-      it_should_behave_like "git config is absent"
-    end
   end
 
   it "generates a valid gemspec" do


### PR DESCRIPTION
So the `gem` command is still breaking on master if `git` is not installed on the machine. This is because we're not checking if git is installed before we init a new git repo.

The test for #5466 is also not actually testing if git is not installed, it's only removing the git config which we already have tests for as well.

@segiddins Do you know a way i can stub `Bundler.git_present?` in the sub-process or have `git` appear to not be present in rspec?