### PR TITLE
Add --shebang option to binstubs command

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -260,6 +260,8 @@ module Bundler
       "Overwrite existing binstubs if they exist"
     method_option "path", :type => :string, :lazy_default => "bin", :banner =>
       "Binstub destination directory (default bin)"
+    method_option "shebang", :type => :string, :banner =>
+      "Specify a different shebang executable name than the default (usually 'ruby')"
     method_option "standalone", :type => :boolean, :banner =>
       "Make binstubs that can work without the Bundler runtime"
     def binstubs(*gems)

--- a/lib/bundler/cli/binstubs.rb
+++ b/lib/bundler/cli/binstubs.rb
@@ -13,6 +13,7 @@ module Bundler
       Bundler.definition.validate_runtime!
       Bundler.settings[:bin] = options["path"] if options["path"]
       Bundler.settings[:bin] = nil if options["path"] && options["path"].empty?
+      Bundler.settings[:shebang] = options["shebang"] if options["shebang"]
       installer = Installer.new(Bundler.root, Bundler.definition)
 
       if gems.empty?

--- a/spec/commands/binstubs_spec.rb
+++ b/spec/commands/binstubs_spec.rb
@@ -103,6 +103,19 @@ RSpec.describe "bundle binstubs <gem>" do
         expect(File.stat(binary).mode.to_s(8)).to eq("100775")
       end
     end
+
+    context "when using --shebang" do
+      it "sets the specified shebang for the the binstub" do
+        install_gemfile <<-G
+          source "file://#{gem_repo1}"
+          gem "rack"
+        G
+
+        bundle "binstubs rack --shebang jruby"
+
+        expect(File.open("bin/rackup").gets).to eq("#!/usr/bin/env jruby\n")
+      end
+    end
   end
 
   context "when the gem doesn't exist" do


### PR DESCRIPTION
Ports https://github.com/bundler/bundler/pull/4070 to master.

bundle install `--binstubs` option is to be removed from Bundler 2.0 but
currently supports setting the shebang using the `--shebang` option.

See #1467 introducing the `--shebang` option, which with this commit
is ported to the binstubs command.