### PR TITLE
Default to printing a help message when `bundle` is run without arguments on 2.0

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -55,7 +55,14 @@ module Bundler
     check_unknown_options!(:except => [:config, :exec])
     stop_on_unknown_option! :exec
 
-    default_task :install
+    desc "cli_help", "Prints a summary of bundler commands", :hide => true
+    def cli_help
+      version
+      Bundler.ui.info "\n"
+      self.class.help(shell)
+    end
+    default_task(Bundler.feature_flag.default_cli_command)
+
     class_option "no-color", :type => :boolean, :desc => "Disable colorization in output"
     class_option "retry",    :type => :numeric, :aliases => "-r", :banner => "NUM",
                              :desc => "Specify the number of times you wish to attempt network commands"

--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -169,6 +169,7 @@ RSpec.describe "The library itself" do
 
   it "documents all used settings" do
     exemptions = %w[
+      default_cli_command
       gem.coc
       gem.mit
       warned_version


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that users unfamiliar with Bundler would run `bundle` and either install gems (if in a directory with a gemfile), or else get the error `Could not locate Gemfile`. You'd need to know to run `bundle help` or `bundle -h` to get the man page, and even that could be overwhelming (not to mention turfing you into a pager).

### Was was your diagnosis of the problem?

My diagnosis was that we ought to print some form of help when the bare `bundle` command is run, rather than defaulting to running `bundle install`.

This work was prompted by https://trello.com/c/OpuOdTZl/112-print-help-when-bundle-is-run-without-arguments, and is an improvement (rather than a straight port) on https://github.com/bundler/bundler/pull/3831.

### What is your fix for the problem, implemented in this PR?

My fix was to print the following help output when the CLI is invoked without arguments, contingent upon a feature flag.

```
Bundler version 1.15.1

Commands:
  bundle add GEM VERSION            # Add gem to Gemfile and run bundle install
  bundle binstubs GEM [OPTIONS]     # Install the binstubs of the listed gem
  bundle check [OPTIONS]            # Checks if the dependencies listed in Gemfile are satisfied by currently installed gems
  bundle clean [OPTIONS]            # Cleans up unused gems in your bundler directory
  bundle config NAME [VALUE]        # retrieve or set a configuration value
  bundle console [GROUP]            # Opens an IRB session with the bundle pre-loaded
  bundle doctor [OPTIONS]           # Checks the bundle for common problems
  bundle env                        # Print information about the environment Bundler is running under
  bundle exec [OPTIONS]             # Run the command in context of the bundle
  bundle gem GEM [OPTIONS]          # Creates a skeleton for creating a rubygem
  bundle help [COMMAND]             # Describe available commands or one specific command
  bundle help [COMMAND]             # Describe subcommands or one specific subcommand
  bundle info GEM [OPTIONS]         # Show information for the given gem
  bundle init [OPTIONS]             # Generates a Gemfile into the current working directory
  bundle inject GEM VERSION         # Add the named gem, with version requirements, to the resolved Gemfile
  bundle install PLUGINS            # Install the plugin from the source
  bundle install [OPTIONS]          # Install the current environment to the system
  bundle issue                      # Learn how to report an issue in Bundler
  bundle licenses                   # Prints the license of all gems in the bundle
  bundle lock                       # Creates a lockfile without installing
  bundle open GEM                   # Opens the source directory of the given bundled gem
  bundle outdated GEM [OPTIONS]     # list installed gems with newer versions available
  bundle package [OPTIONS]          # Locks and then caches all of the gems into vendor/cache
  bundle platform [OPTIONS]         # Displays platform compatibility information
  bundle plugin SUBCOMMAND ...ARGS  # manage the bundler plugins
  bundle pristine                   # Restores installed gems to pristine condition from files located in the gem cache. Gem installed from a git repository will be issued `git checkout --force`.
  bundle show GEM [OPTIONS]         # Shows all gems that are part of the bundle, or the path to a given gem
  bundle update [OPTIONS]           # update the current environment
  bundle version                    # Prints the bundler's version information
  bundle viz [OPTIONS]              # Generates a visual dependency graph

Options:
      [--no-color]                 # Disable colorization in output
  -r, [--retry=NUM]                # Specify the number of times you wish to attempt network commands
  -V, [--verbose], [--no-verbose]  # Enable verbose output mode
```

### Why did you choose this fix out of the possible options?

I chose this fix because it aligns the Bundler CLI with many other package managers that display a help message of some sort when invoked without arguments:

- CocoaPods
- npm
- RubyGems
- Homebrew
- pip
- Swift Package Manager
- Carthage
- Cargo

And unlike the following, which _do_ install by default:

- yarn

As to the particular format of the help printed, I thought something concise would be less disruptive than the full man page.

Improvements to the output would be welcome, this is just using the Thor default right now but we can easily implement our own. This will require test coverage, but I thought I'd hold off until the general change got some buy-in.