### PR TITLE
[GitProxy] Force deinitializing submodules

### DIFF
--- a/lib/bundler/source/git/git_proxy.rb
+++ b/lib/bundler/source/git/git_proxy.rb
@@ -135,7 +135,7 @@ module Bundler
             if submodules
               git_retry "submodule update --init --recursive"
             elsif Gem::Version.create(version) >= Gem::Version.create("2.9.0")
-              git_retry "submodule deinit --all"
+              git_retry "submodule deinit --all --force"
             end
           end
         end


### PR DESCRIPTION
Fixes  the following test under newer git versions

```
bundle update
  git sources
    with submodules
      unlocks the source when submodules are removed from git source
```