### PR TITLE
Specify `--require spec_helper` in .rspec

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,4 @@
 --format documentation
 --color
 --warnings
+--require spec_helper

--- a/spec/bundler/bundler_spec.rb
+++ b/spec/bundler/bundler_spec.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 # frozen_string_literal: true
-require "spec_helper"
 require "bundler"
 
 RSpec.describe Bundler do

--- a/spec/bundler/cli_spec.rb
+++ b/spec/bundler/cli_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 require "bundler/cli"
 
 RSpec.describe "bundle executable" do

--- a/spec/bundler/compact_index_client/updater_spec.rb
+++ b/spec/bundler/compact_index_client/updater_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 require "net/http"
 require "bundler/compact_index_client"
 require "bundler/compact_index_client/updater"

--- a/spec/bundler/definition_spec.rb
+++ b/spec/bundler/definition_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 require "bundler/definition"
 
 RSpec.describe Bundler::Definition do

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe Bundler::Dsl do
   before do

--- a/spec/bundler/endpoint_specification_spec.rb
+++ b/spec/bundler/endpoint_specification_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe Bundler::EndpointSpecification do
   let(:name)         { "foo" }

--- a/spec/bundler/env_spec.rb
+++ b/spec/bundler/env_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 require "bundler/settings"
 
 RSpec.describe Bundler::Env do

--- a/spec/bundler/environment_preserver_spec.rb
+++ b/spec/bundler/environment_preserver_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe Bundler::EnvironmentPreserver do
   let(:preserver) { described_class.new(env, ["foo"]) }

--- a/spec/bundler/fetcher/base_spec.rb
+++ b/spec/bundler/fetcher/base_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe Bundler::Fetcher::Base do
   let(:downloader)  { double(:downloader) }

--- a/spec/bundler/fetcher/compact_index_spec.rb
+++ b/spec/bundler/fetcher/compact_index_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe Bundler::Fetcher::CompactIndex do
   let(:downloader)  { double(:downloader) }

--- a/spec/bundler/fetcher/dependency_spec.rb
+++ b/spec/bundler/fetcher/dependency_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe Bundler::Fetcher::Dependency do
   let(:downloader)  { double(:downloader) }

--- a/spec/bundler/fetcher/downloader_spec.rb
+++ b/spec/bundler/fetcher/downloader_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe Bundler::Fetcher::Downloader do
   let(:connection)     { double(:connection) }

--- a/spec/bundler/fetcher/index_spec.rb
+++ b/spec/bundler/fetcher/index_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe Bundler::Fetcher::Index do
   let(:downloader)  { nil }

--- a/spec/bundler/fetcher_spec.rb
+++ b/spec/bundler/fetcher_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 require "bundler/fetcher"
 
 RSpec.describe Bundler::Fetcher do

--- a/spec/bundler/friendly_errors_spec.rb
+++ b/spec/bundler/friendly_errors_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 require "bundler"
 require "bundler/friendly_errors"
 require "cgi"

--- a/spec/bundler/gem_helper_spec.rb
+++ b/spec/bundler/gem_helper_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 require "rake"
 require "bundler/gem_helper"
 

--- a/spec/bundler/gem_version_promoter_spec.rb
+++ b/spec/bundler/gem_version_promoter_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe Bundler::GemVersionPromoter do
   context "conservative resolver" do

--- a/spec/bundler/index_spec.rb
+++ b/spec/bundler/index_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe Bundler::Index do
   let(:specs) { [] }

--- a/spec/bundler/installer/gem_installer_spec.rb
+++ b/spec/bundler/installer/gem_installer_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 require "bundler/installer/gem_installer"
 
 RSpec.describe Bundler::GemInstaller do

--- a/spec/bundler/installer/parallel_installer_spec.rb
+++ b/spec/bundler/installer/parallel_installer_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 require "bundler/installer/parallel_installer"
 
 RSpec.describe Bundler::ParallelInstaller do

