### PR TITLE
Avoid warnings in the specs on Ruby 1.8.7

### DIFF
--- a/bundler.gemspec
+++ b/bundler.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake",       "~> 10.0"
   s.add_development_dependency "rdiscount",  "~> 2.2"
   s.add_development_dependency "ronn",       "~> 0.7.3"
-  s.add_development_dependency "rspec",      "~> 3.5"
+  s.add_development_dependency "rspec",      "~> 3.6"
 
   s.files = `git ls-files -z`.split("\x0").reject {|f| f.match(%r{^(test|spec|features)/}) }
   # we don't check in man pages, but we need to ship them because

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,6 +36,7 @@ else
 end
 
 Dir["#{File.expand_path("../support", __FILE__)}/*.rb"].each do |file|
+  file = file.gsub(%r{\A#{Regexp.escape File.expand_path("..", __FILE__)}/}, "")
   require file unless file.end_with?("hax.rb")
 end
 
@@ -104,14 +105,6 @@ RSpec.configure do |config|
 
   config.before :all do
     build_repo1
-    # HACK: necessary until rspec-mocks > 3.5.0 is used
-    # see https://github.com/bundler/bundler/pull/5363#issuecomment-278089256
-    if RUBY_VERSION < "1.9"
-      FileUtils.module_eval do
-        alias_method :mkpath, :mkdir_p
-        module_function :mkpath
-      end
-    end
   end
 
   config.before :each do


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was the specs had method redefinition warnings on 1.8.7.

### Was was your diagnosis of the problem?

My diagnosis was the `mkpath` hack was causing some, as well as us requiring support files by their absolute paths.

### What is your fix for the problem, implemented in this PR?

My fix requires support files by relative paths and updates rspec to 3.6, where the `mkpath` hack is unnecessary.

### Why did you choose this fix out of the possible options?

I chose this fix because it works on 1.8.7 without any adverse effects on modern rubies.