### PR TITLE
move implementation of Bundler::Env to class methods

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -530,7 +530,7 @@ module Bundler
 
     desc "env", "Print information about the environment Bundler is running under"
     def env
-      Env.new.write($stdout)
+      Env.write($stdout)
     end
 
     desc "doctor [OPTIONS]", "Checks the bundle for common problems"

--- a/lib/bundler/cli/issue.rb
+++ b/lib/bundler/cli/issue.rb
@@ -26,7 +26,7 @@ module Bundler
 
       EOS
 
-      Bundler.ui.info Bundler::Env.new.report
+      Bundler.ui.info Bundler::Env.report
 
       Bundler.ui.info "\n## Bundle Doctor"
       doctor

--- a/lib/bundler/env.rb
+++ b/lib/bundler/env.rb
@@ -4,11 +4,11 @@ require "bundler/source/git/git_proxy"
 
 module Bundler
   class Env
-    def write(io)
+    def self.write(io)
       io.write report
     end
 
-    def report(options = {})
+    def self.report(options = {})
       print_gemfile = options.delete(:print_gemfile) { true }
       print_gemspecs = options.delete(:print_gemspecs) { true }
 
@@ -61,9 +61,7 @@ module Bundler
       out
     end
 
-  private
-
-    def read_file(filename)
+    def self.read_file(filename)
       File.read(filename.to_s).strip
     rescue Errno::ENOENT
       "<No #{filename} found>"
@@ -71,7 +69,7 @@ module Bundler
       "#{e.class}: #{e.message}"
     end
 
-    def ruby_version
+    def self.ruby_version
       str = String.new("#{RUBY_VERSION}")
       if RUBY_VERSION < "1.9"
         str << " (#{RUBY_RELEASE_DATE}"
@@ -83,10 +81,12 @@ module Bundler
       end
     end
 
-    def git_version
+    def self.git_version
       Bundler::Source::Git::GitProxy.new(nil, nil, nil).full_version
     rescue Bundler::Source::Git::GitNotInstalledError
       "not installed"
     end
+
+    private_class_method :read_file, :ruby_version, :git_version
   end
 end

--- a/lib/bundler/friendly_errors.rb
+++ b/lib/bundler/friendly_errors.rb
@@ -92,7 +92,7 @@ module Bundler
           #{e.backtrace && e.backtrace.join("\n          ").chomp}
         ```
 
-        #{Bundler::Env.new.report}
+        #{Bundler::Env.report}
         --- TEMPLATE END ----------------------------------------------------------------
 
       EOS

--- a/spec/bundler/env_spec.rb
+++ b/spec/bundler/env_spec.rb
@@ -3,18 +3,17 @@ require "spec_helper"
 require "bundler/settings"
 
 RSpec.describe Bundler::Env do
-  let(:env)            { described_class.new }
   let(:git_proxy_stub) { Bundler::Source::Git::GitProxy.new(nil, nil, nil) }
 
   describe "#report" do
     it "prints the environment" do
-      out = env.report
+      out = described_class.report
 
       expect(out).to include("Environment")
       expect(out).to include(Bundler::VERSION)
       expect(out).to include(Gem::VERSION)
-      expect(out).to include(env.send(:ruby_version))
-      expect(out).to include(env.send(:git_version))
+      expect(out).to include(described_class.send(:ruby_version))
+      expect(out).to include(described_class.send(:git_version))
       expect(out).to include(OpenSSL::OPENSSL_VERSION)
     end
 
@@ -36,7 +35,7 @@ RSpec.describe Bundler::Env do
         L
       end
 
-      let(:output) { env.report(:print_gemfile => true) }
+      let(:output) { described_class.report(:print_gemfile => true) }
 
       it "prints the Gemfile" do
         expect(output).to include("Gemfile")
@@ -50,7 +49,7 @@ RSpec.describe Bundler::Env do
     end
 
     context "when there no Gemfile and print_gemfile is true" do
-      let(:output) { env.report(:print_gemfile => true) }
+      let(:output) { described_class.report(:print_gemfile => true) }
 
       it "prints the environment" do
         expect(output).to start_with("## Environment")
@@ -76,7 +75,7 @@ RSpec.describe Bundler::Env do
       end
 
       it "prints the gemspec" do
-        output = env.report(:print_gemspecs => true)
+        output = described_class.report(:print_gemspecs => true)
 
         expect(output).to include("foo.gemspec")
         expect(output).to include(gemspec)
@@ -89,7 +88,7 @@ RSpec.describe Bundler::Env do
           and_return("git version 1.2.3 (Apple Git-BS)")
         expect(Bundler::Source::Git::GitProxy).to receive(:new).and_return(git_proxy_stub)
 
-        expect(env.report).to include("Git       1.2.3 (Apple Git-BS)")
+        expect(described_class.report).to include("Git       1.2.3 (Apple Git-BS)")
       end
     end
   end


### PR DESCRIPTION
This is to a comment i made in #5589 

Currently to print the Bundler env report you need to need to invoke it
via:

  Bundler::Env.new.report

This change removes the need to instantiate an instance and just call
a class method of the same name:

  Bundler::Env.report