--- a/spec/bundler/installer/spec_installation_spec.rb
+++ b/spec/bundler/installer/spec_installation_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 require "bundler/installer/parallel_installer"
 
 RSpec.describe Bundler::ParallelInstaller::SpecInstallation do

--- a/spec/bundler/lockfile_parser_spec.rb
+++ b/spec/bundler/lockfile_parser_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 require "bundler/lockfile_parser"
 
 RSpec.describe Bundler::LockfileParser do

--- a/spec/bundler/mirror_spec.rb
+++ b/spec/bundler/mirror_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 require "bundler/mirror"
 
 RSpec.describe Bundler::Settings::Mirror do

--- a/spec/bundler/plugin/api/source_spec.rb
+++ b/spec/bundler/plugin/api/source_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe Bundler::Plugin::API::Source do
   let(:uri) { "uri://to/test" }

--- a/spec/bundler/plugin/api_spec.rb
+++ b/spec/bundler/plugin/api_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe Bundler::Plugin::API do
   context "plugin declarations" do

--- a/spec/bundler/plugin/dsl_spec.rb
+++ b/spec/bundler/plugin/dsl_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe Bundler::Plugin::DSL do
   DSL = Bundler::Plugin::DSL

--- a/spec/bundler/plugin/index_spec.rb
+++ b/spec/bundler/plugin/index_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe Bundler::Plugin::Index do
   Index = Bundler::Plugin::Index

--- a/spec/bundler/plugin/installer_spec.rb
+++ b/spec/bundler/plugin/installer_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe Bundler::Plugin::Installer do
   subject(:installer) { Bundler::Plugin::Installer.new }

--- a/spec/bundler/plugin/source_list_spec.rb
+++ b/spec/bundler/plugin/source_list_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe Bundler::Plugin::SourceList do
   SourceList = Bundler::Plugin::SourceList

--- a/spec/bundler/plugin_spec.rb
+++ b/spec/bundler/plugin_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe Bundler::Plugin do
   Plugin = Bundler::Plugin

--- a/spec/bundler/psyched_yaml_spec.rb
+++ b/spec/bundler/psyched_yaml_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 require "bundler/psyched_yaml"
 
 RSpec.describe "Bundler::YamlLibrarySyntaxError" do

--- a/spec/bundler/remote_specification_spec.rb
+++ b/spec/bundler/remote_specification_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe Bundler::RemoteSpecification do
   let(:name)         { "foo" }

--- a/spec/bundler/retry_spec.rb
+++ b/spec/bundler/retry_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe Bundler::Retry do
   it "return successful result if no errors" do

--- a/spec/bundler/ruby_dsl_spec.rb
+++ b/spec/bundler/ruby_dsl_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 require "bundler/ruby_dsl"
 
 RSpec.describe Bundler::RubyDsl do

--- a/spec/bundler/ruby_version_spec.rb
+++ b/spec/bundler/ruby_version_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 require "bundler/ruby_version"
 
 RSpec.describe "Bundler::RubyVersion and its subclasses" do

--- a/spec/bundler/rubygems_integration_spec.rb
+++ b/spec/bundler/rubygems_integration_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe Bundler::RubygemsIntegration do
   it "uses the same chdir lock as rubygems", :rubygems => "2.1" do

--- a/spec/bundler/settings_spec.rb
+++ b/spec/bundler/settings_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 require "bundler/settings"
 
 RSpec.describe Bundler::Settings do

--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe Bundler::SharedHelpers do
   let(:ext_lock_double) { double(:ext_lock) }

--- a/spec/bundler/source/git/git_proxy_spec.rb
+++ b/spec/bundler/source/git/git_proxy_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe Bundler::Source::Git::GitProxy do
   let(:uri) { "https://github.com/bundler/bundler.git" }

--- a/spec/bundler/source/rubygems/remote_spec.rb
+++ b/spec/bundler/source/rubygems/remote_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 require "bundler/source/rubygems/remote"
 
 RSpec.describe Bundler::Source::Rubygems::Remote do

