### PR TITLE
[CLI::Lock] Fail gracefully when updating a missing gem

### DIFF
--- a/lib/bundler/cli/common.rb
+++ b/lib/bundler/cli/common.rb
@@ -70,6 +70,13 @@ module Bundler
       message
     end
 
+    def self.ensure_all_gems_in_lockfile!(names, locked_gems = Bundler.locked_gems)
+      locked_names = locked_gems.specs.map(&:name)
+      names.-(locked_names).each do |g|
+        raise GemNotFound, gem_not_found_message(g, locked_names)
+      end
+    end
+
     def self.configure_gem_version_promoter(definition, options)
       patch_level = patch_level_options(options)
       raise InvalidOption, "Provide only one of the following options: #{patch_level.join(", ")}" unless patch_level.length <= 1

--- a/lib/bundler/cli/lock.rb
+++ b/lib/bundler/cli/lock.rb
@@ -23,12 +23,7 @@ module Bundler
 
       update = options[:update]
       if update.is_a?(Array) # unlocking specific gems
-        # cycle through the requested gems, to make sure they exist
-        names = Bundler.locked_gems.specs.map(&:name)
-        update.each do |g|
-          next if names.include?(g)
-          raise GemNotFound, Bundler::CLI::Common.gem_not_found_message(g, names)
-        end
+        Bundler::CLI::Common.ensure_all_gems_in_lockfile!(update)
         update = { :gems => update, :lock_shared_dependencies => options[:conservative] }
       end
       definition = Bundler.definition(update)

--- a/lib/bundler/cli/update.rb
+++ b/lib/bundler/cli/update.rb
@@ -25,12 +25,7 @@ module Bundler
           raise GemfileLockNotFound, "This Bundle hasn't been installed yet. " \
             "Run `bundle install` to update and install the bundled gems."
         end
-        # cycle through the requested gems, to make sure they exist
-        names = Bundler.locked_gems.specs.map(&:name)
-        gems.each do |g|
-          next if names.include?(g)
-          raise GemNotFound, Bundler::CLI::Common.gem_not_found_message(g, names)
-        end
+        Bundler::CLI::Common.ensure_all_gems_in_lockfile!(gems)
 
         if groups.any?
           specs = Bundler.definition.specs_for groups

--- a/spec/commands/lock_spec.rb
+++ b/spec/commands/lock_spec.rb
@@ -105,6 +105,15 @@ RSpec.describe "bundle lock" do
     expect(read_lockfile).to eq(@lockfile)
   end
 
+  it "errors when updating a missing specific gems using --update" do
+    lockfile @lockfile
+
+    bundle "lock --update blahblah"
+    expect(out).to eq("Could not find gem 'blahblah'.")
+
+    expect(read_lockfile).to eq(@lockfile)
+  end
+
   # see update_spec for more coverage on same options. logic is shared so it's not necessary
   # to repeat coverage here.
   context "conservative updates" do


### PR DESCRIPTION
Closes #5693 by behaving the same way `bundle update` handles gems that aren't in the lockfile