### PR TITLE
Use the Package command for `bundle cache` on Bundler 2

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -324,16 +324,20 @@ module Bundler
       Outdated.new(options, gems).run
     end
 
-    desc "cache [OPTIONS]", "Cache all the gems to vendor/cache", :hide => true
-    method_option "all",  :type => :boolean, :banner => "Include all sources (including path and git)."
-    method_option "all-platforms", :type => :boolean, :banner => "Include gems for all platforms present in the lockfile, not only the current one"
-    method_option "no-prune", :type => :boolean, :banner => "Don't remove stale gems from the cache."
-    def cache
-      require "bundler/cli/cache"
-      Cache.new(options).run
+    if Bundler.feature_flag.cache_command_is_package?
+      map %w[cache] => :package
+    else
+      desc "cache [OPTIONS]", "Cache all the gems to vendor/cache", :hide => true
+      method_option "all",  :type => :boolean, :banner => "Include all sources (including path and git)."
+      method_option "all-platforms", :type => :boolean, :banner => "Include gems for all platforms present in the lockfile, not only the current one"
+      method_option "no-prune", :type => :boolean, :banner => "Don't remove stale gems from the cache."
+      def cache
+        require "bundler/cli/cache"
+        Cache.new(options).run
+      end
     end
 
-    desc "package [OPTIONS]", "Locks and then caches all of the gems into vendor/cache"
+    desc "#{Bundler.feature_flag.cache_command_is_package? ? :cache : :package} [OPTIONS]", "Locks and then caches all of the gems into vendor/cache"
     method_option "all",  :type => :boolean, :banner => "Include all sources (including path and git)."
     method_option "all-platforms", :type => :boolean, :banner => "Include gems for all platforms present in the lockfile, not only the current one"
     method_option "cache-path", :type => :string, :banner =>

--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -28,6 +28,7 @@ module Bundler
 
     settings_flag(:allow_bundler_dependency_conflicts) { bundler_2_mode? }
     settings_flag(:allow_offline_install) { bundler_2_mode? }
+    settings_flag(:cache_command_is_package) { bundler_2_mode? }
     settings_flag(:console_command) { !bundler_2_mode? }
     settings_flag(:disable_multisource) { bundler_2_mode? }
     settings_flag(:error_on_stderr) { bundler_2_mode? }

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -12,6 +12,7 @@ module Bundler
       auto_install
       cache_all
       cache_all_platforms
+      cache_command_is_package
       console_command
       disable_checksum_validation
       disable_exec_load

--- a/spec/other/cli_dispatch_spec.rb
+++ b/spec/other/cli_dispatch_spec.rb
@@ -17,4 +17,13 @@ RSpec.describe "bundle command names" do
     bundle "in"
     expect(last_command.bundler_err).to eq("Ambiguous command in matches [info, init, inject, install]")
   end
+
+  context "when cache_command_is_package is set" do
+    before { bundle! "config cache_command_is_package true" }
+
+    it "dispatches `bundle cache` to the package command" do
+      bundle "cache --verbose"
+      expect(last_command.stdout).to start_with "Running `bundle package --no-color --verbose`"
+    end
+  end
 end

--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -169,6 +169,7 @@ RSpec.describe "The library itself" do
 
   it "documents all used settings" do
     exemptions = %w[
+      cache_command_is_package
       console_command
       default_cli_command
       gem.coc


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was the current `bundle cache` is obsolete.

### Was was your diagnosis of the problem?

My diagnosis was we want `bundle package` to be `bundle cache`, but can't change the `cache` behavior due to backwards compatibility.

### What is your fix for the problem, implemented in this PR?

My fix is to redirect `bundle cache` to `bundle package` on Bundler 2.

### Why did you choose this fix out of the possible options?

I chose this fix because it implements https://github.com/bundler/bundler/pull/4008 without breaking the current `bundle cache` command on master.