### PR TITLE
[SpecSet] Sort by name in #tsort

### DIFF
--- a/lib/bundler/spec_set.rb
+++ b/lib/bundler/spec_set.rb
@@ -160,7 +160,8 @@ module Bundler
     end
 
     def tsort_each_node
-      @specs.each {|s| yield s }
+      # MUST sort by name for backwards compatibility
+      @specs.sort_by(&:name).each {|s| yield s }
     end
 
     def spec_for_dependency(dep, match_current_platform)


### PR DESCRIPTION
Closes #5696

This is required for backwards compatibility, see
issue #5696  for an example. The issue is that previous versions of bundler would have the load path in one (correct) order, and master has them in another (correct) order. So some projects depend on the load path ordering when multiple gems have the same requirable file.

- [x] Test case