### PR TITLE
[2.0] Add a compatibility guard that prints friendly errors on bundler 2+

### DIFF
--- a/bundler.gemspec
+++ b/bundler.gemspec
@@ -28,8 +28,13 @@ Gem::Specification.new do |s|
     }
   end
 
-  s.required_ruby_version     = ">= 1.8.7"
-  s.required_rubygems_version = ">= 1.3.6"
+  if s.version >= Gem::Version.new("2.a".dup)
+    s.required_ruby_version     = ">= 2.3.0"
+    s.required_rubygems_version = ">= 2.5.0"
+  else
+    s.required_ruby_version     = ">= 1.8.7"
+    s.required_rubygems_version = ">= 1.3.6"
+  end
 
   s.add_development_dependency "automatiek", "~> 0.1.0"
   s.add_development_dependency "mustache",   "0.99.6"

--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "bundler/compatibility_guard"
 
 require "bundler/vendored_fileutils"

--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require "bundler/compatibility_guard"
 
 require "bundler/vendored_fileutils"
 require "pathname"

--- a/lib/bundler/compatibility_guard.rb
+++ b/lib/bundler/compatibility_guard.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rubygems"
+require "bundler/version"
+
+if Bundler::VERSION.split(".").first.to_i >= 2
+  if Gem::Version.new(Object::RUBY_VERSION) < Gem::Version.new("2.0.0")
+    abort "Bundler 2 requires Ruby 2+. Either install bundler 1 or update to a supported Ruby version."
+  end
+
+  if Gem::Version.new(Gem::VERSION) < Gem::Version.new("2.0.0")
+    abort "Bundler 2 requires RubyGems 2+. Either install bundler 1 or update to a supported RubyGems version."
+  end
+end

--- a/lib/bundler/compatibility_guard.rb
+++ b/lib/bundler/compatibility_guard.rb
@@ -1,14 +1,14 @@
-# frozen_string_literal: true
+# frozen_string_literal: false
 
 require "rubygems"
 require "bundler/version"
 
 if Bundler::VERSION.split(".").first.to_i >= 2
-  if Gem::Version.new(Object::RUBY_VERSION) < Gem::Version.new("2.0.0")
-    abort "Bundler 2 requires Ruby 2+. Either install bundler 1 or update to a supported Ruby version."
+  if Gem::Version.new(Object::RUBY_VERSION) < Gem::Version.new("2.3")
+    abort "Bundler 2 requires Ruby 2.3 or later. Either install bundler 1 or update to a supported Ruby version."
   end
 
-  if Gem::Version.new(Gem::VERSION) < Gem::Version.new("2.0.0")
-    abort "Bundler 2 requires RubyGems 2+. Either install bundler 1 or update to a supported RubyGems version."
+  if Gem::Version.new(Gem::VERSION.dup) < Gem::Version.new("2.5")
+    abort "Bundler 2 requires RubyGems 2.5 or later. Either install bundler 1 or update to a supported RubyGems version."
   end
 end

--- a/lib/bundler/compatibility_guard.rb
+++ b/lib/bundler/compatibility_guard.rb
@@ -4,7 +4,7 @@ require "rubygems"
 require "bundler/version"
 
 if Bundler::VERSION.split(".").first.to_i >= 2
-  if Gem::Version.new(Object::RUBY_VERSION) < Gem::Version.new("2.3")
+  if Gem::Version.new(Object::RUBY_VERSION.dup) < Gem::Version.new("2.3")
     abort "Bundler 2 requires Ruby 2.3 or later. Either install bundler 1 or update to a supported Ruby version."
   end
 

--- a/lib/bundler/inline.rb
+++ b/lib/bundler/inline.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require "bundler/compatibility_guard"
 
 # Allows for declaring a Gemfile inline in a ruby script, optionally installing
 # any gems that aren't already installed on the user's system.

--- a/lib/bundler/inline.rb
+++ b/lib/bundler/inline.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "bundler/compatibility_guard"
 
 # Allows for declaring a Gemfile inline in a ruby script, optionally installing

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "bundler/compatibility_guard"
 
 require "pathname"

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require "bundler/compatibility_guard"
 
 require "pathname"
 require "rubygems"

--- a/spec/install/bundler_spec.rb
+++ b/spec/install/bundler_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe "bundle install" do
 
       simulate_bundler_version "99999999.99.1"
 
-      bundle! "check"
+      bundle! "check", :env => { "BUNDLER_SPEC_IGNORE_COMPATIBILITY_GUARD" => "1" }
       expect(out).to include("The Gemfile's dependencies are satisfied")
     end
 
@@ -147,7 +147,7 @@ RSpec.describe "bundle install" do
 
       simulate_bundler_version "99999999.99.1"
 
-      bundle! "check"
+      bundle! "check", :env => { "BUNDLER_SPEC_IGNORE_COMPATIBILITY_GUARD" => "1" }
       expect(out).to include("The Gemfile's dependencies are satisfied")
     end
 

