### PR TITLE
[2.0] Add a feature flag to prefer gems.rb to Gemfile

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -206,7 +206,7 @@ module Bundler
 
     def root
       @root ||= begin
-                  default_gemfile.dirname.expand_path
+                  SharedHelpers.root
                 rescue GemfileNotFound
                   bundle_dir = default_bundle_dir
                   raise GemfileNotFound, "Could not locate Gemfile or .bundle/ directory" unless bundle_dir

--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -19,6 +19,7 @@ module Bundler
     settings_flag(:init_gems_rb) { bundler_2_mode? }
     settings_flag(:only_update_to_newer_versions) { bundler_2_mode? }
     settings_flag(:plugins) { @bundler_version >= Gem::Version.new("1.14") }
+    settings_flag(:prefer_gems_rb) { bundler_2_mode? }
     settings_flag(:update_requires_all_flag) { bundler_2_mode? }
 
     def initialize(bundler_version)

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -28,6 +28,7 @@ module Bundler
       no_prune
       only_update_to_newer_versions
       plugins
+      prefer_gems_rb
       silence_root_warning
       update_requires_all_flag
     ].freeze

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -223,9 +223,11 @@ learn more about their operation in [bundle install(1)][bundle-install].
    Sets the `--key` parameter for `gem push` when using the `rake release`
    command with a private gemstash server.
 * `error_on_stderr` (`BUNDLE_ERROR_ON_STDERR`)
-   Print Bundler errors to stderr
+   Print Bundler errors to stderr.
 * `init_gems_rb` (`BUNDLE_NEW_GEMFILE_NAME`)
-   generate a new gems.rb on `bundle init` instead of the `Gemfile`
+   Generate a `gems.rb` instead of a `Gemfile` when running `bundle init`.
+* `prefer_gems_rb` (`BUNDLE_PREFER_GEMS_RB`)
+   Prefer `gems.rb` to `Gemfile` when Bundler is searching for a Gemfile.
 * `update_requires_all_flag` (`BUNDLE_UPDATE_REQUIRES_ALL_FLAG`)
    Require passing `--all` to `bundle update` when everything should be updated,
    and disallow passing no options to `bundle update`.

--- a/spec/bundler/definition_spec.rb
+++ b/spec/bundler/definition_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Bundler::Definition do
   describe "#lock" do
     before do
       allow(Bundler).to receive(:settings) { Bundler::Settings.new(".") }
-      allow(Bundler).to receive(:default_gemfile) { Pathname.new("Gemfile") }
+      allow(Bundler::SharedHelpers).to receive(:find_gemfile) { Pathname.new("Gemfile") }
       allow(Bundler).to receive(:ui) { double("UI", :info => "", :debug => "") }
     end
     context "when it's not possible to write to the file" do

--- a/spec/install/gemfile_spec.rb
+++ b/spec/install/gemfile_spec.rb
@@ -66,6 +66,22 @@ RSpec.describe "bundle install" do
     end
   end
 
+  context "with prefer_gems_rb set" do
+    before { bundle! "config prefer_gems_rb true" }
+
+    it "prefers gems.rb to Gemfile" do
+      create_file("gems.rb", "gem 'bundler'")
+      create_file("Gemfile", "raise 'wrong Gemfile!'")
+
+      bundle! :install
+
+      expect(bundled_app("gems.rb")).to be_file
+      expect(bundled_app("Gemfile.lock")).not_to be_file
+
+      expect(the_bundle).to include_gem "bundler #{Bundler::VERSION}"
+    end
+  end
+
   context "with engine specified in symbol" do
     it "does not raise any error parsing Gemfile" do
       simulate_ruby_version "2.3.0" do


### PR DESCRIPTION
With `prefer_gems_rb` set (by default on 2.0), Bundler will prefer a `gems.rb` that is in the same directory as a `Gemfile`