### PR TITLE
print an error message when a non-git gem is given a `branch` option

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -385,7 +385,8 @@ module Bundler
     def validate_keys(command, opts, valid_keys)
       invalid_keys = opts.keys - valid_keys
 
-      if opts["branch"] && !(opts["git"] || opts["github"])
+      git_source = opts.keys & @git_sources.keys.map(&:to_s)
+      if opts["branch"] && !(opts["git"] || opts["github"] || git_source.any?)
         raise GemfileError, %(The `branch` option for `#{command}` is not allowed. Only gems with a git source can specify a branch)
       end
 

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -321,10 +321,6 @@ module Bundler
 
       normalize_hash(opts)
 
-      if opts["branch"] && !(opts["git"] || opts["github"])
-        raise GemfileError, %(The `branch` option for `gem "#{name}"` is not allowed. Only gems with a git source can specify a branch)
-      end
-
       git_names = @git_sources.keys.map(&:to_s)
       validate_keys("gem '#{name}'", opts, valid_keys + git_names)
 
@@ -388,6 +384,11 @@ module Bundler
 
     def validate_keys(command, opts, valid_keys)
       invalid_keys = opts.keys - valid_keys
+
+      if opts["branch"] && !(opts["git"] || opts["github"])
+        raise GemfileError, %(The `branch` option for `#{command}` is not allowed. Only gems with a git source can specify a branch)
+      end
+
       if invalid_keys.any?
         message = String.new
         message << "You passed #{invalid_keys.map {|k| ":" + k }.join(", ")} "

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -321,6 +321,10 @@ module Bundler
 
       normalize_hash(opts)
 
+      if opts["branch"] && !(opts["git"] || opts["github"])
+        raise GemfileError, %(The `branch` option for `gem "#{name}"` is not allowed. Only gems with a git source can specify a branch)
+      end
+
       git_names = @git_sources.keys.map(&:to_s)
       validate_keys("gem '#{name}'", opts, valid_keys + git_names)
 

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -149,6 +149,12 @@ RSpec.describe Bundler::Dsl do
       expect { subject.gem("foo", :branch => "test") }.
         to raise_error(Bundler::GemfileError, /The `branch` option for `gem 'foo'` is not allowed. Only gems with a git source can specify a branch/)
     end
+
+    it "allows specifiying a branch on git gems" do
+      subject.gem("foo", :branch => "test", :git => "http://mytestrepo")
+      dep = subject.dependencies.last
+      expect(dep.name).to eq "foo"
+    end
   end
 
   describe "#gemspec" do

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe Bundler::Dsl do
 
     it "rejects branch option on non-git gems" do
       expect { subject.gem("foo", :branch => "test") }.
-        to raise_error(Bundler::GemfileError, /The `branch` option for `gem "foo"` is not allowed. Only gems with a git source can specify a branch/)
+        to raise_error(Bundler::GemfileError, /The `branch` option for `gem 'foo'` is not allowed. Only gems with a git source can specify a branch/)
     end
   end
 

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -155,6 +155,13 @@ RSpec.describe Bundler::Dsl do
       dep = subject.dependencies.last
       expect(dep.name).to eq "foo"
     end
+
+    it "allows specifiying a branch on git gems with a git_source" do
+      subject.git_source(:test_source) {|n| "https://github.com/#{n}" }
+      subject.gem("foo", :branch => "test", :test_source => "bundler/bundler")
+      dep = subject.dependencies.last
+      expect(dep.name).to eq "foo"
+    end
   end
 
   describe "#gemspec" do

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -144,6 +144,11 @@ RSpec.describe Bundler::Dsl do
       expect { subject.gem(:foo) }.
         to raise_error(Bundler::GemfileError, /You need to specify gem names as Strings. Use 'gem "foo"' instead/)
     end
+
+    it "rejects branch option on non-git gems" do
+      expect { subject.gem("foo", :branch => "test") }.
+        to raise_error(Bundler::GemfileError, /The `branch` option for `gem "foo"` is not allowed. Only gems with a git source can specify a branch/)
+    end
   end
 
   describe "#gemspec" do


### PR DESCRIPTION
When the user supplies the `branch` option to a non-git gem an error message should be printed.

Relates to #5530.