### PR TITLE
Stop caching @setup in Bundler

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -89,16 +89,13 @@ module Bundler
     end
 
     def setup(*groups)
-      # Return if all groups are already loaded
-      return @setup if defined?(@setup) && @setup
-
       definition.validate_runtime!
 
       SharedHelpers.print_major_deprecations!
 
       if groups.empty?
         # Load all groups, but only once
-        @setup = load.setup
+        load.setup
       else
         load.setup(*groups)
       end
@@ -452,7 +449,6 @@ EOF
       @root = nil
       @settings = nil
       @definition = nil
-      @setup = nil
       @load = nil
       @locked_gems = nil
       @bundle_path = nil


### PR DESCRIPTION
> **TL;DR:** This PR stops caching `@setup` in `Bundler`.

Caching `@setup` might cause an issue when users want to have their own setup.

I encountered an issue with `Bundler.setup`, here's my code

```rb
# test.rb
require 'rubygems'
require 'bundler'

Bundler.setup(:default, :development)

require 'foo'
Foo
```

Also I have gem `foo` in Gemfile with `production` group, let's assume there is a `Foo` constant in it.

When I ran `bundle exec ruby ./test.rb`, it turned out `Foo` can be loaded, while it should not.

It seems like the culprit is `Bundler.kernel_load` method (https://github.com/bundler/bundler/blob/master/lib/bundler/cli/exec.rb#L71), it tries to load everything with `bundler/setup` since no group is specified, then `@setup` is forever cached in `Bundler`.

I could probably use `Bundler.reset!` to reset every variable I have in `Bundler` (or could I?), but it seems to me that we don't call `Bundle.set` that often (I actually have no clue how expensive that call is), is there a chance we don't need to cache it?