### PR TITLE
[Installer] Load plugin files from path gems

### DIFF
--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -174,7 +174,7 @@ module Bundler
 
       requested_path_gems = @definition.requested_specs.select {|s| s.source.is_a?(Source::Path) }
       path_plugin_files = requested_path_gems.map do |spec|
-        spec.matches_for_glob("rubygems_plugin#{Bundler.rubygems.suffix_pattern}")
+        Bundler.rubygems.spec_matches_for_glob(spec, "rubygems_plugin#{Bundler.rubygems.suffix_pattern}")
       end.flatten
       Bundler.rubygems.load_plugin_files(path_plugin_files)
     end

--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -174,7 +174,12 @@ module Bundler
 
       requested_path_gems = @definition.requested_specs.select {|s| s.source.is_a?(Source::Path) }
       path_plugin_files = requested_path_gems.map do |spec|
-        Bundler.rubygems.spec_matches_for_glob(spec, "rubygems_plugin#{Bundler.rubygems.suffix_pattern}")
+        begin
+          Bundler.rubygems.spec_matches_for_glob(spec, "rubygems_plugin#{Bundler.rubygems.suffix_pattern}")
+        rescue TypeError
+          error_message = "#{spec.name} #{spec.version} has an invalid gemspec"
+          raise Gem::InvalidSpecificationException, error_message
+        end
       end.flatten
       Bundler.rubygems.load_plugin_files(path_plugin_files)
     end

--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -158,6 +158,10 @@ module Bundler
       Gem.post_reset_hooks
     end
 
+    def suffix_pattern
+      Gem.suffix_pattern
+    end
+
     def gem_cache
       gem_path.map {|p| File.expand_path("cache", p) }
     end
@@ -210,6 +214,10 @@ module Bundler
 
     def load_plugins
       Gem.load_plugins if Gem.respond_to?(:load_plugins)
+    end
+
+    def load_plugin_files(files)
+      Gem.load_plugin_files(files) if Gem.respond_to?(:load_plugin_files)
     end
 
     def ui=(obj)

--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -84,6 +84,14 @@ module Bundler
       spec.respond_to?(:default_gem?) && spec.default_gem?
     end
 
+    def spec_matches_for_glob(spec, glob)
+      return spec.matches_for_glob(glob) if spec.respond_to?(:matches_for_glob)
+
+      spec.load_paths.map do |lp|
+        Dir["#{lp}/#{glob}#{suffix_pattern}"]
+      end.flatten(1)
+    end
+
     def stub_set_spec(stub, spec)
       stub.instance_variable_set(:@spec, spec)
     end

--- a/spec/install/gemfile/path_spec.rb
+++ b/spec/install/gemfile/path_spec.rb
@@ -590,5 +590,28 @@ RSpec.describe "bundle install with explicit source paths" do
         :requires => [lib_path("install_hooks.rb")]
       expect(out).to include("failed for foo-1.0")
     end
+
+    it "loads plugins from the path gem" do
+      foo_file = home("foo_plugin_loaded")
+      bar_file = home("bar_plugin_loaded")
+      expect(foo_file).not_to be_file
+      expect(bar_file).not_to be_file
+
+      build_lib "foo" do |s|
+        s.write("lib/rubygems_plugin.rb", "FileUtils.touch('#{foo_file}')")
+      end
+
+      build_git "bar" do |s|
+        s.write("lib/rubygems_plugin.rb", "FileUtils.touch('#{bar_file}')")
+      end
+
+      install_gemfile! <<-G
+        gem "foo", :path => "#{lib_path("foo-1.0")}"
+        gem "bar", :path => "#{lib_path("bar-1.0")}"
+      G
+
+      expect(foo_file).to be_file
+      expect(bar_file).to be_file
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,7 @@ begin
   rspec = spec.dependencies.find {|d| d.name == "rspec" }
   gem "rspec", rspec.requirement.to_s
   require "rspec"
+  require "diff/lcs"
 rescue LoadError
   abort "Run rake spec:deps to install development dependencies"
 end


### PR DESCRIPTION
Closes #5429 .

Because RubyGems doesn't know about path gems before we install, we need to manually load the plugin files for the path gems we're installing. This is basically copying the logic RG uses, but scoped only to those gems that we're entirely responsible for.