### PR TITLE
[2.0] Add a feature flag for `bundle install` not `—cache`ing by default

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -163,8 +163,8 @@ module Bundler
       "Specify the number of jobs to run in parallel"
     method_option "local", :type => :boolean, :banner =>
       "Do not attempt to fetch gems remotely and use the gem cache instead"
-    method_option "no-cache", :type => :boolean, :banner =>
-      "Don't update the existing gem cache."
+    method_option "cache", :type => :boolean, :default => Bundler.feature_flag.install_caches_by_default?, :banner =>
+      "Update the existing gem cache."
     method_option "force", :type => :boolean, :banner =>
       "Force downloading every gem."
     method_option "no-prune", :type => :boolean, :banner =>

--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -66,7 +66,7 @@ module Bundler
       definition.validate_runtime!
 
       installer = Installer.install(Bundler.root, definition, options)
-      Bundler.load.cache if Bundler.app_cache.exist? && !options["no-cache"] && !Bundler.settings[:frozen]
+      Bundler.load.cache if Bundler.app_cache.exist? && options["cache"] && !Bundler.settings[:frozen]
 
       Bundler.ui.confirm "Bundle complete! #{dependencies_count_for(definition)}, #{gems_installed_for(definition)}."
       Bundler::CLI::Common.output_without_groups_message

--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -34,6 +34,7 @@ module Bundler
     settings_flag(:error_on_stderr) { bundler_2_mode? }
     settings_flag(:global_gem_cache) { bundler_2_mode? }
     settings_flag(:init_gems_rb) { bundler_2_mode? }
+    settings_flag(:install_caches_by_default) { !bundler_2_mode? }
     settings_flag(:lockfile_uses_separate_rubygems_sources) { bundler_2_mode? }
     settings_flag(:only_update_to_newer_versions) { bundler_2_mode? }
     settings_flag(:plugins) { @bundler_version >= Gem::Version.new("1.14") }

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -28,6 +28,7 @@ module Bundler
       global_gem_cache
       ignore_messages
       init_gems_rb
+      install_caches_by_default
       lockfile_uses_separate_rubygems_sources
       major_deprecations
       no_install

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -222,16 +222,16 @@ learn more about their operation in [bundle install(1)][bundle-install].
 * `gem.push_key` (`BUNDLE_GEM__PUSH_KEY`):
    Sets the `--key` parameter for `gem push` when using the `rake release`
    command with a private gemstash server.
-* `error_on_stderr` (`BUNDLE_ERROR_ON_STDERR`)
+* `error_on_stderr` (`BUNDLE_ERROR_ON_STDERR`):
    Print Bundler errors to stderr.
-* `init_gems_rb` (`BUNDLE_NEW_GEMFILE_NAME`)
+* `init_gems_rb` (`BUNDLE_NEW_GEMFILE_NAME`):
    Generate a `gems.rb` instead of a `Gemfile` when running `bundle init`.
-* `prefer_gems_rb` (`BUNDLE_PREFER_GEMS_RB`)
+* `prefer_gems_rb` (`BUNDLE_PREFER_GEMS_RB`):
    Prefer `gems.rb` to `Gemfile` when Bundler is searching for a Gemfile.
 * `unlock_source_unlocks_spec` (`BUNDLE_UNLOCK_SOURCE_UNLOCKS_SPEC`):
    Whether running `bundle update --source NAME` unlocks a gem with the given
    name. Defaults to `true`.
-* `update_requires_all_flag` (`BUNDLE_UPDATE_REQUIRES_ALL_FLAG`)
+* `update_requires_all_flag` (`BUNDLE_UPDATE_REQUIRES_ALL_FLAG`):
    Require passing `--all` to `bundle update` when everything should be updated,
    and disallow passing no options to `bundle update`.
 * `allow_bundler_dependency_conflicts` (`BUNDLE_ALLOW_BUNDLER_DEPENDENCY_CONFLICTS`):
@@ -243,6 +243,9 @@ learn more about their operation in [bundle install(1)][bundle-install].
 * `skip_default_git_sources` (`BUNDLE_SKIP_DEFAULT_GIT_SOURCES`):
    Whether Bundler should skip adding default git source shortcuts to the
    Gemfile DSL.
+* `install_caches_by_default` (`BUNDLE_INSTALL_CACHES_BY_DEFAULT`):
+   Whether `bundle install` with no options passed should act as if `--cache`
+   has been passed.
 * `suppress_install_using_messages` (`BUNDLE_SUPPRESS_INSTALL_USING_MESSAGES`):
    Avoid printing `Using ...` messages during installation when the version of
    a gem has not changed.

--- a/man/bundle-install.ronn
+++ b/man/bundle-install.ronn
@@ -12,7 +12,7 @@ bundle-install(1) -- Install the dependencies specified in your Gemfile
                  [--deployment]
                  [--force]
                  [--frozen]
-                 [--no-cache]
+                 [--cache]
                  [--no-prune]
                  [--path PATH]
                  [--system]
@@ -98,10 +98,10 @@ time `bundle install` is run, use `bundle config` (see bundle-config(1)).
   Installs the gems specified in the bundle to the system's Rubygems location.
   This overrides any previous configuration of `--path`.
 
