### PR TITLE
[2.0] Remove RubyGems Aggregate & support transitive source pinning

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -73,6 +73,7 @@ Lint/AmbiguousBlockAssociation:
     - 'spec/commands/install_spec.rb'
     - 'spec/install/gems/flex_spec.rb'
     - 'spec/lock/lockfile_spec.rb'
+    - 'spec/lock/lockfile_bundler_1_spec.rb'
     - 'spec/other/major_deprecation_spec.rb'
     - 'spec/runtime/setup_spec.rb'
     - 'spec/support/helpers.rb'

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -255,10 +255,38 @@ module Bundler
           dependency_names -= pinned_spec_names(source.specs)
           dependency_names.concat(source.unmet_deps).uniq!
         end
-        idx << Gem::Specification.new("ruby\0", RubyVersion.system.to_gem_version_with_patchlevel)
-        idx << Gem::Specification.new("rubygems\0", Gem::VERSION)
+
+        double_check_for_index(idx, dependency_names)
       end
     end
+
+    # Suppose the gem Foo depends on the gem Bar.  Foo exists in Source A.  Bar has some versions that exist in both
+    # sources A and B.  At this point, the API request will have found all the versions of Bar in source A,
+    # but will not have found any versions of Bar from source B, which is a problem if the requested version
+    # of Foo specifically depends on a version of Bar that is only found in source B. This ensures that for
+    # each spec we found, we add all possible versions from all sources to the index.
+    def double_check_for_index(idx, dependency_names)
+      return unless Bundler.feature_flag.lockfile_uses_separate_rubygems_sources?
+
+      loop do
+        idxcount = idx.size
+        sources.all_sources.each do |source|
+          names = :names # do this so we only have to traverse to get dependency_names from the index once
+          unmet_dependency_names = proc do
+            break names unless names == :names
+            names = if idx.size > Source::Rubygems::API_REQUEST_LIMIT
+              new_names = idx.dependency_names_if_available
+              new_names && dependency_names.+(new_names).uniq
+            else
+              dependency_names.+(idx.dependency_names).uniq
+            end
+          end
+          source.double_check_for(unmet_dependency_names, :override_dupes)
+        end
+        break if idxcount == idx.size
+      end
+    end
+    private :double_check_for_index
 
     # used when frozen is enabled so we can find the bundler
     # spec, even if (say) a git gem is not checked out.
@@ -640,7 +668,9 @@ module Bundler
       end
     end
 
-    def converge_sources
+    def converge_rubygems_sources
+      return false if Bundler.feature_flag.lockfile_uses_separate_rubygems_sources?
+
       changes = false
 
       # Get the RubyGems sources from the Gemfile.lock
@@ -655,6 +685,14 @@ module Bundler
           changes |= locked_gem.replace_remotes(actual_remotes)
         end
       end
+
+      changes
+    end
+
+    def converge_sources
+      changes = false
+
+      changes |= converge_rubygems_sources
 
       # Replace the sources from the Gemfile with the sources from the Gemfile.lock,
       # if they exist in the Gemfile.lock and are `==`. If you can't find an equivalent
@@ -829,17 +867,21 @@ module Bundler
     # the metadata dependencies here
     def expanded_dependencies
       @expanded_dependencies ||= begin
+        expand_dependencies(dependencies + metadata_dependencies, @remote)
+      end
+    end
+
+    def metadata_dependencies
+      @metadata_dependencies ||= begin
         ruby_versions = concat_ruby_version_requirements(@ruby_version)
         if ruby_versions.empty? || !@ruby_version.exact?
           concat_ruby_version_requirements(RubyVersion.system)
           concat_ruby_version_requirements(locked_ruby_version_object) unless @unlock[:ruby]
         end
