### PR TITLE
dsl parsing performance improvement

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -21,7 +21,7 @@ module Bundler
       @source               = nil
       @sources              = SourceList.new
       @git_sources          = {}
-      @dependencies         = []
+      @dependencies         = {}
       @groups               = []
       @install_conditionals = []
       @optional_groups      = []
@@ -94,10 +94,10 @@ module Bundler
       dep = Dependency.new(name, version, options)
 
       # if there's already a dependency with this name we try to prefer one
-      if current = @dependencies.find {|d| d.name == dep.name }
+      if current = dependencies[dep.name]
         if current.requirement != dep.requirement
           if current.type == :development
-            @dependencies.delete current
+            dependencies.delete current
           else
             return if dep.type == :development
             raise GemfileError, "You cannot specify the same gem twice with different version requirements.\n" \
@@ -112,7 +112,7 @@ module Bundler
 
         if current.source != dep.source
           if current.type == :development
-            @dependencies.delete current
+            dependencies.delete current
           else
             return if dep.type == :development
             raise GemfileError, "You cannot specify the same gem twice coming from different sources.\n" \
@@ -122,7 +122,7 @@ module Bundler
         end
       end
 
-      @dependencies << dep
+      dependencies[dep.name] = dep
     end
 
     def source(source, *args, &blk)
@@ -197,7 +197,7 @@ module Bundler
     end
 
     def to_definition(lockfile, unlock)
-      Definition.new(lockfile, @dependencies, @sources, unlock, @ruby_version, @optional_groups)
+      Definition.new(lockfile, dependencies.values, @sources, unlock, @ruby_version, @optional_groups)
     end
 
     def group(*args, &blk)

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Bundler::Dsl do
       subject.git_source(:foobar) {|repo_name| "git@foobar.com:#{repo_name}.git" }
       subject.gem("dobry-pies", :example => "strzalek/dobry-pies")
       example_uri = "git@git.example.com:strzalek/dobry-pies.git"
-      expect(subject.dependencies.first.source.uri).to eq(example_uri)
+      expect(subject.dependencies["dobry-pies"].source.uri).to eq(example_uri)
     end
 
     it "raises exception on invalid hostname" do
@@ -30,37 +30,37 @@ RSpec.describe Bundler::Dsl do
       it "converts :github to :git" do
         subject.gem("sparks", :github => "indirect/sparks")
         github_uri = "git://github.com/indirect/sparks.git"
-        expect(subject.dependencies.first.source.uri).to eq(github_uri)
+        expect(subject.dependencies["sparks"].source.uri).to eq(github_uri)
       end
 
       it "converts numeric :gist to :git" do
         subject.gem("not-really-a-gem", :gist => 2_859_988)
         github_uri = "https://gist.github.com/2859988.git"
-        expect(subject.dependencies.first.source.uri).to eq(github_uri)
+        expect(subject.dependencies["not-really-a-gem"].source.uri).to eq(github_uri)
       end
 
       it "converts :gist to :git" do
         subject.gem("not-really-a-gem", :gist => "2859988")
         github_uri = "https://gist.github.com/2859988.git"
-        expect(subject.dependencies.first.source.uri).to eq(github_uri)
+        expect(subject.dependencies["not-really-a-gem"].source.uri).to eq(github_uri)
       end
 
       it "converts 'rails' to 'rails/rails'" do
         subject.gem("rails", :github => "rails")
         github_uri = "git://github.com/rails/rails.git"
-        expect(subject.dependencies.first.source.uri).to eq(github_uri)
+        expect(subject.dependencies["rails"].source.uri).to eq(github_uri)
       end
 
       it "converts :bitbucket to :git" do
         subject.gem("not-really-a-gem", :bitbucket => "mcorp/flatlab-rails")
         bitbucket_uri = "https://mcorp@bitbucket.org/mcorp/flatlab-rails.git"
-        expect(subject.dependencies.first.source.uri).to eq(bitbucket_uri)
+        expect(subject.dependencies["not-really-a-gem"].source.uri).to eq(bitbucket_uri)
       end
 
       it "converts 'mcorp' to 'mcorp/mcorp'" do
         subject.gem("not-really-a-gem", :bitbucket => "mcorp")
         bitbucket_uri = "https://mcorp@bitbucket.org/mcorp/mcorp.git"
