### PR TITLE
Permit absolute paths in cache_path setting

### DIFF
--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -213,11 +213,7 @@ module Bundler
     end
 
     def app_cache_path
-      @app_cache_path ||= begin
-        path = self[:cache_path] || "vendor/cache"
-        raise InvalidOption, "Cache path must be relative to the bundle path" if path.start_with?("/")
-        path
-      end
+      @app_cache_path ||= self[:cache_path] || "vendor/cache"
     end
 
   private

--- a/spec/cache/cache_path_spec.rb
+++ b/spec/cache/cache_path_spec.rb
@@ -23,12 +23,4 @@ RSpec.describe "bundle package" do
       expect(bundled_app("vendor/cache-foo/rack-1.0.0.gem")).to exist
     end
   end
-
-  context "when given an absolute path" do
-    it "exits with non-zero status" do
-      bundle :package, "cache-path" => "/tmp/cache-foo"
-      expect(out).to match(/must be relative/)
-      expect(exitstatus).to eq(15) if exitstatus
-    end
-  end
 end

--- a/spec/cache/cache_path_spec.rb
+++ b/spec/cache/cache_path_spec.rb
@@ -23,4 +23,11 @@ RSpec.describe "bundle package" do
       expect(bundled_app("vendor/cache-foo/rack-1.0.0.gem")).to exist
     end
   end
+
+  context "with absolute --cache-path" do
+    it "caches gems at given path" do
+      bundle :package, "cache-path" => "/tmp/cache-foo"
+      expect(bundled_app("/tmp/cache-foo/rack-1.0.0.gem")).to exist
+    end
+  end
 end


### PR DESCRIPTION
Removes check on leading `/` from `cache_path` and updates tests.

Fixes #5627 