### PR TITLE
[StubSpecification] Avoid loading the full spec when possible

### DIFF
--- a/lib/bundler/lazy_specification.rb
+++ b/lib/bundler/lazy_specification.rb
@@ -79,6 +79,7 @@ module Bundler
             "To use the platform-specific version of the gem, run `bundle config specific_platform true` and install again."
           search = source.specs.search(self).last
         end
+        search.dependencies = dependencies if search.is_a?(RemoteSpecification)
         search
       end
     end

--- a/lib/bundler/remote_specification.rb
+++ b/lib/bundler/remote_specification.rb
@@ -11,6 +11,7 @@ module Bundler
     include Comparable
 
     attr_reader :name, :version, :platform
+    attr_writer :dependencies
     attr_accessor :source, :remote
 
     def initialize(name, version, platform, spec_fetcher)
@@ -18,6 +19,7 @@ module Bundler
       @version      = Gem::Version.create version
       @platform     = platform
       @spec_fetcher = spec_fetcher
+      @dependencies = nil
     end
 
     # Needed before installs, since the arch matters then and quick
@@ -76,7 +78,15 @@ module Bundler
       "#<#{self.class} name=#{name} version=#{version} platform=#{platform}>"
     end
 
+    def dependencies
+      @dependencies || method_missing(:dependencies)
+    end
+
   private
+
+    def to_ary
+      nil
+    end
 
     def _remote_specification
       @_remote_specification ||= @spec_fetcher.fetch_spec([@name, @version, @platform])

--- a/lib/bundler/remote_specification.rb
+++ b/lib/bundler/remote_specification.rb
@@ -82,6 +82,11 @@ module Bundler
       @dependencies || method_missing(:dependencies)
     end
 
+    def git_version
+      return unless loaded_from && source.is_a?(Bundler::Source::Git)
+      " #{source.revision[0..6]}"
+    end
+
   private
 
     def to_ary

--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -437,8 +437,10 @@ module Bundler
         # Copy of Rubygems activate_bin_path impl
         requirement = args.last
         spec = find_spec_for_exe name, exec_name, [requirement]
-        Gem::LOADED_SPECS_MUTEX.synchronize { spec.activate }
-        spec.bin_file exec_name
+
+        gem_bin = File.join(spec.full_gem_path, spec.bindir, exec_name)
+        gem_from_path_bin = File.join(File.dirname(spec.loaded_from), spec.bindir, exec_name)
+        File.exist?(gem_bin) ? gem_bin : gem_from_path_bin
       end
 
       redefine_method(gem_class, :bin_path) do |name, *args|

--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -323,11 +323,12 @@ module Bundler
     def replace_gem(specs, specs_by_name)
       reverse_rubygems_kernel_mixin
 
-      executables = specs.map(&:executables).flatten
+      executables = nil
 
       kernel = (class << ::Kernel; self; end)
       [kernel, ::Kernel].each do |kernel_class|
         redefine_method(kernel_class, :gem) do |dep, *reqs|
+          executables ||= specs.map(&:executables).flatten
           if executables.include? File.basename(caller.first.split(":").first)
             break
           end

--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -234,6 +234,7 @@ module Bundler
           # The gemspecs we cache should already be evaluated.
           spec = Bundler.load_gemspec(spec_path)
           next unless spec
+          Bundler.rubygems.set_installed_by_version(spec)
           Bundler.rubygems.validate(spec)
           File.open(spec_path, "wb") {|file| file.write(spec.to_ruby) }
         end
@@ -302,6 +303,13 @@ module Bundler
 
       # no-op, since we validate when re-serializing the gemspec
       def validate_spec(_spec); end
+
+      if defined?(::Gem::StubSpecification)
+        def load_gemspec(file)
+          stub = Gem::StubSpecification.gemspec_stub(file, install_path.parent, install_path.parent)
+          StubSpecification.from_stub(stub)
+        end
+      end
     end
   end
 end

--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -304,7 +304,10 @@ module Bundler
       # no-op, since we validate when re-serializing the gemspec
       def validate_spec(_spec); end
 
-      if defined?(::Gem::StubSpecification)
+      # only 2.5.1+ has this method for stub creation, and since this is a
+      # performance optimization _only_, we'll restrict ourselves to the most
+      # recent RG versions instead of all versions that have stubs
+      if Bundler.rubygems.provides?(">= 2.5.1")
         def load_gemspec(file)
           stub = Gem::StubSpecification.gemspec_stub(file, install_path.parent, install_path.parent)
           stub.full_gem_path = Pathname.new(file).dirname.expand_path(root).to_s.untaint

