### PR TITLE
[2.0] Remove the console command

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -395,11 +395,12 @@ module Bundler
       Open.new(options, name).run
     end
 
-    desc "console [GROUP]", "Opens an IRB session with the bundle pre-loaded"
-    def console(group = nil)
-      # TODO: Remove for 2.0
-      require "bundler/cli/console"
-      Console.new(options, group).run
+    if Bundler.feature_flag.console_command?
+      desc "console [GROUP]", "Opens an IRB session with the bundle pre-loaded"
+      def console(group = nil)
+        require "bundler/cli/console"
+        Console.new(options, group).run
+      end
     end
 
     desc "version", "Prints the bundler's version information"

--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -28,6 +28,7 @@ module Bundler
 
     settings_flag(:allow_bundler_dependency_conflicts) { bundler_2_mode? }
     settings_flag(:allow_offline_install) { bundler_2_mode? }
+    settings_flag(:console_command) { !bundler_2_mode? }
     settings_flag(:disable_multisource) { bundler_2_mode? }
     settings_flag(:error_on_stderr) { bundler_2_mode? }
     settings_flag(:global_gem_cache) { bundler_2_mode? }

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -12,6 +12,7 @@ module Bundler
       auto_install
       cache_all
       cache_all_platforms
+      console_command
       disable_checksum_validation
       disable_exec_load
       disable_local_branch_check

--- a/spec/commands/console_spec.rb
+++ b/spec/commands/console_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "bundle console" do
+RSpec.describe "bundle console", :bundler => "< 2" do
   before :each do
     install_gemfile <<-G
       source "file://#{gem_repo1}"

--- a/spec/other/platform_spec.rb
+++ b/spec/other/platform_spec.rb
@@ -908,7 +908,7 @@ G
     end
   end
 
-  context "bundle console" do
+  context "bundle console", :bundler => "< 2" do
     before do
       install_gemfile <<-G
         source "file://#{gem_repo1}"

--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -169,6 +169,7 @@ RSpec.describe "The library itself" do
 
   it "documents all used settings" do
     exemptions = %w[
+      console_command
       default_cli_command
       gem.coc
       gem.mit


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

> The console command has gotten many, many pull requests for different kinds of customization and so we eventually realized that an editable bin/console is the only way to provide that level of customization. The gem command already creates bin/console, so all that's left is to remove the console command.

From https://github.com/bundler/bundler/issues/4025.

### Was was your diagnosis of the problem?

My diagnosis was `bundle console` needed to go.

### What is your fix for the problem, implemented in this PR?

My fix removes the console command behind a feature flag, enabled by default on 2.0.

See https://github.com/bundler/bundler/pull/4034.

### Why did you choose this fix out of the possible options?

I chose this fix because it didn't require touching any of the console logic and would give the proper missing command error on 2.0.