### PR TITLE
[2.0] Suppress `Using …` messages during installation when a version has not changed

### DIFF
--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -37,6 +37,7 @@ module Bundler
     settings_flag(:plugins) { @bundler_version >= Gem::Version.new("1.14") }
     settings_flag(:prefer_gems_rb) { bundler_2_mode? }
     settings_flag(:skip_default_git_sources) { bundler_2_mode? }
+    settings_flag(:suppress_install_using_messages) { bundler_2_mode? }
     settings_flag(:unlock_source_unlocks_spec) { !bundler_2_mode? }
     settings_flag(:update_requires_all_flag) { bundler_2_mode? }
 

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -35,6 +35,7 @@ module Bundler
       prefer_gems_rb
       silence_root_warning
       skip_default_git_sources
+      suppress_install_using_messages
       unlock_source_unlocks_spec
       update_requires_all_flag
     ].freeze

--- a/lib/bundler/source.rb
+++ b/lib/bundler/source.rb
@@ -60,5 +60,13 @@ module Bundler
     def earlier_version?(spec_version, locked_spec_version)
       Gem::Version.new(spec_version) < Gem::Version.new(locked_spec_version)
     end
+
+    def print_using_message(message)
+      if !message.include?("(was ") && Bundler.feature_flag.suppress_install_using_messages?
+        Bundler.ui.debug message
+      else
+        Bundler.ui.info message
+      end
+    end
   end
 end

--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -169,7 +169,7 @@ module Bundler
       def install(spec, options = {})
         force = options[:force]
 
-        Bundler.ui.info "Using #{version_message(spec)} from #{self}"
+        print_using_message "Using #{version_message(spec)} from #{self}"
 
         if requires_checkout? && !@copied && !force
           Bundler.ui.debug "  * Checking out revision: #{ref}"

--- a/lib/bundler/source/metadata.rb
+++ b/lib/bundler/source/metadata.rb
@@ -36,7 +36,7 @@ module Bundler
       end
 
       def install(spec, _opts = {})
-        Bundler.ui.info "Using #{version_message(spec)}"
+        print_using_message "Using #{version_message(spec)}"
         nil
       end
 

--- a/lib/bundler/source/path.rb
+++ b/lib/bundler/source/path.rb
@@ -76,7 +76,7 @@ module Bundler
       end
 
       def install(spec, options = {})
-        Bundler.ui.info "Using #{version_message(spec)} from #{self}"
+        print_using_message "Using #{version_message(spec)} from #{self}"
         generate_bin(spec, :disable_extensions => true)
         nil # no post-install message
       end

--- a/lib/bundler/source/rubygems.rb
+++ b/lib/bundler/source/rubygems.rb
@@ -106,7 +106,7 @@ module Bundler
         end
 
         if installed?(spec) && !force
-          Bundler.ui.info "Using #{version_message(spec)}"
+          print_using_message "Using #{version_message(spec)}"
           return nil # no post-install message
         end
 

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -243,6 +243,9 @@ learn more about their operation in [bundle install(1)][bundle-install].
 * `skip_default_git_sources` (`BUNDLE_SKIP_DEFAULT_GIT_SOURCES`):
    Whether Bundler should skip adding default git source shortcuts to the
    Gemfile DSL.
+* `suppress_install_using_messages` (`BUNDLE_SUPPRESS_INSTALL_USING_MESSAGES`):
+   Avoid printing `Using ...` messages during installation when the version of
+   a gem has not changed.
 
 In general, you should set these settings per-application by using the applicable
 flag to the [bundle install(1)][bundle-install] or [bundle package(1)][bundle-package] command.

--- a/spec/commands/pristine_spec.rb
+++ b/spec/commands/pristine_spec.rb
@@ -116,7 +116,6 @@ RSpec.describe "bundle pristine" do
       foo_changes_txt = Pathname.new(foo.full_gem_path).join("lib/changes.txt")
       FileUtils.touch(foo_changes_txt)
       expect(foo_changes_txt).to be_file
-      foo_ref = Spec::Builders::GitReader.new(lib_path("foo")).ref_for("HEAD", 6)
 
       bar = Bundler.definition.specs["bar"].first
       bar_changes_txt = Pathname.new(bar.full_gem_path).join("lib/changes.txt")
@@ -130,11 +129,9 @@ RSpec.describe "bundle pristine" do
 
       bundle! "pristine foo bar weakling"
 