--- a/spec/lock/lockfile_bundler_1_spec.rb
+++ b/spec/lock/lockfile_bundler_1_spec.rb
@@ -3,6 +3,8 @@
 RSpec.describe "the lockfile format", :bundler => "< 2" do
   include Bundler::GemHelpers
 
+  before { ENV["BUNDLER_SPEC_IGNORE_COMPATIBILITY_GUARD"] = "TRUE" }
+
   it "generates a simple lockfile for a single source, gem" do
     install_gemfile <<-G
       source "file://#{gem_repo1}"

--- a/spec/lock/lockfile_spec.rb
+++ b/spec/lock/lockfile_spec.rb
@@ -3,6 +3,8 @@
 RSpec.describe "the lockfile format", :bundler => "2" do
   include Bundler::GemHelpers
 
+  before { ENV["BUNDLER_SPEC_IGNORE_COMPATIBILITY_GUARD"] = "TRUE" }
+
   it "generates a simple lockfile for a single source, gem" do
     install_gemfile <<-G
       source "file://#{gem_repo1}"

--- a/spec/other/compatibility_guard_spec.rb
+++ b/spec/other/compatibility_guard_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec.describe "bundler compatibility guard" do
+  context "when the bundler version is 2+" do
+    before { simulate_bundler_version "2.0.a" }
+
+    context "when running on Ruby < 2", :ruby => "< 2.a" do
+      it "raises a friendly error" do
+        bundle :version
+        expect(err).to eq("Bundler 2 requires Ruby 2+. Either install bundler 1 or update to a supported Ruby version.")
+      end
+    end
+
+    context "when running on RubyGems < 2" do
+      before { simulate_rubygems_version "1.3.6" }
+
+      it "raises a friendly error" do
+        bundle :version
+        expect(err).to eq("Bundler 2 requires RubyGems 2+. Either install bundler 1 or update to a supported RubyGems version.")
+      end
+    end
+  end
+end

--- a/spec/other/compatibility_guard_spec.rb
+++ b/spec/other/compatibility_guard_spec.rb
@@ -4,14 +4,16 @@ RSpec.describe "bundler compatibility guard" do
   context "when the bundler version is 2+" do
     before { simulate_bundler_version "2.0.a" }
 
-    context "when running on Ruby < 2", :ruby => "< 2.3" do
+    context "when running on Ruby < 2.3", :ruby => "< 2.3" do
+      before { simulate_rubygems_version "2.6.11" }
+
       it "raises a friendly error" do
         bundle :version
         expect(err).to eq("Bundler 2 requires Ruby 2.3 or later. Either install bundler 1 or update to a supported Ruby version.")
       end
     end
 
-    context "when running on RubyGems < 2" do
+    context "when running on RubyGems < 2.5", :ruby => ">= 2.5" do
       before { simulate_rubygems_version "1.3.6" }
 
       it "raises a friendly error" do

--- a/spec/other/compatibility_guard_spec.rb
+++ b/spec/other/compatibility_guard_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe "bundler compatibility guard" do
   context "when the bundler version is 2+" do
     before { simulate_bundler_version "2.0.a" }
 
-    context "when running on Ruby < 2", :ruby => "< 2.a" do
+    context "when running on Ruby < 2", :ruby => "< 2.3" do
       it "raises a friendly error" do
         bundle :version
-        expect(err).to eq("Bundler 2 requires Ruby 2+. Either install bundler 1 or update to a supported Ruby version.")
+        expect(err).to eq("Bundler 2 requires Ruby 2.3 or later. Either install bundler 1 or update to a supported Ruby version.")
       end
     end
 
@@ -16,7 +16,7 @@ RSpec.describe "bundler compatibility guard" do
 
       it "raises a friendly error" do
         bundle :version
-        expect(err).to eq("Bundler 2 requires RubyGems 2+. Either install bundler 1 or update to a supported RubyGems version.")
+        expect(err).to eq("Bundler 2 requires RubyGems 2.5 or later. Either install bundler 1 or update to a supported RubyGems version.")
       end
     end
   end

--- a/spec/runtime/with_clean_env_spec.rb
+++ b/spec/runtime/with_clean_env_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Bundler.with_env helpers" do
       code = "print Bundler.original_env['PATH']"
       path = `getconf PATH`.strip + "#{File::PATH_SEPARATOR}/foo"
       with_path_as(path) do
-        result = bundle("exec ruby -e #{code.dump}")
+        result = bundle("exec '#{Gem.ruby}' -e #{code.dump}")
         expect(result).to eq(path)
       end
     end
@@ -20,7 +20,7 @@ RSpec.describe "Bundler.with_env helpers" do
       code = "print Bundler.original_env['GEM_PATH']"
       gem_path = ENV["GEM_PATH"] + ":/foo"
       with_gem_path_as(gem_path) do
-        result = bundle("exec ruby -e #{code.inspect}")
+        result = bundle("exec '#{Gem.ruby}' -e #{code.inspect}")
         expect(result).to eq(gem_path)
       end
     end
@@ -33,11 +33,11 @@ RSpec.describe "Bundler.with_env helpers" do
         if count == 2
           ENV["PATH"] = "#{ENV["PATH"]}:/foo"
         end
