### PR TITLE
[Worker] Allow interrups to exit the process even after the threads are disposed

### DIFF
--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -145,6 +145,13 @@ module Bundler
       major_deprecation("Bundler will only support rubygems >= 2.0, you are running #{Bundler.rubygems.version}")
     end
 
+    def trap(signal, override = false, &block)
+      prior = Signal.trap(signal) do
+        block.call
+        prior.call unless override
+      end
+    end
+
   private
 
     def find_gemfile

--- a/lib/bundler/worker.rb
+++ b/lib/bundler/worker.rb
@@ -27,7 +27,7 @@ module Bundler
       @func = func
       @size = size
       @threads = nil
-      trap("INT") { abort_threads }
+      SharedHelpers.trap("INT") { abort_threads }
     end
 
     # Enqueue a request to be executed in the worker pool


### PR DESCRIPTION
This means that SIGINT during, say, dependency resolution will still cleanly exit the process.