-* `--no-cache`:
-  Do not update the cache in `vendor/cache` with the newly bundled gems. This
+* `--cache`:
+  Update the cache in `vendor/cache` with the newly bundled gems. This
   does not remove any gems in the cache but keeps the newly bundled gems from
-  being cached during the install.
+  being cached during the install. Defaults to true.
 
 * `--no-prune`:
   Don't remove stale gems from the cache when the installation finishes.

--- a/spec/cache/gems_spec.rb
+++ b/spec/cache/gems_spec.rb
@@ -174,11 +174,25 @@ RSpec.describe "bundle cache" do
       expect(cached_gem("activesupport-2.3.2")).to exist
     end
 
-    it "re-caches during install" do
+    it "re-caches during install with --cache", :bundler => "< 2" do
+      cached_gem("rack-1.0.0").rmtree
+      bundle! :install, :cache => true
+      expect(out).to include("Updating files in vendor/cache")
+      expect(cached_gem("rack-1.0.0")).to exist
+    end
+
+    it "re-caches during install", :bundler => "< 2" do
       cached_gem("rack-1.0.0").rmtree
       bundle :install
       expect(out).to include("Updating files in vendor/cache")
       expect(cached_gem("rack-1.0.0")).to exist
+    end
+
+    it "does not re-cache during install", :bundler => "2" do
+      cached_gem("rack-1.0.0").rmtree
+      bundle! :install
+      expect(out).not_to include("Updating files in vendor/cache")
+      expect(cached_gem("rack-1.0.0")).not_to exist
     end
 
     it "adds and removes when gems are updated" do
@@ -189,7 +203,7 @@ RSpec.describe "bundle cache" do
     end
 
     it "adds new gems and dependencies" do
-      install_gemfile <<-G
+      install_gemfile <<-G, :cache => true
         source "file://#{gem_repo2}"
         gem "rails"
       G
@@ -198,7 +212,7 @@ RSpec.describe "bundle cache" do
     end
 
     it "removes .gems for removed gems and dependencies" do
-      install_gemfile <<-G
+      install_gemfile <<-G, :cache => true
         source "file://#{gem_repo2}"
         gem "rack"
       G
@@ -210,7 +224,7 @@ RSpec.describe "bundle cache" do
     it "removes .gems when gem changes to git source" do
       build_git "rack"
 
-      install_gemfile <<-G
+      install_gemfile <<-G, :cache => true
         source "file://#{gem_repo2}"
         gem "rack", :git => "#{lib_path("rack-1.0")}"
         gem "actionpack"
@@ -232,7 +246,7 @@ RSpec.describe "bundle cache" do
       end
 
       simulate_new_machine
-      install_gemfile <<-G
+      install_gemfile <<-G, :cache => true
         source "file://#{gem_repo1}"
         gem "platform_specific"
       G
@@ -248,7 +262,7 @@ RSpec.describe "bundle cache" do
         :rubygems_version => "1.3.2"
       simulate_new_machine
 
-      bundle :install
+      bundle :install, :cache => true
       expect(cached_gem("rack-1.0.0")).to exist
     end
 
@@ -264,7 +278,7 @@ RSpec.describe "bundle cache" do
         gem "rack"
       G
       bundle "cache"
-      bundle "install"
+      bundle "install", :cache => true
       expect(out).not_to match(/removing/i)
     end
 

--- a/spec/commands/package_spec.rb
+++ b/spec/commands/package_spec.rb
@@ -301,5 +301,33 @@ RSpec.describe "bundle install with gem sources" do
       bundle "install --no-cache"
       expect(bundled_app("vendor/cache").children).to be_empty
     end
+
+    context "when install_caches_by_default is set to false" do
+      before { bundle! "config install_caches_by_default false" }
+
+      it "does not update the cache if --cache is not passed" do
+        create_file "gems.rb", <<-G
+          source "file://#{gem_repo1}"
+          gem "rack"
+        G
+        bundled_app("vendor/cache").mkpath
+        expect(bundled_app("vendor/cache").children).to be_empty
+
+        bundle! "install"
+        expect(bundled_app("vendor/cache").children).to be_empty
+      end
+
+      it "updates the cache if --cache is passed" do
+        create_file "gems.rb", <<-G
+          source "file://#{gem_repo1}"
+          gem "rack"
+        G
+        bundled_app("vendor/cache").mkpath
+        expect(bundled_app("vendor/cache").children).to be_empty
+
+        bundle! "install --cache"
+        expect(bundled_app("vendor/cache").children).not_to be_empty
+      end
+    end
   end
 end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that `bundle install` would default to always updating the cache in `vendor/bundle` (if it existed).

### Was was your diagnosis of the problem?

My diagnosis was that the default for the `--cache` flag should be `false` instead of `true`.

### What is your fix for the problem, implemented in this PR?

My fix is to invert the default on 2.0, using a feature flag. Taken from https://github.com/bundler/bundler/pull/3555.

### Why did you choose this fix out of the possible options?

I chose this fix because it allowed a feature flag for a breaking change in 2.0 and was minimally invasive.