### PR TITLE
[Viz] Work correctly when another gem with a graphviz file is present

### DIFF
--- a/lib/bundler/cli/viz.rb
+++ b/lib/bundler/cli/viz.rb
@@ -7,6 +7,9 @@ module Bundler
     end
 
     def run
+      # make sure we get the right `graphviz`. There is also a `graphviz`
+      # gem we're not built to support
+      gem "ruby-graphviz"
       require "graphviz"
 
       options[:without] = options[:without].join(":").tr(" ", ":").split(":")

--- a/spec/commands/viz_spec.rb
+++ b/spec/commands/viz_spec.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.describe "bundle viz", :ruby => "1.9.3", :if => Bundler.which("dot") do
-  let(:graphviz_lib) do
-    graphviz_glob = base_system_gems.join("gems/ruby-graphviz*/lib")
-    Dir[graphviz_glob].first
+  let(:ruby_graphviz) do
+    graphviz_glob = base_system_gems.join("cache/ruby-graphviz*")
+    Pathname.glob(graphviz_glob).first
   end
 
   before do
-    ENV["RUBYOPT"] = "-I #{graphviz_lib}"
+    system_gems ruby_graphviz
   end
 
   it "graphs gems from the Gemfile" do
@@ -72,6 +72,45 @@ RSpec.describe "bundle viz", :ruby => "1.9.3", :if => Bundler.which("dot") do
       }
       debugging bundle viz...
     EOS
+  end
+
+  context "with another gem that has a graphviz file" do
+    before do
+      build_repo4 do
+        build_gem "graphviz", "999" do |s|
+          s.write("lib/graphviz.rb", "abort 'wrong graphviz gem loaded'")
+        end
+      end
+
+      system_gems ruby_graphviz, "graphviz-999", :gem_repo => gem_repo4
+    end
+
+    it "loads the correct ruby-graphviz gem" do
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem "rack"
+        gem "rack-obama"
+      G
+
+      bundle! "viz", :format => "debug"
+      expect(out).to eq(strip_whitespace(<<-DOT).strip)
+        digraph Gemfile {
+        concentrate = "true";
+        normalize = "true";
+        nodesep = "0.55";
+        edge[ weight  =  "2"];
+        node[ fontname  =  "Arial, Helvetica, SansSerif"];
+        edge[ fontname  =  "Arial, Helvetica, SansSerif" , fontsize  =  "12"];
+        default [style = "filled", fillcolor = "#B9B9D5", shape = "box3d", fontsize = "16", label = "default"];
+        rack [style = "filled", fillcolor = "#B9B9D5", label = "rack"];
+          default -> rack [constraint = "false"];
+        "rack-obama" [style = "filled", fillcolor = "#B9B9D5", label = "rack-obama"];
+          default -> "rack-obama" [constraint = "false"];
+          "rack-obama" -> rack;
+        }
+        debugging bundle viz...
+      DOT
+    end
   end
 
   context "--without option" do

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -250,6 +250,8 @@ module Spec
         path = if g == :bundler
           Dir.chdir(root) { gem_command! :build, "#{root}/bundler.gemspec" }
           bundler_path = root + "bundler-#{Bundler::VERSION}.gem"
+        elsif g.to_s =~ %r{\A/.*\.gem\z}
+          g
         else
           "#{gem_repo}/gems/#{g}.gem"
         end


### PR DESCRIPTION
Closes #5706 by ensuring we always have the correct gem that contains a requirable `graphviz` file loaded (`ruby-graphviz` is the one we test against and suggest installing)