-
-        metadata_dependencies = [
+        [
           Dependency.new("ruby\0", ruby_versions),
           Dependency.new("rubygems\0", Gem::VERSION),
         ]
-        expand_dependencies(dependencies + metadata_dependencies, @remote)
       end
     end
 
@@ -894,10 +936,15 @@ module Bundler
       # Record the specs available in each gem's source, so that those
       # specs will be available later when the resolver knows where to
       # look for that gemspec (or its dependencies)
-      source_requirements = {}
+      default = sources.default_source
+      source_requirements = { :default => default }
+      default = nil unless Bundler.feature_flag.lockfile_uses_separate_rubygems_sources?
       dependencies.each do |dep|
-        next unless dep.source
-        source_requirements[dep.name] = dep.source.specs
+        next unless source = dep.source || default
+        source_requirements[dep.name] = source
+      end
+      metadata_dependencies.each do |dep|
+        source_requirements[dep.name] = sources.metadata_source
       end
       source_requirements
     end

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -167,8 +167,8 @@ module Bundler
                              "to a different version of #{locked_gem} that hasn't been removed in order to install."
         end
         unless specs["bundler"].any?
-          bundler = rubygems_index.search(Gem::Dependency.new("bundler", VERSION)).last
-          specs["bundler"] = bundler if bundler
+          bundler = sources.metadata_source.specs.search(Gem::Dependency.new("bundler", VERSION)).last
+          specs["bundler"] = bundler
         end
 
         specs
@@ -285,16 +285,6 @@ module Bundler
       end
     end
     private :double_check_for_index
-
-    # used when frozen is enabled so we can find the bundler
-    # spec, even if (say) a git gem is not checked out.
-    def rubygems_index
-      @rubygems_index ||= Index.build do |idx|
-        sources.rubygems_sources.each do |rubygems|
-          idx.add_source rubygems.specs
-        end
-      end
-    end
 
     def has_rubygems_remotes?
       sources.rubygems_sources.any? {|s| s.remotes.any? }
@@ -935,7 +925,7 @@ module Bundler
       # specs will be available later when the resolver knows where to
       # look for that gemspec (or its dependencies)
       default = sources.default_source
-      source_requirements = { :default => default }
+      source_requirements = { :default => default, "bundler" => sources.metadata_source }
       default = nil unless Bundler.feature_flag.lockfile_uses_separate_rubygems_sources?
       dependencies.each do |dep|
         next unless source = dep.source || default

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -925,7 +925,7 @@ module Bundler
       # specs will be available later when the resolver knows where to
       # look for that gemspec (or its dependencies)
       default = sources.default_source
-      source_requirements = { :default => default, "bundler" => sources.metadata_source }
+      source_requirements = { :default => default }
       default = nil unless Bundler.feature_flag.lockfile_uses_separate_rubygems_sources?
       dependencies.each do |dep|
         next unless source = dep.source || default
@@ -934,6 +934,7 @@ module Bundler
       metadata_dependencies.each do |dep|
         source_requirements[dep.name] = sources.metadata_source
       end
+      source_requirements["bundler"] = sources.metadata_source # needs to come last to override
       source_requirements
     end
 

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -266,8 +266,6 @@ module Bundler
     # of Foo specifically depends on a version of Bar that is only found in source B. This ensures that for
     # each spec we found, we add all possible versions from all sources to the index.
     def double_check_for_index(idx, dependency_names)
-      return unless Bundler.feature_flag.lockfile_uses_separate_rubygems_sources?
-
       loop do
         idxcount = idx.size
         sources.all_sources.each do |source|

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -134,7 +134,7 @@ module Bundler
       if options.key?("type")
         options["type"] = options["type"].to_s
         unless Plugin.source?(options["type"])
-          raise "No sources available for #{options["type"]}"
+          raise InvalidOption, "No plugin sources available for #{options["type"]}"
         end
 
         unless block_given?

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -172,10 +172,10 @@ module Bundler
               "the path method, like: \n\n" \
               "    path 'dir/containing/rails' do\n" \
               "      gem 'rails'\n" \
-              "    end"
+              "    end\n\n"
 
         raise DeprecatedError, msg if Bundler.feature_flag.disable_multisource?
-        SharedHelpers.major_deprecation(msg)
+        SharedHelpers.major_deprecation(msg.strip)
       end
 
       source_options = normalize_hash(options).merge(
@@ -446,10 +446,14 @@ repo_name ||= user_name
       return if source_list.rubygems_primary_remotes.empty? && source_list.global_rubygems_source.nil?
 
       if Bundler.feature_flag.disable_multisource?
-        raise GemfileError, "Warning: this Gemfile contains multiple primary sources. " \
+        msg = "This Gemfile contains multiple primary sources. " \
           "Each source after the first must include a block to indicate which gems " \
-          "should come from that source. To downgrade this error to a warning, run " \
-          "`bundle config --delete disable_multisource`"
+          "should come from that source"
+        unless Bundler.feature_flag.bundler_2_mode?
+          msg += ". To downgrade this error to a warning, run " \
+            "`bundle config --delete disable_multisource`"
+        end
+        raise GemfileEvalError, msg
       else
         Bundler::SharedHelpers.major_deprecation "Your Gemfile contains multiple primary sources. " \
           "Using `source` more than once without a block is a security risk, and " \

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -432,8 +432,7 @@ repo_name ||= user_name
     def check_primary_source_safety(source)
       return unless source.rubygems_primary_remotes.any?
 
-      # TODO: 2.0 upgrade from setting to default
-      if Bundler.settings[:disable_multisource]
+      if Bundler.feature_flag.disable_multisource?
         raise GemfileError, "Warning: this Gemfile contains multiple primary sources. " \
           "Each source after the first must include a block to indicate which gems " \
           "should come from that source. To downgrade this error to a warning, run " \

--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -28,6 +28,7 @@ module Bundler
 
     settings_flag(:allow_bundler_dependency_conflicts) { bundler_2_mode? }
     settings_flag(:allow_offline_install) { bundler_2_mode? }
+    settings_flag(:disable_multisource) { bundler_2_mode? }
     settings_flag(:error_on_stderr) { bundler_2_mode? }
     settings_flag(:init_gems_rb) { bundler_2_mode? }
     settings_flag(:lockfile_uses_separate_rubygems_sources) { bundler_2_mode? }

--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -30,6 +30,7 @@ module Bundler
     settings_flag(:allow_offline_install) { bundler_2_mode? }
     settings_flag(:error_on_stderr) { bundler_2_mode? }
     settings_flag(:init_gems_rb) { bundler_2_mode? }
+    settings_flag(:lockfile_uses_separate_rubygems_sources) { bundler_2_mode? }
     settings_flag(:only_update_to_newer_versions) { bundler_2_mode? }
     settings_flag(:plugins) { @bundler_version >= Gem::Version.new("1.14") }
     settings_flag(:prefer_gems_rb) { bundler_2_mode? }

--- a/lib/bundler/index.rb
+++ b/lib/bundler/index.rb
@@ -131,6 +131,19 @@ module Bundler
       names.uniq
     end
 
+    def dependency_names_if_available
+      reduce([]) do |names, spec|
+        case spec
+        when EndpointSpecification, Gem::Specification, LazySpecification, StubSpecification
+          names.concat(spec.dependencies)
+        when RemoteSpecification # from the full index
+          return nil
+        else
+          raise "unhandled spec type in #dependency_names_if_available (#{spec.inspect})"
+        end
+      end.tap {|n| n && n.map!(&:name) }
+    end
+
     def use(other, override_dupes = false)
       return unless other
       other.each do |s|

--- a/lib/bundler/plugin/api/source.rb
+++ b/lib/bundler/plugin/api/source.rb
@@ -293,6 +293,13 @@ module Bundler
         def bundler_plugin_api_source?
           true
         end
+
+        # @private
+        # This API on source might not be stable, and for now we expect plugins
+        # to download all specs in `#specs`, so we implement the method for
+        # compatibility purposes and leave it undocumented (and don't support)
+        # overriding it)
+        def double_check_for(*); end
       end
     end
   end

--- a/lib/bundler/plugin/installer.rb
+++ b/lib/bundler/plugin/installer.rb
@@ -13,12 +13,13 @@ module Bundler
 
       def install(names, options)
         version = options[:version] || [">= 0"]
-
-        if options[:git]
-          install_git(names, version, options)
-        else
-          sources = options[:source] || Bundler.rubygems.sources
-          install_rubygems(names, version, sources)
+        Bundler.settings.temporary(:lockfile_uses_separate_rubygems_sources => false, :disable_multisource => false) do
+          if options[:git]
+            install_git(names, version, options)
+          else
+            sources = options[:source] || Bundler.rubygems.sources
+            install_rubygems(names, version, sources)
+          end
         end
       end
 

--- a/lib/bundler/plugin/source_list.rb
+++ b/lib/bundler/plugin/source_list.rb
@@ -5,13 +5,6 @@ module Bundler
   # approptiate options to be used with Source classes for plugin installation
   module Plugin
     class SourceList < Bundler::SourceList
-      def initialize
-        @path_sources       = []
-        @git_sources        = []
-        @rubygems_aggregate = Plugin::Installer::Rubygems.new
-        @rubygems_sources   = []
-      end
-
       def add_git_source(options = {})
         add_source_to_list Plugin::Installer::Git.new(options), git_sources
       end
@@ -21,7 +14,13 @@ module Bundler
       end
 
       def all_sources
-        path_sources + git_sources + rubygems_sources
+        path_sources + git_sources + rubygems_sources + [metadata_source]
+      end
+
+    private
+
+      def rubygems_aggregate_class
+        Plugin::Installer::Rubygems
       end
     end
   end

--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -415,6 +415,12 @@ module Bundler
         next if name == "bundler"
         next unless search_for(requirement).empty?
 
+        cache_message = begin
+                            " or in gems cached in #{Bundler.settings.app_cache_path}" if Bundler.app_cache.exist?
+                          rescue GemfileNotFound
+                            nil
+                          end
+
         if (base = @base[name]) && !base.empty?
           version = base.first.version
           message = "You have requested:\n" \
@@ -426,18 +432,13 @@ module Bundler
         elsif source = @source_requirements[name]
           specs = source.specs[name]
           versions_with_platforms = specs.map {|s| [s.version, s.platform] }
-          message = String.new("Could not find gem '#{requirement}' in #{source}.\n")
+          message = String.new("Could not find gem '#{requirement}' in #{source}#{cache_message}.\n")
           message << if versions_with_platforms.any?
                        "The source contains '#{name}' at: #{formatted_versions_with_platforms(versions_with_platforms)}"
                      else
                        "The source does not contain any versions of '#{requirement}'"
                      end
         else
-          cache_message = begin
-                            " or in gems cached in #{Bundler.settings.app_cache_path}" if Bundler.app_cache.exist?
-                          rescue GemfileNotFound
-                            nil
-                          end
           message = "Could not find gem '#{requirement}' in any of the gem sources " \
             "listed in your Gemfile#{cache_message}."
         end

--- a/lib/bundler/rubygems_ext.rb
+++ b/lib/bundler/rubygems_ext.rb
@@ -135,7 +135,7 @@ module Gem
   end
 
   class Dependency
-    attr_accessor :source, :groups
+    attr_accessor :source, :groups, :all_sources
 
     alias_method :eql?, :==
 
@@ -146,7 +146,7 @@ module Gem
     end
 
     def to_yaml_properties
-      instance_variables.reject {|p| ["@source", "@groups"].include?(p.to_s) }
+      instance_variables.reject {|p| ["@source", "@groups", "@all_sources"].include?(p.to_s) }
     end
 
     def to_lock

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -24,6 +24,7 @@ module Bundler
       gem.mit
       ignore_messages
       init_gems_rb
+      lockfile_uses_separate_rubygems_sources
       major_deprecations
       no_install
       no_prune

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -15,6 +15,7 @@ module Bundler
       disable_checksum_validation
       disable_exec_load
       disable_local_branch_check
+      disable_multisource
       disable_shared_gems
       disable_version_check
       error_on_stderr

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -114,7 +114,7 @@ module Bundler
     end
 
     def all
-      env_keys = ENV.keys.select {|k| k =~ /BUNDLE_.*/ }
+      env_keys = ENV.keys.grep(/\ABUNDLE_.+/)
 
       keys = @global_config.keys | @local_config.keys | env_keys
 

--- a/lib/bundler/source.rb
+++ b/lib/bundler/source.rb
@@ -3,6 +3,7 @@ module Bundler
   class Source
     autoload :Gemspec,  "bundler/source/gemspec"
     autoload :Git,      "bundler/source/git"
+    autoload :Metadata, "bundler/source/metadata"
     autoload :Path,     "bundler/source/path"
     autoload :Rubygems, "bundler/source/rubygems"
 
@@ -30,6 +31,11 @@ module Bundler
     def can_lock?(spec)
       spec.source == self
     end
+
+    # it's possible that gems from one source depend on gems from some
+    # other source, so now we download gemspecs and iterate over those
+    # dependencies, looking for gems we don't have info on yet.
+    def double_check_for(*); end
 
     def include?(other)
       other == self

--- a/lib/bundler/source/metadata.rb
+++ b/lib/bundler/source/metadata.rb
@@ -7,12 +7,36 @@ module Bundler
         @specs ||= Index.build do |idx|
           idx << Gem::Specification.new("ruby\0", RubyVersion.system.to_gem_version_with_patchlevel)
           idx << Gem::Specification.new("rubygems\0", Gem::VERSION)
+
+          idx << Gem::Specification.new do |s|
+            s.name     = "bundler"
+            s.version  = VERSION
+            s.platform = Gem::Platform::RUBY
+            s.source   = self
+            s.authors  = ["bundler team"]
+            # can't point to the actual gemspec or else the require paths will be wrong
+            s.loaded_from = File.expand_path("..", __FILE__)
+          end
+          if loaded_spec = nil && Bundler.rubygems.loaded_specs("bundler")
+            idx << loaded_spec # this has to come after the fake gemspec, to override it
+          elsif local_spec = Bundler.rubygems.find_name("bundler").find {|s| s.version.to_s == VERSION }
+            idx << local_spec
+          end
         end
       end
 
       def cached!; end
 
       def remote!; end
+
+      def options
+        {}
+      end
+
+      def install(spec, opts)
+        Bundler.ui.info "Using #{version_message(spec)}"
+        nil
+      end
 
       def to_s
         "the local ruby installation"

--- a/lib/bundler/source/metadata.rb
+++ b/lib/bundler/source/metadata.rb
@@ -33,7 +33,7 @@ module Bundler
         {}
       end
 
-      def install(spec, opts)
+      def install(spec, _opts = {})
         Bundler.ui.info "Using #{version_message(spec)}"
         nil
       end
@@ -49,6 +49,10 @@ module Bundler
 
       def hash
         self.class.hash
+      end
+
+      def version_message(spec)
+        "#{spec.name} #{spec.version}"
       end
     end
   end

--- a/lib/bundler/source/metadata.rb
+++ b/lib/bundler/source/metadata.rb
@@ -22,6 +22,8 @@ module Bundler
           elsif local_spec = Bundler.rubygems.find_name("bundler").find {|s| s.version.to_s == VERSION }
             idx << local_spec
           end
+
+          idx.each {|s| s.source = self }
         end
       end
 

--- a/lib/bundler/source/metadata.rb
+++ b/lib/bundler/source/metadata.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Bundler
+  class Source
+    class Metadata < Source
+      def specs
+        @specs ||= Index.build do |idx|
+          idx << Gem::Specification.new("ruby\0", RubyVersion.system.to_gem_version_with_patchlevel)
+          idx << Gem::Specification.new("rubygems\0", Gem::VERSION)
+        end
+      end
+
+      def cached!; end
+
+      def remote!; end
+
+      def to_s
+        "the local ruby installation"
+      end
+
+      def ==(other)
+        self.class == other.class
+      end
+      alias_method :eql?, :==
+
+      def hash
+        self.class.hash
+      end
+    end
+  end
+end

--- a/lib/bundler/source/rubygems.rb
+++ b/lib/bundler/source/rubygems.rb
@@ -368,62 +368,28 @@ module Bundler
           index_fetchers = fetchers - api_fetchers
 
           # gather lists from non-api sites
-          index_fetchers.each do |f|
-            Bundler.ui.info "Fetching source index from #{f.uri}"
-            idx.use f.specs_with_retry(nil, self)
-          end
+          fetch_names(index_fetchers, nil, idx, false)
 
           # because ensuring we have all the gems we need involves downloading
           # the gemspecs of those gems, if the non-api sites contain more than
-          # about 100 gems, we treat all sites as non-api for speed.
+          # about 500 gems, we treat all sites as non-api for speed.
           allow_api = idx.size < API_REQUEST_LIMIT && dependency_names.size < API_REQUEST_LIMIT
           Bundler.ui.debug "Need to query more than #{API_REQUEST_LIMIT} gems." \
             " Downloading full index instead..." unless allow_api
 
-          if allow_api
-            api_fetchers.each do |f|
-              Bundler.ui.info "Fetching gem metadata from #{f.uri}", Bundler.ui.debug?
-              idx.use f.specs_with_retry(dependency_names, self)
-              Bundler.ui.info "" unless Bundler.ui.debug? # new line now that the dots are over
-            end
+          fetch_names(api_fetchers, allow_api && dependency_names, idx, false)
+        end
+      end
 
-            # Suppose the gem Foo depends on the gem Bar.  Foo exists in Source A.  Bar has some versions that exist in both
-            # sources A and B.  At this point, the API request will have found all the versions of Bar in source A,
-            # but will not have found any versions of Bar from source B, which is a problem if the requested version
-            # of Foo specifically depends on a version of Bar that is only found in source B. This ensures that for
-            # each spec we found, we add all possible versions from all sources to the index.
-            loop do
-              idxcount = idx.size
-              api_fetchers.each do |f|
-                Bundler.ui.info "Fetching version metadata from #{f.uri}", Bundler.ui.debug?
-                idx.use f.specs_with_retry(idx.dependency_names, self), true
-                Bundler.ui.info "" unless Bundler.ui.debug? # new line now that the dots are over
-              end
-              break if idxcount == idx.size
-            end
-
-            if api_fetchers.any?
-              # it's possible that gems from one source depend on gems from some
-              # other source, so now we download gemspecs and iterate over those
-              # dependencies, looking for gems we don't have info on yet.
-              unmet = idx.unmet_dependency_names
-
-              # if there are any cross-site gems we missed, get them now
-              api_fetchers.each do |f|
-                Bundler.ui.info "Fetching dependency metadata from #{f.uri}", Bundler.ui.debug?
-                idx.use f.specs_with_retry(unmet, self)
-                Bundler.ui.info "" unless Bundler.ui.debug? # new line now that the dots are over
-              end if unmet.any?
-            else
-              allow_api = false
-            end
-          end
-
-          unless allow_api
-            api_fetchers.each do |f|
-              Bundler.ui.info "Fetching source index from #{f.uri}"
-              idx.use f.specs_with_retry(nil, self)
-            end
+      def fetch_names(fetchers, dependency_names, index, override_dupes)
+        fetchers.each do |f|
+          if dependency_names
+            Bundler.ui.info "Fetching gem metadata from #{f.uri}", Bundler.ui.debug?
+            index.use f.specs_with_retry(dependency_names, self), override_dupes
+            Bundler.ui.info "" unless Bundler.ui.debug? # new line now that the dots are over
+          else
+            Bundler.ui.info "Fetching source index from #{f.uri}"
+            index.use f.specs_with_retry(nil, self), override_dupes
           end
         end
       end

--- a/lib/bundler/source/rubygems.rb
+++ b/lib/bundler/source/rubygems.rb
@@ -249,9 +249,9 @@ module Bundler
         return unless api_fetchers.any?
 
         unmet_dependency_names = unmet_dependency_names.call
-        Bundler.ui.debug "#{self}: 2x check for #{unmet_dependency_names}"
+        return if !unmet_dependency_names.nil? && unmet_dependency_names.empty?
 
-        return if unmet_dependency_names && unmet_dependency_names.empty?
+        Bundler.ui.debug "Double checking for #{unmet_dependency_names || "all specs (due to the size of the request)"} in #{self}"
 
         fetch_names(api_fetchers, unmet_dependency_names, index, override_dupes)
       end

--- a/lib/bundler/source_list.rb
+++ b/lib/bundler/source_list.rb
@@ -47,7 +47,10 @@ module Bundler
     end
 
     def add_rubygems_remote(uri)
-      return if Bundler.feature_flag.lockfile_uses_separate_rubygems_sources?
+      if Bundler.feature_flag.lockfile_uses_separate_rubygems_sources?
+        return if Bundler.feature_flag.disable_multisource?
+        raise InvalidOption, "`lockfile_uses_separate_rubygems_sources` cannot be set without `disable_multisource` being set"
+      end
       @rubygems_aggregate.add_remote(uri)
       @rubygems_aggregate
     end

--- a/spec/bundler/definition_spec.rb
+++ b/spec/bundler/definition_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe Bundler::Definition do
       G
     end
 
-    it "for a path gem with deps and no changes" do
+    it "for a path gem with deps and no changes", :bundler => "< 2" do
       build_lib "foo", "1.0", :path => lib_path("foo") do |s|
         s.add_dependency "rack", "1.0"
         s.add_development_dependency "net-ssh", "1.0"
@@ -132,6 +132,43 @@ RSpec.describe Bundler::Definition do
           remote: file:#{gem_repo1}/
           specs:
             rack (1.0.0)
+
+        PLATFORMS
+          ruby
+
+        DEPENDENCIES
+          foo!
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      G
+    end
+
+    it "for a path gem with deps and no changes", :bundler => "2" do
+      build_lib "foo", "1.0", :path => lib_path("foo") do |s|
+        s.add_dependency "rack", "1.0"
+        s.add_development_dependency "net-ssh", "1.0"
+      end
+
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem "foo", :path => "#{lib_path("foo")}"
+      G
+
+      bundle :check, :env => { "DEBUG" => 1 }
+
+      expect(out).to match(/using resolution from the lockfile/)
+      lockfile_should_be <<-G
+        GEM
+          remote: file:#{gem_repo1}/
+          specs:
+            rack (1.0.0)
+
+        PATH
+          remote: #{lib_path("foo")}
+          specs:
+            foo (1.0)
+              rack (= 1.0)
 
         PLATFORMS
           ruby
@@ -197,6 +234,12 @@ RSpec.describe Bundler::Definition do
       end
 
       context "eager unlock" do
+        let(:source_list) do
+          Bundler::SourceList.new.tap do |source_list|
+            source_list.global_rubygems_source = "file://#{gem_repo4}"
+          end
+        end
+
         before do
           gemfile <<-G
             source "file://#{gem_repo4}"
@@ -240,11 +283,11 @@ RSpec.describe Bundler::Definition do
           definition = Bundler::Definition.new(
             bundled_app("Gemfile.lock"),
             updated_deps_in_gemfile,
-            Bundler::SourceList.new,
+            source_list,
             unlock_hash_for_bundle_install
           )
           locked = definition.send(:converge_locked_specs).map(&:name)
-          expect(locked.include?("shared_dep")).to be_truthy
+          expect(locked).to include "shared_dep"
         end
 
         it "should not eagerly unlock shared dependency with bundle update conservative updating behavior" do
@@ -254,7 +297,7 @@ RSpec.describe Bundler::Definition do
           definition = Bundler::Definition.new(
             bundled_app("Gemfile.lock"),
             updated_deps_in_gemfile,
-            Bundler::SourceList.new,
+            source_list,
             :gems => ["shared_owner_a"], :lock_shared_dependencies => true
           )
           locked = definition.send(:converge_locked_specs).map(&:name)

--- a/spec/bundler/plugin/installer_spec.rb
+++ b/spec/bundler/plugin/installer_spec.rb
@@ -3,6 +3,10 @@
 RSpec.describe Bundler::Plugin::Installer do
   subject(:installer) { Bundler::Plugin::Installer.new }
 
+  before do
+    # allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(Pathname.new("/Gemfile"))
+  end
+
   describe "cli install" do
     it "uses Gem.sources when non of the source is provided" do
       sources = double(:sources)

--- a/spec/bundler/plugin/installer_spec.rb
+++ b/spec/bundler/plugin/installer_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Bundler::Plugin::Installer do
   describe "cli install" do
     it "uses Gem.sources when non of the source is provided" do
       sources = double(:sources)
+      Bundler.settings # initialize it before we have to touch rubygems.ext_lock
       allow(Bundler).to receive_message_chain("rubygems.sources") { sources }
 
       allow(installer).to receive(:install_rubygems).

--- a/spec/bundler/source_list_spec.rb
+++ b/spec/bundler/source_list_spec.rb
@@ -115,18 +115,19 @@ RSpec.describe Bundler::SourceList do
       end
     end
 
-    describe "#add_rubygems_remote" do
-      before do
-        @returned_source = source_list.add_rubygems_remote("https://rubygems.org/")
-      end
+    describe "#add_rubygems_remote", :bundler => "< 2" do
+      let!(:returned_source) { source_list.add_rubygems_remote("https://rubygems.org/") }
 
       it "returns the aggregate rubygems source" do
-        expect(@returned_source).to be_instance_of(Bundler::Source::Rubygems)
+        expect(returned_source).to be_instance_of(Bundler::Source::Rubygems)
       end
 
       it "adds the provided remote to the beginning of the aggregate source" do
         source_list.add_rubygems_remote("https://othersource.org")
-        expect(@returned_source.remotes.first).to eq(URI("https://othersource.org/"))
+        expect(returned_source.remotes).to eq [
+          URI("https://othersource.org/"),
+          URI("https://rubygems.org/"),
+        ]
       end
     end
 
@@ -355,7 +356,7 @@ RSpec.describe Bundler::SourceList do
   end
 
   describe "#lock_sources" do
-    it "combines the rubygems sources into a single instance, removing duplicate remotes from the end" do
+    before do
       source_list.add_git_source("uri" => "git://third-git.org/path.git")
       source_list.add_rubygems_source("remotes" => ["https://duplicate-rubygems.org"])
       source_list.add_plugin_source("new_source", "uri" => "https://third-bar.org/foo")
@@ -369,7 +370,9 @@ RSpec.describe Bundler::SourceList do
       source_list.add_path_source("path" => "/first/path/to/gem")
       source_list.add_rubygems_source("remotes" => ["https://duplicate-rubygems.org"])
       source_list.add_git_source("uri" => "git://first-git.org/path.git")
+    end
 
+    it "combines the rubygems sources into a single instance, removing duplicate remotes from the end", :bundler => "< 2" do
       expect(source_list.lock_sources).to eq [
         Bundler::Source::Git.new("uri" => "git://first-git.org/path.git"),
         Bundler::Source::Git.new("uri" => "git://second-git.org/path.git"),
@@ -385,6 +388,24 @@ RSpec.describe Bundler::SourceList do
           "https://second-rubygems.org",
           "https://third-rubygems.org",
         ]),
+      ]
+    end
+
+    it "returns all sources, without combining rubygems sources", :bundler => "2" do
+      expect(source_list.lock_sources).to eq [
+        Bundler::Source::Rubygems.new,
+        Bundler::Source::Rubygems.new("remotes" => ["https://duplicate-rubygems.org"]),
+        Bundler::Source::Rubygems.new("remotes" => ["https://first-rubygems.org"]),
+        Bundler::Source::Rubygems.new("remotes" => ["https://second-rubygems.org"]),
+        Bundler::Source::Rubygems.new("remotes" => ["https://third-rubygems.org"]),
+        Bundler::Source::Git.new("uri" => "git://first-git.org/path.git"),
+        Bundler::Source::Git.new("uri" => "git://second-git.org/path.git"),
+        Bundler::Source::Git.new("uri" => "git://third-git.org/path.git"),
+        Bundler::Source::Path.new("path" => "/first/path/to/gem"),
+        Bundler::Source::Path.new("path" => "/second/path/to/gem"),
+        Bundler::Source::Path.new("path" => "/third/path/to/gem"),
+        ASourcePlugin.new("uri" => "https://second-plugin.org/random"),
+        ASourcePlugin.new("uri" => "https://third-bar.org/foo"),
       ]
     end
   end
