### PR TITLE
Add a feature flag for `bundle update —source NAME` not unlocking a gem with that name

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -748,6 +748,8 @@ module Bundler
         end
       end
 
+      unlock_source_unlocks_spec = Bundler.feature_flag.unlock_source_unlocks_spec?
+
       converged = []
       @locked_specs.each do |s|
         # Replace the locked dependency's source with the equivalent source from the Gemfile
@@ -762,7 +764,7 @@ module Bundler
         # XXX This is a backwards-compatibility fix to preserve the ability to
         # unlock a single gem by passing its name via `--source`. See issue #3759
         # TODO: delete in Bundler 2
-        next if @unlock[:sources].include?(s.name)
+        next if unlock_source_unlocks_spec && @unlock[:sources].include?(s.name)
 
         # If the spec is from a path source and it doesn't exist anymore
         # then we unlock it.

--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -20,6 +20,7 @@ module Bundler
     settings_flag(:only_update_to_newer_versions) { bundler_2_mode? }
     settings_flag(:plugins) { @bundler_version >= Gem::Version.new("1.14") }
     settings_flag(:prefer_gems_rb) { bundler_2_mode? }
+    settings_flag(:unlock_source_unlocks_spec) { !bundler_2_mode? }
     settings_flag(:update_requires_all_flag) { bundler_2_mode? }
 
     def initialize(bundler_version)

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -30,6 +30,7 @@ module Bundler
       plugins
       prefer_gems_rb
       silence_root_warning
+      unlock_source_unlocks_spec
       update_requires_all_flag
     ].freeze
 

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -228,6 +228,9 @@ learn more about their operation in [bundle install(1)][bundle-install].
    Generate a `gems.rb` instead of a `Gemfile` when running `bundle init`.
 * `prefer_gems_rb` (`BUNDLE_PREFER_GEMS_RB`)
    Prefer `gems.rb` to `Gemfile` when Bundler is searching for a Gemfile.
+* `unlock_source_unlocks_spec` (`BUNDLE_UNLOCK_SOURCE_UNLOCKS_SPEC`):
+   Whether running `bundle update --source NAME` unlocks a gem with the given
+   name. Defaults to `true`.
 * `update_requires_all_flag` (`BUNDLE_UPDATE_REQUIRES_ALL_FLAG`)
    Require passing `--all` to `bundle update` when everything should be updated,
    and disallow passing no options to `bundle update`.

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -216,6 +216,21 @@ RSpec.describe "bundle update" do
       bundle "update --source activesupport"
       expect(the_bundle).to include_gems "activesupport 3.0"
     end
+
+    context "with unlock_source_unlocks_spec set to false" do
+      before { bundle! "config unlock_source_unlocks_spec false" }
+
+      it "should not update gems not included in the source that happen to have the same name" do
+        install_gemfile <<-G
+          source "file://#{gem_repo2}"
+          gem "activesupport"
+        G
+        update_repo2 { build_gem "activesupport", "3.0" }
+
+        bundle "update --source activesupport"
+        expect(the_bundle).not_to include_gems "activesupport 3.0"
+      end
+    end
   end
 
   context "when there is a child dependency that is also in the gemfile" do


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem is that `bundle update --source NAME` will unlock a _gem_ with that name, in addition to the source.

### Was was your diagnosis of the problem?

My diagnosis was that we unlocked based on `spec.name` instead of `spec.source.name`.

### What is your fix for the problem, implemented in this PR?

My fix is to put this backwards-compatibility hack behind a feature flag that will turn off on 2.0.

### Why did you choose this fix out of the possible options?

I chose this fix because it allows the current behavior to continue for those who depend upon it, but the hack will be disabled by default on 2.0, or when `unlock_source_unlocks_spec` is set to true.