### PR TITLE
[2.0] Allow conflicts between bundler dependencies and the current bundler version

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -567,10 +567,7 @@ module Bundler
     end
 
     def pretty_dep(dep, source = false)
-      msg = String.new(dep.name)
-      msg << " (#{dep.requirement})" unless dep.requirement == Gem::Requirement.default
-      msg << " from the `#{dep.source}` source" if source && dep.source
-      msg
+      SharedHelpers.pretty_dependency(dep, source)
     end
 
     # Check if the specs of the given source changed

--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -14,6 +14,7 @@ module Bundler
 
     (1..10).each {|v| define_method("bundler_#{v}_mode?") { major_version >= v } }
 
+    settings_flag(:allow_bundler_dependency_conflicts) { bundler_2_mode? }
     settings_flag(:allow_offline_install) { bundler_2_mode? }
     settings_flag(:error_on_stderr) { bundler_2_mode? }
     settings_flag(:init_gems_rb) { bundler_2_mode? }

--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -211,7 +211,8 @@ module Bundler
           next unless dep.name == "bundler".freeze
           next if dep.requirement.satisfied_by?(bundler_version)
 
-          Bundler.ui.warn "#{spec.name} (#{spec.version}) has dependency #{dep}" \
+          Bundler.ui.warn "#{spec.name} (#{spec.version}) has dependency" \
+            " #{SharedHelpers.pretty_dependency(dep)}" \
             ", which is unsatisfied by the current bundler version #{VERSION}" \
             ", so the dependency is being ignored"
         end

--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -79,6 +79,7 @@ module Bundler
       include GemHelpers
 
       attr_reader :activated
+      attr_accessor :ignores_bundler_dependencies
 
       def initialize(a)
         super
@@ -88,6 +89,7 @@ module Bundler
         @specs        = Hash.new do |specs, platform|
           specs[platform] = select_best_platform_match(self, platform)
         end
+        @ignores_bundler_dependencies = true
       end
 
       def initialize_copy(o)
@@ -151,6 +153,7 @@ module Bundler
           if spec = @specs[platform]
             spec.dependencies.each do |dep|
               next if dep.type == :development
+              next if @ignores_bundler_dependencies && dep.name == "bundler".freeze
               dependencies[platform] << DepProxy.new(dep, platform)
             end
           end
@@ -206,6 +209,7 @@ module Bundler
       additional_base_requirements.each {|d| @base_dg.add_vertex(d.name, d) }
       @platforms = platforms
       @gem_version_promoter = gem_version_promoter
+      @allow_bundler_dependency_conflicts = Bundler.feature_flag.allow_bundler_dependency_conflicts?
     end
 
     def start(requirements)
@@ -281,7 +285,9 @@ module Bundler
           end
           nested.reduce([]) do |groups, (version, specs)|
             next groups if locked_requirement && !locked_requirement.satisfied_by?(version)
-            groups << SpecGroup.new(specs)
+            spec_group = SpecGroup.new(specs)
+            spec_group.ignores_bundler_dependencies = @allow_bundler_dependency_conflicts
+            groups << spec_group
           end
         else
           []

--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -5,11 +5,7 @@ module Bundler
 
     class Molinillo::VersionConflict
       def printable_dep(dep)
-        if dep.is_a?(Bundler::Dependency)
-          DepProxy.new(dep, dep.platforms.join(", ")).to_s.strip
-        else
-          dep.to_s
-        end
+        SharedHelpers.pretty_dependency(dep)
       end
 
       def message

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -7,6 +7,7 @@ module Bundler
     autoload :Mirrors, "bundler/mirror"
 
     BOOL_KEYS = %w[
+      allow_bundler_dependency_conflicts
       allow_offline_install
       auto_install
       cache_all

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -176,6 +176,17 @@ module Bundler
         "\nEither installing with `--full-index` or running `bundle update #{spec.name}` should fix the problem."
     end
 
+    def pretty_dependency(dep, print_source = false)
+      msg = String.new(dep.name)
+      msg << " (#{dep.requirement})" unless dep.requirement == Gem::Requirement.default
+      if dep.is_a?(Bundler::Dependency)
+        platform_string = dep.platforms.join(", ")
+        msg << " " << platform_string if !platform_string.empty? && platform_string != Gem::Platform::RUBY
+      end
+      msg << " from the `#{dep.source}` source" if print_source && dep.source
+      msg
+    end
+
   private
 
     def find_gemfile(order_matters = false)

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -234,6 +234,9 @@ learn more about their operation in [bundle install(1)][bundle-install].
 * `update_requires_all_flag` (`BUNDLE_UPDATE_REQUIRES_ALL_FLAG`)
    Require passing `--all` to `bundle update` when everything should be updated,
    and disallow passing no options to `bundle update`.
+* `allow_bundler_dependency_conflicts` (`BUNDLE_ALLOW_BUNDLER_DEPENDENCY_CONFLICTS`):
+   Allow resolving to specifications that have dependencies on `bundler` that
+   are incompatible with the running Bundler version.
 
 In general, you should set these settings per-application by using the applicable
 flag to the [bundle install(1)][bundle-install] or [bundle package(1)][bundle-package] command.


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem will occur once 2.0 is released -- there are many gems that declare a `s.dependency "bundler", "~> 1.x"` dependency on bundler. This would essentially make them inoperable with Bundler 2. We want to make adopting 2.0 as pain-free as possible, so hard conflicts are a no-go.

### Was was your diagnosis of the problem?

My diagnosis was that we need a way to allow conflicts on the bundler dependency once 2.0 comes out, so people can use 2.0.

### What is your fix for the problem, implemented in this PR?

My fix introduces a feature flag for allowing these conflicts (enabled on 2.0), which when enabled will ignore bundler dependencies during resolution, and warn in the installer when a conflict would've occurred.

### Why did you choose this fix out of the possible options?

I chose this fix because it has the minimal performance penalty with the feature flag enabled. This is mostly a port of https://github.com/bundler/bundler/pull/3871 to master.