### PR TITLE
Allow to add username and password to a remote during a deployment

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -100,6 +100,9 @@ Style/TrailingCommaInArguments:
 Performance/FlatMap:
   Enabled: false
 
+Security/YAMLLoad:
+  Enabled: false
+
 # Metrics
 
 # We've chosen to use Rubocop only for style, and not for complexity or quality checks.

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -407,8 +407,8 @@ module Bundler
 
       # Check if it is possible that the source is only changed thing
       if (new_deps.empty? && deleted_deps.empty?) && (!new_sources.empty? && !deleted_sources.empty?)
-        new_sources.reject! {|source| source.is_a_path? && source.path.exist? }
-        deleted_sources.reject! {|source| source.is_a_path? && source.path.exist? }
+        new_sources.reject! {|source| (source.path? && source.path.exist?) || equivalent_rubygems_remotes?(source) }
+        deleted_sources.reject! {|source| (source.path? && source.path.exist?) || equivalent_rubygems_remotes?(source) }
       end
 
       if @locked_sources != gemfile_sources
@@ -636,7 +636,7 @@ module Bundler
       if !locked_gem_sources.empty? && !actual_remotes.empty?
         locked_gem_sources.each do |locked_gem|
           # Merge the remotes from the Gemfile into the Gemfile.lock
-          changes |= locked_gem.replace_remotes(actual_remotes)
+          changes |= locked_gem.replace_remotes(actual_remotes, Bundler.settings[:allow_deployment_source_credential_changes])
         end
       end
 
@@ -963,6 +963,12 @@ module Bundler
         requirements[name] = DepProxy.new(dep, locked_spec.platform)
         requirements
       end.values
+    end
+
+    def equivalent_rubygems_remotes?(source)
+      return false unless source.is_a?(Source::Rubygems)
+
+      Bundler.settings[:allow_deployment_source_credential_changes] && source.equivalent_remotes?(sources.rubygems_remotes)
     end
   end
 end

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -10,6 +10,7 @@ module Bundler
 
     BOOL_KEYS = %w[
       allow_bundler_dependency_conflicts
+      allow_deployment_source_credential_changes
       allow_offline_install
       auto_install
       cache_all

--- a/lib/bundler/source.rb
+++ b/lib/bundler/source.rb
@@ -46,6 +46,10 @@ module Bundler
       "#<#{self.class}:0x#{object_id} #{self}>"
     end
 
+    def path?
+      instance_of?(Bundler::Source::Path)
+    end
+
   private
 
     def version_color(spec_version, locked_spec_version)

--- a/lib/bundler/source/path.rb
+++ b/lib/bundler/source/path.rb
@@ -116,10 +116,6 @@ module Bundler
         Bundler.root
       end
 
-      def is_a_path?
-        instance_of?(Path)
-      end
-
       def expanded_original_path
         @expanded_original_path ||= expand(original_path)
       end

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -121,6 +121,9 @@ learn more about their operation in [bundle install(1)][bundle-install].
 * `allow_bundler_dependency_conflicts` (`BUNDLE_ALLOW_BUNDLER_DEPENDENCY_CONFLICTS`):
    Allow resolving to specifications that have dependencies on `bundler` that
    are incompatible with the running Bundler version.
+* `allow_deployment_source_credential_changes` (`BUNDLE_ALLOW_DEPLOYMENT_SOURCE_CREDENTIAL_CHANGES`):
+   When in deployment mode, allow changing the credentials to a gem's source.
+   Ex: `https://some.host.com/gems/path/` -> `https://user_name:password@some.host.com/gems/path`
 * `allow_offline_install` (`BUNDLE_ALLOW_OFFLINE_INSTALL`):
    Allow Bundler to use cached data when installing without network access.
 * `auto_install` (`BUNDLE_AUTO_INSTALL`):


### PR DESCRIPTION
This is my first PR to bundler, so if something is out of place let me know and I'll do my best to correct it.

The issue I'm trying to fix is allowing to change a remote on a frozen bundler for the same remote adding username and password.
In our dev boxes we have configured bundle to store the username and password for a given domain, but on our qa boxes we don't want to do that for various reasons.

As far as I can tell this should not have any negative side effects as we are keeping the same remote but only adding some auth to it