### PR TITLE
remove Rails 2.3 from ISSUES.md guide

### DIFF
--- a/doc/contributing/ISSUES.md
+++ b/doc/contributing/ISSUES.md
@@ -43,7 +43,7 @@ If your version of Bundler does not have the `bundle env` command, then please i
  - Whether you are using RVM, and if so what version (run `rvm -v`)
  - Whether you have the `rubygems-bundler` gem, which can break gem executables (run `gem list rubygems-bundler`)
  - Whether you have the `open_gem` gem, which can cause rake activation conflicts (run `gem list open_gem`)
- 
+
 If you have either `rubygems-bundler` or `open_gem` installed, please try removing them and then following the troubleshooting steps above before opening a new ticket.
 
 [Create a gist](https://gist.github.com) containing all of that information, then visit the [Bundler issue tracker](https://github.com/bundler/bundler/issues) and [create a ticket](https://github.com/bundler/bundler/issues/new) describing your problem and linking to your gist.

--- a/doc/contributing/ISSUES.md
+++ b/doc/contributing/ISSUES.md
@@ -43,13 +43,7 @@ If your version of Bundler does not have the `bundle env` command, then please i
  - Whether you are using RVM, and if so what version (run `rvm -v`)
  - Whether you have the `rubygems-bundler` gem, which can break gem executables (run `gem list rubygems-bundler`)
  - Whether you have the `open_gem` gem, which can cause rake activation conflicts (run `gem list open_gem`)
-
-If you are using Rails 2.3, please also include:
-
-  - Your `boot.rb` file
-  - Your `preinitializer.rb` file
-  - Your `environment.rb` file
-
+ 
 If you have either `rubygems-bundler` or `open_gem` installed, please try removing them and then following the troubleshooting steps above before opening a new ticket.
 
 [Create a gist](https://gist.github.com) containing all of that information, then visit the [Bundler issue tracker](https://github.com/bundler/bundler/issues) and [create a ticket](https://github.com/bundler/bundler/issues/new) describing your problem and linking to your gist.


### PR DESCRIPTION
Rails 2.3 has been EOL since 2013 and i have not seen any issue currently in Bundler's open issues or recently closed that is dealing with it. So i propose we remove it as it no longer has any value.