-      expect(out).to eq(strip_whitespace(<<-EOS).strip)
-        Cannot pristine bar (1.0). Gem is sourced from local path.
-        Using foo 1.0 from #{lib_path("foo")} (at master@#{foo_ref})
-        Installing weakling 1.0
-      EOS
+      expect(out).to include("Cannot pristine bar (1.0). Gem is sourced from local path.").
+        and include("Installing weakling 1.0")
+
       expect(weakling_changes_txt).not_to be_file
       expect(foo_changes_txt).not_to be_file
       expect(bar_changes_txt).to be_file

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -430,7 +430,7 @@ RSpec.describe "bundle update when a gem depends on a newer version of bundler" 
 end
 
 RSpec.describe "bundle update" do
-  it "shows the previous version of the gem when updated from rubygems source" do
+  it "shows the previous version of the gem when updated from rubygems source", :bundler => "< 2" do
     build_repo2
 
     install_gemfile <<-G
@@ -464,7 +464,7 @@ RSpec.describe "bundle update" do
         gem "foo"
       G
 
-      bundle! "update"
+      bundle! "update", :all => bundle_update_requires_all?
       out.gsub!(/RubyGems [\d\.]+ is not threadsafe.*\n?/, "")
       expect(out).to include "Resolving dependencies...\nBundle updated!"
 
@@ -472,7 +472,7 @@ RSpec.describe "bundle update" do
         build_gem "foo", "2.0"
       end
 
-      bundle! "update"
+      bundle! "update", :all => bundle_update_requires_all?
       out.gsub!(/RubyGems [\d\.]+ is not threadsafe.*\n?/, "")
       expect(out).to include strip_whitespace(<<-EOS).strip
         Resolving dependencies...

--- a/spec/install/deploy_spec.rb
+++ b/spec/install/deploy_spec.rb
@@ -312,15 +312,13 @@ You have deleted from the Gemfile:
       expect(bundled_app("vendor/cache/foo")).to be_directory
 
       bundle! "install --local"
-      expect(out).to include("Using foo 1.0 from source at")
-      expect(out).to include("vendor/cache/foo")
+      expect(out).to include("Updating files in vendor/cache")
 
       simulate_new_machine
       bundle! "install --deployment --verbose"
       expect(out).not_to include("You are trying to install in deployment mode after changing your Gemfile")
       expect(out).not_to include("You have added to the Gemfile")
       expect(out).not_to include("You have deleted from the Gemfile")
-      expect(out).to include("Using foo 1.0 from source at")
       expect(out).to include("vendor/cache/foo")
       expect(the_bundle).to include_gems "foo 1.0"
     end

--- a/spec/install/force_spec.rb
+++ b/spec/install/force_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe "bundle install" do
       bundle "install --force"
 
       expect(exitstatus).to eq(0) if exitstatus
-      expect(out).to include "Using bundler"
       expect(out).to include "Installing rack 1.0.0"
       expect(rack_lib.open(&:read)).to eq("RACK = '1.0.0'\n")
       expect(the_bundle).to include_gems "rack 1.0.0"
@@ -27,7 +26,6 @@ RSpec.describe "bundle install" do
       bundle "install --force"
 
       expect(exitstatus).to eq(0) if exitstatus
-      expect(out).to include "Using bundler"
       expect(out).to include "Installing rack 1.0.0"
       expect(the_bundle).to include_gems "rack 1.0.0"
     end
@@ -48,8 +46,6 @@ RSpec.describe "bundle install" do
         foo_lib.open("w") {|f| f.write("blah blah blah") }
         bundle! "install --force"
 
-        expect(out).to include "Using bundler"
-        expect(out).to include "Using foo 1.0 from #{lib_path("foo-1.0")} (at master@#{ref[0, 7]})"
         expect(foo_lib.open(&:read)).to eq("FOO = '1.0'\n")
         expect(the_bundle).to include_gems "foo 1.0"
       end
@@ -57,8 +53,6 @@ RSpec.describe "bundle install" do
       it "works on first bundle install" do
         bundle! "install --force"
 
-        expect(out).to include "Using bundler"
-        expect(out).to include "Using foo 1.0 from #{lib_path("foo-1.0")} (at master@#{ref[0, 7]})"
         expect(the_bundle).to include_gems "foo 1.0"
       end
     end

--- a/spec/install/gemfile/eval_gemfile_spec.rb
+++ b/spec/install/gemfile/eval_gemfile_spec.rb
@@ -20,8 +20,9 @@ RSpec.describe "bundle install with gemfile that uses eval_gemfile" do
         eval_gemfile 'Gemfile-other'
       G
       expect(out).to include("Resolving dependencies")
-      expect(out).to include("Using gunks 0.0.1 from source at `gems/gunks`")
       expect(out).to include("Bundle complete")
+
+      expect(the_bundle).to include_gem "gunks 0.0.1", :source => "path@#{bundled_app("gems", "gunks")}"
     end
   end
 
