### PR TITLE
Fix `bundle init --gemspec` breaking when gemspec is invalid

### DIFF
--- a/lib/bundler/cli/init.rb
+++ b/lib/bundler/cli/init.rb
@@ -19,11 +19,7 @@ module Bundler
           exit 1
         end
 
-        spec = Gem::Specification.load(gemspec)
-        unless spec
-          Bundler.ui.error "Gem specification #{gemspec} is invalid"
-          exit 1
-        end
+        spec = Bundler.load_gemspec_uncached(gemspec)
 
         puts "Writing new Gemfile to #{SharedHelpers.pwd}/Gemfile"
         File.open("Gemfile", "wb") do |file|

--- a/lib/bundler/cli/init.rb
+++ b/lib/bundler/cli/init.rb
@@ -18,7 +18,13 @@ module Bundler
           Bundler.ui.error "Gem specification #{gemspec} doesn't exist"
           exit 1
         end
+
         spec = Gem::Specification.load(gemspec)
+        unless spec
+          Bundler.ui.error "Gem specification #{gemspec} is invalid"
+          exit 1
+        end
+
         puts "Writing new Gemfile to #{SharedHelpers.pwd}/Gemfile"
         File.open("Gemfile", "wb") do |file|
           file << "# Generated from #{gemspec}\n"

--- a/spec/commands/init_spec.rb
+++ b/spec/commands/init_spec.rb
@@ -6,34 +6,60 @@ RSpec.describe "bundle init" do
     expect(bundled_app("Gemfile")).to exist
   end
 
-  it "does not change existing Gemfiles" do
-    gemfile <<-G
-      gem "rails"
-    G
-
-    expect do
-      bundle :init
-    end.not_to change { File.read(bundled_app("Gemfile")) }
-  end
-
-  it "should generate from an existing gemspec" do
-    spec_file = tmp.join("test.gemspec")
-    File.open(spec_file, "w") do |file|
-      file << <<-S
-        Gem::Specification.new do |s|
-        s.name = 'test'
-        s.add_dependency 'rack', '= 1.0.1'
-        s.add_development_dependency 'rspec', '1.2'
-        end
-      S
+  context "when a Gemfile already exists" do
+    before do
+      gemfile <<-G
+        gem "rails"
+      G
     end
 
-    bundle :init, :gemspec => spec_file
+    it "does not change existing Gemfiles" do
+      expect { bundle :init }.not_to change { File.read(bundled_app("Gemfile")) }
+    end
 
-    gemfile = bundled_app("Gemfile").read
-    expect(gemfile).to match(%r{source 'https://rubygems.org'})
-    expect(gemfile.scan(/gem "rack", "= 1.0.1"/).size).to eq(1)
-    expect(gemfile.scan(/gem "rspec", "= 1.2"/).size).to eq(1)
-    expect(gemfile.scan(/group :development/).size).to eq(1)
+    it "notifies the user that an existing Gemfile already exists" do
+      bundle :init
+      expect(out).to include("Gemfile already exists")
+    end
+  end
+
+  context "given --gemspec option" do
+    let(:spec_file) { tmp.join("test.gemspec") }
+
+    it "should generate from an existing gemspec" do
+      File.open(spec_file, "w") do |file|
+        file << <<-S
+          Gem::Specification.new do |s|
+          s.name = 'test'
+          s.add_dependency 'rack', '= 1.0.1'
+          s.add_development_dependency 'rspec', '1.2'
+          end
+        S
+      end
+
+      bundle :init, :gemspec => spec_file
+
+      gemfile = bundled_app("Gemfile").read
+      expect(gemfile).to match(%r{source 'https://rubygems.org'})
+      expect(gemfile.scan(/gem "rack", "= 1.0.1"/).size).to eq(1)
+      expect(gemfile.scan(/gem "rspec", "= 1.2"/).size).to eq(1)
+      expect(gemfile.scan(/group :development/).size).to eq(1)
+    end
+
+    context "when gemspec file is invalid" do
+      it "notifies the user that specification is invalid" do
+        File.open(spec_file, "w") do |file|
+          file << <<-S
+            Gem::Specification.new do |s|
+            s.name = 'test'
+            s.invalid_method_name
+            end
+          S
+        end
+
+        bundle :init, :gemspec => spec_file
+        expect(out).to include("Gem specification #{spec_file} is invalid")
+      end
+    end
   end
 end

--- a/spec/commands/init_spec.rb
+++ b/spec/commands/init_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "bundle init" do
         end
 
         bundle :init, :gemspec => spec_file
-        expect(out).to include("Gem specification #{spec_file} is invalid")
+        expect(out).to include("There was an error while loading `test.gemspec`")
       end
     end
   end


### PR DESCRIPTION
Also added some specs to init what wasn't being tested.