### PR TITLE
[2.0] Add a global cache for downloaded .gem files

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -216,8 +216,8 @@ module Bundler
     end
 
     def app_config_path
-      if ENV["BUNDLE_APP_CONFIG"]
-        Pathname.new(ENV["BUNDLE_APP_CONFIG"]).expand_path(root)
+      if app_config = ENV["BUNDLE_APP_CONFIG"]
+        Pathname.new(app_config).expand_path(root)
       else
         root.join(".bundle")
       end

--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -29,6 +29,7 @@ module Bundler
     settings_flag(:allow_bundler_dependency_conflicts) { bundler_2_mode? }
     settings_flag(:allow_offline_install) { bundler_2_mode? }
     settings_flag(:error_on_stderr) { bundler_2_mode? }
+    settings_flag(:global_gem_cache) { bundler_2_mode? }
     settings_flag(:init_gems_rb) { bundler_2_mode? }
     settings_flag(:only_update_to_newer_versions) { bundler_2_mode? }
     settings_flag(:plugins) { @bundler_version >= Gem::Version.new("1.14") }

--- a/lib/bundler/fetcher/compact_index.rb
+++ b/lib/bundler/fetcher/compact_index.rb
@@ -61,7 +61,7 @@ module Bundler
       compact_index_request :fetch_spec
 
       def available?
-        return nil unless md5_available?
+        return nil unless SharedHelpers.md5_available?
         user_home = Bundler.user_home
         return nil unless user_home.directory? && user_home.writable?
         # Read info file checksums out of /versions, so we can know if gems are up to date
@@ -119,16 +119,6 @@ module Bundler
           ui.warn "Using the cached data for the new index because of a network error: #{e}"
           Net::HTTPNotModified.new(nil, nil, nil)
         end
-      end
-
-      def md5_available?
-        require "openssl"
-        OpenSSL::Digest::MD5.digest("")
-        true
-      rescue LoadError
-        true
-      rescue OpenSSL::Digest::DigestError
-        false
       end
     end
   end

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -22,6 +22,7 @@ module Bundler
       frozen
       gem.coc
       gem.mit
+      global_gem_cache
       ignore_messages
       init_gems_rb
       major_deprecations

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -187,6 +187,19 @@ module Bundler
       msg
     end
 
+    def md5_available?
+      return @md5_available if defined?(@md5_available)
+      @md5_available = begin
+        require "openssl"
+        OpenSSL::Digest::MD5.digest("")
+        true
+      rescue LoadError
+        true
+      rescue OpenSSL::Digest::DigestError
+        false
+      end
+    end
+
   private
 
     def find_gemfile(order_matters = false)

--- a/lib/bundler/source/rubygems.rb
+++ b/lib/bundler/source/rubygems.rb
@@ -516,6 +516,7 @@ module Bundler
       # @return [Pathname] The global cache path.
       #
       def download_cache_path(spec)
+        return unless Bundler.feature_flag.global_gem_cache?
         return unless remote = spec.remote
         return unless cache_slug = remote.cache_slug
 

--- a/lib/bundler/source/rubygems.rb
+++ b/lib/bundler/source/rubygems.rb
@@ -90,7 +90,6 @@ module Bundler
       def install(spec, opts = {})
         force = opts[:force]
         ensure_builtin_gems_cached = opts[:ensure_builtin_gems_cached]
-        cache_globally(spec, cached_path(spec)) if spec && cached_path(spec)
 
         if ensure_builtin_gems_cached && builtin_gem?(spec)
           if !cached_path(spec)

--- a/lib/bundler/source/rubygems/remote.rb
+++ b/lib/bundler/source/rubygems/remote.rb
@@ -20,6 +20,8 @@ module Bundler
         #
         def cache_slug
           @cache_slug ||= begin
