### PR TITLE
Tweak a newgem template for RSpec

### DIFF
--- a/lib/bundler/templates/newgem/rspec.tt
+++ b/lib/bundler/templates/newgem/rspec.tt
@@ -1,2 +1,3 @@
 --format documentation
 --color
+--require spec_helper

--- a/lib/bundler/templates/newgem/spec/newgem_spec.rb.tt
+++ b/lib/bundler/templates/newgem/spec/newgem_spec.rb.tt
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 RSpec.describe <%= config[:constant_name] %> do
   it "has a version number" do
     expect(<%= config[:constant_name] %>::VERSION).not_to be nil


### PR DESCRIPTION
`--require spec_helper` is contained in .rspec by default when running `rspec --init` on RSpec 3.

```sh
% rspec --version
3.5.4
% rspec --init
  create   .rspec
  create   spec/spec_helper.rb
% cat .rspec
--color
--require spec_helper
```

It seems that the code of template premise the RSpec 3, so I think that it was reasonable to adjust to it.

Related PR #5634