### PR TITLE
tell_err is private and the last caller was already removed

### DIFF
--- a/lib/bundler/ui/shell.rb
+++ b/lib/bundler/ui/shell.rb
@@ -102,14 +102,6 @@ module Bundler
         end
       end
 
-      def tell_err(message, color = nil, newline = nil)
-        buffer = @shell.send(:prepare_message, message, *color)
-        buffer << "\n" if newline && !message.to_s.end_with?("\n")
-
-        @shell.send(:stderr).print(buffer)
-        @shell.send(:stderr).flush
-      end
-
       def strip_leading_spaces(text)
         spaces = text[/\A\s+/, 0]
         spaces ? text.gsub(/#{spaces}/, "") : text


### PR DESCRIPTION
tell_err was added in e120f40f72fe53f55e05db9204f98d28f1065e81
It's last caller was removed in d88627a8191644fb970cce2140f3c320f3101c32 as part of a
removal of old deprecation code.

I don't know if this was intentional, but it seems like a good idea to remove this private method.

@segiddins please review.  I was going to use this method since I wanted a way to write to stderr instead of stdout but realized I couldn't use it since it was private.  