### PR TITLE
Unify the names of GitHub and RuboCop

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -14,7 +14,7 @@ Individuals asked to stop any harassing behavior are expected to comply immediat
 
 Maintainers, including the core team, are also subject to the anti-harassment policy.
 
-If anyone engages in abusive, harassing, or otherwise unacceptable behavior, including maintainers, we may take appropriate action, up to and including warning the offender, deletion of comments, removal from the project’s codebase and communication systems, and escalation to Github support.
+If anyone engages in abusive, harassing, or otherwise unacceptable behavior, including maintainers, we may take appropriate action, up to and including warning the offender, deletion of comments, removal from the project’s codebase and communication systems, and escalation to GitHub support.
 
 If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of [the core team](http://bundler.io/contributors.html) or [email the core team](mailto:team@bundler.io) immediately.
 

--- a/doc/contributing/COMMUNITY.md
+++ b/doc/contributing/COMMUNITY.md
@@ -6,7 +6,7 @@ It would be tremendously helpful to have more people answering questions about B
 
 Additional documentation and explanation is always helpful, too. If you have any suggestions for the Bundler website [bundler.io](http://bundler.io), we would absolutely love it if you opened an issue or pull request on the [bundler-site](https://github.com/bundler/bundler-site) repository.
 
-Sharing your experiences and discoveries by writing them up is a valuable way to help others who have similar problems or experiences in the future. You can write a blog post, create an example and commit it to Github, take screenshots, or make videos.
+Sharing your experiences and discoveries by writing them up is a valuable way to help others who have similar problems or experiences in the future. You can write a blog post, create an example and commit it to GitHub, take screenshots, or make videos.
 
 Publishing examples of how Bundler is used helps everyone, and we’ve discovered that people already use it in ways that we never imagined when we were writing it. If you’re still not sure what to write about, there are also several projects doing interesting things based on Bundler. They could probably use publicity too.
 

--- a/doc/development/PULL_REQUESTS.md
+++ b/doc/development/PULL_REQUESTS.md
@@ -8,7 +8,7 @@ Before you submit a pull request, please remember to do the following:
 
 ## Code formatting
 
-Make sure the code formatting and styling adheres to the guidelines. We use Rubocop for this. Lack of formatting adherence will result in automatic Travis build failures.
+Make sure the code formatting and styling adheres to the guidelines. We use RuboCop for this. Lack of formatting adherence will result in automatic Travis build failures.
 
       $ bin/rubocop -a
 

--- a/doc/development/PULL_REQUESTS.md
+++ b/doc/development/PULL_REQUESTS.md
@@ -28,7 +28,7 @@ Ex. For a pull request that changes something with `bundle update`, you might ru
 ## Commit messages
 
 Please ensure that the commit messages included in the pull request __do not__ have the following:
-  - `@tag` Github user or team references (ex. `@indirect` or `@bundler/core`)
+  - `@tag` GitHub user or team references (ex. `@indirect` or `@bundler/core`)
   - `#id` references to issues or pull requests (ex. `#43` or `bundler/bundler-site#12`)
 
 If you want to use these mechanisms, please instead include them in the pull request description. This prevents multiple notifications or references being created on commit rebases or pull request/branch force pushes.

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -190,7 +190,7 @@ module Bundler
     end
 
     def github(repo, options = {})
-      raise ArgumentError, "Github sources require a block" unless block_given?
+      raise ArgumentError, "GitHub sources require a block" unless block_given?
       github_uri  = @git_sources["github"].call(repo)
       git_options = normalize_hash(options).merge("uri" => github_uri)
       git_source  = @sources.add_git_source(git_options)


### PR DESCRIPTION
As far as I know, I think that "GitHub" and "RuboCop" become more precise names.   This PR unifies the name in that way.