### PR TITLE
Bundle open default gems

### DIFF
--- a/lib/bundler/cli/common.rb
+++ b/lib/bundler/cli/common.rb
@@ -26,13 +26,18 @@ module Bundler
       "Gems in the #{group_str} #{group_list} were not installed."
     end
 
-    def self.select_spec(name, regex_match = nil)
+    def self.select_spec(name, regex_match = nil, options = {})
       specs = []
       regexp = Regexp.new(name) if regex_match
 
       Bundler.definition.specs.each do |spec|
         return spec if spec.name == name
         specs << spec if regexp && spec.name =~ regexp
+      end
+
+      if options[:include_default] && Gem::Specification.respond_to?(:find_all_by_name)
+        spec = Gem::Specification.find_all_by_name(name).last
+        return spec if spec.respond_to?(:default_gem?) && spec.default_gem?
       end
 
       case specs.count

--- a/lib/bundler/cli/info.rb
+++ b/lib/bundler/cli/info.rb
@@ -10,29 +10,13 @@ module Bundler
     end
 
     def run
-      spec = spec_for_gem(gem_name)
+      spec = Bundler::CLI::Common.select_spec(gem_name, :regex_match, :include_default => true)
 
-      spec_not_found(gem_name) unless spec
       return print_gem_path(spec) if @options[:path]
       print_gem_info(spec)
     end
 
   private
-
-    def spec_for_gem(gem_name)
-      spec = Bundler.definition.specs.find {|s| s.name == gem_name }
-      spec || default_gem_spec(gem_name)
-    end
-
-    def default_gem_spec(gem_name)
-      return unless Gem::Specification.respond_to?(:find_all_by_name)
-      gem_spec = Gem::Specification.find_all_by_name(gem_name).last
-      return gem_spec if gem_spec && gem_spec.respond_to?(:default_gem?) && gem_spec.default_gem?
-    end
-
-    def spec_not_found(gem_name)
-      raise GemNotFound, Bundler::CLI::Common.gem_not_found_message(gem_name, Bundler.definition.dependencies)
-    end
 
     def print_gem_path(spec)
       Bundler.ui.info spec.full_gem_path

--- a/lib/bundler/cli/open.rb
+++ b/lib/bundler/cli/open.rb
@@ -13,7 +13,7 @@ module Bundler
     def run
       editor = [ENV["BUNDLER_EDITOR"], ENV["VISUAL"], ENV["EDITOR"]].find {|e| !e.nil? && !e.empty? }
       return Bundler.ui.info("To open a bundled gem, set $EDITOR or $BUNDLER_EDITOR") unless editor
-      return unless spec = Bundler::CLI::Common.select_spec(name, :regex_match)
+      return unless spec = Bundler::CLI::Common.select_spec(name, :regex_match, :include_default => true)
       path = spec.full_gem_path
       Dir.chdir(path) do
         command = Shellwords.split(editor) + [path]

--- a/spec/commands/open_spec.rb
+++ b/spec/commands/open_spec.rb
@@ -90,4 +90,9 @@ RSpec.describe "bundle open" do
     bundle "open", :env => { "EDITOR" => "sh -c 'env'", "VISUAL" => "", "BUNDLER_EDITOR" => "" }
     expect(out).not_to include("BUNDLE_GEMFILE=")
   end
+
+  it "opens default gems", :if => (RUBY_VERSION >= "2.0") do
+    bundle "open rdoc", :env => { "EDITOR" => "echo editor", "VISUAL" => "", "BUNDLER_EDITOR" => "" }
+    expect(out).to include("editor #{default_gem_path("rdoc")}")
+  end
 end

--- a/spec/support/path.rb
+++ b/spec/support/path.rb
@@ -93,6 +93,11 @@ module Spec
       tmp "tmpdir", *args
     end
 
+    def default_gem_path(gem_name)
+      gem = Gem::Specification.find_by_name(gem_name)
+      nil unless gem.default_gem?
+    end
+
     extend self
   end
 end


### PR DESCRIPTION
Fixes #4436

This PR allows the `bundle open` command to open up default gems