### PR TITLE
Unify the notation of RubyGems

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -122,14 +122,14 @@ begin
       system "sudo rm -rf #{File.expand_path("../tmp/sudo_gem_home", __FILE__)}"
     end
 
-    # Rubygems specs by version
+    # RubyGems specs by version
     namespace :rubygems do
       rubyopt = ENV["RUBYOPT"]
       # When editing this list, also edit .travis.yml!
       branches = %w(master)
       releases = %w(v1.3.6 v1.3.7 v1.4.2 v1.5.3 v1.6.2 v1.7.2 v1.8.29 v2.0.14 v2.1.11 v2.2.5 v2.4.8 v2.5.2 v2.6.8)
       (branches + releases).each do |rg|
-        desc "Run specs with Rubygems #{rg}"
+        desc "Run specs with RubyGems #{rg}"
         RSpec::Core::RakeTask.new(rg) do |t|
           t.rspec_opts = %w(--format progress --color)
           t.ruby_opts  = %w(-w)
@@ -153,7 +153,7 @@ begin
               if rg == "master"
                 system("git checkout origin/master")
               else
-                system("git checkout #{rg}") || raise("Unknown Rubygems ref #{rg}")
+                system("git checkout #{rg}") || raise("Unknown RubyGems ref #{rg}")
               end
               hash = `git rev-parse HEAD`.chomp
             end
@@ -170,7 +170,7 @@ begin
         task "rubygems:all" => rg
       end
 
-      desc "Run specs under a Rubygems checkout (set RG=path)"
+      desc "Run specs under a RubyGems checkout (set RG=path)"
       RSpec::Core::RakeTask.new("co") do |t|
         t.rspec_opts = %w(--format documentation --color)
         t.ruby_opts  = %w(-w)
@@ -178,7 +178,7 @@ begin
 
       task "setup_co" do
         rg = File.expand_path ENV["RG"]
-        puts "Running specs against Rubygems in #{rg}..."
+        puts "Running specs against RubyGems in #{rg}..."
         ENV["RUBYOPT"] = "-I#{rg} #{rubyopt}"
       end
 
@@ -186,28 +186,28 @@ begin
       task "rubygems:all" => "co"
     end
 
-    desc "Run the tests on Travis CI against a rubygem version (using ENV['RGV'])"
+    desc "Run the tests on Travis CI against a RubyGem version (using ENV['RGV'])"
     task :travis do
-      rg = ENV["RGV"] || raise("Rubygems version is required on Travis!")
+      rg = ENV["RGV"] || raise("RubyGems version is required on Travis!")
 
       if RUBY_VERSION >= "2.0.0"
         puts "\n\e[1;33m[Travis CI] Running bundler linter\e[m\n\n"
         Rake::Task["rubocop"].invoke
       end
 
-      puts "\n\e[1;33m[Travis CI] Running bundler specs against rubygems #{rg}\e[m\n\n"
+      puts "\n\e[1;33m[Travis CI] Running bundler specs against RubyGems #{rg}\e[m\n\n"
       specs = safe_task { Rake::Task["spec:rubygems:#{rg}"].invoke }
 
       Rake::Task["spec:rubygems:#{rg}"].reenable
 
-      puts "\n\e[1;33m[Travis CI] Running bundler sudo specs against rubygems #{rg}\e[m\n\n"
+      puts "\n\e[1;33m[Travis CI] Running bundler sudo specs against RubyGems #{rg}\e[m\n\n"
       sudos = system("sudo -E rake spec:rubygems:#{rg}:sudo")
       # clean up by chowning the newly root-owned tmp directory back to the travis user
       system("sudo chown -R #{ENV["USER"]} #{File.join(File.dirname(__FILE__), "tmp")}")
 
       Rake::Task["spec:rubygems:#{rg}"].reenable
 