@@ -415,7 +436,7 @@ RSpec.describe Bundler::SourceList do
   end
 
   describe "#cached!" do
-    let(:rubygems_source) { source_list.add_rubygems_remote("https://rubygems.org") }
+    let(:rubygems_source) { source_list.add_rubygems_source("remotes" => ["https://rubygems.org"]) }
     let(:git_source)      { source_list.add_git_source("uri" => "git://host/path.git") }
     let(:path_source)     { source_list.add_path_source("path" => "/path/to/gem") }
 
@@ -428,7 +449,7 @@ RSpec.describe Bundler::SourceList do
   end
 
   describe "#remote!" do
-    let(:rubygems_source) { source_list.add_rubygems_remote("https://rubygems.org") }
+    let(:rubygems_source) { source_list.add_rubygems_source("remotes" => ["https://rubygems.org"]) }
     let(:git_source)      { source_list.add_git_source("uri" => "git://host/path.git") }
     let(:path_source)     { source_list.add_path_source("path" => "/path/to/gem") }
 

--- a/spec/bundler/source_list_spec.rb
+++ b/spec/bundler/source_list_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Bundler::SourceList do
   subject(:source_list) { Bundler::SourceList.new }
 
   let(:rubygems_aggregate) { Bundler::Source::Rubygems.new }