--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -307,6 +307,7 @@ module Bundler
       if defined?(::Gem::StubSpecification)
         def load_gemspec(file)
           stub = Gem::StubSpecification.gemspec_stub(file, install_path.parent, install_path.parent)
+          stub.full_gem_path = Pathname.new(file).dirname.expand_path(root).to_s.untaint
           StubSpecification.from_stub(stub)
         end
       end

--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -304,10 +304,7 @@ module Bundler
       # no-op, since we validate when re-serializing the gemspec
       def validate_spec(_spec); end
 
-      # only 2.5.1+ has this method for stub creation, and since this is a
-      # performance optimization _only_, we'll restrict ourselves to the most
-      # recent RG versions instead of all versions that have stubs
-      if Bundler.rubygems.provides?(">= 2.5.1")
+      if Bundler.rubygems.stubs_provide_full_functionality?
         def load_gemspec(file)
           stub = Gem::StubSpecification.gemspec_stub(file, install_path.parent, install_path.parent)
           stub.full_gem_path = Pathname.new(file).dirname.expand_path(root).to_s.untaint

--- a/lib/bundler/source/path.rb
+++ b/lib/bundler/source/path.rb
@@ -144,6 +144,12 @@ module Bundler
         SharedHelpers.in_bundle? && app_cache_path.exist?
       end
 
+      def load_gemspec(file)
+        return unless spec = Bundler.load_gemspec(file)
+        Bundler.rubygems.set_installed_by_version(spec)
+        spec
+      end
+
       def validate_spec(spec)
         Bundler.rubygems.validate(spec)
       end
@@ -154,9 +160,9 @@ module Bundler
         if File.directory?(expanded_path)
           # We sort depth-first since `<<` will override the earlier-found specs
           Dir["#{expanded_path}/#{@glob}"].sort_by {|p| -p.split(File::SEPARATOR).size }.each do |file|
-            next unless spec = Bundler.load_gemspec(file)
+            next unless spec = load_gemspec(file)
             spec.source = self
-            Bundler.rubygems.set_installed_by_version(spec)
+
             # Validation causes extension_dir to be calculated, which depends
             # on #source, so we validate here instead of load_gemspec
             validate_spec(spec)

--- a/lib/bundler/stub_specification.rb
+++ b/lib/bundler/stub_specification.rb
@@ -48,8 +48,8 @@ module Bundler
       stub.loaded_from
     end
 
-    def matches_for_glob
-      stub.matches_for_glob
+    def matches_for_glob(glob)
+      stub.matches_for_glob(glob)
     end
 
     def raw_require_paths
@@ -77,6 +77,8 @@ module Bundler
             " was missing or broken. Try running `gem pristine #{name} -v #{version}`" \
             " to fix the cached spec."
         end
+
+        rs.source = source
 
         rs
       end

--- a/lib/bundler/stub_specification.rb
+++ b/lib/bundler/stub_specification.rb
@@ -9,11 +9,13 @@ module Bundler
       spec
     end
 
-    attr_accessor :stub
+    attr_accessor :stub, :ignored
 
     def to_yaml
       _remote_specification.to_yaml
     end
+
+    # @!group Stub Delegates
 
     if Bundler.rubygems.provides?(">= 2.3")
       # This is defined directly to avoid having to load every installed spec
@@ -22,10 +24,62 @@ module Bundler
       end
     end
 
+    def activated
+      stub.activated
+    end
+
+    def activated=(activated)
+      stub.instance_variable_set(:@activated, activated)
+    end
+
+    def default_gem
+      stub.default_gem
+    end
+
+    def full_gem_path
+      stub.full_gem_path
+    end
+
+    def full_require_paths
+      stub.full_require_paths
+    end
+
+    def loaded_from
+      stub.loaded_from
+    end
+
+    def matches_for_glob
+      stub.matches_for_glob
+    end
+
+    def raw_require_paths
+      stub.raw_require_paths
+    end
+
+    # This is what we do in bundler/rubygems_ext
+    # full_require_paths is always implemented in versions that have stubs
+    def load_paths
+      full_require_paths
+    end
+
   private
 
     def _remote_specification