-        expect(subject.dependencies.first.source.uri).to eq(bitbucket_uri)
+        expect(subject.dependencies["not-really-a-gem"].source.uri).to eq(bitbucket_uri)
       end
     end
   end
@@ -165,7 +165,7 @@ RSpec.describe Bundler::Dsl do
 
       it "keeps track of the ruby platforms in the dependency" do
         subject.gemspec
-        expect(subject.dependencies.last.platforms).to eq(Bundler::Dependency::REVERSE_PLATFORM_MAP[Gem::Platform::RUBY])
+        expect(subject.dependencies["example"].platforms).to eq(Bundler::Dependency::REVERSE_PLATFORM_MAP[Gem::Platform::RUBY])
       end
     end
 
@@ -175,7 +175,7 @@ RSpec.describe Bundler::Dsl do
       it "keeps track of the jruby platforms in the dependency" do
         allow(Gem::Platform).to receive(:local).and_return(java)
         subject.gemspec
-        expect(subject.dependencies.last.platforms).to eq(Bundler::Dependency::REVERSE_PLATFORM_MAP[Gem::Platform::JAVA])
+        expect(subject.dependencies["example"].platforms).to eq(Bundler::Dependency::REVERSE_PLATFORM_MAP[Gem::Platform::JAVA])
       end
     end
   end
@@ -192,7 +192,7 @@ RSpec.describe Bundler::Dsl do
         subject.git "https://github.com/rails/rails.git" do
           rails_gems.each {|rails_gem| subject.send :gem, rails_gem }
         end
-        expect(subject.dependencies.map(&:name)).to match_array rails_gems
+        expect(subject.dependencies.values.map(&:name)).to match_array rails_gems
       end
     end
 
@@ -208,8 +208,8 @@ RSpec.describe Bundler::Dsl do
           spree_gems.each {|spree_gem| subject.send :gem, spree_gem }
         end
 
-        subject.dependencies.each do |d|
-          expect(d.source.uri).to eq("git://github.com/spree/spree.git")
+        subject.dependencies.each do |_k,v|
+          expect(v.source.uri).to eq("git://github.com/spree/spree.git")
         end
       end
     end
@@ -243,7 +243,7 @@ RSpec.describe Bundler::Dsl do
           subject.gem("foo")
         end
 
-        expect(subject.dependencies.last.source).to eq(other_source)
+        expect(subject.dependencies["foo"].source).to eq(other_source)
       end
     end
   end


### PR DESCRIPTION
i noticed in the Dsl that we're storing the `gem` dependencies in an array and performing certain operations with it like: `@dependencies.find {|d| d.name == dep.name }`. This can be improved and simplified with using a hash map instead.

Before:
```
› ruby -I ~/Desktop/Projects/bundler/lib benchmark.rb
  2.130000   0.020000   2.150000 (  2.166532)
› ruby -I ~/Desktop/Projects/bundler/lib benchmark.rb
  2.160000   0.030000   2.190000 (  2.204423)
› ruby -I ~/Desktop/Projects/bundler/lib benchmark.rb
  2.130000   0.030000   2.160000 (  2.184379)

```  

After:
```
› ruby -I ~/Desktop/Projects/bundler/lib benchmark.rb
  1.880000   0.020000   1.900000 (  1.919140)
› ruby -I ~/Desktop/Projects/bundler/lib benchmark.rb
  1.890000   0.020000   1.910000 (  1.933193)
```

Script: `ruby -I ~/Desktop/Projects/bundler/lib benchmark.rb`
```
require 'bundler'
require 'bundler/dsl'
require 'benchmark'

dsl = Bundler::Dsl.new
puts Benchmark.measure { 100.times { dsl.eval_gemfile('Gemfile') } }
```

Gemfile: https://gist.github.com/colby-swandale/5d04d5d72b6847bc242eeef87f9035b7

It's not a drastic improvement but i think is worth having.