### PR TITLE
try a version that uses the local cache on install

### DIFF
--- a/lib/bundler/inline.rb
+++ b/lib/bundler/inline.rb
@@ -52,7 +52,7 @@ def gemfile(install = false, options = {}, &gemfile)
   definition = builder.to_definition(nil, true)
   def definition.lock(*); end
   definition.validate_runtime!
-  
+
   missing_specs = proc do
     begin
       !definition.missing_specs.empty?

--- a/lib/bundler/inline.rb
+++ b/lib/bundler/inline.rb
@@ -11,6 +11,9 @@
 #                          user's system should be installed.
 #                          Defaults to `false`.
 #
+# @param options [Hash] :ui the Bundler-UI to use
+#                       :local pass true to use the local bundler cache for installation
+#
 # @param gemfile [Proc]    a block that is evaluated as a `Gemfile`.
 #
 # @example Using an inline Gemfile
@@ -32,6 +35,7 @@ def gemfile(install = false, options = {}, &gemfile)
   require "bundler"
 
   opts = options.dup
+  local = opts.delete(:local) { false }
   ui = opts.delete(:ui) { Bundler::UI::Shell.new }
   raise ArgumentError, "Unknown options: #{opts.keys.join(", ")}" unless opts.empty?
 
@@ -48,7 +52,7 @@ def gemfile(install = false, options = {}, &gemfile)
   definition = builder.to_definition(nil, true)
   def definition.lock(*); end
   definition.validate_runtime!
-
+  
   missing_specs = proc do
     begin
       !definition.missing_specs.empty?
@@ -60,7 +64,7 @@ def gemfile(install = false, options = {}, &gemfile)
 
   Bundler.ui = ui if install
   if install || missing_specs.call
-    installer = Bundler::Installer.install(Bundler.root, definition, :system => true, :inline => true)
+    installer = Bundler::Installer.install(Bundler.root, definition, :system => true, :inline => true, :local => local)
     installer.post_install_messages.each do |name, message|
       Bundler.ui.info "Post-install message from #{name}:\n#{message}"
     end


### PR DESCRIPTION
i'm using `bundler/inline` quite heavily to configure dependencies for scripts in a rails project.

the inlining is great as i don't have pollute the apps dependency namespace for the scripts.

there are still a lot of transitive dependencies that could just be used from what is already installed.

when setting the `install` param to `true`, inline checks the rubygems repo every time. that is not really fast, especially from the eu or without internet. it also installs more things than necessary as it will use the best/latest compatible dependency. 

passing the `local` flag as in `bundle install --local` would save me from a lot of those problems.

i did not actually try this change (i would probably need to manually install my bundler fork as a gem?) i hope CI will complain about any issues 😸 