+            return nil unless SharedHelpers.md5_available?
+
             cache_uri = original_uri || uri
 
             uri_parts = [cache_uri.host, cache_uri.user, cache_uri.port, cache_uri.path]

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -237,6 +237,9 @@ learn more about their operation in [bundle install(1)][bundle-install].
 * `allow_bundler_dependency_conflicts` (`BUNDLE_ALLOW_BUNDLER_DEPENDENCY_CONFLICTS`):
    Allow resolving to specifications that have dependencies on `bundler` that
    are incompatible with the running Bundler version.
+* `global_gem_cache` (`BUNDLE_GLOBAL_GEM_CACHE`):
+   Whether Bundler should cache all gems globally, rather than locally to the
+   installing Ruby installation.
 
 In general, you should set these settings per-application by using the applicable
 flag to the [bundle install(1)][bundle-install] or [bundle package(1)][bundle-package] command.

--- a/spec/bundler/fetcher/compact_index_spec.rb
+++ b/spec/bundler/fetcher/compact_index_spec.rb
@@ -45,10 +45,17 @@ RSpec.describe Bundler::Fetcher::CompactIndex do
       end
 
       context "when OpenSSL is FIPS-enabled", :ruby => ">= 2.0.0" do
-        before do
+        def remove_cached_md5_availability
+          return unless Bundler::SharedHelpers.instance_variable_defined?(:@md5_available)
           Bundler::SharedHelpers.remove_instance_variable(:@md5_available)
+        end
+
+        before do
+          remove_cached_md5_availability
           stub_const("OpenSSL::OPENSSL_FIPS", true)
         end
+
+        after { remove_cached_md5_availability }
 
         context "when FIPS-mode is active" do
           before do

--- a/spec/bundler/fetcher/compact_index_spec.rb
+++ b/spec/bundler/fetcher/compact_index_spec.rb
@@ -45,7 +45,10 @@ RSpec.describe Bundler::Fetcher::CompactIndex do
       end
 
       context "when OpenSSL is FIPS-enabled", :ruby => ">= 2.0.0" do
-        before { stub_const("OpenSSL::OPENSSL_FIPS", true) }
+        before do
+          Bundler::SharedHelpers.remove_instance_variable(:@md5_available)
+          stub_const("OpenSSL::OPENSSL_FIPS", true)
+        end
 
         context "when FIPS-mode is active" do
           before do

--- a/spec/install/global_cache_spec.rb
+++ b/spec/install/global_cache_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe "global gem caching" do
+  before { bundle! "config global_gem_cache true" }
+
   describe "using the cross-application user cache" do
     let(:source)  { "http://localgemserver.test" }
     let(:source2) { "http://gemserver.example.org" }

