### PR TITLE
Ensure pre-existing Git caches are updated from remote sources

### DIFF
--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -147,7 +147,6 @@ module Bundler
         changed
       end
 
-      # TODO: cache git specs
       def specs(*)
         set_local!(app_cache_path) if has_app_cache? && !local?
 

--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -105,6 +105,8 @@ module Bundler
 
       def unlock!
         git_proxy.revision = nil
+        options["revision"] = nil
+
         @unlocked = true
       end
 


### PR DESCRIPTION
This will be my first contribution to Bundler. Thanks for the amazing dev setup guides!

This fixes issue #5423 where Git sources would not be updated if they were already cached in `vendor/cache`.

When we build a Git source from Gemfile.lock, we store the revision listed in the lockfile. However, when unlocking the source for an update, we don't clear that revision, and the update proceeds to grab the stale version from `vendor/cache`. Interestingly, this behaviour only occurs when updating a specific gem, i.e. `bundle update timecop`. This bug isn't present when doing a global `bundle update`, possibly because of the differences in how we build up the Definition between the two methods.

Closes #5423.
