### PR TITLE
Change LockFileParse dependencies class variable from an array to a hash

### DIFF
--- a/lib/bundler/lockfile_parser.rb
+++ b/lib/bundler/lockfile_parser.rb
@@ -61,7 +61,7 @@ module Bundler
     def initialize(lockfile)
       @platforms    = []
       @sources      = []
-      @dependencies = []
+      @dependencies = {}
       @state        = nil
       @specs        = {}
 
@@ -199,7 +199,7 @@ module Bundler
           end
         end
 
-        @dependencies << dep
+        @dependencies[dep.name] = dep
       end
     end
 


### PR DESCRIPTION
What this addresses
---
The LockFileParser dependenies class variable is used throughout definition
using a series of select and find statements. While measuring Bundler performance, it was
noticed that pieces that interacted with @locked_deps took a fair chunk of time.

This chart shows some timings for `Definition.new` which is called during `require 'bundler/setup'`

![image](https://cloud.githubusercontent.com/assets/3074765/24419149/39598a98-13bc-11e7-8fa5-ee255abd79c3.png)

** Note: The time scale is a little off because `TracePoint` slows it down, but this does show us a slow point we can optimize.

Diving into that a bit more, we can see the following timings

![image](https://cloud.githubusercontent.com/assets/3074765/24419245/82891774-13bc-11e7-9449-6a0b0c28d520.png)

Again, despite the timings being off due to TracePoint, we can see that `locked_source = @locked_deps.select {|d| d.name == dep.name }.last (run 112812 times) :a1, 0.001, 0.182` was run upwards of 113K times for the Shopify application. Each one of these runs would run in `O(n)` time since we are literally iterating the array.

Looking at `LockFileParser`, we can see that the `dependencies` can easily be changed to a hash.

How this addresses it
---
This change makes the dependencies class variable a hash, which reduces the lookup
from `O(n)` to `O(1)` for each usage. Overall, the operation was `O(n^2)` as we iterated the array for each entry in the array. Now it's `O(n)` :tada:

In the Shopify application, this equated to a 20ms performance gain on each bundler/setup.

Some numbers
---
In particular, the `converge_dependencies` method in `definition.rb` took, on average, 24 ms for an application the size of Shopify. By simply changing the `dependencies` class variable, this was knocked down to 12ms. There was also a savings of a few ms on other method calls, such as `converge_locked_specs`.

Overall, I saw the time to `require 'bundler/setup'` from from 744ms to 724ms for a savings of 20ms.