--- a/spec/install/global_cache_spec.rb
+++ b/spec/install/global_cache_spec.rb
@@ -1,0 +1,187 @@
+# frozen_string_literal: true
+
+RSpec.describe "global gem caching" do
+  describe "using the cross-application user cache" do
+    let(:source)  { "http://localgemserver.test" }
+    let(:source2) { "http://gemserver.example.org" }
+
+    def source_global_cache(*segments)
+      home(".bundle", "cache", "gems", "localgemserver.test.80.dd34752a738ee965a2a4298dc16db6c5", *segments)
+    end
+
+    def source2_global_cache(*segments)
+      home(".bundle", "cache", "gems", "gemserver.example.org.80.1ae1663619ffe0a3c9d97712f44c705b", *segments)
+    end
+
+    it "caches gems into the global cache on download" do
+      install_gemfile! <<-G, :artifice => "compact_index"
+        source "#{source}"
+        gem "rack"
+      G
+
+      expect(the_bundle).to include_gems "rack 1.0.0"
+      expect(source_global_cache("rack-1.0.0.gem")).to exist
+    end
+
+    it "uses globally cached gems if they exist" do
+      source_global_cache.mkpath
+      FileUtils.cp(gem_repo1("gems/rack-1.0.0.gem"), source_global_cache("rack-1.0.0.gem"))
+
+      install_gemfile! <<-G, :artifice => "compact_index_no_gem"
+        source "#{source}"
+        gem "rack"
+      G
+
+      expect(the_bundle).to include_gems "rack 1.0.0"
+    end
+
+    describe "when the same gem from different sources is installed" do
+      it "should use the appropriate one from the global cache" do
+        install_gemfile! <<-G, :artifice => "compact_index"
+          source "#{source}"
+          gem "rack"
+        G
+
+        FileUtils.rm_r(default_bundle_path)
+        expect(the_bundle).not_to include_gems "rack 1.0.0"
+        expect(source_global_cache("rack-1.0.0.gem")).to exist
+        # rack 1.0.0 is not installed and it is in the global cache
+
+        install_gemfile! <<-G, :artifice => "compact_index"
+          source "#{source2}"
+          gem "rack", "0.9.1"
+        G
+
+        FileUtils.rm_r(default_bundle_path)
+        expect(the_bundle).not_to include_gems "rack 0.9.1"
+        expect(source2_global_cache("rack-0.9.1.gem")).to exist
+        # rack 0.9.1 is not installed and it is in the global cache
+
+        gemfile <<-G
+          source "#{source}"
+          gem "rack", "1.0.0"
+        G
+
+        bundle! :install, :artifice => "compact_index_no_gem"
+        # rack 1.0.0 is installed and rack 0.9.1 is not
+        expect(the_bundle).to include_gems "rack 1.0.0"
+        expect(the_bundle).not_to include_gems "rack 0.9.1"
+        FileUtils.rm_r(default_bundle_path)
+
+        gemfile <<-G
+          source "#{source2}"
+          gem "rack", "0.9.1"
+        G
+
+        bundle! :install, :artifice => "compact_index_no_gem"
+        # rack 0.9.1 is installed and rack 1.0.0 is not
+        expect(the_bundle).to include_gems "rack 0.9.1"
+        expect(the_bundle).not_to include_gems "rack 1.0.0"
+      end
+
+      it "should not install if the wrong source is provided" do
+        gemfile <<-G
+          source "#{source}"
+          gem "rack"
+        G
+
+        bundle! :install, :artifice => "compact_index"
+        FileUtils.rm_r(default_bundle_path)
+        expect(the_bundle).not_to include_gems "rack 1.0.0"
+        expect(source_global_cache("rack-1.0.0.gem")).to exist
+        # rack 1.0.0 is not installed and it is in the global cache
+
+        gemfile <<-G
+          source "#{source2}"
+          gem "rack", "0.9.1"
+        G
+
+        bundle! :install, :artifice => "compact_index"
+        FileUtils.rm_r(default_bundle_path)
+        expect(the_bundle).not_to include_gems "rack 0.9.1"
+        expect(source2_global_cache("rack-0.9.1.gem")).to exist
+        # rack 0.9.1 is not installed and it is in the global cache
+
+        gemfile <<-G
+          source "#{source2}"
+          gem "rack", "1.0.0"
+        G
+
+        expect(source_global_cache("rack-1.0.0.gem")).to exist
+        expect(source2_global_cache("rack-0.9.1.gem")).to exist
+        bundle :install, :artifice => "compact_index_no_gem"
+        expect(out).to include("Internal Server Error 500")
+        # rack 1.0.0 is not installed and rack 0.9.1 is not
+        expect(the_bundle).not_to include_gems "rack 1.0.0"
+        expect(the_bundle).not_to include_gems "rack 0.9.1"
+
+        gemfile <<-G
+          source "#{source}"
+          gem "rack", "0.9.1"
+        G
+
+        expect(source_global_cache("rack-1.0.0.gem")).to exist
+        expect(source2_global_cache("rack-0.9.1.gem")).to exist
+        bundle :install, :artifice => "compact_index_no_gem"
+        expect(out).to include("Internal Server Error 500")
+        # rack 0.9.1 is not installed and rack 1.0.0 is not
+        expect(the_bundle).not_to include_gems "rack 0.9.1"
+        expect(the_bundle).not_to include_gems "rack 1.0.0"
+      end
+    end
+
+    describe "when installing gems from a different directory" do
+      it "uses the global cache as a source" do
+        install_gemfile! <<-G, :artifice => "compact_index"
+          source "#{source}"
+          gem "rack"
+          gem "activesupport"
+        G
+
+        # Both gems are installed and in the global cache
+        expect(the_bundle).to include_gems "rack 1.0.0"
+        expect(the_bundle).to include_gems "activesupport 2.3.5"
+        expect(source_global_cache("rack-1.0.0.gem")).to exist
+        expect(source_global_cache("activesupport-2.3.5.gem")).to exist
+        FileUtils.rm_r(default_bundle_path)
+        # Both gems are now only in the global cache
+        expect(the_bundle).not_to include_gems "rack 1.0.0"
+        expect(the_bundle).not_to include_gems "activesupport 2.3.5"
+
+        install_gemfile! <<-G, :artifice => "compact_index_no_gem"
+          source "#{source}"
+          gem "rack"
+        G
+
+        # rack is installed and both are in the global cache
+        expect(the_bundle).to include_gems "rack 1.0.0"
+        expect(the_bundle).not_to include_gems "activesupport 2.3.5"
+        expect(source_global_cache("rack-1.0.0.gem")).to exist
+        expect(source_global_cache("activesupport-2.3.5.gem")).to exist
+
+        Dir.chdir bundled_app2 do
+          create_file bundled_app2("gems.rb"), <<-G
+            source "#{source}"
+            gem "activesupport"
+          G
+
+          # Neither gem is installed and both are in the global cache
+          expect(the_bundle).not_to include_gems "rack 1.0.0"
+          expect(the_bundle).not_to include_gems "activesupport 2.3.5"
+          expect(source_global_cache("rack-1.0.0.gem")).to exist
+          expect(source_global_cache("activesupport-2.3.5.gem")).to exist
+
+          # Install using the global cache instead of by downloading the .gem
+          # from the server
+          bundle! :install, :artifice => "compact_index_no_gem"
+
+          # activesupport is installed and both are in the global cache
+          expect(the_bundle).not_to include_gems "rack 1.0.0"
+          expect(the_bundle).to include_gems "activesupport 2.3.5"
+          expect(source_global_cache("rack-1.0.0.gem")).to exist
+          expect(source_global_cache("activesupport-2.3.5.gem")).to exist
+        end
+      end
+    end
+  end
+end

--- a/spec/support/artifice/compact_index_no_gem.rb
+++ b/spec/support/artifice/compact_index_no_gem.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+require File.expand_path("../compact_index", __FILE__)
+
+Artifice.deactivate
+
+class CompactIndexNoGem < CompactIndexAPI
+  get "/gems/:id" do
+    halt 500
+  end
+end
+
+Artifice.activate_with(CompactIndexNoGem)


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that bundler would need to download `foo-1.0.gem` files from a RubyGems server for each different ruby version installed on a user's machine. It also meant that people installing into a per-app path would need to re-download every gem for that bundle an additional time. This adds up, and makes `bundle install` slower than it needs to be.

### Was was your diagnosis of the problem?

My diagnosis was that Bundler could keep a (per-source) cache of these `.gem` files, and pull from that cache instead of hitting the network whenever possible.

### What is your fix for the problem, implemented in this PR?

My fix implements said cache, in a very similar way to the compact index cache (same cache slug per remote strategy, etc). This largely comes from https://github.com/bundler/bundler/pull/3983.

### Why did you choose this fix out of the possible options?

I chose this fix because it is safe when used from multi-source gemfiles, it is easy to clear (`rm -rf bundle cache`), and it minimally interferes with the existing installation process.