-      puts "\n\e[1;33m[Travis CI] Running bundler real world specs against rubygems #{rg}\e[m\n\n"
+      puts "\n\e[1;33m[Travis CI] Running bundler real world specs against RubyGems #{rg}\e[m\n\n"
       realworld = safe_task { Rake::Task["spec:rubygems:#{rg}:realworld"].invoke }
 
       { "specs" => specs, "sudo" => sudos, "realworld" => realworld }.each do |name, passed|
@@ -331,7 +331,7 @@ rescue LoadError
   end
 end
 
-desc "Update vendored SSL certs to match the certs vendored by Rubygems"
+desc "Update vendored SSL certs to match the certs vendored by RubyGems"
 task :update_certs => "spec:rubygems:clone_rubygems_master" do
   require "bundler/ssl_certs/certificate_manager"
   Bundler::SSLCerts::CertificateManager.update_from!(RUBYGEMS_REPO)

--- a/doc/TROUBLESHOOTING.md
+++ b/doc/TROUBLESHOOTING.md
@@ -28,7 +28,7 @@ Please open a ticket with [Heroku](https://www.heroku.com) if you're having trou
 First, figure out exactly what it is that you're trying to do (see [XY Problem](http://xyproblem.info/)). Then, go to the [Bundler documentation website](http://bundler.io) and see if we have instructions on how to do that.
 
 Second, check [the compatibility
-list](http://bundler.io/compatibility.html), and make sure that the version of Bundler that you are using works with the versions of Ruby and Rubygems that you are using. To see your versions:
+list](http://bundler.io/compatibility.html), and make sure that the version of Bundler that you are using works with the versions of Ruby and RubyGems that you are using. To see your versions:
 
     # Bundler version
     bundle -v
@@ -36,7 +36,7 @@ list](http://bundler.io/compatibility.html), and make sure that the version of B
     # Ruby version
     ruby -v
 
-    # Rubygems version
+    # RubyGems version
     gem -v
 
 If these instructions don't work, or you can't find any appropriate instructions, you can try these troubleshooting steps:

--- a/doc/contributing/COMMUNITY.md
+++ b/doc/contributing/COMMUNITY.md
@@ -2,7 +2,7 @@
 
 Community is an important part of all we do. If you’d like to be part of the Bundler community, you can jump right in and start helping make Bundler better for everyone who uses it.
 
-It would be tremendously helpful to have more people answering questions about Bundler (and often simply about [Rubygems](https://github.com/rubygems/rubygems) or Ruby itself) in our [issue tracker](https://github.com/bundler/bundler/issues) or on [Stack Overflow](http://stackoverflow.com/questions/tagged/bundler).
+It would be tremendously helpful to have more people answering questions about Bundler (and often simply about [RubyGems](https://github.com/rubygems/rubygems) or Ruby itself) in our [issue tracker](https://github.com/bundler/bundler/issues) or on [Stack Overflow](http://stackoverflow.com/questions/tagged/bundler).
 
 Additional documentation and explanation is always helpful, too. If you have any suggestions for the Bundler website [bundler.io](http://bundler.io), we would absolutely love it if you opened an issue or pull request on the [bundler-site](https://github.com/bundler/bundler-site) repository.
 

--- a/doc/contributing/ISSUES.md
+++ b/doc/contributing/ISSUES.md
@@ -39,7 +39,7 @@ If your version of Bundler does not have the `bundle env` command, then please i
  - Your Bundler configuration settings (run `bundle config`)
  - What version of bundler you are using (run `bundle -v`)
  - What version of Ruby you are using (run `ruby -v`)
- - What version of Rubygems you are using (run `gem -v`)
+ - What version of RubyGems you are using (run `gem -v`)
  - Whether you are using RVM, and if so what version (run `rvm -v`)
  - Whether you have the `rubygems-bundler` gem, which can break gem executables (run `gem list rubygems-bundler`)
  - Whether you have the `open_gem` gem, which can cause rake activation conflicts (run `gem list open_gem`)

--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -313,9 +313,9 @@ EOF
     end
 
     def system_bindir
-      # Gem.bindir doesn't always return the location that Rubygems will install
-      # system binaries. If you put '-n foo' in your .gemrc, Rubygems will
-      # install binstubs there instead. Unfortunately, Rubygems doesn't expose
+      # Gem.bindir doesn't always return the location that RubyGems will install
+      # system binaries. If you put '-n foo' in your .gemrc, RubyGems will
+      # install binstubs there instead. Unfortunately, RubyGems doesn't expose
       # that directory at all, so rather than parse .gemrc ourselves, we allow
       # the directory to be set as well, via `bundle config bindir foo`.
       Bundler.settings[:system_bindir] || Bundler.rubygems.gem_bindir
@@ -327,7 +327,7 @@ EOF
       sudo_present = which "sudo" if settings.allow_sudo?
 
       if sudo_present
-        # the bundle path and subdirectories need to be writable for Rubygems
+        # the bundle path and subdirectories need to be writable for RubyGems
         # to be able to unpack and install gems without exploding
         path = bundle_path
         path = path.parent until path.exist?

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -352,7 +352,7 @@ module Bundler
     long_desc <<-D
       Exec runs a command, providing it access to the gems in the bundle. While using
       bundle exec you can require and call the bundled gems as if they were installed
-      into the system wide Rubygems repository.
+      into the system wide RubyGems repository.
     D
     map "e" => "exec"
     def exec(*args)

--- a/lib/bundler/cli/binstubs.rb
+++ b/lib/bundler/cli/binstubs.rb
@@ -29,7 +29,7 @@ module Bundler
         end
 
         if spec.name == "bundler"
-          Bundler.ui.warn "Sorry, Bundler can only be run via Rubygems."
+          Bundler.ui.warn "Sorry, Bundler can only be run via RubyGems."
         elsif options[:standalone]
           installer.generate_standalone_bundler_executable_stubs(spec)
         else

--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -163,7 +163,7 @@ module Bundler
     def check_trust_policy
       if options["trust-policy"]
         unless Bundler.rubygems.security_policies.keys.include?(options["trust-policy"])
-          Bundler.ui.error "Rubygems doesn't know about trust policy '#{options["trust-policy"]}'. " \
+          Bundler.ui.error "RubyGems doesn't know about trust policy '#{options["trust-policy"]}'. " \
             "The known policies are: #{Bundler.rubygems.security_policies.keys.join(", ")}."
           exit 1
         end

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -635,12 +635,12 @@ module Bundler
     def converge_sources
       changes = false
 
-      # Get the Rubygems sources from the Gemfile.lock
+      # Get the RubyGems sources from the Gemfile.lock
       locked_gem_sources = @locked_sources.select {|s| s.is_a?(Source::Rubygems) }
-      # Get the Rubygems remotes from the Gemfile
+      # Get the RubyGems remotes from the Gemfile
       actual_remotes = sources.rubygems_remotes
 
-      # If there is a Rubygems source in both
+      # If there is a RubyGems source in both
       if !locked_gem_sources.empty? && !actual_remotes.empty?
         locked_gem_sources.each do |locked_gem|
           # Merge the remotes from the Gemfile into the Gemfile.lock
@@ -746,7 +746,7 @@ module Bundler
         s.source = (dep && dep.source) || sources.get(s.source)
 
         # Don't add a spec to the list if its source is expired. For example,
-        # if you change a Git gem to Rubygems.
+        # if you change a Git gem to RubyGems.
         next if s.source.nil?
         next if @unlock[:sources].include?(s.source.name)
 
@@ -885,7 +885,7 @@ module Bundler
       specs.each do |s|
         # TODO: when two sources without blocks is an error, we can change
         # this check to !s.source.is_a?(Source::LocalRubygems). For now,
-        # we need to ask every Rubygems for every gem name.
+        # we need to ask every RubyGems for every gem name.
         if s.source.is_a?(Source::Git) || s.source.is_a?(Source::Path)
           names << s.name
         end

--- a/lib/bundler/env.rb
+++ b/lib/bundler/env.rb
@@ -14,7 +14,7 @@ module Bundler
 
       out = String.new("## Environment\n\n```\n")
       out << "Bundler   #{Bundler::VERSION}\n"
-      out << "Rubygems  #{Gem::VERSION}\n"
+      out << "RubyGems  #{Gem::VERSION}\n"
       out << "Ruby      #{ruby_version}"
       out << "GEM_HOME  #{ENV["GEM_HOME"]}\n" unless ENV["GEM_HOME"].nil? || ENV["GEM_HOME"].empty?
       out << "GEM_PATH  #{ENV["GEM_PATH"]}\n" unless ENV["GEM_PATH"] == ENV["GEM_HOME"]

--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -50,8 +50,8 @@ module Bundler
         install_gem(built_gem_path, :local)
       end
 
-      desc "Create tag #{version_tag} and build and push #{name}-#{version}.gem to Rubygems\n" \
-           "To prevent publishing in Rubygems use `gem_push=no rake release`"
+      desc "Create tag #{version_tag} and build and push #{name}-#{version}.gem to RubyGems\n" \
+           "To prevent publishing in RubyGems use `gem_push=no rake release`"
       task "release", [:remote] => ["build", "release:guard_clean",
                                     "release:source_control_push", "release:rubygem_push"] do
       end

--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -188,8 +188,8 @@ module Bundler
       if Bundler.rubygems.provides?(">= 2.1.0")
         true
       else
-        Bundler.ui.warn "Rubygems #{Gem::VERSION} is not threadsafe, so your "\
-          "gems will be installed one at a time. Upgrade to Rubygems 2.1.0 " \
+        Bundler.ui.warn "RubyGems #{Gem::VERSION} is not threadsafe, so your "\
+          "gems will be installed one at a time. Upgrade to RubyGems 2.1.0 " \
           "or higher to enable parallel gem installation."
         false
       end

--- a/lib/bundler/rubygems_ext.rb
+++ b/lib/bundler/rubygems_ext.rb
@@ -14,7 +14,7 @@ begin
   # shouldn't be deferred.
   require "rubygems/source"
 rescue LoadError
-  # Not available before Rubygems 2.0.0, ignore
+  # Not available before RubyGems 2.0.0, ignore
   nil
 end
 
@@ -158,7 +158,7 @@ module Gem
       out
     end
 
-    # Backport of performance enhancement added to Rubygems 1.4
+    # Backport of performance enhancement added to RubyGems 1.4
     def matches_spec?(spec)
       # name can be a Regexp, so use ===
       return false unless name === spec.name

--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -165,7 +165,7 @@ module Bundler
     def spec_cache_dirs
       @spec_cache_dirs ||= begin
         dirs = gem_path.map {|dir| File.join(dir, "specifications") }
-        dirs << Gem.spec_cache_dir if Gem.respond_to?(:spec_cache_dir) # Not in Rubygems 2.0.3 or earlier
+        dirs << Gem.spec_cache_dir if Gem.respond_to?(:spec_cache_dir) # Not in RubyGems 2.0.3 or earlier
         dirs.uniq.select {|dir| File.directory? dir }
       end
     end
@@ -191,7 +191,7 @@ module Bundler
     end
 
     def preserve_paths
-      # this is a no-op outside of Rubygems 1.8
+      # this is a no-op outside of RubyGems 1.8
       yield
     end
 
@@ -233,9 +233,9 @@ module Bundler
       {} # if we can't download them, there aren't any
     end
 
-    # TODO: This is for older versions of Rubygems... should we support the
+    # TODO: This is for older versions of RubyGems... should we support the
     # X-Gemfile-Source header on these old versions?
-    # Maybe the newer implementation will work on older Rubygems?
+    # Maybe the newer implementation will work on older RubyGems?
     # It seems difficult to keep this implementation and still send the header.
     def fetch_all_remote_specs(remote)
       old_sources = Bundler.rubygems.sources
@@ -476,7 +476,7 @@ module Bundler
       redefine_method(gem_class, :refresh) {}
     end
 
-    # Replace or hook into Rubygems to provide a bundlerized view
+    # Replace or hook into RubyGems to provide a bundlerized view
     # of the world.
     def replace_entrypoints(specs)
       specs_by_name = specs.reduce({}) do |h, s|
@@ -492,8 +492,8 @@ module Bundler
       Gem.clear_paths
     end
 
-    # This backports the correct segment generation code from Rubygems 1.4+
-    # by monkeypatching it into the method in Rubygems 1.3.6 and 1.3.7.
+    # This backports the correct segment generation code from RubyGems 1.4+
+    # by monkeypatching it into the method in RubyGems 1.3.6 and 1.3.7.
     def backport_segment_generation
       redefine_method(Gem::Version, :segments) do
         @segments ||= @version.scan(/[0-9]+|[a-z]+/i).map do |s|
@@ -512,7 +512,7 @@ module Bundler
     end
 
     # This backports base_dir which replaces installation path
-    # Rubygems 1.8+
+    # RubyGems 1.8+
     def backport_base_dir
       redefine_method(Gem::Specification, :base_dir) do
         return Gem.dir unless loaded_from
@@ -581,7 +581,7 @@ module Bundler
       end
     end
 
-    # Rubygems 1.4 through 1.6
+    # RubyGems 1.4 through 1.6
     class Legacy < RubygemsIntegration
       def initialize
         super
@@ -592,7 +592,7 @@ module Bundler
       end
 
       def stub_rubygems(specs)
-        # Rubygems versions lower than 1.7 use SourceIndex#from_gems_in
+        # RubyGems versions lower than 1.7 use SourceIndex#from_gems_in
         source_index_class = (class << Gem::SourceIndex; self; end)
         redefine_method(source_index_class, :from_gems_in) do |*args|
           Gem::SourceIndex.new.tap do |source_index|
@@ -624,7 +624,7 @@ module Bundler
       end
     end
 
-    # Rubygems versions 1.3.6 and 1.3.7
+    # RubyGems versions 1.3.6 and 1.3.7
     class Ancient < Legacy
       def initialize
         super
@@ -632,7 +632,7 @@ module Bundler
       end
     end
 
-    # Rubygems 1.7
+    # RubyGems 1.7
     class Transitional < Legacy
       def stub_rubygems(specs)
         stub_source_index(specs)
@@ -646,7 +646,7 @@ module Bundler
       end
     end
 
-    # Rubygems 1.8.5-1.8.19
+    # RubyGems 1.8.5-1.8.19
     class Modern < RubygemsIntegration
       def stub_rubygems(specs)
         Gem::Specification.all = specs
@@ -667,9 +667,9 @@ module Bundler
       end
     end
 
-    # Rubygems 1.8.0 to 1.8.4
+    # RubyGems 1.8.0 to 1.8.4
     class AlmostModern < Modern
-      # Rubygems [>= 1.8.0, < 1.8.5] has a bug that changes Gem.dir whenever
+      # RubyGems [>= 1.8.0, < 1.8.5] has a bug that changes Gem.dir whenever
       # you call Gem::Installer#install with an :install_dir set. We have to
       # change it back for our sudo mode to work.
       def preserve_paths
@@ -680,9 +680,9 @@ module Bundler
       end
     end
 
-    # Rubygems 1.8.20+
+    # RubyGems 1.8.20+
     class MoreModern < Modern
-      # Rubygems 1.8.20 and adds the skip_validation parameter, so that's
+      # RubyGems 1.8.20 and adds the skip_validation parameter, so that's
       # when we start passing it through.
       def build(spec, skip_validation = false)
         require "rubygems/builder"
@@ -690,7 +690,7 @@ module Bundler
       end
     end
 
-    # Rubygems 2.0
+    # RubyGems 2.0
     class Future < RubygemsIntegration
       def stub_rubygems(specs)
         Gem::Specification.all = specs
@@ -848,7 +848,7 @@ module Bundler
       RubygemsIntegration::Transitional.new
     elsif RubygemsIntegration.provides?(">= 1.4.0")
       RubygemsIntegration::Legacy.new
-    else # Rubygems 1.3.6 and 1.3.7
+    else # RubyGems 1.3.6 and 1.3.7
       RubygemsIntegration::Ancient.new
     end
   end

--- a/lib/bundler/source/path.rb
+++ b/lib/bundler/source/path.rb
@@ -238,7 +238,7 @@ module Bundler
                           "to modify their .gemspec so it can work with `gem build`."
         end
 
-        Bundler.ui.warn "The validation message from Rubygems was:\n  #{e.message}"
+        Bundler.ui.warn "The validation message from RubyGems was:\n  #{e.message}"
       end
     end
   end

--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.authors       = [<%= config[:author].inspect %>]
   spec.email         = [<%= config[:email].inspect %>]
 
-  spec.summary       = %q{TODO: Write a short summary, because Rubygems requires one.}
+  spec.summary       = %q{TODO: Write a short summary, because RubyGems requires one.}
   spec.description   = %q{TODO: Write a longer description or delete this line.}
   spec.homepage      = "TODO: Put your gem's website or public repo URL here."
 <%- if config[:mit] -%>

--- a/spec/bundler/fetcher/dependency_spec.rb
+++ b/spec/bundler/fetcher/dependency_spec.rb
@@ -220,7 +220,7 @@ RSpec.describe Bundler::Fetcher::Dependency do
 
     before { allow(subject).to receive(:dependency_api_uri).with(gem_names).and_return(dep_api_uri) }
 
-    it "should fetch dependencies from Rubygems and unmarshal them" do
+    it "should fetch dependencies from RubyGems and unmarshal them" do
       expect(gem_names).to receive(:each_slice).with(rubygems_limit).and_call_original
       expect(downloader).to receive(:fetch).with(dep_api_uri).and_return(fetch_response)
       expect(Bundler).to receive(:load_marshal).with(fetch_response.body).and_return([unmarshalled_gems])

--- a/spec/commands/binstubs_spec.rb
+++ b/spec/commands/binstubs_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "bundle binstubs <gem>" do
       bundle "binstubs bundler"
 
       expect(bundled_app("bin/bundle")).not_to exist
-      expect(out).to include("Sorry, Bundler can only be run via Rubygems.")
+      expect(out).to include("Sorry, Bundler can only be run via RubyGems.")
     end
 
     it "installs binstubs from git gems" do

--- a/spec/commands/help_spec.rb
+++ b/spec/commands/help_spec.rb
@@ -2,7 +2,7 @@
 require "spec_helper"
 
 RSpec.describe "bundle help" do
-  # Rubygems 1.4+ no longer load gem plugins so this test is no longer needed
+  # RubyGems 1.4+ no longer load gem plugins so this test is no longer needed
   it "complains if older versions of bundler are installed", :rubygems => "< 1.4" do
     system_gems "bundler-0.8.1"
 

--- a/spec/commands/pristine_spec.rb
+++ b/spec/commands/pristine_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "bundle pristine" do
     G
   end
 
-  context "when sourced from Rubygems" do
+  context "when sourced from RubyGems" do
     it "reverts using cached .gem file" do
       spec = Bundler.definition.specs["weakling"].first
       changes_txt = Pathname.new(spec.full_gem_path).join("lib/changes.txt")

--- a/spec/install/gems/compact_index_spec.rb
+++ b/spec/install/gems/compact_index_spec.rb
@@ -640,7 +640,7 @@ The checksum of /versions does not match the checksum provided by the server! So
   context "when SSL certificate verification fails" do
     it "explains what happened" do
       # Install a monkeypatch that reproduces the effects of openssl raising
-      # a certificate validation error when Rubygems tries to connect.
+      # a certificate validation error when RubyGems tries to connect.
       gemfile <<-G
         class Net::HTTP
           def start

--- a/spec/install/gems/dependency_api_spec.rb
+++ b/spec/install/gems/dependency_api_spec.rb
@@ -629,7 +629,7 @@ RSpec.describe "gemcutter's dependency API" do
   context "when SSL certificate verification fails" do
     it "explains what happened" do
       # Install a monkeypatch that reproduces the effects of openssl raising
-      # a certificate validation error when Rubygems tries to connect.
+      # a certificate validation error when RubyGems tries to connect.
       gemfile <<-G
         class Net::HTTP
           def start

--- a/spec/install/gems/sudo_spec.rb
+++ b/spec/install/gems/sudo_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "when using sudo", :sudo => true do
       expect(the_bundle).to include_gems "rack 1.0"
     end
 
-    it "installs extensions/ compiled by Rubygems 2.2", :rubygems => "2.2" do
+    it "installs extensions/ compiled by RubyGems 2.2", :rubygems => "2.2" do
       install_gemfile <<-G
         source "file://#{gem_repo1}"
         gem "very_simple_binary"

--- a/spec/install/security_policy_spec.rb
+++ b/spec/install/security_policy_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "policies with unsigned gems" do
 
   it "will fail when given invalid security policy" do
     bundle "install --trust-policy=InvalidPolicyName"
-    expect(out).to include("Rubygems doesn't know about trust policy")
+    expect(out).to include("RubyGems doesn't know about trust policy")
   end
 
   it "will fail with High Security setting due to presence of unsigned gem" do
@@ -32,7 +32,7 @@ RSpec.describe "policies with unsigned gems" do
     expect(out).to include("security policy didn't allow")
   end
 
-  # This spec will fail on Rubygems 2 rc1 due to a bug in policy.rb. the bug is fixed in rc3.
+  # This spec will fail on RubyGems 2 rc1 due to a bug in policy.rb. the bug is fixed in rc3.
   it "will fail with Medium Security setting due to presence of unsigned gem", :unless => ENV["RGV"] == "v2.0.0.rc.1" do
     bundle "install --trust-policy=MediumSecurity"
     expect(out).to include("security policy didn't allow")

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -652,7 +652,7 @@ RSpec.describe "Bundler.setup" do
     end
   end
 
-  # Rubygems returns loaded_from as a string
+  # RubyGems returns loaded_from as a string
   it "has loaded_from as a string on all specs" do
     build_git "foo"
     build_git "no-gemspec", :gemspec => false

--- a/spec/support/builders.rb
+++ b/spec/support/builders.rb
@@ -256,7 +256,7 @@ module Spec
         end
 
         # Capistrano did this (at least until version 2.5.10)
-        # Rubygems 2.2 doesn't allow the specifying of a dependency twice
+        # RubyGems 2.2 doesn't allow the specifying of a dependency twice
         # See https://github.com/rubygems/rubygems/commit/03dbac93a3396a80db258d9bc63500333c25bd2f
         build_gem "double_deps", "1.0", :skip_validation => true do |s|
           s.add_dependency "net-ssh", ">= 1.0.0"


### PR DESCRIPTION
This PR is mainly replacing Rubygems with RubyGems. 

`Rubygems` is a Ruby module name (e.g. `Bundler::Source::Rubygems`) , whereas RubyGems is the proper notation as below.

https://github.com/rubygems/rubygems/blob/master/README.md

In this PR, it changed the notation mainly used in console output and documentation  (and some source code comments) .