### PR TITLE
Apply source and git_version to stub spec extension

### DIFF
--- a/lib/bundler/stub_specification.rb
+++ b/lib/bundler/stub_specification.rb
@@ -11,6 +11,18 @@ module Bundler
 
     attr_accessor :stub, :ignored
 
+    def source=(source)
+      super
+      # Stub has no concept of source, which means that extension_dir may be wrong
+      # This is the case for git-based gems. So, instead manually assign the extension dir
+      if source.respond_to?(:extension_dir_name)
+        path = File.join(stub.extensions_dir, source.extension_dir_name)
+        stub.extension_dir = File.expand_path(path)
+      else
+        stub.extension_dir = nil
+      end
+    end
+
     def to_yaml
       _remote_specification.to_yaml
     end

--- a/lib/bundler/stub_specification.rb
+++ b/lib/bundler/stub_specification.rb
@@ -11,15 +11,17 @@ module Bundler
 
     attr_accessor :stub, :ignored
 
-    def source=(source)
-      super
-      # Stub has no concept of source, which means that extension_dir may be wrong
-      # This is the case for git-based gems. So, instead manually assign the extension dir
-      if source.respond_to?(:extension_dir_name)
-        path = File.join(stub.extensions_dir, source.extension_dir_name)
-        stub.extension_dir = File.expand_path(path)
-      else
-        stub.extension_dir = nil
+    # Pre 2.2.0 did not include extension_dir
+    # https://github.com/rubygems/rubygems/commit/9485ca2d101b82a946d6f327f4bdcdea6d4946ea
+    if Bundler.rubygems.provides?(">= 2.2.0")
+      def source=(source)
+        super
+        # Stub has no concept of source, which means that extension_dir may be wrong
+        # This is the case for git-based gems. So, instead manually assign the extension dir
+        if source.respond_to?(:extension_dir_name)
+          path = File.join(stub.extensions_dir, source.extension_dir_name)
+          stub.extension_dir = File.expand_path(path)
+        end
       end
     end
 

--- a/lib/bundler/stub_specification.rb
+++ b/lib/bundler/stub_specification.rb
@@ -18,10 +18,9 @@ module Bundler
         super
         # Stub has no concept of source, which means that extension_dir may be wrong
         # This is the case for git-based gems. So, instead manually assign the extension dir
-        if source.respond_to?(:extension_dir_name)
-          path = File.join(stub.extensions_dir, source.extension_dir_name)
-          stub.extension_dir = File.expand_path(path)
-        end
+        return unless source.respond_to?(:extension_dir_name)
+        path = File.join(stub.extensions_dir, source.extension_dir_name)
+        stub.extension_dir = File.expand_path(path)
       end
     end
 

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -1030,6 +1030,11 @@ RSpec.describe "bundle install with git sources" do
         puts FOO
       R
       expect(out).to eq("YES")
+
+      run! <<-R
+        puts $:.grep(/ext/)
+      R
+      expect(out).to eq(Pathname.glob(system_gem_path("bundler/gems/extensions/**/foo-1.0-*")).first.to_s)
     end
 
     it "does not use old extension after ref changes" do


### PR DESCRIPTION
Fixes https://github.com/bundler/bundler/issues/5594

`stub_specification` doesn't know what `full_name` should be because we don't have a record of the source, so it resolves to `cityhash-0.6.0` rather than `cityhash-3cfc7d01f333`

This makes `StubSpecification` aware of the source to we can still avoid loading the full spec when needed. This is done by bringing remote_specs `attr_accessor :source` to `stub_spec`, and assigning source to the `stub`.

I am probably missing some edge cases to check for though 🙈  Need to write specs.

cc @segiddins 