### PR TITLE
[Pristine] Skip the bundler gem

### DIFF
--- a/lib/bundler/cli/pristine.rb
+++ b/lib/bundler/cli/pristine.rb
@@ -4,7 +4,9 @@ require "bundler/cli/common"
 module Bundler
   class CLI::Pristine
     def run
-      ::Bundler.load.specs.each do |spec|
+      Bundler.load.specs.each do |spec|
+        next if spec.name == "bundler" # Source::Rubygems doesn't install bundler
+
         gem_name = "#{spec.name} (#{spec.version}#{spec.git_version})"
         gem_name += " (#{spec.platform})" if !spec.platform.nil? && spec.platform != Gem::Platform::RUBY
 
@@ -12,7 +14,7 @@ module Bundler
         when Source::Rubygems
           cached_gem = spec.cache_file
           unless File.exist?(cached_gem)
-            ::Bundler.ui.error("Failed to pristine #{gem_name}. Cached gem #{cached_gem} does not exist.")
+            Bundler.ui.error("Failed to pristine #{gem_name}. Cached gem #{cached_gem} does not exist.")
             next
           end
 
@@ -23,7 +25,7 @@ module Bundler
           git_source.remote!
           git_source.install(spec, :force => true)
         else
-          ::Bundler.ui.warn("Cannot pristine #{gem_name}. Gem is sourced from local path.")
+          Bundler.ui.warn("Cannot pristine #{gem_name}. Gem is sourced from local path.")
         end
       end
     end

--- a/lib/bundler/source/rubygems.rb
+++ b/lib/bundler/source/rubygems.rb
@@ -289,8 +289,10 @@ module Bundler
           idx = Index.new
           have_bundler = false
           Bundler.rubygems.all_specs.reverse_each do |spec|
-            next if spec.name == "bundler" && spec.version.to_s != VERSION
-            have_bundler = true if spec.name == "bundler"
+            if spec.name == "bundler"
+              next unless spec.version.to_s == VERSION
+              have_bundler = true
+            end
             spec.source = self
             if Bundler.rubygems.spec_missing_extensions?(spec, false)
               Bundler.ui.debug "Source #{self} is ignoring #{spec} because it is missing extensions"

--- a/spec/commands/pristine_spec.rb
+++ b/spec/commands/pristine_spec.rb
@@ -24,8 +24,6 @@ RSpec.describe "bundle pristine" do
 
       gemspec
     G
-
-    bundle "install"
   end
 
   context "when sourced from Rubygems" do
@@ -38,6 +36,14 @@ RSpec.describe "bundle pristine" do
 
       bundle "pristine"
       expect(changes_txt).to_not be_file
+    end
+
+    it "does not delete the bundler gem" do
+      system_gems :bundler
+      bundle! "install"
+      bundle! "pristine", :system_bundler => true
+      bundle! "-v", :system_bundler => true
+      expect(out).to end_with(Bundler::VERSION)
     end
   end
 


### PR DESCRIPTION
Since Source::Rubygems will never re-install it

Closes #5578 