-        exec("ruby", __FILE__, (count - 1).to_s)
+        exec(Gem.ruby, __FILE__, (count - 1).to_s)
       RB
       path = `getconf PATH`.strip + File::PATH_SEPARATOR + File.dirname(Gem.ruby)
       with_path_as(path) do
-        bundle!("exec ruby #{bundled_app("exe.rb")} 2")
+        bundle!("exec '#{Gem.ruby}' #{bundled_app("exe.rb")} 2")
       end
       expect(err).to eq <<-EOS.strip
 2 false
@@ -50,7 +50,7 @@ RSpec.describe "Bundler.with_env helpers" do
       system_gems :bundler
       original = ruby!('puts ENV.to_a.map {|e| e.join("=") }.sort.join("\n")')
       code = 'puts Bundler.original_env.to_a.map {|e| e.join("=") }.sort.join("\n")'
-      bundle!("exec ruby -e #{code.inspect}", :system_bundler => true)
+      bundle!("exec '#{Gem.ruby}' -e #{code.inspect}", :system_bundler => true)
       expect(out).to eq original
     end
   end
@@ -64,21 +64,21 @@ RSpec.describe "Bundler.with_env helpers" do
     it "should delete BUNDLE_PATH" do
       code = "print Bundler.clean_env.has_key?('BUNDLE_PATH')"
       ENV["BUNDLE_PATH"] = "./foo"
-      result = bundle("exec ruby -e #{code.inspect}")
+      result = bundle("exec '#{Gem.ruby}' -e #{code.inspect}")
       expect(result).to eq("false")
     end
 
     it "should remove '-rbundler/setup' from RUBYOPT" do
       code = "print Bundler.clean_env['RUBYOPT']"
       ENV["RUBYOPT"] = "-W2 -rbundler/setup"
-      result = bundle("exec ruby -e #{code.inspect}")
+      result = bundle("exec '#{Gem.ruby}' -e #{code.inspect}")
       expect(result).not_to include("-rbundler/setup")
     end
 
     it "should clean up RUBYLIB" do
       code = "print Bundler.clean_env['RUBYLIB']"
       ENV["RUBYLIB"] = File.expand_path("../../../lib", __FILE__) + File::PATH_SEPARATOR + "/foo"
-      result = bundle("exec ruby -e #{code.inspect}")
+      result = bundle("exec '#{Gem.ruby}' -e #{code.inspect}")
       expect(result).to eq("/foo")
     end
 
@@ -86,7 +86,7 @@ RSpec.describe "Bundler.with_env helpers" do
       code = "print Bundler.clean_env['MANPATH']"
       ENV["MANPATH"] = "/foo"
       ENV["BUNDLER_ORIG_MANPATH"] = "/foo-original"
-      result = bundle("exec ruby -e #{code.inspect}")
+      result = bundle("exec '#{Gem.ruby}' -e #{code.inspect}")
       expect(result).to eq("/foo-original")
     end
   end

--- a/spec/support/hax.rb
+++ b/spec/support/hax.rb
@@ -3,6 +3,11 @@
 require "rubygems"
 
 module Gem
+  if version = ENV["BUNDLER_SPEC_RUBYGEMS_VERSION"]
+    remove_const(:VERSION) if const_defined?(:VERSION)
+    VERSION = version
+  end
+
   class Platform
     @local = new(ENV["BUNDLER_SPEC_PLATFORM"]) if ENV["BUNDLER_SPEC_PLATFORM"]
   end

--- a/spec/support/hax.rb
+++ b/spec/support/hax.rb
@@ -51,3 +51,11 @@ class Object
     end
   end
 end
+
+if ENV["BUNDLER_SPEC_IGNORE_COMPATIBILITY_GUARD"]
+  $LOADED_FEATURES << File.expand_path("../../../bundler/compatibility_guard.rb", __FILE__)
+  $LOADED_FEATURES << File.expand_path("../../../bundler/compatibility_guard", __FILE__)
+  $LOADED_FEATURES << "bundler/compatibility_guard.rb"
+  $LOADED_FEATURES << "bundler/compatibility_guard"
+  require "bundler/compatibility_guard"
+end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -481,6 +481,14 @@ module Spec
       ENV["BUNDLER_SPEC_VERSION"] = old if block_given?
     end
 
+    def simulate_rubygems_version(version)
+      old = ENV["BUNDLER_SPEC_RUBYGEMS_VERSION"]
+      ENV["BUNDLER_SPEC_RUBYGEMS_VERSION"] = version.to_s
+      yield if block_given?
+    ensure
+      ENV["BUNDLER_SPEC_RUBYGEMS_VERSION"] = old if block_given?
+    end
+
     def simulate_windows
       old = ENV["BUNDLER_SPEC_WINDOWS"]
       ENV["BUNDLER_SPEC_WINDOWS"] = "true"


### PR DESCRIPTION
This way, if someone manages to get bundler 2 installed on a system we don't support, they'll get a very obvious message saying so