--- a/spec/bundler/source/rubygems_spec.rb
+++ b/spec/bundler/source/rubygems_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe Bundler::Source::Rubygems do
   before do

--- a/spec/bundler/source_list_spec.rb
+++ b/spec/bundler/source_list_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe Bundler::SourceList do
   before do

--- a/spec/bundler/source_spec.rb
+++ b/spec/bundler/source_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe Bundler::Source do
   class ExampleSource < Bundler::Source

--- a/spec/bundler/spec_set_spec.rb
+++ b/spec/bundler/spec_set_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe Bundler::SpecSet do
   let(:specs) do

--- a/spec/bundler/ssl_certs/certificate_manager_spec.rb
+++ b/spec/bundler/ssl_certs/certificate_manager_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 require "bundler/ssl_certs/certificate_manager"
 
 RSpec.describe Bundler::SSLCerts::CertificateManager do

--- a/spec/bundler/ui_spec.rb
+++ b/spec/bundler/ui_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe Bundler::UI do
   describe Bundler::UI::Silent do

--- a/spec/bundler/uri_credentials_filter_spec.rb
+++ b/spec/bundler/uri_credentials_filter_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe Bundler::URICredentialsFilter do
   subject { described_class }

--- a/spec/bundler/version_ranges_spec.rb
+++ b/spec/bundler/version_ranges_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 require "bundler/version_ranges"
 
 RSpec.describe Bundler::VersionRanges do

--- a/spec/bundler/worker_spec.rb
+++ b/spec/bundler/worker_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 require "bundler/worker"
 
 RSpec.describe Bundler::Worker do

--- a/spec/bundler/yaml_serializer_spec.rb
+++ b/spec/bundler/yaml_serializer_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 require "bundler/yaml_serializer"
 
 RSpec.describe Bundler::YAMLSerializer do

--- a/spec/cache/cache_path_spec.rb
+++ b/spec/cache/cache_path_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle package" do
   before do

--- a/spec/cache/gems_spec.rb
+++ b/spec/cache/gems_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle cache" do
   describe "when there are only gemsources" do

--- a/spec/cache/git_spec.rb
+++ b/spec/cache/git_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "git base name" do
   it "base_name should strip private repo uris" do

--- a/spec/cache/path_spec.rb
+++ b/spec/cache/path_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 %w(cache package).each do |cmd|
   RSpec.describe "bundle #{cmd} with path" do

--- a/spec/cache/platform_spec.rb
+++ b/spec/cache/platform_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle cache with multiple platforms" do
   before :each do

--- a/spec/commands/add_spec.rb
+++ b/spec/commands/add_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle add" do
   before :each do

--- a/spec/commands/binstubs_spec.rb
+++ b/spec/commands/binstubs_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle binstubs <gem>" do
   context "when the gem exists in the lockfile" do

--- a/spec/commands/check_spec.rb
+++ b/spec/commands/check_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle check" do
   it "returns success when the Gemfile is satisfied" do

--- a/spec/commands/clean_spec.rb
+++ b/spec/commands/clean_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle clean" do
   def should_have_gems(*gems)

--- a/spec/commands/config_spec.rb
+++ b/spec/commands/config_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe ".bundle/config" do
   before :each do

--- a/spec/commands/console_spec.rb
+++ b/spec/commands/console_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle console" do
   before :each do

--- a/spec/commands/doctor_spec.rb
+++ b/spec/commands/doctor_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 require "stringio"
 require "bundler/cli"
 require "bundler/cli/doctor"

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle exec" do
   let(:system_gems_to_install) { %w(rack-1.0.0 rack-0.9.1) }

--- a/spec/commands/help_spec.rb
+++ b/spec/commands/help_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle help" do
   # Rubygems 1.4+ no longer load gem plugins so this test is no longer needed

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle info" do
   context "info from specific gem in gemfile" do

--- a/spec/commands/init_spec.rb
+++ b/spec/commands/init_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle init" do
   it "generates a Gemfile" do

--- a/spec/commands/inject_spec.rb
+++ b/spec/commands/inject_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle inject" do
   before :each do

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle install with gem sources" do
   describe "the simple case" do

