### PR TITLE
[DSL] Allow forcing a particular version of a gem

### DIFF
--- a/lib/bundler/dependency.rb
+++ b/lib/bundler/dependency.rb
@@ -88,6 +88,7 @@ module Bundler
       @should_include = options.fetch("should_include", true)
 
       @autorequire = Array(options["require"] || []) if options.key?("require")
+      @force_version = options.fetch("force_version", false)
     end
 
     def gem_platforms(valid_platforms)
@@ -104,6 +105,10 @@ module Bundler
 
     def should_include?
       @should_include && current_env? && current_platform?
+    end
+
+    def force_version?
+      @force_version
     end
 
     def current_env?

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -15,7 +15,7 @@ module Bundler
     VALID_PLATFORMS = Bundler::Dependency::PLATFORM_MAP.keys.freeze
 
     VALID_KEYS = %w[group groups git path glob name branch ref tag require submodules
-                    platform platforms type source install_if].freeze
+                    platform platforms type source install_if force_version].freeze
 
     attr_reader :gemspecs
     attr_accessor :dependencies
@@ -374,6 +374,10 @@ repo_name ||= user_name
       if opts.key?("source")
         source = normalize_source(opts["source"])
         opts["source"] = @sources.add_rubygems_source("remotes" => source)
+      end
+
+      if opts.key?("force_version") && (r = Gem::Requirement.new(version)) && !r.exact?
+        raise GemfileError, "Cannot use force_version for inexact version requirement `#{r}`"
       end
 
       git_name = (git_names & opts.keys).last

--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -354,7 +354,7 @@ module Bundler
     end
 
     def requirement_satisfied_by?(requirement, activated, spec)
-      return false unless requirement.matches_spec?(spec) || spec.source.is_a?(Source::Gemspec)
+      return false unless requirement.matches_spec?(spec) || allows_conflicts?(requirement, activated, spec)
       spec.activate_platform!(requirement.__platform) if !@platforms || @platforms.include?(requirement.__platform)
       true
     end
@@ -455,6 +455,13 @@ module Bundler
         version_platform_str
       end
       version_platform_strs.join(", ")
+    end
+
+    def allows_conflicts?(requirement, activated, spec)
+      return true if spec.source.is_a?(Source::Gemspec)
+      return false if requirement.force_version?
+      return true if activated.vertex_named(spec.name).requirements.any?(&:force_version?)
+      false
     end
   end
 end

--- a/lib/bundler/rubygems_ext.rb
+++ b/lib/bundler/rubygems_ext.rb
@@ -166,6 +166,10 @@ module Gem
 
       requirement.satisfied_by?(spec.version)
     end unless allocate.respond_to?(:matches_spec?)
+
+    def force_version?
+      false
+    end
   end
 
   class Requirement

--- a/spec/install/gemfile/force_spec.rb
+++ b/spec/install/gemfile/force_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+RSpec.describe "bundle install with a gemfile that forces a gem version" do
+  context "with a simple conflict" do
+    it "works" do
+      install_gemfile! <<-G
+        source "file:#{gem_repo1}"
+        gem "rack_middleware"
+        gem "rack", "1.0.0", :force_version => true
+      G
+
+      expect(the_bundle).to include_gems("rack 1.0.0", "rack_middleware 1.0")
+    end
+
+    it "raises when forcing to an inexact version" do
+      install_gemfile <<-G
+        gem "rack", "> 1.0.0", :force_version => true
+      G
+      expect(out).to include("Cannot use force_version for inexact version requirement `> 1.0.0`.")
+    end
+
+    it "raises when forcing without specifying a version" do
+      install_gemfile <<-G
+        gem "rack", :force_version => true
+      G
+      expect(out).to include("Cannot use force_version for inexact version requirement `>= 0`.")
+    end
+
+    it "works when there's no conflict" do
+      install_gemfile! <<-G
+        source "file:#{gem_repo1}"
+        gem "rack", "1.0.0", :force_version => true
+      G
+
+      expect(the_bundle).to include_gems("rack 1.0.0")
+    end
+  end
+
+  context "with a complex conflict" do
+    it "works" do
+      install_gemfile! <<-G
+        source "file:#{gem_repo1}"
+        gem "rails", "2.3.2"
+        gem "activesupport", "2.3.5", :force_version => true
+      G
+
+      expect(the_bundle).to include_gems("rails 2.3.2", "activesupport 2.3.5", "actionpack 2.3.2", "activerecord 2.3.2", "actionmailer 2.3.2", "activeresource 2.3.2")
+    end
+  end
+end


### PR DESCRIPTION
Closes https://github.com/bundler/bundler/issues/4552.

Even if it conflicts. This will hopefully add a way out of situations where a gem author has added overly-strict requirements, without adding a huge amount of overhead in bundler or conceptually for a user. By forcing the Gemfile to explicitly say what version is being forced, there's no opportunity for something unexpected to happen.

This is rough & unpolished, and I'd appreciate feedback on the UX, but I believe the basic implementation works (as I imagined this feature working :P).