### PR TITLE
Avoid duplicating specs in the lockfile after updating w/ the gem uninstalled

### DIFF
--- a/lib/bundler/lazy_specification.rb
+++ b/lib/bundler/lazy_specification.rb
@@ -29,7 +29,7 @@ module Bundler
       @name          = name
       @version       = version
       @dependencies  = []
-      @platform      = platform
+      @platform      = platform || Gem::Platform::RUBY
       @source        = source
       @specification = nil
     end

--- a/spec/install/gems/compact_index_spec.rb
+++ b/spec/install/gems/compact_index_spec.rb
@@ -769,4 +769,16 @@ Bundler::APIResponseMismatchError: Downloading rails-2.3.2 revealed dependencies
 Either installing with `--full-index` or running `bundle update rails` should fix the problem.
     E
   end
+
+  it "does not duplicate specs in the lockfile when updating and a dependency is not installed" do
+    install_gemfile! <<-G, :artifice => "compact_index"
+      source "#{source_uri}" do
+        gem "rails"
+        gem "activemerchant"
+      end
+    G
+    gem_command! :uninstall, "activemerchant"
+    bundle! "update rails", :artifice => "compact_index"
+    expect(lockfile.scan(/activemerchant \(/).size).to eq(1)
+  end
 end


### PR DESCRIPTION
Closes https://github.com/bundler/bundler/issues/5599

I decided to not compare using `full_name` in `SpecSet#merge` for the sake of performance, since `#full_name` is uncached