--- a/spec/commands/issue_spec.rb
+++ b/spec/commands/issue_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle issue" do
   it "exits with a message" do

--- a/spec/commands/licenses_spec.rb
+++ b/spec/commands/licenses_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle licenses" do
   before :each do

--- a/spec/commands/lock_spec.rb
+++ b/spec/commands/lock_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle lock" do
   def strip_lockfile(lockfile)

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle gem" do
   def reset!

--- a/spec/commands/open_spec.rb
+++ b/spec/commands/open_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle open" do
   before :each do

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle outdated" do
   before :each do

--- a/spec/commands/package_spec.rb
+++ b/spec/commands/package_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle package" do
   context "with --gemfile" do

--- a/spec/commands/pristine_spec.rb
+++ b/spec/commands/pristine_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 require "fileutils"
 
 RSpec.describe "bundle pristine" do

--- a/spec/commands/show_spec.rb
+++ b/spec/commands/show_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle show" do
   context "with a standard Gemfile" do

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle update" do
   before :each do

--- a/spec/commands/viz_spec.rb
+++ b/spec/commands/viz_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle viz", :ruby => "1.9.3", :if => Bundler.which("dot") do
   let(:graphviz_lib) do

--- a/spec/install/allow_offline_install_spec.rb
+++ b/spec/install/allow_offline_install_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle install with :allow_offline_install" do
   before do

--- a/spec/install/binstubs_spec.rb
+++ b/spec/install/binstubs_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle install" do
   describe "when system_bindir is set" do

--- a/spec/install/bundler_spec.rb
+++ b/spec/install/bundler_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle install" do
   describe "with bundler dependencies" do

--- a/spec/install/deploy_spec.rb
+++ b/spec/install/deploy_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "install with --deployment or --frozen" do
   before do

--- a/spec/install/failure_spec.rb
+++ b/spec/install/failure_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle install" do
   context "installing a gem fails" do

--- a/spec/install/force_spec.rb
+++ b/spec/install/force_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle install" do
   describe "with --force" do

--- a/spec/install/gemfile/eval_gemfile_spec.rb
+++ b/spec/install/gemfile/eval_gemfile_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle install with gemfile that uses eval_gemfile" do
   before do

--- a/spec/install/gemfile/gemspec_spec.rb
+++ b/spec/install/gemfile/gemspec_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle install from an existing gemspec" do
   before(:each) do

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle install with git sources" do
   describe "when floating on master" do

--- a/spec/install/gemfile/groups_spec.rb
+++ b/spec/install/gemfile/groups_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle install with groups" do
   describe "installing with no options" do

--- a/spec/install/gemfile/path_spec.rb
+++ b/spec/install/gemfile/path_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle install with explicit source paths" do
   it "fetches gems" do

--- a/spec/install/gemfile/platform_spec.rb
+++ b/spec/install/gemfile/platform_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle install across platforms" do
   it "maintains the same lockfile if all gems are compatible across platforms" do

--- a/spec/install/gemfile/ruby_spec.rb
+++ b/spec/install/gemfile/ruby_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "ruby requirement" do
   def locked_ruby_version

--- a/spec/install/gemfile/sources_spec.rb
+++ b/spec/install/gemfile/sources_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle install with gems on multiple sources" do
   # repo1 is built automatically before all of the specs run

--- a/spec/install/gemfile/specific_platform_spec.rb
+++ b/spec/install/gemfile/specific_platform_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle install with specific_platform enabled" do
   before do

--- a/spec/install/gemfile_spec.rb
+++ b/spec/install/gemfile_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle install" do
   context "with duplicated gems" do

--- a/spec/install/gems/compact_index_spec.rb
+++ b/spec/install/gems/compact_index_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "compact index api" do
   let(:source_hostname) { "localgemserver.test" }

--- a/spec/install/gems/dependency_api_spec.rb
+++ b/spec/install/gems/dependency_api_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "gemcutter's dependency API" do
   let(:source_hostname) { "localgemserver.test" }

