### PR TITLE
[CLI] Dont print defaults in the command printed with --verbose

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -621,10 +621,16 @@ module Bundler
     def print_command
       return unless ENV["BUNDLE_POSTIT_TRAMPOLINING_VERSION"] || Bundler.ui.debug?
       _, _, config = @_initializer
-      current_command = config[:current_command].name
-      return if %w[exec version check platform show help].include?(current_command)
-      command = ["bundle", current_command] + args
-      command << Thor::Options.to_switches(options)
+      current_command = config[:current_command]
+      command_name = current_command.name
+      return if %w[exec version check platform show help].include?(command_name)
+      command = ["bundle", command_name] + args
+      options_to_print = options.dup
+      options_to_print.delete_if do |k, v|
+        next unless o = current_command.options[k]
+        o.default == v
+      end
+      command << Thor::Options.to_switches(options_to_print).strip
       command.reject!(&:empty?)
       Bundler.ui.info "Running `#{command * " "}` with bundler #{Bundler::VERSION}"
     end

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -630,7 +630,7 @@ module Bundler
         next unless o = current_command.options[k]
         o.default == v
       end
-      command << Thor::Options.to_switches(options_to_print).strip
+      command << Thor::Options.to_switches(options_to_print.sort_by(&:first)).strip
       command.reject!(&:empty?)
       Bundler.ui.info "Running `#{command * " "}` with bundler #{Bundler::VERSION}"
     end

--- a/spec/bundler/cli_spec.rb
+++ b/spec/bundler/cli_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "bundle executable" do
 
     it "doesn't print defaults" do
       install_gemfile! "", :verbose => true
-      expect(out).to start_with("Running `bundle install --verbose --retry 0 --no-color` with bundler #{Bundler::VERSION}")
+      expect(out).to start_with("Running `bundle install --no-color --retry 0 --verbose` with bundler #{Bundler::VERSION}")
     end
   end
 

--- a/spec/bundler/cli_spec.rb
+++ b/spec/bundler/cli_spec.rb
@@ -59,6 +59,11 @@ RSpec.describe "bundle executable" do
       bundle! "config", :verbose => true
       expect(out).to start_with("Running `bundle config --verbose` with bundler #{Bundler::VERSION}")
     end
+
+    it "doesn't print defaults" do
+      install_gemfile! "", :verbose => true
+      expect(out).to start_with("Running `bundle install --verbose --retry 0 --no-color` with bundler #{Bundler::VERSION}")
+    end
   end
 
   describe "printing the outdated warning" do


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that running `bundle lock --verbose`  would print 

    Running `bundle lock    --add-platform  --remove-platform  --verbose` with bundler 1.15.1

even though the platform flags were never specified. This was surfaced by https://github.com/bundler/bundler/pull/5724, which will be fixed by this PR.

### Was was your diagnosis of the problem?

My diagnosis was that default values of options were being printed.

### What is your fix for the problem, implemented in this PR?

My fix is to filter out the default values before getting Thor 

### Why did you choose this fix out of the possible options?

I chose this fix because there is no way, within the `CLI` instance, to tell which flags the user has explicitly given, so I felt that filtering out those options that had default values was the next-best thing.