### PR TITLE
make #ensure_specs_are_compatible more readable

### DIFF
--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -173,13 +173,16 @@ module Bundler
       system_ruby = Bundler::RubyVersion.system
       rubygems_version = Gem::Version.create(Gem::VERSION)
       @definition.specs.each do |spec|
-        if required_ruby_version = spec.required_ruby_version
-          unless required_ruby_version.satisfied_by?(system_ruby.gem_version)
-            raise InstallError, "#{spec.full_name} requires ruby version #{required_ruby_version}, " \
-              "which is incompatible with the current version, #{system_ruby}"
-          end
+        required_ruby_version = spec.required_ruby_version
+        required_rubygems_version = spec.required_rubygems_version
+
+        next unless required_ruby_version || required_rubygems_version
+
+        unless required_ruby_version.satisfied_by?(system_ruby.gem_version)
+          raise InstallError, "#{spec.full_name} requires ruby version #{required_ruby_version}, " \
+            "which is incompatible with the current version, #{system_ruby}"
         end
-        next unless required_rubygems_version = spec.required_rubygems_version
+
         unless required_rubygems_version.satisfied_by?(rubygems_version)
           raise InstallError, "#{spec.full_name} requires rubygems version #{required_rubygems_version}, " \
             "which is incompatible with the current version, #{rubygems_version}"

--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -178,12 +178,12 @@ module Bundler
 
         next unless required_ruby_version || required_rubygems_version
 
-        unless required_ruby_version.satisfied_by?(system_ruby.gem_version)
+        unless required_ruby_version && required_ruby_version.satisfied_by?(system_ruby.gem_version)
           raise InstallError, "#{spec.full_name} requires ruby version #{required_ruby_version}, " \
             "which is incompatible with the current version, #{system_ruby}"
         end
 
-        unless required_rubygems_version.satisfied_by?(rubygems_version)
+        unless required_rubygems_version && required_rubygems_version.satisfied_by?(rubygems_version)
           raise InstallError, "#{spec.full_name} requires rubygems version #{required_rubygems_version}, " \
             "which is incompatible with the current version, #{rubygems_version}"
         end


### PR DESCRIPTION
This is just a tiny change that just makes `#ensure_specs_are_compatible!` a bit more readable. 

On a sidenote: Does this method need the bang? What's the convention we're using?