### PR TITLE
Allow bundle install --force to work with git specs

### DIFF
--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -215,7 +215,7 @@ module Bundler
     end
 
     def resolve_if_need(options)
-      if !options["update"] && !options[:inline] && Bundler.default_lockfile.file?
+      if !options["update"] && !options[:inline] && !options["force"] && Bundler.default_lockfile.file?
         local = Bundler.ui.silence do
           begin
             tmpdef = Definition.build(Bundler.default_gemfile, Bundler.default_lockfile, nil)

--- a/lib/bundler/source/git/git_proxy.rb
+++ b/lib/bundler/source/git/git_proxy.rb
@@ -3,7 +3,7 @@ require "shellwords"
 require "tempfile"
 module Bundler
   class Source
-    class Git < Path
+    class Git
       class GitNotInstalledError < GitError
         def initialize
           msg = String.new

--- a/spec/install/force_spec.rb
+++ b/spec/install/force_spec.rb
@@ -32,5 +32,36 @@ RSpec.describe "bundle install" do
       expect(out).to include "Installing rack 1.0.0"
       expect(the_bundle).to include_gems "rack 1.0.0"
     end
+
+    context "with a git gem" do
+      let!(:ref) { build_git("foo", "1.0").ref_for("HEAD", 11) }
+
+      before do
+        gemfile <<-G
+          gem "foo", :git => "#{lib_path("foo-1.0")}"
+        G
+      end
+
+      it "re-installs installed gems" do
+        foo_lib = default_bundle_path("bundler/gems/foo-1.0-#{ref}/lib/foo.rb")
+
+        bundle! "install"
+        foo_lib.open("w") {|f| f.write("blah blah blah") }
+        bundle! "install --force"
+
+        expect(out).to include "Using bundler"
+        expect(out).to include "Using foo 1.0 from #{lib_path("foo-1.0")} (at master@#{ref[0, 7]})"
+        expect(foo_lib.open(&:read)).to eq("FOO = '1.0'\n")
+        expect(the_bundle).to include_gems "foo 1.0"
+      end
+
+      it "works on first bundle install" do
+        bundle! "install --force"
+
+        expect(out).to include "Using bundler"
+        expect(out).to include "Using foo 1.0 from #{lib_path("foo-1.0")} (at master@#{ref[0, 7]})"
+        expect(the_bundle).to include_gems "foo 1.0"
+      end
+    end
   end
 end


### PR DESCRIPTION
This allows `bundle install --force` to work when the gemfile includes a git spec, previously it would error nonsensically. This happened because sources needed to be `remote!`ed for installation to succeed, and this wouldn't happen when `--force` was called with no other changes to the gemfile.

Closes #5678 