### PR TITLE
Ensure Bundler.original_env preserves _all_ keys bundler sets

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -15,7 +15,7 @@ require "bundler/constants"
 require "bundler/current_ruby"
 
 module Bundler
-  environment_preserver = EnvironmentPreserver.new(ENV, %w[PATH GEM_PATH])
+  environment_preserver = EnvironmentPreserver.new(ENV, EnvironmentPreserver::BUNDLER_KEYS)
   ORIGINAL_ENV = environment_preserver.restore
   ENV.replace(environment_preserver.backup)
   SUDO_MUTEX = Mutex.new
@@ -517,7 +517,7 @@ EOF
         nil
       end
 
-      ENV["GEM_HOME"] = File.expand_path(bundle_path, root)
+      Bundler::SharedHelpers.set_env "GEM_HOME", File.expand_path(bundle_path, root)
       Bundler.rubygems.clear_paths
     end
 

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -25,7 +25,7 @@ module Bundler
 
       custom_gemfile = options[:gemfile] || Bundler.settings[:gemfile]
       if custom_gemfile && !custom_gemfile.empty?
-        ENV["BUNDLE_GEMFILE"] = File.expand_path(custom_gemfile)
+        Bundler::SharedHelpers.set_env "BUNDLE_GEMFILE", File.expand_path(custom_gemfile)
         Bundler.reset_paths!
       end
 

--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -25,7 +25,7 @@ module Bundler
 
       normalize_groups
 
-      ENV["RB_USER_INSTALL"] = "1" if Bundler::FREEBSD
+      Bundler::SharedHelpers.set_env "RB_USER_INSTALL", "1" if Bundler::FREEBSD
 
       # Disable color in deployment mode
       Bundler.ui.shell = Thor::Shell::Basic.new if options[:deployment]

--- a/lib/bundler/environment_preserver.rb
+++ b/lib/bundler/environment_preserver.rb
@@ -1,12 +1,26 @@
 # frozen_string_literal: true
 module Bundler
   class EnvironmentPreserver
+    INTENTIONALLY_NIL = "BUNDLER_ENVIRONMENT_PRESERVER_INTENTIONALLY_NIL".freeze
+    BUNDLER_KEYS = %w[
+      BUNDLE_BIN_PATH
+      BUNDLE_GEMFILE
+      BUNDLER_ORIG_MANPATH
+      BUNDLER_VERSION
+      GEM_HOME
+      GEM_PATH
+      PATH
+      RUBYLIB
+      RUBYOPT
+    ].map(&:freeze).freeze
+    BUNDLER_PREFIX = "BUNDLER_ORIG_".freeze
+
     # @param env [ENV]
     # @param keys [Array<String>]
     def initialize(env, keys)
       @original = env.to_hash
       @keys = keys
-      @prefix = "BUNDLER_ORIG_"
+      @prefix = BUNDLER_PREFIX
     end
 
     # @return [Hash]
@@ -14,9 +28,10 @@ module Bundler
       env = @original.clone
       @keys.each do |key|
         value = env[key]
-        original_value = env[@prefix + key]
-        if !value.nil? && !value.empty? && original_value.nil?
-          env[@prefix + key] = value
+        if !value.nil? && !value.empty?
+          env[@prefix + key] ||= value
+        elsif value.nil?
+          env[@prefix + key] ||= INTENTIONALLY_NIL
         end
       end
       env
@@ -27,10 +42,13 @@ module Bundler
       env = @original.clone
       @keys.each do |key|
         value_original = env[@prefix + key]
-        unless value_original.nil? || value_original.empty?
+        next if value_original.nil? || value_original.empty?
+        if value_original == INTENTIONALLY_NIL
+          env.delete(key)
+        else
           env[key] = value_original
-          env.delete(@prefix + key)
         end
+        env.delete(@prefix + key)
       end
       env
     end

--- a/lib/bundler/inline.rb
+++ b/lib/bundler/inline.rb
@@ -39,7 +39,7 @@ def gemfile(install = false, options = {}, &gemfile)
   def Bundler.root
     Bundler::SharedHelpers.pwd.expand_path
   end
-  ENV["BUNDLE_GEMFILE"] = "Gemfile"
+  Bundler::SharedHelpers.set_env "BUNDLE_GEMFILE", "Gemfile"
 
   Bundler::Plugin.gemfile_install(&gemfile) if Bundler.feature_flag.plugins?
   builder = Bundler::Dsl.new

--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -262,9 +262,6 @@ module Bundler
     end
 
     def setup_manpath
-      # Store original MANPATH for restoration later in with_clean_env()
-      ENV["BUNDLER_ORIG_MANPATH"] = ENV["MANPATH"]
-
       # Add man/ subdirectories from activated bundles to MANPATH for man(1)
       manuals = $LOAD_PATH.map do |path|
         man_subdir = path.sub(/lib$/, "man")
@@ -272,7 +269,7 @@ module Bundler
       end.compact
 
       return if manuals.empty?
-      ENV["MANPATH"] = manuals.concat(
+      Bundler::SharedHelpers.set_env "MANPATH", manuals.concat(
         ENV["MANPATH"].to_s.split(File::PATH_SEPARATOR)
       ).uniq.join(File::PATH_SEPARATOR)
     end

--- a/spec/bundler/environment_preserver_spec.rb
+++ b/spec/bundler/environment_preserver_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Bundler::EnvironmentPreserver do
       let(:env) { { "foo" => "" } }
 
       it "should not create backup entries" do
-        expect(subject.key?("BUNDLER_ORIG_foo")).to eq(false)
+        expect(subject).not_to have_key "BUNDLER_ORIG_foo"
       end
     end
 

--- a/spec/runtime/with_clean_env_spec.rb
+++ b/spec/runtime/with_clean_env_spec.rb
@@ -45,6 +45,14 @@ RSpec.describe "Bundler.with_env helpers" do
 0 true
       EOS
     end
+
+    it "removes variables that bundler added" do
+      system_gems :bundler
+      original = ruby!('puts ENV.to_a.map {|e| e.join("=") }.sort.join("\n")')
+      code = 'puts Bundler.original_env.to_a.map {|e| e.join("=") }.sort.join("\n")'
+      bundle!("exec ruby -e #{code.inspect}", :system_bundler => true)
+      expect(out).to eq original
+    end
   end
 
   describe "Bundler.clean_env" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -96,7 +96,7 @@ RSpec.configure do |config|
   config.filter_run_when_matching :focus unless ENV["CI"]
 
   original_wd  = Dir.pwd
-  original_env = ENV.to_hash
+  original_env = ENV.to_hash.delete_if {|k, _v| k.start_with?(Bundler::EnvironmentPreserver::BUNDLER_PREFIX) }
 
   config.expect_with :rspec do |c|
     c.syntax = :expect


### PR DESCRIPTION
Closes #5700.

Attempts to make sure we properly preserve missing env variables such as `RUBYOPT` across `bundle exec` invocations so that `Bundler.original_env` is accurate