--- a/spec/install/gems/env_spec.rb
+++ b/spec/install/gems/env_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle install with ENV conditionals" do
   describe "when just setting an ENV key as a string" do

--- a/spec/install/gems/flex_spec.rb
+++ b/spec/install/gems/flex_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle flex_install" do
   it "installs the gems as expected" do

--- a/spec/install/gems/mirror_spec.rb
+++ b/spec/install/gems/mirror_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle install with a mirror configured" do
   describe "when the mirror does not match the gem source" do

--- a/spec/install/gems/native_extensions_spec.rb
+++ b/spec/install/gems/native_extensions_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "installing a gem with native extensions" do
   it "installs" do

--- a/spec/install/gems/post_install_spec.rb
+++ b/spec/install/gems/post_install_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle install" do
   context "with gem sources" do

--- a/spec/install/gems/resolving_spec.rb
+++ b/spec/install/gems/resolving_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle install with install-time dependencies" do
   it "installs gems with implicit rake dependencies" do

--- a/spec/install/gems/standalone_spec.rb
+++ b/spec/install/gems/standalone_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.shared_examples "bundle install --standalone" do
   shared_examples "common functionality" do

--- a/spec/install/gems/sudo_spec.rb
+++ b/spec/install/gems/sudo_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "when using sudo", :sudo => true do
   describe "and BUNDLE_PATH is writable" do

--- a/spec/install/gems/win32_spec.rb
+++ b/spec/install/gems/win32_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle install with win32-generated lockfile" do
   it "should read lockfile" do

--- a/spec/install/gemspecs_spec.rb
+++ b/spec/install/gemspecs_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle install" do
   describe "when a gem has a YAML gemspec" do

--- a/spec/install/git_spec.rb
+++ b/spec/install/git_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle install" do
   context "git sources" do

--- a/spec/install/path_spec.rb
+++ b/spec/install/path_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle install" do
   describe "with --path" do

--- a/spec/install/post_bundle_message_spec.rb
+++ b/spec/install/post_bundle_message_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "post bundle message" do
   before :each do

--- a/spec/install/prereleases_spec.rb
+++ b/spec/install/prereleases_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle install" do
   describe "when prerelease gems are available" do

--- a/spec/install/security_policy_spec.rb
+++ b/spec/install/security_policy_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 require "rubygems/security"
 
 # unfortunately, testing signed gems with a provided CA is extremely difficult

--- a/spec/install/yanked_spec.rb
+++ b/spec/install/yanked_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.context "when installing a bundle that includes yanked gems" do
   before(:each) do

--- a/spec/lock/git_spec.rb
+++ b/spec/lock/git_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle lock with git gems" do
   before :each do

--- a/spec/lock/lockfile_spec.rb
+++ b/spec/lock/lockfile_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "the lockfile format" do
   include Bundler::GemHelpers

--- a/spec/other/bundle_ruby_spec.rb
+++ b/spec/other/bundle_ruby_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle_ruby" do
   context "without patchlevel" do

--- a/spec/other/cli_dispatch_spec.rb
+++ b/spec/other/cli_dispatch_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle command names" do
   it "work when given fully" do

--- a/spec/other/ext_spec.rb
+++ b/spec/other/ext_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "Gem::Specification#match_platform" do
   it "does not match platforms other than the gem platform" do

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "major deprecations" do
   let(:warnings) { out } # change to err in 2.0

--- a/spec/other/platform_spec.rb
+++ b/spec/other/platform_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle platform" do
   context "without flags" do

--- a/spec/other/ssl_cert_spec.rb
+++ b/spec/other/ssl_cert_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 require "bundler/ssl_certs/certificate_manager"
 
 RSpec.describe "SSL Certificates", :rubygems_master do

--- a/spec/other/trampoline_spec.rb
+++ b/spec/other/trampoline_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundler version trampolining" do
   before do

--- a/spec/plugins/command_spec.rb
+++ b/spec/plugins/command_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "command plugins" do
   before do