-      stub.to_spec
+      @_remote_specification ||= begin
+        rs = stub.to_spec
+        if rs.equal?(self) # happens when to_spec gets the spec from Gem.loaded_specs
+          rs = Gem::Specification.load(loaded_from)
+          stub.instance_variable_set(:@spec, rs)
+        end
+
+        unless rs
+          raise GemspecError, "The gemspec for #{full_name} at #{loaded_from}" \
+            " was missing or broken. Try running `gem pristine #{name} -v #{version}`" \
+            " to fix the cached spec."
+        end
+
+        rs
+      end
     end
   end
 end

--- a/lib/bundler/stub_specification.rb
+++ b/lib/bundler/stub_specification.rb
@@ -37,7 +37,9 @@ module Bundler
     end
 
     def full_gem_path
-      stub.full_gem_path
+      # deleted gems can have their stubs return nil, so in that case grab the
+      # expired path from the full spec
+      stub.full_gem_path || method_missing(:full_gem_path)
     end
 
     if Bundler.rubygems.provides?(">= 2.2.0")

--- a/lib/bundler/stub_specification.rb
+++ b/lib/bundler/stub_specification.rb
@@ -36,17 +36,8 @@ module Bundler
       stub.default_gem
     end
 
-    # This is what we do in bundler/rubygems_ext
     def full_gem_path
-      # this cannot check source.is_a?(Bundler::Plugin::API::Source)
-      # because that _could_ trip the autoload, and if there are unresolved
-      # gems at that time, this method could be called inside another require,
-      # thus raising with that constant being undefined. Better to check a method
-      if source.respond_to?(:path) || (source.respond_to?(:bundler_plugin_api_source?) && source.bundler_plugin_api_source?)
-        Pathname.new(loaded_from).dirname.expand_path(source.root).to_s.untaint
-      else
-        rg_full_gem_path
-      end
+      stub.full_gem_path
     end
 
     def full_require_paths

--- a/lib/bundler/stub_specification.rb
+++ b/lib/bundler/stub_specification.rb
@@ -36,8 +36,17 @@ module Bundler
       stub.default_gem
     end
 
+    # This is what we do in bundler/rubygems_ext
     def full_gem_path
-      stub.full_gem_path
+      # this cannot check source.is_a?(Bundler::Plugin::API::Source)
+      # because that _could_ trip the autoload, and if there are unresolved
+      # gems at that time, this method could be called inside another require,
+      # thus raising with that constant being undefined. Better to check a method
+      if source.respond_to?(:path) || (source.respond_to?(:bundler_plugin_api_source?) && source.bundler_plugin_api_source?)
+        Pathname.new(loaded_from).dirname.expand_path(source.root).to_s.untaint
+      else
+        rg_full_gem_path
+      end
     end
 
     def full_require_paths

--- a/lib/bundler/stub_specification.rb
+++ b/lib/bundler/stub_specification.rb
@@ -40,8 +40,10 @@ module Bundler
       stub.full_gem_path
     end
 
-    def full_require_paths
-      stub.full_require_paths
+    if Bundler.rubygems.provides?(">= 2.2.0")
+      def full_require_paths
+        stub.full_require_paths
+      end
     end
 
     def loaded_from

--- a/lib/bundler/stub_specification.rb
+++ b/lib/bundler/stub_specification.rb
@@ -44,6 +44,12 @@ module Bundler
       def full_require_paths
         stub.full_require_paths
       end
+
+      # This is what we do in bundler/rubygems_ext
+      # full_require_paths is always implemented in >= 2.2.0
+      def load_paths
+        full_require_paths
+      end
     end
 
     def loaded_from
@@ -58,12 +64,6 @@ module Bundler
 
     def raw_require_paths
       stub.raw_require_paths
-    end
-
-    # This is what we do in bundler/rubygems_ext
-    # full_require_paths is always implemented in versions that have stubs
-    def load_paths
-      full_require_paths
     end
 
   private

--- a/lib/bundler/stub_specification.rb
+++ b/lib/bundler/stub_specification.rb
@@ -48,8 +48,10 @@ module Bundler
       stub.loaded_from
     end
 
-    def matches_for_glob(glob)
-      stub.matches_for_glob(glob)
+    if Bundler.rubygems.stubs_provide_full_functionality?
+      def matches_for_glob(glob)
+        stub.matches_for_glob(glob)
+      end
     end
 
     def raw_require_paths
