### PR TITLE
[RubygemsIntegration] Stub out Gem.finish_resolve

### DIFF
--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -698,6 +698,10 @@ module Bundler
         Gem.post_reset do
           Gem::Specification.all = specs
         end
+
+        redefine_method((class << Gem; self; end), :finish_resolve) do |*|
+          []
+        end
       end
 
       def all_specs


### PR DESCRIPTION
Fixes https://github.com/rubygems/rubygems/issues/1911

Small novel:

In RubyGems 2.6.11, I changed `Gem.finish_resolve` to respect all of the currently resolved (i.e. `Gem.loaded_specs`) gems. This fixed some bugs that would lead `Gem.finish_resolve` to incorrectly raise gem incompatibility exceptions. That's great, except Bundler's resolver doesn't always resolve the same thing as RG's. In particular, `Source::Gemspec` gems that come from the `gemspec` DSL method are allowed to have conflicts. It appears projects, such as rails, were taking advantage of that fact. Since `stub_entrypoints` is called whenever `Bundler.setup` is run, this is essentially us 'activating' all of the gems in the bundle. Since everything is eagerly activated, it should be impossible for there to ever be any unresolved dependencies, and thus `Gem.finish_resolve` should always be a no-op anyways. We can save CPU cycles and keep our special resolution behavior for `Source::Gemspec` by just acknowledging that `Gem.finish_resolve` should always be a no-op once the bundle has been setup.