### PR TITLE
Print build metadata when running `bundle version`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ man/*
 
 # rspec failure tracking
 .rspec_status
+
+# files generated during packaging
+/lib/bundler/generated/

--- a/Rakefile
+++ b/Rakefile
@@ -355,9 +355,11 @@ task :update_certs => "spec:rubygems:clone_rubygems_master" do
 end
 
 require "bundler/gem_tasks"
-task :build => ["man:build"]
+task :build => ["man:build", "generate_files"]
 task :release => ["man:require", "man:build"]
 
 task :default => :spec
 
 Dir["task/*.{rb,rake}"].each(&method(:load))
+
+task :generate_files => Rake::Task.tasks.select {|t| t.name.start_with?("lib/bundler/generated") }

--- a/Rakefile
+++ b/Rakefile
@@ -354,10 +354,6 @@ task :update_certs => "spec:rubygems:clone_rubygems_master" do
   Bundler::SSLCerts::CertificateManager.update_from!(RUBYGEMS_REPO)
 end
 
-require "bundler/gem_tasks"
-task :build => ["man:build", "generate_files"]
-task :release => ["man:require", "man:build"]
-
 task :default => :spec
 
 Dir["task/*.{rb,rake}"].each(&method(:load))

--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -13,7 +13,7 @@ require "bundler/rubygems_integration"
 require "bundler/version"
 require "bundler/constants"
 require "bundler/current_ruby"
-require "bundler/generated/build_metadata"
+require "bundler/build_metadata"
 
 module Bundler
   environment_preserver = EnvironmentPreserver.new(ENV, %w[PATH GEM_PATH])

--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -13,6 +13,7 @@ require "bundler/rubygems_integration"
 require "bundler/version"
 require "bundler/constants"
 require "bundler/current_ruby"
+require "bundler/generated/build_metadata"
 
 module Bundler
   environment_preserver = EnvironmentPreserver.new(ENV, %w[PATH GEM_PATH])

--- a/lib/bundler/build_metadata.rb
+++ b/lib/bundler/build_metadata.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Bundler
+  # Represents metadata from when the Bundler gem was built.
+  module BuildMetadata
+    # begin ivars
+    @release = false
+    # end ivars
+
+    # A hash representation of the build metadata.
+    def self.to_h
+      {
+        "Built At" => built_at,
+        "Git SHA" => git_commit_sha,
+        "Released Version" => release?,
+      }
+    end
+
+    # A string representing the date the bundler gem was built.
+    def self.built_at
+      @built_at ||= Time.now.utc.strftime("%Y-%m-%d").freeze
+    end
+
+    # The SHA for the git commit the bundler gem was built from.
+    def self.git_commit_sha
+      @git_commit_sha ||= Dir.chdir(File.expand_path("..", __FILE__)) do
+        `git rev-parse --short HEAD`.strip.freeze
+      end
+    end
+
+    # Whether this is an official release build of Bundler.
+    def self.release?
+      @release
+    end
+  end
+end

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -394,7 +394,7 @@ module Bundler
     desc "version", "Prints the bundler's version information"
     def version
       if ARGV.include?("version")
-        build_info = " (#{BUILD_METADATA[:built_at]} commit #{BUILD_METADATA[:git_sha]})"
+        build_info = " (#{BuildMetadata.built_at} commit #{BuildMetadata.git_commit_sha})"
       end
       Bundler.ui.info "Bundler version #{Bundler::VERSION}#{build_info}"
     end

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -393,7 +393,10 @@ module Bundler
 
     desc "version", "Prints the bundler's version information"
     def version
-      Bundler.ui.info "Bundler version #{Bundler::VERSION}"
+      if ARGV.include?("version")
+        build_info = " (#{BUILD_METADATA[:built_at]} commit #{BUILD_METADATA[:git_sha]})"
+      end
+      Bundler.ui.info "Bundler version #{Bundler::VERSION}#{build_info}"
     end
     map %w[-v --version] => :version
 

--- a/lib/bundler/env.rb
+++ b/lib/bundler/env.rb
@@ -14,6 +14,7 @@ module Bundler
 
       out = String.new
       append_formatted_table("Environment", environment, out)
+      append_formatted_table("Bundler Build Metadata", BuildMetadata.to_h, out)
 
       unless Bundler.settings.all.empty?
         out << "\n## Bundler settings\n\n```\n"

--- a/lib/bundler/generated/build_metadata.rb
+++ b/lib/bundler/generated/build_metadata.rb
@@ -2,8 +2,8 @@
 
 module Bundler
   BUILD_METADATA = {
-    :built_at => "1999-01-01".freeze,
-    :git_sha => "000000000".freeze,
+    :built_at => Time.now.strftime("%Y-%m-%d").freeze,
+    :git_sha => Dir.chdir(File.expand_path("..", __FILE__)) { `git rev-parse --short HEAD`.strip }.freeze,
     :release => false,
   }.freeze
 end

--- a/lib/bundler/generated/build_metadata.rb
+++ b/lib/bundler/generated/build_metadata.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Bundler
+  BUILD_METADATA = {
+    :built_at => "1999-01-01".freeze,
+    :git_sha => "000000000".freeze,
+    :release => false,
+  }.freeze
+end

--- a/lib/bundler/generated/build_metadata.rb
+++ b/lib/bundler/generated/build_metadata.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-module Bundler
-  BUILD_METADATA = {
-    :built_at => Time.now.strftime("%Y-%m-%d").freeze,
-    :git_sha => Dir.chdir(File.expand_path("..", __FILE__)) { `git rev-parse --short HEAD`.strip }.freeze,
-    :release => false,
-  }.freeze
-end

--- a/spec/commands/version_spec.rb
+++ b/spec/commands/version_spec.rb
@@ -17,10 +17,10 @@ RSpec.describe "bundle version" do
 
   context "with version" do
     it "outputs the version with build metadata" do
-      date = Bundler::BUILD_METADATA[:built_at]
-      git_sha = Bundler::BUILD_METADATA[:git_sha]
+      date = Bundler::BuildMetadata.built_at
+      git_commit_sha = Bundler::BuildMetadata.git_commit_sha
       bundle! "version"
-      expect(out).to eq("Bundler version #{Bundler::VERSION} (#{date} commit #{git_sha})")
+      expect(out).to eq("Bundler version #{Bundler::VERSION} (#{date} commit #{git_commit_sha})")
     end
   end
 end

--- a/spec/commands/version_spec.rb
+++ b/spec/commands/version_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+RSpec.describe "bundle version" do
+  context "with -v" do
+    it "outputs the version" do
+      bundle! "-v"
+      expect(out).to eq("Bundler version #{Bundler::VERSION}")
+    end
+  end
+
+  context "with --version" do
+    it "outputs the version" do
+      bundle! "--version"
+      expect(out).to eq("Bundler version #{Bundler::VERSION}")
+    end
+  end
+
+  context "with version" do
+    it "outputs the version with build metadata" do
+      date = Bundler::BUILD_METADATA[:built_at]
+      git_sha = Bundler::BUILD_METADATA[:git_sha]
+      bundle! "version"
+      expect(out).to eq("Bundler version #{Bundler::VERSION} (#{date} commit #{git_sha})")
+    end
+  end
+end

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -1144,11 +1144,11 @@ RSpec.describe "bundle install with git sources" do
           end
           `git commit -m 'commit for iteration #{i}' ext/foo.c`
         end
-        git_sha = git_reader.ref_for("HEAD")
+        git_commit_sha = git_reader.ref_for("HEAD")
 
         install_gemfile <<-G
           source "file://#{gem_repo1}"
-          gem "foo", :git => "#{lib_path("foo-1.0")}", :ref => "#{git_sha}"
+          gem "foo", :git => "#{lib_path("foo-1.0")}", :ref => "#{git_commit_sha}"
         G
 
         run <<-R

--- a/task/build_metadata.rake
+++ b/task/build_metadata.rake
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 file "lib/bundler/generated/build_metadata.rb" => [".git/HEAD", __FILE__] do |t|
+  sh "git update-index --assume-unchanged #{t.name}"
+
   build_metadata = {
     :built_at => BUNDLER_SPEC.date.strftime("%Y-%m-%d"),
     :git_sha => `git rev-parse --short HEAD`.strip,

--- a/task/build_metadata.rake
+++ b/task/build_metadata.rake
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-file "lib/bundler/generated/build_metadata.rb" => [".git/HEAD", __FILE__] do |t|
+file "lib/bundler/generated/build_metadata.rb" => [".git/HEAD", ".git/logs/HEAD", __FILE__] do |t|
   sh "git update-index --assume-unchanged #{t.name}"
 
   build_metadata = {

--- a/task/build_metadata.rake
+++ b/task/build_metadata.rake
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+file "lib/bundler/generated/build_metadata.rb" => [".git/HEAD", __FILE__] do |t|
+  build_metadata = {
+    :built_at => BUNDLER_SPEC.date.strftime("%Y-%m-%d"),
+    :git_sha => `git rev-parse --short HEAD`.strip,
+    :release => Rake::Task["release"].instance_variable_get(:@already_invoked),
+  }
+
+  File.open(t.name, "w") {|f| f << <<-RUBY }
+# frozen_string_literal: true
+
+module Bundler
+  BUILD_METADATA = {
+#{build_metadata.sort.map {|k, v| "    #{k.inspect} => #{BUNDLER_SPEC.send(:ruby_code, v)}," }.join("\n")}
+  }.freeze
+end
+  RUBY
+end

--- a/task/build_metadata.rake
+++ b/task/build_metadata.rake
@@ -1,20 +1,33 @@
 # frozen_string_literal: true
-file "lib/bundler/generated/build_metadata.rb" => [".git/HEAD", ".git/logs/HEAD", __FILE__, :git_hooks] do |t|
-  sh "git update-index --assume-unchanged #{t.name}", :verbose => false
 
+def write_build_metadata(build_metadata)
+  build_metadata_file = "lib/bundler/build_metadata.rb"
+
+  ivars = build_metadata.sort.map do |k, v|
+    "    @#{k} = #{BUNDLER_SPEC.send(:ruby_code, v)}"
+  end.join("\n")
+
+  contents = File.read(build_metadata_file)
+  contents.sub!(/^(\s+# begin ivars).+(^\s+# end ivars)/m, "\\1\n#{ivars}\n\\2")
+  File.open(build_metadata_file, "w") {|f| f << contents }
+end
+
+task :build_metadata do
   build_metadata = {
-    :built_at => BUNDLER_SPEC.date.strftime("%Y-%m-%d"),
-    :git_sha => `git rev-parse --short HEAD`.strip,
+    :built_at => BUNDLER_SPEC.date.utc.strftime("%Y-%m-%d"),
+    :git_commit_sha => `git rev-parse --short HEAD`.strip,
     :release => Rake::Task["release"].instance_variable_get(:@already_invoked),
   }
 
-  File.open(t.name, "w") {|f| f << <<-RUBY }
-# frozen_string_literal: true
-
-module Bundler
-  BUILD_METADATA = {
-#{build_metadata.sort.map {|k, v| "    #{k.inspect} => #{BUNDLER_SPEC.send(:ruby_code, v)}," }.join("\n")}
-  }.freeze
+  write_build_metadata(build_metadata)
 end
-  RUBY
+
+namespace :build_metadata do
+  task :clean do
+    build_metadata = {
+      :release => false,
+    }
+
+    write_build_metadata(build_metadata)
+  end
 end

--- a/task/build_metadata.rake
+++ b/task/build_metadata.rake
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-file "lib/bundler/generated/build_metadata.rb" => [".git/HEAD", ".git/logs/HEAD", __FILE__] do |t|
+file "lib/bundler/generated/build_metadata.rb" => [".git/HEAD", ".git/logs/HEAD", __FILE__, :git_hooks] do |t|
   sh "git update-index --assume-unchanged #{t.name}"
 
   build_metadata = {

--- a/task/build_metadata.rake
+++ b/task/build_metadata.rake
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 file "lib/bundler/generated/build_metadata.rb" => [".git/HEAD", ".git/logs/HEAD", __FILE__, :git_hooks] do |t|
-  sh "git update-index --assume-unchanged #{t.name}"
+  sh "git update-index --assume-unchanged #{t.name}", :verbose => false
 
   build_metadata = {
     :built_at => BUNDLER_SPEC.date.strftime("%Y-%m-%d"),

--- a/task/git_hooks.rake
+++ b/task/git_hooks.rake
@@ -1,18 +1,6 @@
 # frozen_string_literal: true
 directory ".git/hooks"
 
-file ".git/hooks/post-commit" => [__FILE__] do |t|
-  File.open(t.name, "w") {|f| f << <<-SH }
-#! /usr/bin/env sh
-
-set -e
-
-.git/hooks/run-ruby bin/rake generate_files
-  SH
-
-  chmod 0o755, t.name, :verbose => false
-end
-
 file ".git/hooks/pre-commit" => [__FILE__] do |t|
   File.open(t.name, "w") {|f| f << <<-SH }
 #!/bin/sh

--- a/task/git_hooks.rake
+++ b/task/git_hooks.rake
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+directory ".git/hooks"
+
+file ".git/hooks/post-commit" => [__FILE__] do |t|
+  File.open(t.name, "w") {|f| f << <<-SH }
+#! /usr/bin/env sh
+
+set -e
+
+.git/hooks/run-ruby bin/rake generate_files
+  SH
+
+  chmod 0o755, t.name
+end
+
+file ".git/hooks/pre-commit" => [__FILE__] do |t|
+  File.open(t.name, "w") {|f| f << <<-SH }
+#!/bin/sh
+
+set -e
+
+.git/hooks/run-ruby bin/rubocop
+.git/hooks/run-ruby bin/rspec spec/quality_spec.rb
+  SH
+
+  chmod 0o755, t.name
+end
+
+file ".git/hooks/pre-push" => [__FILE__] do |_t|
+  Dir.chdir(".git/hooks") do
+    safe_ln "pre-commit", "pre-push"
+  end
+end
+
+file ".git/hooks/run-ruby" => [__FILE__] do |t|
+  File.open(t.name, "w") {|f| f << <<-SH }
+#!/bin/bash
+
+ruby="ruby"
+command -v chruby-exec >/dev/null 2>&1 && [[ -f ~/.ruby-version ]] && ruby="chruby-exec $(cat ~/.ruby-version) --"
+ruby $@
+  SH
+
+  chmod 0o755, t.name
+end
+
+task :git_hooks => Rake::Task.tasks.select {|t| t.name.start_with?(".git/hooks") }

--- a/task/git_hooks.rake
+++ b/task/git_hooks.rake
@@ -10,7 +10,7 @@ set -e
 .git/hooks/run-ruby bin/rake generate_files
   SH
 
-  chmod 0o755, t.name
+  chmod 0o755, t.name, :verbose => false
 end
 
 file ".git/hooks/pre-commit" => [__FILE__] do |t|
@@ -23,12 +23,12 @@ set -e
 .git/hooks/run-ruby bin/rspec spec/quality_spec.rb
   SH
 
-  chmod 0o755, t.name
+  chmod 0o755, t.name, :verbose => false
 end
 
 file ".git/hooks/pre-push" => [__FILE__] do |_t|
   Dir.chdir(".git/hooks") do
-    safe_ln "pre-commit", "pre-push"
+    safe_ln "pre-commit", "pre-push", :verbose => false
   end
 end
 
@@ -41,7 +41,7 @@ command -v chruby-exec >/dev/null 2>&1 && [[ -f ~/.ruby-version ]] && ruby="chru
 ruby $@
   SH
 
-  chmod 0o755, t.name
+  chmod 0o755, t.name, :verbose => false
 end
 
 task :git_hooks => Rake::Task.tasks.select {|t| t.name.start_with?(".git/hooks") }

--- a/task/release.rake
+++ b/task/release.rake
@@ -1,4 +1,11 @@
 # frozen_string_literal: true
+
+require "bundler/gem_tasks"
+task :build => ["build_metadata", "man:build", "generate_files"] do
+  Rake::Task["build_metadata:clean"].tap(&:reenable).real_invoke
+end
+task :release => ["man:require", "man:build", "build_metadata"]
+
 namespace :release do
   def confirm(prompt = "")
     loop do


### PR DESCRIPTION
Closes #5049.

Will get all the build metadata into `bundle env` once https://github.com/bundler/bundler/pull/5703 lands, since I don't want conflicts and want to use that code for generating the "tables"