### PR TITLE
Use XDG directory for cache

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -181,6 +181,12 @@ module Bundler
       raise e.exception("#{warning}\nBundler also failed to create a temporary home directory at `#{path}':\n#{e}")
     end
 
+    def xdg_home(type, alt)
+      xdg_path = Pathname.new(ENV.fetch("XDG_#{type}_HOME", alt)).join("bundler")
+      xdg_path.mkpath unless xdg_path.exist?
+      xdg_path
+    end
+
     def user_bundle_path
       Pathname.new(user_home).join(".bundle")
     end
@@ -202,7 +208,12 @@ module Bundler
     end
 
     def user_cache
-      user_bundle_path.join("cache")
+      legacy_path = user_bundle_path.join("cache")
+      if legacy_path.exist?
+        legacy_path
+      else
+        xdg_home("CACHE", user_home.join(".cache"))
+      end
     end
 
     def root


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Bundler was storing user cache in the user's home directory.
Issue: #4333 

### What is your fix for the problem, implemented in this PR?

Store cache in XDG_CACHE_HOME if ~/.bundle/cache does not exist.
Otherwise continue to use the legacy directory.
