### PR TITLE
List the remote host correctly in rake task desc.

### DIFF
--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -50,7 +50,7 @@ module Bundler
         install_gem(built_gem_path, :local)
       end
 
-      desc "Create tag #{version_tag} and build and push #{name}-#{version}.gem to RubyGems\n" \
+      desc "Create tag #{version_tag} and build and push #{name}-#{version}.gem to #{gem_push_host}\n" \
            "To prevent publishing in RubyGems use `gem_push=no rake release`"
       task "release", [:remote] => ["build", "release:guard_clean",
                                     "release:source_control_push", "release:rubygem_push"] do
@@ -92,18 +92,14 @@ module Bundler
   protected
 
     def rubygem_push(path)
-      allowed_push_host = nil
       gem_command = "gem push '#{path}'"
       gem_command += " --key #{gem_key}" if gem_key
-      if @gemspec.respond_to?(:metadata)
-        allowed_push_host = @gemspec.metadata["allowed_push_host"]
-        gem_command += " --host #{allowed_push_host}" if allowed_push_host
-      end
+      gem_command += " --host #{allowed_push_host}" if allowed_push_host
       unless allowed_push_host || Bundler.user_home.join(".gem/credentials").file?
         raise "Your rubygems.org credentials aren't set. Run `gem push` to set them."
       end
       sh(gem_command)
-      Bundler.ui.confirm "Pushed #{name} #{version} to #{allowed_push_host ? allowed_push_host : "rubygems.org."}"
+      Bundler.ui.confirm "Pushed #{name} #{version} to #{gem_push_host}"
     end
 
     def built_gem_path
@@ -114,6 +110,14 @@ module Bundler
       perform_git_push remote
       perform_git_push "#{remote} --tags"
       Bundler.ui.confirm "Pushed git commits and tags."
+    end
+
+    def allowed_push_host
+      @gemspec.metadata["allowed_push_host"] if @gemspec.respond_to?(:metadata)
+    end
+
+    def gem_push_host
+      allowed_push_host || "rubygems.org"
     end
 
     def perform_git_push(options = "")


### PR DESCRIPTION
When using the `allowed_push_host` metadata in a gems gemspec along with `bundler/gem_tasks` `rake release` shows that the gem will be pushed to rubygems.org rather then showing the configured `allowed_push_host` if that has been set.  This resolves that confusion by showing the correct host that `rake release` will attempt to push to.

* [x] `bin/rspec`
* [x] `rubocop -a`