### PR TITLE
Fix headers in contributing README

### DIFF
--- a/doc/contributing/README.md
+++ b/doc/contributing/README.md
@@ -17,22 +17,22 @@ Welcome to Bundler! We are so happy that you're here. We know it can be daunting
 
 You can start learning about Bundler by reading [the documentation](http://bundler.io). If you want, you can also read a (lengthy) explanation of [why Bundler exists and what it does](http://bundler.io/rationale.html).
 
-##[How you can help: your first contributions!](HOW_YOU_CAN_HELP.md)
+## [How you can help: your first contributions!](HOW_YOU_CAN_HELP.md)
 
 A detailed overview of how to get started contributing to Bundler, including a long list of suggestions for your first project.
 
-##[Bug triage](BUG_TRIAGE.md)
+## [Bug triage](BUG_TRIAGE.md)
 
 Want to take a stab at processing issues? Start here.
 
-##[Getting help](GETTING_HELP.md)
+## [Getting help](GETTING_HELP.md)
 
 How to get in touch with folks who can help when you're stuck. Don't worry! This happens to all of us. We're really nice, we promise.
 
-##[Filing issues](ISSUES.md)
+## [Filing issues](ISSUES.md)
 
 We see a lot of issues in the Bundler repo! Use this guide to file informative, actionable issues.
 
-##[Community](COMMUNITY.md)
+## [Community](COMMUNITY.md)
 
 Learn more about our goals for the Bundler community and the ways you can help us build better together.


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Some headers in contributing/README.md aren't displaying properly.
![bundler 2017-06-14 09-02-41](https://user-images.githubusercontent.com/916368/27142561-407a4cde-50e0-11e7-8681-7cff43ff053f.png)

Also, I promised @indirect that I'd start contributing to bundler last night.

### Was was your diagnosis of the problem?

The markdown was missing some spaces.

### What is your fix for the problem, implemented in this PR?

I added some spaces. TADA!

![bundler 2017-06-14 09-08-32](https://user-images.githubusercontent.com/916368/27142790-0e2a73de-50e1-11e7-86bb-a64d7f43449b.png)


### Why did you choose this fix out of the possible options?

Adding spaces seemed like the most reasonable choice to transition from a state of non-spaces to a spaceful state.