--- a/spec/plugins/hook_spec.rb
+++ b/spec/plugins/hook_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "hook plugins" do
   before do

--- a/spec/plugins/install_spec.rb
+++ b/spec/plugins/install_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundler plugin install" do
   before do

--- a/spec/plugins/source/example_spec.rb
+++ b/spec/plugins/source/example_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "real source plugins" do
   context "with a minimal source plugin" do

--- a/spec/plugins/source_spec.rb
+++ b/spec/plugins/source_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundler source plugin" do
   describe "plugins dsl eval for #source with :type option" do

--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 if defined?(Encoding) && Encoding.default_external.name != "UTF-8"
   # Poor man's ruby -E UTF-8, since it works on 1.8.7

--- a/spec/realworld/dependency_api_spec.rb
+++ b/spec/realworld/dependency_api_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "gemcutter's dependency API", :realworld => true do
   context "when Gemcutter API takes too long to respond" do

--- a/spec/realworld/edgecases_spec.rb
+++ b/spec/realworld/edgecases_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "real world edgecases", :realworld => true, :sometimes => true do
   def rubygems_version(name, requirement)

--- a/spec/realworld/gemfile_source_header_spec.rb
+++ b/spec/realworld/gemfile_source_header_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 require "thread"
 
 RSpec.describe "fetching dependencies with a mirrored source", :realworld => true, :rubygems => ">= 2.0" do

--- a/spec/realworld/mirror_probe_spec.rb
+++ b/spec/realworld/mirror_probe_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 require "thread"
 
 RSpec.describe "fetching dependencies with a not available mirror", :realworld => true do

--- a/spec/realworld/parallel_spec.rb
+++ b/spec/realworld/parallel_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "parallel", :realworld => true, :sometimes => true do
   it "installs" do

--- a/spec/resolver/basic_spec.rb
+++ b/spec/resolver/basic_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "Resolving" do
   before :each do

--- a/spec/resolver/platform_spec.rb
+++ b/spec/resolver/platform_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "Resolving platform craziness" do
   describe "with cross-platform gems" do

--- a/spec/runtime/executable_spec.rb
+++ b/spec/runtime/executable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "Running bin/* commands" do
   before :each do

--- a/spec/runtime/gem_tasks_spec.rb
+++ b/spec/runtime/gem_tasks_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "require 'bundler/gem_tasks'" do
   before :each do

--- a/spec/runtime/inline_spec.rb
+++ b/spec/runtime/inline_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundler/inline#gemfile" do
   def script(code, options = {})

--- a/spec/runtime/load_spec.rb
+++ b/spec/runtime/load_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "Bundler.load" do
   before :each do

--- a/spec/runtime/platform_spec.rb
+++ b/spec/runtime/platform_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "Bundler.setup with multi platform stuff" do
   it "raises a friendly error when gems are missing locally" do

--- a/spec/runtime/require_spec.rb
+++ b/spec/runtime/require_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "Bundler.require" do
   before :each do

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "Bundler.setup" do
   describe "with no arguments" do

--- a/spec/runtime/with_clean_env_spec.rb
+++ b/spec/runtime/with_clean_env_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "Bundler.with_env helpers" do
   describe "Bundler.original_env" do

--- a/spec/update/gems/post_install_spec.rb
+++ b/spec/update/gems/post_install_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle update" do
   let(:config) {}

--- a/spec/update/git_spec.rb
+++ b/spec/update/git_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "bundle update" do
   describe "git sources" do

--- a/spec/update/path_spec.rb
+++ b/spec/update/path_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe "path sources" do
   describe "bundle update --source" do


### PR DESCRIPTION
Specifying `--require spec_helper` in .rspec will automatically require spec_helper in *_spec.rb.
It isn't necessary to specify `require "spec_helper"` in individual *_spec.rb. I think that it's a [DRY](https://en.wikipedia.org/wiki/Don't_repeat_yourself) way.

Refer: https://github.com/rspec/rspec/wiki#rspec