@@ -69,7 +71,7 @@ module Bundler
         rs = stub.to_spec
         if rs.equal?(self) # happens when to_spec gets the spec from Gem.loaded_specs
           rs = Gem::Specification.load(loaded_from)
-          stub.instance_variable_set(:@spec, rs)
+          Bundler.rubygems.stub_set_spec(stub, rs)
         end
 
         unless rs

--- a/spec/bundler/plugin/installer_spec.rb
+++ b/spec/bundler/plugin/installer_spec.rb
@@ -54,7 +54,8 @@ RSpec.describe Bundler::Plugin::Installer do
         end
 
         it "returns the installed spec after installing" do
-          expect(result["ga-plugin"]).to be_kind_of(Gem::Specification)
+          spec = result["ga-plugin"]
+          expect(spec.full_name).to eq "ga-plugin-1.0"
         end
 
         it "has expected full gem path" do

--- a/spec/runtime/require_spec.rb
+++ b/spec/runtime/require_spec.rb
@@ -370,7 +370,7 @@ RSpec.describe "Bundler.require" do
     run! <<-R
       path = File.join(Gem.dir, "specifications", "rack-1.0.0.gemspec")
       contents = File.read(path)
-      contents = contents.lines.insert(-2, "\n  raise 'broken gemspec'\n").join
+      contents = contents.lines.to_a.insert(-2, "\n  raise 'broken gemspec'\n").join
       File.open(path, "w") do |f|
         f.write contents
       end
@@ -394,7 +394,7 @@ RSpec.describe "Bundler.require" do
     run! <<-R
       path = Gem.loaded_specs["foo"].loaded_from
       contents = File.read(path)
-      contents = contents.lines.insert(-2, "\n  raise 'broken gemspec'\n").join
+      contents = contents.lines.to_a.insert(-2, "\n  raise 'broken gemspec'\n").join
       File.open(path, "w") do |f|
         f.write contents
       end

--- a/spec/runtime/require_spec.rb
+++ b/spec/runtime/require_spec.rb
@@ -384,7 +384,7 @@ RSpec.describe "Bundler.require" do
     expect(out).to eq("WIN")
   end
 
-  it "does not load git gemspecs that are used", :rubygems => ">= 2.3" do
+  it "does not load git gemspecs that are used", :rubygems => ">= 2.5.1" do
     build_git "foo"
 
     install_gemfile! <<-G

--- a/spec/runtime/require_spec.rb
+++ b/spec/runtime/require_spec.rb
@@ -361,7 +361,7 @@ RSpec.describe "Bundler.require" do
     end
   end
 
-  it "does not load rubygems gemspecs that are used", :rubygems => ">= 2.3" do
+  it "does not load rubygems gemspecs that are used", :rubygems => ">= 2.5.2" do
     install_gemfile! <<-G
       source "file://#{gem_repo1}"
       gem "rack"
@@ -384,7 +384,7 @@ RSpec.describe "Bundler.require" do
     expect(out).to eq("WIN")
   end
 
-  it "does not load git gemspecs that are used", :rubygems => ">= 2.5.1" do
+  it "does not load git gemspecs that are used", :rubygems => ">= 2.5.2" do
     build_git "foo"
 
     install_gemfile! <<-G

--- a/spec/runtime/require_spec.rb
+++ b/spec/runtime/require_spec.rb
@@ -360,6 +360,29 @@ RSpec.describe "Bundler.require" do
       end
     end
   end
+
+  it "does not load rubygems gemspecs that are used", :rubygems => ">= 2.3" do
+    install_gemfile! <<-G
+      source "file://#{gem_repo1}"
+      gem "rack"
+    G
+
+    run! <<-R
+      path = File.join(Gem.dir, "specifications", "rack-1.0.0.gemspec")
+      contents = File.read(path)
+      contents = contents.lines.insert(-2, "\n  raise 'broken gemspec'\n").join
+      File.open(path, "w") do |f|
+        f.write contents
+      end
+    R
+
+    run! <<-R
+      Bundler.require
+      puts "WIN"
+    R
+
+    expect(out).to eq("WIN")
+  end
 end
 
 RSpec.describe "Bundler.require with platform specific dependencies" do


### PR DESCRIPTION
This should save us the hit of needing to `eval` all the gemspecs we use when the user has a modern (>= 2.3) RubyGems