### PR TITLE
[EnvironmentPreserver] Allow preserving MANPATH

### DIFF
--- a/lib/bundler/environment_preserver.rb
+++ b/lib/bundler/environment_preserver.rb
@@ -9,6 +9,7 @@ module Bundler
       BUNDLER_VERSION
       GEM_HOME
       GEM_PATH
+      MANPATH
       PATH
       RUBYLIB
       RUBYOPT

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -740,6 +740,44 @@ end
     expect(err).to lack_errors
   end
 
+  describe "$MANPATH" do
+    before do
+      build_repo4 do
+        build_gem "with_man" do |s|
+          s.write("man/man1/page.1", "MANPAGE")
+        end
+      end
+    end
+
+    context "when the user has one set" do
+      before { ENV["MANPATH"] = "/foo:" }
+
+      it "adds the gem's man dir to the MANPATH" do
+        install_gemfile! <<-G
+          source "file:#{gem_repo4}"
+          gem "with_man"
+        G
+
+        run! "puts ENV['MANPATH']"
+        expect(out).to eq("#{system_gem_path("gems/with_man-1.0/man")}:/foo")
+      end
+    end
+
+    context "when the user does not have one set" do
+      before { ENV.delete("MANPATH") }
+
+      it "adds the gem's man dir to the MANPATH" do
+        install_gemfile! <<-G
+          source "file:#{gem_repo4}"
+          gem "with_man"
+        G
+
+        run! "puts ENV['MANPATH']"
+        expect(out).to eq(system_gem_path("gems/with_man-1.0/man").to_s)
+      end
+    end
+  end
+
   it "should prepend gemspec require paths to $LOAD_PATH in order" do
     update_repo2 do
       build_gem("requirepaths") do |s|


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was Bundler could throw an exception during setup when a gem contained manpages we were adding to `$MANPATH`.

Fixes #5730.

### Was was your diagnosis of the problem?

My diagnosis was that `$MANPATH` wasn't whitelisted as a key we preserved / were 'allowed' to override via `SharedHelpers.set_env`.

### What is your fix for the problem, implemented in this PR?

My fix is to add `$MANPATH` to that list of keys, as @jules2689 suggested. I also added some test coverage around us setting the proper man path.

### Why did you choose this fix out of the possible options?

I chose this fix because it treats that env var in the same way as others bundler sets.