+  let(:metadata_source) { Bundler::Source::Metadata.new }
 
   describe "adding sources" do
     before do
@@ -203,6 +204,7 @@ RSpec.describe Bundler::SourceList do
         Bundler::Source::Rubygems.new("remotes" => ["https://fourth-rubygems.org"]),
         Bundler::Source::Rubygems.new("remotes" => ["https://fifth-rubygems.org"]),
         rubygems_aggregate,
+        metadata_source,
       ]
     end
   end

--- a/spec/commands/add_spec.rb
+++ b/spec/commands/add_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe "bundle add" do
 
   it "shows error message when gem cannot be found" do
     bundle "add 'werk_it'"
-    expect(out).to match("Could not find gem 'werk_it' in any of the gem sources listed in your Gemfile.")
+    expect(out).to match("Could not find gem 'werk_it' in")
 
     bundle "add 'werk_it' -s='file://#{gem_repo2}'"
     expect(out).to match("Could not find gem 'werk_it' in rubygems repository")

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -589,7 +589,7 @@ RSpec.describe "bundle exec" do
       it_behaves_like "it runs"
     end
 
-    context "when Bundler.setup fails" do
+    context "when Bundler.setup fails", :bundler => "< 2" do
       before do
         gemfile <<-G
           gem 'rack', '2'
