### PR TITLE
[Env] Print shebang when it doesnt match Gem.ruby

### DIFF
--- a/lib/bundler/env.rb
+++ b/lib/bundler/env.rb
@@ -26,6 +26,14 @@ module Bundler
         specs = Bundler.rubygems.find_name(name)
         out << "#{name} (#{specs.map(&:version).join(",")})\n" unless specs.empty?
       end
+      if (exe = caller.last.split(":").first) && exe =~ %r{(exe|bin)/bundler?\z}
+        shebang = File.read(exe).lines.first
+        shebang.sub!(/^#!\s*/, "")
+        unless shebang.start_with?(Gem.ruby, "/usr/bin/env ruby")
+          out << "Gem.ruby  #{Gem.ruby}\n"
+          out << "bundle #! #{shebang}\n"
+        end
+      end
 
       out << "```\n"
 

--- a/lib/bundler/env.rb
+++ b/lib/bundler/env.rb
@@ -12,13 +12,8 @@ module Bundler
       print_gemfile = options.delete(:print_gemfile) { true }
       print_gemspecs = options.delete(:print_gemspecs) { true }
 
-      out = String.new("## Environment\n\n```\n")
-      env = environment
-      environment_ljust = env.map {|(k, _v)| k.to_s.length }.max
-      env.each do |(k, v)|
-        out << "#{k.to_s.ljust(environment_ljust)}  #{v}\n"
-      end
-      out << "```\n"
+      out = String.new
+      append_formatted_table("Environment", environment, out)
 
       unless Bundler.settings.all.empty?
         out << "\n## Bundler settings\n\n```\n"
@@ -108,6 +103,17 @@ module Bundler
       out
     end
 
-    private_class_method :read_file, :ruby_version, :git_version
+    def self.append_formatted_table(title, pairs, out)
+      return if pairs.empty?
+      out << "\n" unless out.empty?
+      out << "## #{title}\n\n```\n"
+      ljust = pairs.map {|k, _v| k.to_s.length }.max
+      pairs.each do |k, v|
+        out << "#{k.to_s.ljust(ljust)}  #{v}\n"
+      end
+      out << "```\n"
+    end
+
+    private_class_method :read_file, :ruby_version, :git_version, :append_formatted_table
   end
 end


### PR DESCRIPTION
Closes #5616.

Prints out `Gem.ruby` and the `bundle` binstub shebang when they don't match, which should help us pinpoint when ruby installation shenanigans are the root cause of an issue