### PR TITLE
Add to_spec to stub_specification

### DIFF
--- a/lib/bundler/stub_specification.rb
+++ b/lib/bundler/stub_specification.rb
@@ -68,6 +68,10 @@ module Bundler
       stub.raw_require_paths
     end
 
+    def to_spec
+      stub.to_spec
+    end
+
   private
 
     def _remote_specification

--- a/spec/bundler/stub_specification_spec.rb
+++ b/spec/bundler/stub_specification_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+if Bundler.rubygems.provides?(">= 2.1")
+  RSpec.describe Bundler::StubSpecification do
+    let(:with_gem_stub_spec) do
+      stub = Gem::Specification.stubs.first
+      described_class.from_stub(stub)
+    end
+
+    let(:with_bundler_stub_spec) do
+      described_class.from_stub(with_gem_stub_spec)
+    end
+
+    describe "#to_spec" do
+      it "returns a Gem::Specification" do
+        expect(with_gem_stub_spec.to_spec).to be_a(Gem::Specification)
+        expect(with_bundler_stub_spec.to_spec).to be_a(Gem::Specification)
+      end
+    end
+  end
+end

--- a/spec/bundler/stub_specification_spec.rb
+++ b/spec/bundler/stub_specification_spec.rb
@@ -14,6 +14,7 @@ if Bundler.rubygems.provides?(">= 2.1")
 
     describe "#to_spec" do
       it "returns a Gem::Specification" do
+        bundle :install
         expect(with_gem_stub_spec.to_spec).to be_a(Gem::Specification)
         expect(with_bundler_stub_spec.to_spec).to be_a(Gem::Specification)
       end


### PR DESCRIPTION
Fixes https://github.com/bundler/bundler/issues/5592

Interestingly enough, I did not hit this case in Shopify core but a smaller app due to a gem's loading of Gems.

I think this is caused by the gem [loading the gem](https://github.com/fnando/i18n-js/blob/12b8cbc73d5ff8e69622ed9c9aaf4dde903827a2/lib/i18n/js/dependencies.rb#L68) after we initialize our caches. This causes the `stub` to be of type `Bundler::StubSpecification`, which means we need to also delegate `to_spec` to the stub's stub.

cc @segiddins 