### PR TITLE
Add bundle binstubs to the main man page

### DIFF
--- a/man/bundle.ronn
+++ b/man/bundle.ronn
@@ -48,6 +48,9 @@ We divide `bundle` subcommands into primary commands and utilities.
 
 ## UTILITIES
 
+* `bundle binstubs(1)`:
+  Generate binstubs for executables in a gem
+
 * `bundle check(1)`:
   Determine whether the requirements for your application are installed
   and available to bundler


### PR DESCRIPTION
Fixes #5560. Hope I understood correctly, I only added a reference because the full man page was already there.