@@ -600,6 +600,24 @@ RSpec.describe "bundle exec" do
       let(:exit_code) { Bundler::GemNotFound.new.status_code }
       let(:expected) { <<-EOS.strip }
 \e[31mCould not find gem 'rack (= 2)' in any of the gem sources listed in your Gemfile.\e[0m
+\e[33mRun `bundle install` to install missing gems.\e[0m
+      EOS
+
+      it_behaves_like "it runs"
+    end
+
+    context "when Bundler.setup fails", :bundler => "2" do
+      before do
+        gemfile <<-G
+          gem 'rack', '2'
+        G
+        ENV["BUNDLER_FORCE_TTY"] = "true"
+      end
+
+      let(:exit_code) { Bundler::GemNotFound.new.status_code }
+      let(:expected) { <<-EOS.strip }
+\e[31mCould not find gem 'rack (= 2)' in locally installed gems.
+The source contains 'rack' at: 0.9.1, 1.0.0\e[0m
 \e[33mRun `bundle install` to install missing gems.\e[0m
       EOS
 

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -280,7 +280,7 @@ RSpec.describe "bundle install with gem sources" do
       end
     end
 
-    it "finds gems in multiple sources" do
+    it "finds gems in multiple sources", :bundler => "< 2" do
       build_repo2
       update_repo2
 
@@ -314,9 +314,9 @@ RSpec.describe "bundle install with gem sources" do
     it "gracefully handles error when rubygems server is unavailable" do
       install_gemfile <<-G, :artifice => nil
         source "file://#{gem_repo1}"
-        source "http://localhost:9384"
-
-        gem 'foo'
+        source "http://localhost:9384" do
+          gem 'foo'
+        end
       G
 
       bundle :install, :artifice => nil

--- a/spec/commands/lock_spec.rb
+++ b/spec/commands/lock_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "bundle lock" do
   it "does not fetch remote specs when using the --local option" do
     bundle "lock --update --local"
 
-    expect(out).to include("sources listed in your Gemfile")
+    expect(out).to match(/sources listed in your Gemfile|installed locally/)
   end
 
   it "writes to a custom location using --lockfile" do

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -214,12 +214,10 @@ RSpec.describe "bundle gem" do
     end
 
     Dir.chdir(bundled_app("newgem")) do
-      bundle "exec rake build"
+      bundle! "exec rake build"
     end
 
-    expect(exitstatus).to be_zero if exitstatus
-    expect(out).not_to include("ERROR")
-    expect(err).not_to include("ERROR")
+    expect(last_command.stdboth).not_to include("ERROR")
   end
 
   context "gem naming with relative paths" do

--- a/spec/install/bundler_spec.rb
+++ b/spec/install/bundler_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "bundle install" do
         This Gemfile requires a different version of Bundler.
         Perhaps you need to update Bundler by running `gem install bundler`?
 
-        Could not find gem 'bundler (= 0.9.2)' in any of the sources.
+        Could not find gem 'bundler (= 0.9.2)' in any
         E
       expect(last_command.bundler_err).to include(nice_error)
     end

--- a/spec/install/bundler_spec.rb
+++ b/spec/install/bundler_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe "bundle install" do
         gem "rails", "3.0"
       G
 
-      simulate_bundler_version "10.0.0"
+      simulate_bundler_version "99999999.99.1"
 
       bundle "check"
       expect(out).to include("The Gemfile's dependencies are satisfied")

--- a/spec/install/bundler_spec.rb
+++ b/spec/install/bundler_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "bundle install" do
         This Gemfile requires a different version of Bundler.
         Perhaps you need to update Bundler by running `gem install bundler`?
 
-        Could not find gem 'bundler (= 0.9.2)' in any of the sources
+        Could not find gem 'bundler (= 0.9.2)' in any of the sources.
         E
       expect(last_command.bundler_err).to include(nice_error)
     end

--- a/spec/install/deploy_spec.rb
+++ b/spec/install/deploy_spec.rb
@@ -93,15 +93,14 @@ RSpec.describe "install with --deployment or --frozen" do
   end
 
   it "works with sources given by a block" do
-    install_gemfile <<-G
+    install_gemfile! <<-G
       source "file://#{gem_repo1}" do
         gem "rack"
       end
     G
 
-    bundle "install --deployment"
+    bundle! "install --deployment"
 
-    expect(exitstatus).to eq(0) if exitstatus
     expect(the_bundle).to include_gems "rack 1.0"
   end
 

--- a/spec/install/gemfile/gemspec_spec.rb
+++ b/spec/install/gemfile/gemspec_spec.rb
@@ -424,7 +424,7 @@ RSpec.describe "bundle install from an existing gemspec" do
         end
       end
 
-      context "on ruby" do
+      context "on ruby", :bundler => "< 2" do
         before do
           simulate_platform("ruby")
           bundle :install
@@ -509,6 +509,107 @@ RSpec.describe "bundle install from an existing gemspec" do
                     platform_specific
                   platform_specific (1.0)
                   platform_specific (1.0-java)
+
+              PLATFORMS
+                java
+                ruby
+
+              DEPENDENCIES
+                foo!
+                indirect_platform_specific
+
+              BUNDLED WITH
+                 #{Bundler::VERSION}
+            L
+          end
+        end
+      end
+
+      context "on ruby", :bundler => "2" do
+        before do
+          simulate_platform("ruby")
+          bundle :install
+        end
+
+        context "as a runtime dependency" do
+          it "keeps java dependencies in the lockfile" do
+            expect(the_bundle).to include_gems "foo 1.0", "platform_specific 1.0 RUBY"
+            expect(lockfile).to eq strip_whitespace(<<-L)
+              GEM
+                remote: file:#{gem_repo2}/
+                specs:
+                  platform_specific (1.0)
+                  platform_specific (1.0-java)
+
+              PATH
+                remote: .
+                specs:
+                  foo (1.0)
+                    platform_specific
+
+              PLATFORMS
+                java
+                ruby
+
+              DEPENDENCIES
+                foo!
+
+              BUNDLED WITH
+                 #{Bundler::VERSION}
+            L
+          end
+        end
+
+        context "as a development dependency" do
+          let(:platform_specific_type) { :development }
+
+          it "keeps java dependencies in the lockfile" do
+            expect(the_bundle).to include_gems "foo 1.0", "platform_specific 1.0 RUBY"
+            expect(lockfile).to eq strip_whitespace(<<-L)
+              GEM
+                remote: file:#{gem_repo2}/
+                specs:
+                  platform_specific (1.0)
+                  platform_specific (1.0-java)
+
+              PATH
+                remote: .
+                specs:
+                  foo (1.0)
+
+              PLATFORMS
+                java
+                ruby
+
+              DEPENDENCIES
+                foo!
+                platform_specific
+
+              BUNDLED WITH
+                 #{Bundler::VERSION}
+            L
+          end
+        end
+
+        context "with an indirect platform-specific development dependency" do
+          let(:platform_specific_type) { :development }
+          let(:dependency) { "indirect_platform_specific" }
+
+          it "keeps java dependencies in the lockfile" do
+            expect(the_bundle).to include_gems "foo 1.0", "indirect_platform_specific 1.0", "platform_specific 1.0 RUBY"
+            expect(lockfile).to eq strip_whitespace(<<-L)
+              GEM
+                remote: file:#{gem_repo2}/
+                specs:
+                  indirect_platform_specific (1.0)
+                    platform_specific
+                  platform_specific (1.0)
+                  platform_specific (1.0-java)
+
+              PATH
+                remote: .
+                specs:
+                  foo (1.0)
 
               PLATFORMS
                 java

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe "bundle install with git sources" do
         gem "foo", "1.1", :git => "#{lib_path("foo-1.0")}"
       G
 
-      expect(out).to include("Source contains 'foo' at: 1.0 ruby")
+      expect(out).to include("The source contains 'foo' at: 1.0")
     end
 
     it "complains with version and platform if pinned specs don't exist in the git repo" do
@@ -96,7 +96,7 @@ RSpec.describe "bundle install with git sources" do
         end
       G
 
-      expect(out).to include("Source contains 'only_java' at: 1.0 java")
+      expect(out).to include("The source contains 'only_java' at: 1.0 java")
     end
 
     it "complains with multiple versions and platforms if pinned specs don't exist in the git repo" do
@@ -117,7 +117,7 @@ RSpec.describe "bundle install with git sources" do
         end
       G
 
-      expect(out).to include("Source contains 'only_java' at: 1.0 java, 1.1 java")
+      expect(out).to include("The source contains 'only_java' at: 1.0 java, 1.1 java")
     end
 
     it "still works after moving the application directory" do

--- a/spec/install/gemfile/path_spec.rb
+++ b/spec/install/gemfile/path_spec.rb
@@ -1,12 +1,24 @@
 # frozen_string_literal: true
 
 RSpec.describe "bundle install with explicit source paths" do
-  it "fetches gems" do
+  it "fetches gems with a global path source", :bundler => "< 2" do
     build_lib "foo"
 
     install_gemfile <<-G
       path "#{lib_path("foo-1.0")}"
       gem 'foo'
+    G
+
+    expect(the_bundle).to include_gems("foo 1.0")
+  end
+
+  it "fetches gems" do
+    build_lib "foo"
+
+    install_gemfile <<-G
+      path "#{lib_path("foo-1.0")}" do
+        gem 'foo'
+      end
     G
 
     expect(the_bundle).to include_gems("foo 1.0")

--- a/spec/install/gemfile/path_spec.rb
+++ b/spec/install/gemfile/path_spec.rb
@@ -281,8 +281,9 @@ RSpec.describe "bundle install with explicit source paths" do
     end
 
     install_gemfile <<-G
-      path "#{lib_path("foo-1.0")}"
-      gem 'foo'
+      path "#{lib_path("foo-1.0")}" do
+        gem 'foo'
+      end
     G
     expect(the_bundle).to include_gems "foo 1.0"
 

--- a/spec/install/gemfile/sources_spec.rb
+++ b/spec/install/gemfile/sources_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
         bundle "config major_deprecations true"
       end
 
-      it "warns about ambiguous gems, but installs anyway, prioritizing sources last to first" do
+      it "warns about ambiguous gems, but installs anyway, prioritizing sources last to first", :bundler => "< 2" do
         bundle :install
 
         expect(out).to have_major_deprecation a_string_including("Your Gemfile contains multiple primary sources.")
@@ -58,7 +58,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
         bundle "config major_deprecations true"
       end
 
-      it "warns about ambiguous gems, but installs anyway" do
+      it "warns about ambiguous gems, but installs anyway", :bundler => "< 2" do
         bundle :install
 
         expect(out).to have_major_deprecation a_string_including("Your Gemfile contains multiple primary sources.")
@@ -249,7 +249,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
             G
           end
 
-          it "installs from the other source and warns about ambiguous gems" do
+          it "installs from the other source and warns about ambiguous gems", :bundler => "< 2" do
             bundle "config major_deprecations true"
             bundle :install
             expect(out).to have_major_deprecation a_string_including("Your Gemfile contains multiple primary sources.")
@@ -277,7 +277,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
             G
           end
 
-          it "installs the dependency from the pinned source without warning" do
+          it "installs the dependency from the pinned source without warning", :bundler => "< 2" do
             bundle :install
 
             expect(out).not_to include("Warning: the gem 'rack' was found in multiple sources.")

--- a/spec/install/gemfile/sources_spec.rb
+++ b/spec/install/gemfile/sources_spec.rb
@@ -78,6 +78,10 @@ RSpec.describe "bundle install with gems on multiple sources" do
           build_gem "rack", "1.0.0" do |s|
             s.write "lib/rack.rb", "RACK = 'FAIL'"
           end
+
+          build_gem "rack-obama" do |s|
+            s.add_dependency "rack"
+          end
         end
 
         gemfile <<-G
@@ -91,19 +95,19 @@ RSpec.describe "bundle install with gems on multiple sources" do
       end
 
       it "installs the gems without any warning" do
-        bundle :install
+        bundle! :install
         expect(out).not_to include("Warning")
         expect(the_bundle).to include_gems("rack-obama 1.0.0")
         expect(the_bundle).to include_gems("rack 1.0.0", :source => "remote1")
       end
 
       it "can cache and deploy" do
-        bundle :package
+        bundle! :package
 
         expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
         expect(bundled_app("vendor/cache/rack-obama-1.0.gem")).to exist
 
-        bundle "install --deployment"
+        bundle! "install --deployment"
 
         expect(exitstatus).to eq(0) if exitstatus
         expect(the_bundle).to include_gems("rack-obama 1.0.0", "rack 1.0.0")
@@ -117,6 +121,10 @@ RSpec.describe "bundle install with gems on multiple sources" do
         build_repo gem_repo3 do
           build_gem "rack", "1.0.0" do |s|
             s.write "lib/rack.rb", "RACK = 'FAIL'"
+          end
+
+          build_gem "rack-obama" do |s|
+            s.add_dependency "rack"
           end
         end
 
@@ -335,7 +343,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
           it "does not find the dependency" do
             bundle :install
-            expect(out).to include("Could not find gem 'rack (>= 0) ruby'")
+            expect(out).to include("Could not find gem 'rack', which is required by gem 'depends_on_rack', in any of the relevant sources")
           end
         end
 

--- a/spec/install/gemfile/sources_spec.rb
+++ b/spec/install/gemfile/sources_spec.rb
@@ -189,7 +189,10 @@ RSpec.describe "bundle install with gems on multiple sources" do
           end
 
           context "when lockfile_uses_separate_rubygems_sources is set" do
-            before { bundle! "config lockfile_uses_separate_rubygems_sources true" }
+            before do
+              bundle! "config lockfile_uses_separate_rubygems_sources true"
+              bundle! "config disable_multisource true"
+            end
 
             it "installs from the same source without any warning" do
               bundle! :install
@@ -294,7 +297,10 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
     context "when a top-level gem has an indirect dependency" do
       context "when lockfile_uses_separate_rubygems_sources is set" do
-        before { bundle! "config lockfile_uses_separate_rubygems_sources true" }
+        before do
+          bundle! "config lockfile_uses_separate_rubygems_sources true"
+          bundle! "config disable_multisource true"
+        end
 
         before do
           build_repo gem_repo2 do

--- a/spec/install/gemfile/sources_spec.rb
+++ b/spec/install/gemfile/sources_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
       end
     end
 
-    context "with an indirect dependency" do
+    context "when a pinned gem has an indirect dependency" do
       before do
         build_repo gem_repo3 do
           build_gem "depends_on_rack", "1.0.1" do |s|
@@ -266,6 +266,79 @@ RSpec.describe "bundle install with gems on multiple sources" do
             expect(out).not_to include("Warning: the gem 'rack' was found in multiple sources.")
             expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0")
           end
+        end
+      end
+    end
+
+    context "when a top-level gem has an indirect dependency" do
+      before do
+        build_repo gem_repo2 do
+          build_gem "depends_on_rack", "1.0.1" do |s|
+            s.add_dependency "rack"
+          end
+        end
+
+        build_repo gem_repo3 do
+          build_gem "unrelated_gem", "1.0.0"
+        end
+
+        gemfile <<-G
+          source "file://#{gem_repo2}"
+
+          gem "depends_on_rack"
+
+          source "file://#{gem_repo3}" do
+            gem "unrelated_gem"
+          end
+        G
+      end
+
+      context "and the dependency is only in the top-level source" do
+        before do
+          update_repo gem_repo2 do
+            build_gem "rack", "1.0.0"
+          end
+        end
+
+        it "installs all gems without warning" do
+          bundle :install
+          expect(out).not_to include("Warning")
+          should_be_installed("depends_on_rack 1.0.1", "rack 1.0.0", "unrelated_gem 1.0.0")
+        end
+      end
+
+      context "and the dependency is only in a pinned source" do
+        before do
+          update_repo gem_repo3 do
+            build_gem "rack", "1.0.0" do |s|
+              s.write "lib/rack.rb", "RACK = 'FAIL'"
+            end
+          end
+        end
+
+        it "does not find the dependency" do
+          bundle :install
+          expect(out).to include("Could not find gem 'rack (>= 0) ruby'")
+        end
+      end
+
+      context "and the dependency is in both the top-level and a pinned source" do
+        before do
+          update_repo gem_repo2 do
+            build_gem "rack", "1.0.0"
+          end
+
+          update_repo gem_repo3 do
+            build_gem "rack", "1.0.0" do |s|
+              s.write "lib/rack.rb", "RACK = 'FAIL'"
+            end
+          end
+        end
+
+        it "installs the dependency from the top-level source without warning" do
+          bundle :install
+          expect(out).not_to include("Warning")
+          should_be_installed("depends_on_rack 1.0.1", "rack 1.0.0", "unrelated_gem 1.0.0")
         end
       end
     end

--- a/spec/install/gemfile/sources_spec.rb
+++ b/spec/install/gemfile/sources_spec.rb
@@ -180,10 +180,24 @@ RSpec.describe "bundle install with gems on multiple sources" do
             end
           end
 
-          it "installs from the same source without any warning" do
-            bundle :install
-            expect(out).not_to include("Warning")
-            expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0")
+          context "when lockfile_uses_separate_rubygems_sources is set" do
+            before { bundle! "config lockfile_uses_separate_rubygems_sources true" }
+
+            it "installs from the same source without any warning" do
+              bundle! :install
+
+              expect(out).not_to include("Warning: the gem 'rack' was found in multiple sources.")
+              expect(err).not_to include("Warning: the gem 'rack' was found in multiple sources.")
+              expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0")
+
+              # when there is already a lock file, and the gems are missing, so try again
+              system_gems []
+              bundle! :install
+
+              expect(out).not_to include("Warning: the gem 'rack' was found in multiple sources.")
+              expect(err).not_to include("Warning: the gem 'rack' was found in multiple sources.")
+              expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0")
+            end
           end
         end
       end

--- a/spec/install/gems/compact_index_spec.rb
+++ b/spec/install/gems/compact_index_spec.rb
@@ -539,7 +539,7 @@ The checksum of /versions does not match the checksum provided by the server! So
       expect(out).not_to include("#{user}:#{password}")
     end
 
-    it "strips http basic auth creds when warning about ambiguous sources" do
+    it "strips http basic auth creds when warning about ambiguous sources", :bundler => "< 2" do
       gemfile <<-G
         source "#{basic_auth_source_uri}"
         source "file://#{gem_repo1}"

--- a/spec/install/gems/flex_spec.rb
+++ b/spec/install/gems/flex_spec.rb
@@ -246,11 +246,11 @@ RSpec.describe "bundle flex_install" do
   describe "when adding a new source" do
     it "updates the lockfile" do
       build_repo2
-      install_gemfile <<-G
+      install_gemfile! <<-G
         source "file://#{gem_repo1}"
         gem "rack"
       G
-      install_gemfile <<-G
+      install_gemfile! <<-G
         source "file://#{gem_repo1}"
         source "file://#{gem_repo2}"
         gem "rack"

--- a/spec/install/gems/flex_spec.rb
+++ b/spec/install/gems/flex_spec.rb
@@ -244,7 +244,7 @@ RSpec.describe "bundle flex_install" do
   end
 
   describe "when adding a new source" do
-    it "updates the lockfile" do
+    it "updates the lockfile", :bundler => "< 2" do
       build_repo2
       install_gemfile! <<-G
         source "file://#{gem_repo1}"
@@ -262,6 +262,41 @@ RSpec.describe "bundle flex_install" do
         remote: file:#{gem_repo2}/
         specs:
           rack (1.0.0)
+
+      PLATFORMS
+        ruby
+
+      DEPENDENCIES
+        rack
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+      L
+    end
+
+    it "updates the lockfile", :bundler => "2" do
+      build_repo2
+      install_gemfile! <<-G
+        source "file://#{gem_repo1}"
+        gem "rack"
+      G
+
+      install_gemfile! <<-G
+        source "file://#{gem_repo1}"
+        source "file://#{gem_repo2}" do
+        end
+        gem "rack"
+      G
+
+      lockfile_should_be <<-L
+      GEM
+        remote: file:#{gem_repo1}/
+        specs:
+          rack (1.0.0)
+
+      GEM
+        remote: file:#{gem_repo2}/
+        specs:
 
       PLATFORMS
         ruby

--- a/spec/install/gems/resolving_spec.rb
+++ b/spec/install/gems/resolving_spec.rb
@@ -147,7 +147,8 @@ RSpec.describe "bundle install with install-time dependencies" do
                 require_ruby was resolved to 1.0, which depends on
                   ruby\0 (> 9000)
 
-            Could not find gem 'ruby\0 (> 9000)', which is required by gem 'require_ruby', in any of the sources.
+            Could not find gem 'ruby\0 (> 9000)', which is required by gem 'require_ruby', in any of the relevant sources:
+              the local ruby installation
           E
           expect(last_command.bundler_err).to end_with(nice_error)
         end

--- a/spec/install/post_bundle_message_spec.rb
+++ b/spec/install/post_bundle_message_spec.rb
@@ -97,13 +97,25 @@ RSpec.describe "post bundle message" do
     end
 
     describe "with misspelled or non-existent gem name" do
-      it "should report a helpful error message" do
+      it "should report a helpful error message", :bundler => "< 2" do
         install_gemfile <<-G
           source "file://#{gem_repo1}"
           gem "rack"
           gem "not-a-gem", :group => :development
         G
         expect(out).to include("Could not find gem 'not-a-gem' in any of the gem sources listed in your Gemfile.")
+      end
+
+      it "should report a helpful error message", :bundler => "2" do
+        install_gemfile <<-G
+          source "file://#{gem_repo1}"
+          gem "rack"
+          gem "not-a-gem", :group => :development
+        G
+        expect(out).to include <<-EOS.strip
+Could not find gem 'not-a-gem' in rubygems repository file:#{gem_repo1}/ or installed locally.
+The source does not contain any versions of 'not-a-gem'
+        EOS
       end
 
       it "should report a helpful error message with reference to cache if available" do
@@ -118,7 +130,8 @@ RSpec.describe "post bundle message" do
           gem "rack"
           gem "not-a-gem", :group => :development
         G
-        expect(out).to include("Could not find gem 'not-a-gem' in any of the gem sources listed in your Gemfile or in gems cached in vendor/cache.")
+        expect(out).to include("Could not find gem 'not-a-gem' in").
+          and include("or in gems cached in vendor/cache.")
       end
     end
   end

--- a/spec/install/yanked_spec.rb
+++ b/spec/install/yanked_spec.rb
@@ -37,7 +37,7 @@ RSpec.context "when installing a bundle that includes yanked gems" do
     G
 
     expect(out).not_to include("Your bundle is locked to foo (10.0.0)")
-    expect(out).to include("Could not find gem 'foo (= 10.0.0)' in any of the gem sources")
+    expect(out).to include("Could not find gem 'foo (= 10.0.0)' in")
   end
 end
 

--- a/spec/lock/lockfile_bundler_1_spec.rb
+++ b/spec/lock/lockfile_bundler_1_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "the lockfile format", :bundler => "2" do
+RSpec.describe "the lockfile format", :bundler => "< 2" do
   include Bundler::GemHelpers
 
   it "generates a simple lockfile for a single source, gem" do
@@ -360,28 +360,19 @@ RSpec.describe "the lockfile format", :bundler => "2" do
     G
   end
 
-  it "generates a lockfile without credentials for a configured source" do
+  it "generates a lockfile wihout credentials for a configured source" do
     bundle "config http://localgemserver.test/ user:pass"
 
     install_gemfile(<<-G, :artifice => "endpoint_strict_basic_authentication", :quiet => true)
-      source "http://localgemserver.test/" do
+      source "http://localgemserver.test/"
+      source "http://user:pass@othergemserver.test/"
 
-      end
-
-      source "http://user:pass@othergemserver.test/" do
-        gem "rack-obama", ">= 1.0"
-      end
+      gem "rack-obama", ">= 1.0"
     G
 
     lockfile_should_be <<-G
       GEM
-        specs:
-
-      GEM
         remote: http://localgemserver.test/
-        specs:
-
-      GEM
         remote: http://user:pass@othergemserver.test/
         specs:
           rack (1.0.0)
@@ -392,7 +383,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
         #{generic_local_platform}
 
       DEPENDENCIES
-        rack-obama (>= 1.0)!
+        rack-obama (>= 1.0)
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -503,14 +494,14 @@ RSpec.describe "the lockfile format", :bundler => "2" do
     G
 
     lockfile_should_be <<-G
-      GEM
-        specs:
-
       GIT
         remote: #{lib_path("foo-1.0")}
         revision: #{git.ref_for("master")}
         specs:
           foo (1.0)
+
+      GEM
+        specs:
 
       PLATFORMS
         #{generic_local_platform}
@@ -532,15 +523,15 @@ RSpec.describe "the lockfile format", :bundler => "2" do
     G
 
     lockfile_should_be <<-G
-      GEM
-        specs:
-
       GIT
         remote: #{lib_path("foo-1.0")}
         revision: #{git.ref_for("omg")}
         branch: omg
         specs:
           foo (1.0)
+
+      GEM
+        specs:
 
       PLATFORMS
         #{generic_local_platform}
@@ -562,15 +553,15 @@ RSpec.describe "the lockfile format", :bundler => "2" do
     G
 
     lockfile_should_be <<-G
-      GEM
-        specs:
-
       GIT
         remote: #{lib_path("foo-1.0")}
         revision: #{git.ref_for("omg")}
         tag: omg
         specs:
           foo (1.0)
+
+      GEM
+        specs:
 
       PLATFORMS
         #{generic_local_platform}
@@ -591,13 +582,13 @@ RSpec.describe "the lockfile format", :bundler => "2" do
     G
 
     lockfile_should_be <<-G
-      GEM
-        specs:
-
       PATH
         remote: #{lib_path("foo-1.0")}
         specs:
           foo (1.0)
+
+      GEM
+        specs:
 
       PLATFORMS
         #{generic_local_platform}
@@ -621,13 +612,13 @@ RSpec.describe "the lockfile format", :bundler => "2" do
     bundle! "install --local"
 
     lockfile_should_be <<-G
-      GEM
-        specs:
-
       PATH
         remote: #{lib_path("foo-1.0")}
         specs:
           foo (1.0)
+
+      GEM
+        specs:
 
       PLATFORMS
         #{generic_local_platform}
@@ -653,11 +644,6 @@ RSpec.describe "the lockfile format", :bundler => "2" do
     G
 
     lockfile_should_be <<-G
-      GEM
-        remote: file:#{gem_repo1}/
-        specs:
-          rack (1.0.0)
-
       GIT
         remote: #{lib_path("bar-1.0")}
         revision: #{bar.ref_for("master")}
@@ -668,6 +654,11 @@ RSpec.describe "the lockfile format", :bundler => "2" do
         remote: #{lib_path("foo-1.0")}
         specs:
           foo (1.0)
+
+      GEM
+        remote: file:#{gem_repo1}/
+        specs:
+          rack (1.0.0)
 
       PLATFORMS
         #{generic_local_platform}
@@ -838,25 +829,24 @@ RSpec.describe "the lockfile format", :bundler => "2" do
     build_lib "foo", :path => bundled_app("foo")
 
     install_gemfile <<-G
-      path "foo" do
-        gem "foo"
-      end
+      path "foo"
+      gem "foo"
     G
 
     lockfile_should_be <<-G
-      GEM
-        specs:
-
       PATH
         remote: foo
         specs:
           foo (1.0)
 
+      GEM
+        specs:
+
       PLATFORMS
         #{generic_local_platform}
 
       DEPENDENCIES
-        foo!
+        foo
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -867,25 +857,24 @@ RSpec.describe "the lockfile format", :bundler => "2" do
     build_lib "foo", :path => bundled_app(File.join("..", "foo"))
 
     install_gemfile <<-G
-      path "../foo" do
-        gem "foo"
-      end
+      path "../foo"
+      gem "foo"
     G
 
     lockfile_should_be <<-G
-      GEM
-        specs:
-
       PATH
         remote: ../foo
         specs:
           foo (1.0)
 
+      GEM
+        specs:
+
       PLATFORMS
         #{generic_local_platform}
 
       DEPENDENCIES
-        foo!
+        foo
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -896,25 +885,24 @@ RSpec.describe "the lockfile format", :bundler => "2" do
     build_lib "foo", :path => bundled_app("foo")
 
     install_gemfile <<-G
-      path File.expand_path("../foo", __FILE__) do
-        gem "foo"
-      end
+      path File.expand_path("../foo", __FILE__)
+      gem "foo"
     G
 
     lockfile_should_be <<-G
-      GEM
-        specs:
-
       PATH
         remote: foo
         specs:
           foo (1.0)
 
+      GEM
+        specs:
+
       PLATFORMS
         #{generic_local_platform}
 
       DEPENDENCIES
-        foo!
+        foo
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -929,13 +917,13 @@ RSpec.describe "the lockfile format", :bundler => "2" do
     G
 
     lockfile_should_be <<-G
-      GEM
-        specs:
-
       PATH
         remote: ../foo
         specs:
           foo (1.0)
+
+      GEM
+        specs:
 
       PLATFORMS
         #{generic_local_platform}
@@ -1215,23 +1203,23 @@ RSpec.describe "the lockfile format", :bundler => "2" do
 
     # Create a Gemfile.lock that has duplicate GIT sections
     lockfile <<-L
+      GIT
+        remote: #{lib_path("omg")}
+        revision: #{revision}
+        branch: master
+        specs:
+          omg (1.0)
+
+      GIT
+        remote: #{lib_path("omg")}
+        revision: #{revision}
+        branch: master
+        specs:
+          omg (1.0)
+
       GEM
         remote: file:#{gem_repo1}/
         specs:
-
-      GIT
-        remote: #{lib_path("omg")}
-        revision: #{revision}
-        branch: master
-        specs:
-          omg (1.0)
-
-      GIT
-        remote: #{lib_path("omg")}
-        revision: #{revision}
-        branch: master
-        specs:
-          omg (1.0)
 
       PLATFORMS
         #{local}
@@ -1249,16 +1237,16 @@ RSpec.describe "the lockfile format", :bundler => "2" do
 
     # Confirm that duplicate specs do not appear
     expect(File.read(bundled_app("Gemfile.lock"))).to eq(strip_whitespace(<<-L))
-      GEM
-        remote: file:#{gem_repo1}/
-        specs:
-
       GIT
         remote: #{lib_path("omg")}
         revision: #{revision}
         branch: master
         specs:
           omg (1.0)
+
+      GEM
+        remote: file:#{gem_repo1}/
+        specs:
 
       PLATFORMS
         #{local}

--- a/spec/lock/lockfile_spec.rb
+++ b/spec/lock/lockfile_spec.rb
@@ -426,7 +426,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
     expect(the_bundle).to include_gems "net-sftp 1.1.1", "net-ssh 1.0.0"
   end
 
-  it "generates a simple lockfile for a single pinned source, gem with a version requirement" do
+  it "generates a simple lockfile for a single pinned source, gem with a version requirement", :bundler => "< 2" do
     git = build_git "foo"
 
     install_gemfile <<-G
@@ -442,6 +442,34 @@ RSpec.describe "the lockfile format", :bundler => "2" do
 
       GEM
         specs:
+
+      PLATFORMS
+        #{generic_local_platform}
+
+      DEPENDENCIES
+        foo!
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    G
+  end
+
+  it "generates a simple lockfile for a single pinned source, gem with a version requirement" do
+    git = build_git "foo"
+
+    install_gemfile <<-G
+      gem "foo", :git => "#{lib_path("foo-1.0")}"
+    G
+
+    lockfile_should_be <<-G
+      GEM
+        specs:
+
+      GIT
+        remote: #{lib_path("foo-1.0")}
+        revision: #{git.ref_for("master")}
+        specs:
+          foo (1.0)
 
       PLATFORMS
         #{generic_local_platform}

--- a/spec/plugins/source/example_spec.rb
+++ b/spec/plugins/source/example_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "real source plugins" do
       expect(the_bundle).to include_gems("a-path-gem 1.0")
     end
 
-    it "writes to lock file" do
+    it "writes to lock file", :bundler => "< 2" do
       bundle "install"
 
       lockfile_should_be <<-G
@@ -76,6 +76,31 @@ RSpec.describe "real source plugins" do
         GEM
           remote: file:#{gem_repo2}/
           specs:
+
+        PLATFORMS
+          #{generic_local_platform}
+
+        DEPENDENCIES
+          a-path-gem!
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      G
+    end
+
+    it "writes to lock file", :bundler => "2" do
+      bundle "install"
+
+      lockfile_should_be <<-G
+        GEM
+          remote: file:#{gem_repo2}/
+          specs:
+
+        PLUGIN SOURCE
+          remote: #{lib_path("a-path-gem-1.0")}
+          type: mpath
+          specs:
+            a-path-gem (1.0)
 
         PLATFORMS
           #{generic_local_platform}

--- a/spec/plugins/source/example_spec.rb
+++ b/spec/plugins/source/example_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe "real source plugins" do
       end
 
       it "installs" do
-        bundle "install"
+        bundle! "install"
 
         expect(the_bundle).to include_gems("a-path-gem 1.0")
       end

--- a/spec/plugins/source/example_spec.rb
+++ b/spec/plugins/source/example_spec.rb
@@ -326,7 +326,7 @@ RSpec.describe "real source plugins" do
       expect(the_bundle).to include_gems("ma-gitp-gem 1.0")
     end
 
-    it "writes to lock file" do
+    it "writes to lock file", :bundler => "< 2" do
       revision = revision_for(lib_path("ma-gitp-gem-1.0"))
       bundle "install"
 
@@ -341,6 +341,33 @@ RSpec.describe "real source plugins" do
         GEM
           remote: file:#{gem_repo2}/
           specs:
+
+        PLATFORMS
+          #{generic_local_platform}
+
+        DEPENDENCIES
+          ma-gitp-gem!
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      G
+    end
+
+    it "writes to lock file", :bundler => "2" do
+      revision = revision_for(lib_path("ma-gitp-gem-1.0"))
+      bundle "install"
+
+      lockfile_should_be <<-G
+        GEM
+          remote: file:#{gem_repo2}/
+          specs:
+
+        PLUGIN SOURCE
+          remote: file://#{lib_path("ma-gitp-gem-1.0")}
+          type: gitp
+          revision: #{revision}
+          specs:
+            ma-gitp-gem (1.0)
 
         PLATFORMS
           #{generic_local_platform}

--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe "The library itself" do
 
   it "does not include any unresolved merge conflicts" do
     error_messages = []
-    exempt = %r{lock/lockfile_spec|quality_spec|vcr_cassettes|\.ronn|lockfile_parser\.rb}
+    exempt = %r{lock/lockfile_(bundler_1_)?spec|quality_spec|vcr_cassettes|\.ronn|lockfile_parser\.rb}
     Dir.chdir(root) do
       `git ls-files -z`.split("\x0").each do |filename|
         next if filename =~ exempt

--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -172,6 +172,7 @@ RSpec.describe "The library itself" do
       default_cli_command
       gem.coc
       gem.mit
+      lockfile_uses_separate_rubygems_sources
       warned_version
     ]
 

--- a/spec/resolver/basic_spec.rb
+++ b/spec/resolver/basic_spec.rb
@@ -124,7 +124,7 @@ Bundler could not find compatible versions for gem "a":
       deps << Bundler::DepProxy.new(d, "ruby")
     end
 
-    should_resolve_and_include %w[foo-1.0.0 bar-1.0.0], [{}, []]
+    should_resolve_and_include %w[foo-1.0.0 bar-1.0.0], [[]]
   end
 
   context "conservative" do

--- a/spec/runtime/inline_spec.rb
+++ b/spec/runtime/inline_spec.rb
@@ -52,8 +52,9 @@ RSpec.describe "bundler/inline#gemfile" do
   it "requires the gems" do
     script <<-RUBY
       gemfile do
-        path "#{lib_path}"
-        gem "two"
+        path "#{lib_path}" do
+          gem "two"
+        end
       end
     RUBY
 
@@ -62,8 +63,9 @@ RSpec.describe "bundler/inline#gemfile" do
 
     script <<-RUBY
       gemfile do
-        path "#{lib_path}"
-        gem "eleven"
+        path "#{lib_path}" do
+          gem "eleven"
+        end
       end
 
       puts "success"
@@ -132,8 +134,9 @@ RSpec.describe "bundler/inline#gemfile" do
       require 'bundler'
       options = { :ui => Bundler::UI::Shell.new }
       gemfile(false, options) do
-        path "#{lib_path}"
-        gem "two"
+        path "#{lib_path}" do
+          gem "two"
+        end
       end
       puts "OKAY" if options.key?(:ui)
     RUBY

--- a/spec/runtime/require_spec.rb
+++ b/spec/runtime/require_spec.rb
@@ -46,19 +46,20 @@ RSpec.describe "Bundler.require" do
     end
 
     gemfile <<-G
-      path "#{lib_path}"
-      gem "one", :group => :bar, :require => %w[baz qux]
-      gem "two"
-      gem "three", :group => :not
-      gem "four", :require => false
-      gem "five"
-      gem "six", :group => "string"
-      gem "seven", :group => :not
-      gem "eight", :require => true, :group => :require_true
-      env "BUNDLER_TEST" => "nine" do
-        gem "nine", :require => true
+      path "#{lib_path}" do
+        gem "one", :group => :bar, :require => %w[baz qux]
+        gem "two"
+        gem "three", :group => :not
+        gem "four", :require => false
+        gem "five"
+        gem "six", :group => "string"
+        gem "seven", :group => :not
+        gem "eight", :require => true, :group => :require_true
+        env "BUNDLER_TEST" => "nine" do
+          gem "nine", :require => true
+        end
+        gem "ten", :install_if => lambda { ENV["BUNDLER_TEST"] == "ten" }
       end
-      gem "ten", :install_if => lambda { ENV["BUNDLER_TEST"] == "ten" }
     G
   end
 
@@ -111,8 +112,9 @@ RSpec.describe "Bundler.require" do
 
   it "raises an exception if a require is specified but the file does not exist" do
     gemfile <<-G
-      path "#{lib_path}"
-      gem "two", :require => 'fail'
+      path "#{lib_path}" do
+        gem "two", :require => 'fail'
+      end
     G
 
     load_error_run <<-R, "fail"
@@ -128,8 +130,9 @@ RSpec.describe "Bundler.require" do
     end
 
     gemfile <<-G
-      path "#{lib_path}"
-      gem "faulty"
+      path "#{lib_path}" do
+        gem "faulty"
+      end
     G
 
     run "Bundler.require"
@@ -143,8 +146,9 @@ RSpec.describe "Bundler.require" do
     end
 
     gemfile <<-G
-      path "#{lib_path}"
-      gem "loadfuuu"
+      path "#{lib_path}" do
+        gem "loadfuuu"
+      end
     G
 
     cmd = <<-RUBY
@@ -169,8 +173,9 @@ RSpec.describe "Bundler.require" do
 
     it "requires gem names that are namespaced" do
       gemfile <<-G
-        path '#{lib_path}'
-        gem 'jquery-rails'
+        path '#{lib_path}' do
+          gem 'jquery-rails'
+        end
       G
 
       run "Bundler.require"
@@ -182,8 +187,9 @@ RSpec.describe "Bundler.require" do
         s.write "lib/brcrypt.rb", "BCrypt = '1.0.0'"
       end
       gemfile <<-G
-        path "#{lib_path}"
-        gem "bcrypt-ruby"
+        path "#{lib_path}" do
+          gem "bcrypt-ruby"
+        end
       G
 
       cmd = <<-RUBY
@@ -197,8 +203,9 @@ RSpec.describe "Bundler.require" do
 
     it "does not mangle explicitly given requires" do
       gemfile <<-G
-        path "#{lib_path}"
-        gem 'jquery-rails', :require => 'jquery-rails'
+        path "#{lib_path}" do
+          gem 'jquery-rails', :require => 'jquery-rails'
+        end
       G
 
       load_error_run <<-R, "jquery-rails"
@@ -213,8 +220,9 @@ RSpec.describe "Bundler.require" do
       end
 
       gemfile <<-G
-        path "#{lib_path}"
-        gem "load-fuuu"
+        path "#{lib_path}" do
+          gem "load-fuuu"
+        end
       G
 
       cmd = <<-RUBY
@@ -236,8 +244,9 @@ RSpec.describe "Bundler.require" do
       lib_path("load-fuuu-1.0.0/lib/load-fuuu.rb").rmtree
 
       gemfile <<-G
-        path "#{lib_path}"
-        gem "load-fuuu"
+        path "#{lib_path}" do
+          gem "load-fuuu"
+        end
       G
 
       cmd = <<-RUBY
@@ -293,9 +302,10 @@ RSpec.describe "Bundler.require" do
 
     it "works when the gems are in the Gemfile in the correct order" do
       gemfile <<-G
-        path "#{lib_path}"
-        gem "two"
-        gem "one"
+        path "#{lib_path}" do
+          gem "two"
+          gem "one"
+        end
       G
 
       run "Bundler.require"
@@ -333,9 +343,10 @@ RSpec.describe "Bundler.require" do
 
     it "fails when the gems are in the Gemfile in the wrong order" do
       gemfile <<-G
-        path "#{lib_path}"
-        gem "one"
-        gem "two"
+        path "#{lib_path}" do
+          gem "one"
+          gem "two"
+        end
       G
 
       run "Bundler.require"

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -395,9 +395,10 @@ RSpec.describe "Bundler.setup" do
       end
 
       gemfile <<-G
-        path "#{lib_path("rack-1.0.0")}"
         source "file://#{gem_repo1}"
-        gem "rack"
+        path "#{lib_path("rack-1.0.0")}" do
+          gem "rack"
+        end
       G
 
       run "require 'rack'"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -73,7 +73,7 @@ RSpec.configure do |config|
   # once we have a large number of failures (indicative of core pieces of
   # bundler being broken) so that running the full test suite doesn't take
   # forever due to memory constraints
-  config.fail_fast ||= 25
+  config.fail_fast ||= 25 if ENV["CI"]
 
   if ENV["BUNDLER_SUDO_TESTS"] && Spec::Sudo.present?
     config.filter_run :sudo => true

--- a/spec/support/artifice/compact_index_extra_api_missing.rb
+++ b/spec/support/artifice/compact_index_extra_api_missing.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+require File.expand_path("../compact_index_extra_api", __FILE__)
+
+Artifice.deactivate
+
+class CompactIndexExtraAPIMissing < CompactIndexExtraApi
+  get "/extra/fetch/actual/gem/:id" do
+    if params[:id] == "missing-1.0.gemspec.rz"
+      halt 404
+    else
+      File.read("#{gem_repo2}/quick/Marshal.4.8/#{params[:id]}")
+    end
+  end
+end
+
+Artifice.activate_with(CompactIndexExtraAPIMissing)

--- a/spec/support/indexes.rb
+++ b/spec/support/indexes.rb
@@ -16,12 +16,16 @@ module Spec
     def resolve(args = [])
       @platforms ||= ["ruby"]
       deps = []
+      default_source = instance_double("Bundler::Source::Rubygems", :specs => @index)
+      source_requirements = { :default => default_source }
       @deps.each do |d|
         @platforms.each do |p|
+          source_requirements[d.name] = d.source = default_source
           deps << Bundler::DepProxy.new(d, p)
         end
       end
-      Bundler::Resolver.resolve(deps, @index, *args)
+      source_requirements ||= {}
+      Bundler::Resolver.resolve(deps, @index, source_requirements, *args)
     end
 
     def should_resolve_as(specs)
@@ -62,7 +66,7 @@ module Spec
         s.level = opts.first
         s.strict = opts.include?(:strict)
       end
-      should_resolve_and_include specs, [{}, @base, search]
+      should_resolve_and_include specs, [@base, search]
     end
 
     def an_awesome_index

--- a/spec/update/git_spec.rb
+++ b/spec/update/git_spec.rb
@@ -294,7 +294,7 @@ RSpec.describe "bundle update" do
       G
     end
 
-    it "the --source flag updates version of gems that were originally pulled in by the source" do
+    it "the --source flag updates version of gems that were originally pulled in by the source", :bundler => "< 2" do
       spec_lines = lib_path("bar/foo.gemspec").read.split("\n")
       spec_lines[5] = "s.version = '2.0'"
 
@@ -317,6 +317,42 @@ RSpec.describe "bundle update" do
           remote: file:#{gem_repo2}/
           specs:
             rack (1.0.0)
+
+        PLATFORMS
+          ruby
+
+        DEPENDENCIES
+          foo!
+          rack
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      G
+    end
+
+    it "the --source flag updates version of gems that were originally pulled in by the source", :bundler => "2" do
+      spec_lines = lib_path("bar/foo.gemspec").read.split("\n")
+      spec_lines[5] = "s.version = '2.0'"
+
+      update_git "foo", "2.0", :path => @git.path do |s|
+        s.write "foo.gemspec", spec_lines.join("\n")
+      end
+
+      ref = @git.ref_for "master"
+
+      bundle "update --source bar"
+
+      lockfile_should_be <<-G
+        GEM
+          remote: file:#{gem_repo2}/
+          specs:
+            rack (1.0.0)
+
+        GIT
+          remote: #{@git.path}
+          revision: #{ref}
+          specs:
+            foo (2.0)
 
         PLATFORMS
           ruby


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that the resolver could resolve specs from _any_ of the sources specified in the Gemfile, even if that source had nothing to do with the spec in question. This was such a large security vulnerability that, when discovered, it warranted a CVE and its own minor release of Bundler.

Closes #3671.
Closes #3696.
Closes #4059.

### Was was your diagnosis of the problem?

My diagnosis was that we needed to get rid of the notion of a `rubygems aggregate` and enforce that specs could only come either from the source they were declared to come from (the top-level source if declared at the top-level of the Gemfile, else a scoped source), or a source that it transitively "inherited" from the gems that required it.

### What is your fix for the problem, implemented in this PR?

My fix is to disable multiple top-level sources in the Gemfile, remove the RubyGems aggregate, and filter the sources gems could come from as described above.

### Why did you choose this fix out of the possible options?

I chose this fix because it allows doing the filtering in a reasonably performant manner, and refactors the way we handle sources to abstract some of the grossness in such a way that the machinations to make sure that all of the necessary gem info is downloaded is encapsulated into a single method, driven from the definition, rather than being specific to rubygems sources.

See https://github.com/bundler/bundler/pull/4714 and https://github.com/bundler/bundler/pull/4930 for the prior implementation.