### PR TITLE
fix a missing space in the group conflict error message

### DIFF
--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -145,7 +145,7 @@ module Bundler
         conflicting_groups = options[:without] & options[:with]
         unless conflicting_groups.empty?
           Bundler.ui.error "You can't list a group in both, --with and --without." \
-          "The offending groups are: #{conflicting_groups.join(", ")}."
+          " The offending groups are: #{conflicting_groups.join(", ")}."
           exit 1
         end
       end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

There is a typo in the error message that is printed to users when a user specifies a set of conflicting groups when running bundle install. There is a missing space after the first sentence. 
```
› bundle install --with foo --without foo
You can't list a group in both, --with and --without.The offending groups are: foo.
```

### Was was your diagnosis of the problem?

execute `bundle install --with foo --without foo`
