### PR TITLE
[Source::Git] Only validate specs once (on download)

### DIFF
--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -234,6 +234,7 @@ module Bundler
           # The gemspecs we cache should already be evaluated.
           spec = Bundler.load_gemspec(spec_path)
           next unless spec
+          Bundler.rubygems.validate(spec)
           File.open(spec_path, "wb") {|file| file.write(spec.to_ruby) }
         end
       end
@@ -298,6 +299,9 @@ module Bundler
         raise unless Bundler.feature_flag.allow_offline_install?
         Bundler.ui.warn "Using cached git data because of network errors"
       end
+
+      # no-op, since we validate when re-serializing the gemspec
+      def validate_spec(_spec); end
     end
   end
 end

--- a/lib/bundler/source/path.rb
+++ b/lib/bundler/source/path.rb
@@ -144,6 +144,10 @@ module Bundler
         SharedHelpers.in_bundle? && app_cache_path.exist?
       end
 
+      def validate_spec(spec)
+        Bundler.rubygems.validate(spec)
+      end
+
       def load_spec_files
         index = Index.new
 
@@ -155,7 +159,7 @@ module Bundler
             Bundler.rubygems.set_installed_by_version(spec)
             # Validation causes extension_dir to be calculated, which depends
             # on #source, so we validate here instead of load_gemspec
-            Bundler.rubygems.validate(spec)
+            validate_spec(spec)
             index << spec
           end
 


### PR DESCRIPTION
Instead of validating every time we setup, only do so when we re-serialize the spec

\c @jules2689 