@@ -52,8 +53,9 @@ RSpec.describe "bundle install with gemfile that uses eval_gemfile" do
         gemspec :path => 'gems/gunks'
       G
       expect(out).to include("Resolving dependencies")
-      expect(out).to include("Using gunks 0.0.1 from source at `gems/gunks`")
       expect(out).to include("Bundle complete")
+
+      expect(the_bundle).to include_gem "gunks 0.0.1", :source => "path@#{bundled_app("gems", "gunks")}"
     end
   end
 end

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -397,9 +397,8 @@ RSpec.describe "bundle install with git sources" do
         gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
       G
 
-      bundle %(config local.rack #{lib_path("local-rack")})
-      bundle :install
-      expect(out).to match(/at #{lib_path('local-rack')}/)
+      bundle! %(config local.rack #{lib_path("local-rack")})
+      bundle! :install
 
       run "require 'rack'"
       expect(out).to eq("LOCAL")

--- a/spec/install/gems/native_extensions_spec.rb
+++ b/spec/install/gems/native_extensions_spec.rb
@@ -83,7 +83,6 @@ RSpec.describe "installing a gem with native extensions" do
     G
 
     expect(out).not_to include("extconf.rb failed")
-    expect(out).to include("Using c_extension 1.0")
 
     run! "Bundler.require; puts CExtension.new.its_true"
     expect(out).to eq("true")

--- a/spec/install/git_spec.rb
+++ b/spec/install/git_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe "bundle install" do
   context "git sources" do
-    it "displays the revision hash of the gem repository" do
+    it "displays the revision hash of the gem repository", :bundler => "< 2" do
       build_git "foo", "1.0", :path => lib_path("foo")
 
       install_gemfile <<-G
@@ -14,7 +14,7 @@ RSpec.describe "bundle install" do
       expect(the_bundle).to include_gems "foo 1.0", :source => "git@#{lib_path("foo")}"
     end
 
-    it "displays the ref of the gem repository when using branch~num as a ref" do
+    it "displays the ref of the gem repository when using branch~num as a ref", :bundler => "< 2" do
       build_git "foo", "1.0", :path => lib_path("foo")
       rev = revision_for(lib_path("foo"))[0..6]
       update_git "foo", "2.0", :path => lib_path("foo"), :gemspec => true

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -529,8 +529,7 @@ RSpec.describe "Bundler.setup" do
       G
 
       bundle %(config local.rack #{lib_path("local-rack")})
-      bundle :install
-      expect(out).to match(/at #{lib_path('local-rack')}/)
+      bundle! :install
 
       FileUtils.rm_rf(lib_path("local-rack"))
       run "require 'rack'"
@@ -548,8 +547,7 @@ RSpec.describe "Bundler.setup" do
       G
 
       bundle %(config local.rack #{lib_path("local-rack")})
-      bundle :install
-      expect(out).to match(/at #{lib_path('local-rack')}/)
+      bundle! :install
 
       gemfile <<-G
         source "file://#{gem_repo1}"
@@ -571,8 +569,7 @@ RSpec.describe "Bundler.setup" do
       G
 
       bundle %(config local.rack #{lib_path("local-rack")})
-      bundle :install
-      expect(out).to match(/at #{lib_path('local-rack')}/)
+      bundle! :install
 
       gemfile <<-G
         source "file://#{gem_repo1}"

--- a/spec/update/git_spec.rb
+++ b/spec/update/git_spec.rb
@@ -27,12 +27,11 @@ RSpec.describe "bundle update" do
         s.add_dependency "activesupport", "= 3.0"
       end
 
-      install_gemfile <<-G
+      install_gemfile! <<-G
         gem "rails", :git => "#{lib_path("rails")}"
       G
 
-      bundle "update rails"
-      expect(out).to include("Using activesupport 3.0 from #{lib_path("rails")} (at master@#{revision_for(lib_path("rails"))[0..6]})")
+      bundle! "update rails"
       expect(the_bundle).to include_gems "rails 3.0", "activesupport 3.0"
     end
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that `bundle install` output can get very verbose, even when Bundler is not doing anything.

See https://github.com/bundler/bundler-features/issues/33.

### Was was your diagnosis of the problem?

My diagnosis was that bundler was printing a bunch of `Using name (version)` messages, even when we were already using that gem at the same version.

### What is your fix for the problem, implemented in this PR?

My fix is to introduce a feature flag (enabled by default on 2.0), that will only print those extra `Using` messages when `--verbose` is passed, and will continue to print them when there was an old version we can tell users about. Note that we still print a message when installing a gem for the first time.

### Why did you choose this fix out of the possible options?

I chose this fix because it was essentially what had been done in https://github.com/bundler/bundler/pull/3872, and allows for easy feature-flagging.