### PR TITLE
Create Gemfiles with an HTTPS github source defined

### DIFF
--- a/lib/bundler/templates/Gemfile
+++ b/lib/bundler/templates/Gemfile
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 source "https://rubygems.org"
 
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
 # gem "rails"

--- a/lib/bundler/templates/gems.rb
+++ b/lib/bundler/templates/gems.rb
@@ -2,4 +2,6 @@
 # A sample gems.rb
 source "https://rubygems.org"
 
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
 # gems "rails"

--- a/lib/bundler/templates/newgem/Gemfile.tt
+++ b/lib/bundler/templates/newgem/Gemfile.tt
@@ -1,4 +1,6 @@
 source "https://rubygems.org"
 
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
 # Specify your gem's dependencies in <%= config[:name] %>.gemspec
 gemspec


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that people are creating new Gemfiles that use the built-in `github` git source, which is being removed in 2.0. Additionally, it does _not_ use an encrypted connection to GitHub.

### Was was your diagnosis of the problem?

My diagnosis was that we can't change the default because of backwards compatibility, but we can encourage _new_ Gemfiles to "do the right thing".

### What is your fix for the problem, implemented in this PR?

My fix is to add our new, recommended definition of the shortcut to all bundler-generated gemfiles.

### Why did you choose this fix out of the possible options?

I chose this fix because it will only affect new Gemfiles.