### PR TITLE
[2.0] Update the specs to pass under Bundler 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 script: rake spec:travis
 before_script:
   - travis_retry rake spec:travis:deps
+  - travis_retry rake spec:travis:sub_version
   - travis_retry rake man:build
   - travis_retry rake spec:rubygems:clone_rubygems_$RGV
 
@@ -43,6 +44,8 @@ env:
 
 matrix:
   include:
+    - rvm: 2.4.1
+      env: RGV=v2.6.8 BUNDLER_SPEC_SUB_VERSION=2.0.0
     # Ruby 2.4, Rubygems 2.6.8 and up
     # Ruby 2.3, Rubygems 2.5.1 and up
     - rvm: 2.2.6

--- a/Rakefile
+++ b/Rakefile
@@ -234,6 +234,18 @@ begin
         raise "Spec run failed, please review the log for more information"
       end
     end
+
+    namespace :travis do
+      task :sub_version do
+        next unless version = ENV["BUNDLER_SPEC_SUB_VERSION"]
+        version_file = File.expand_path("../lib/bundler/version.rb", __FILE__)
+        contents = File.read(version_file)
+        unless contents.sub!(/(^\s+VERSION\s*=\s*)"#{Gem::Version::VERSION_PATTERN}"/, %(\\1"#{version}"))
+          abort("Failed to change bundler version")
+        end
+        File.open(version_file, "w") {|f| f << contents }
+      end
+    end
   end
 
 rescue LoadError

--- a/lib/bundler/cli/init.rb
+++ b/lib/bundler/cli/init.rb
@@ -8,7 +8,7 @@ module Bundler
 
     def run
       if File.exist?(gemfile)
-        Bundler.ui.error "#{gemfile} already exists at #{SharedHelpers.pwd}/#{gemfile}"
+        Bundler.ui.error "#{gemfile} already exists at #{File.expand_path(gemfile)}"
         exit 1
       end
 
@@ -35,7 +35,11 @@ module Bundler
   private
 
     def gemfile
-      @gemfile ||= Bundler.feature_flag.init_gems_rb? ? "gems.rb" : "Gemfile"
+      @gemfile ||= begin
+        Bundler.default_gemfile
+      rescue GemfileNotFound
+        Bundler.feature_flag.init_gems_rb? ? "gems.rb" : "Gemfile"
+      end
     end
   end
 end

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -54,8 +54,7 @@ module Bundler
     def initialize(lockfile, dependencies, sources, unlock, ruby_version = nil, optional_groups = [])
       @unlocking = unlock == true || !unlock.empty?
 
-      @dependencies = dependencies
-      @dependencies_by_name = dependencies.group_by(&:name)
+      @dependencies    = dependencies
       @sources         = sources
       @unlock          = unlock
       @optional_groups = optional_groups
@@ -953,9 +952,10 @@ module Bundler
 
     def additional_base_requirements_for_resolve
       return [] unless @locked_gems && Bundler.feature_flag.only_update_to_newer_versions?
+      dependencies_by_name = dependencies.group_by(&:name)
       @locked_gems.specs.reduce({}) do |requirements, locked_spec|
         name = locked_spec.name
-        next requirements if @locked_deps[name] != @dependencies_by_name[name]
+        next requirements if @locked_deps[name] != dependencies_by_name[name]
         dep = Gem::Dependency.new(name, ">= #{locked_spec.version}")
         requirements[name] = DepProxy.new(dep, locked_spec.platform)
         requirements

--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -304,9 +304,9 @@ module Bundler
 
       def fetch
         git_proxy.checkout
-      rescue GitError
+      rescue GitError => e
         raise unless Bundler.feature_flag.allow_offline_install?
-        Bundler.ui.warn "Using cached git data because of network errors"
+        Bundler.ui.warn "Using cached git data because of network errors:\n#{e}"
       end
 
       # no-op, since we validate when re-serializing the gemspec

--- a/lib/bundler/source/git/git_proxy.rb
+++ b/lib/bundler/source/git/git_proxy.rb
@@ -62,7 +62,7 @@ module Bundler
           begin
             @revision ||= find_local_revision
           rescue GitCommandError
-            raise MissingGitRevisionError.new(ref, uri)
+            raise MissingGitRevisionError.new(ref, URICredentialsFilter.credential_filtered_uri(uri))
           end
 
           @revision

--- a/lib/bundler/ui/shell.rb
+++ b/lib/bundler/ui/shell.rb
@@ -30,9 +30,12 @@ module Bundler
       end
 
       def warn(msg, newline = nil)
+        return unless level("warn")
         return if @warning_history.include? msg
         @warning_history << msg
-        tell_me(msg, :yellow, newline) if level("warn")
+
+        return tell_err(msg, :yellow, newline) if Bundler.feature_flag.error_on_stderr?
+        tell_me(msg, :yellow, newline)
       end
 
       def error(msg, newline = nil)

--- a/spec/bundler/cli_spec.rb
+++ b/spec/bundler/cli_spec.rb
@@ -57,12 +57,12 @@ RSpec.describe "bundle executable" do
   context "with --verbose" do
     it "prints the running command" do
       bundle! "config", :verbose => true
-      expect(out).to start_with("Running `bundle config --verbose` with bundler #{Bundler::VERSION}")
+      expect(last_command.stdout).to start_with("Running `bundle config --verbose` with bundler #{Bundler::VERSION}")
     end
 
     it "doesn't print defaults" do
       install_gemfile! "", :verbose => true
-      expect(out).to start_with("Running `bundle install --no-color --retry 0 --verbose` with bundler #{Bundler::VERSION}")
+      expect(last_command.stdout).to start_with("Running `bundle install --no-color --retry 0 --verbose` with bundler #{Bundler::VERSION}")
     end
   end
 
@@ -103,7 +103,7 @@ RSpec.describe "bundle executable" do
       let(:latest_version) { "2.0" }
       it "prints the version warning" do
         bundle "fail"
-        expect(last_command.bundler_err).to start_with(<<-EOS.strip)
+        expect(last_command.stdout).to start_with(<<-EOS.strip)
 The latest bundler is #{latest_version}, but you are currently running #{bundler_version}.
 To update, run `gem install bundler`
         EOS
@@ -118,7 +118,7 @@ To update, run `gem install bundler`
         let(:latest_version) { "2.0.0.pre.4" }
         it "prints the version warning" do
           bundle "fail"
-          expect(last_command.bundler_err).to start_with(<<-EOS.strip)
+          expect(last_command.stdout).to start_with(<<-EOS.strip)
 The latest bundler is #{latest_version}, but you are currently running #{bundler_version}.
 To update, run `gem install bundler --pre`
           EOS

--- a/spec/bundler/cli_spec.rb
+++ b/spec/bundler/cli_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "bundle executable" do
   describe "printing the outdated warning" do
     shared_examples_for "no warning" do
       it "prints no warning" do
-        bundle! "fail"
+        bundle "fail"
         expect(last_command.stdboth).to eq("Could not find command \"fail\".")
       end
     end

--- a/spec/bundler/cli_spec.rb
+++ b/spec/bundler/cli_spec.rb
@@ -69,8 +69,8 @@ RSpec.describe "bundle executable" do
   describe "printing the outdated warning" do
     shared_examples_for "no warning" do
       it "prints no warning" do
-        bundle "fail"
-        expect(err + out).to eq("Could not find command \"fail\".")
+        bundle! "fail"
+        expect(last_command.stdboth).to eq("Could not find command \"fail\".")
       end
     end
 
@@ -103,10 +103,9 @@ RSpec.describe "bundle executable" do
       let(:latest_version) { "2.0" }
       it "prints the version warning" do
         bundle "fail"
-        expect(err + out).to eq(<<-EOS.strip)
+        expect(last_command.bundler_err).to start_with(<<-EOS.strip)
 The latest bundler is #{latest_version}, but you are currently running #{bundler_version}.
 To update, run `gem install bundler`
-Could not find command "fail".
         EOS
       end
 
@@ -119,10 +118,9 @@ Could not find command "fail".
         let(:latest_version) { "2.0.0.pre.4" }
         it "prints the version warning" do
           bundle "fail"
-          expect(err + out).to eq(<<-EOS.strip)
+          expect(last_command.bundler_err).to start_with(<<-EOS.strip)
 The latest bundler is #{latest_version}, but you are currently running #{bundler_version}.
 To update, run `gem install bundler --pre`
-Could not find command "fail".
           EOS
         end
       end

--- a/spec/bundler/friendly_errors_spec.rb
+++ b/spec/bundler/friendly_errors_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Bundler, "friendly errors" do
 
       bundle :install, :env => { "DEBUG" => true }
 
-      expect(err).to include("Failed to load #{home(".gemrc")}")
+      expect(last_command.stderr).to include("Failed to load #{home(".gemrc")}")
       expect(exitstatus).to eq(0) if exitstatus
     end
   end

--- a/spec/bundler/ui/shell_spec.rb
+++ b/spec/bundler/ui/shell_spec.rb
@@ -21,8 +21,19 @@ RSpec.describe Bundler::UI::Shell do
 
   describe "#warn" do
     before { subject.level = "warn" }
-    it "prints to stdout" do
+    it "prints to stdout", :bundler => "< 2" do
       expect { subject.warn("warning") }.to output("warning\n").to_stdout
+    end
+
+    it "prints to stderr", :bundler => "2" do
+      expect { subject.warn("warning") }.to output("warning\n").to_stderr
+    end
+
+    context "when stderr flag is enabled" do
+      before { Bundler.settings.temporary(:error_on_stderr => true) }
+      it "prints to stderr" do
+        expect { subject.warn("warning!") }.to output("warning!\n").to_stderr
+      end
     end
   end
 
@@ -35,7 +46,7 @@ RSpec.describe Bundler::UI::Shell do
   describe "#error" do
     before { subject.level = "error" }
 
-    it "prints to stdout", :bundler => "<= 2" do
+    it "prints to stdout", :bundler => "< 2" do
       expect { subject.error("error!!!") }.to output("error!!!\n").to_stdout
     end
 

--- a/spec/bundler/ui/shell_spec.rb
+++ b/spec/bundler/ui/shell_spec.rb
@@ -34,8 +34,13 @@ RSpec.describe Bundler::UI::Shell do
 
   describe "#error" do
     before { subject.level = "error" }
-    it "prints to stdout" do
+
+    it "prints to stdout", :bundler => "<= 2" do
       expect { subject.error("error!!!") }.to output("error!!!\n").to_stdout
+    end
+
+    it "prints to stderr", :bundler => "2" do
+      expect { subject.error("error!!!") }.to output("error!!!\n").to_stderr
     end
 
     context "when stderr flag is enabled" do

--- a/spec/cache/gems_spec.rb
+++ b/spec/cache/gems_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe "bundle cache" do
 
     it "adds and removes when gems are updated" do
       update_repo2
-      bundle "update"
+      bundle "update", :all => bundle_update_requires_all?
       expect(cached_gem("rack-1.2")).to exist
       expect(cached_gem("rack-1.0.0")).not_to exist
     end

--- a/spec/cache/git_spec.rb
+++ b/spec/cache/git_spec.rb
@@ -52,14 +52,14 @@ end
     it "runs twice without exploding" do
       build_git "foo"
 
-      install_gemfile <<-G
+      install_gemfile! <<-G
         gem "foo", :git => '#{lib_path("foo-1.0")}'
       G
 
-      bundle "#{cmd} --all"
-      bundle "#{cmd} --all"
+      bundle! "#{cmd} --all"
+      bundle! "#{cmd} --all"
 
-      expect(err).to lack_errors
+      expect(last_command.stdout).to include "Updating files in vendor/cache"
       FileUtils.rm_rf lib_path("foo-1.0")
       expect(the_bundle).to include_gems "foo 1.0"
     end

--- a/spec/cache/git_spec.rb
+++ b/spec/cache/git_spec.rb
@@ -81,14 +81,14 @@ end
       ref = git.ref_for("master", 11)
       expect(ref).not_to eq(old_ref)
 
-      bundle "update"
-      bundle "#{cmd} --all"
+      bundle! "update", :all => bundle_update_requires_all?
+      bundle! "#{cmd} --all"
 
       expect(bundled_app("vendor/cache/foo-1.0-#{ref}")).to exist
       expect(bundled_app("vendor/cache/foo-1.0-#{old_ref}")).not_to exist
 
       FileUtils.rm_rf lib_path("foo-1.0")
-      run "require 'foo'"
+      run! "require 'foo'"
       expect(out).to eq("CACHE")
     end
 

--- a/spec/cache/platform_spec.rb
+++ b/spec/cache/platform_spec.rb
@@ -34,18 +34,14 @@ RSpec.describe "bundle cache with multiple platforms" do
   end
 
   it "ensures that a successful bundle install does not delete gems for other platforms" do
-    bundle "install"
-
-    expect(exitstatus).to eq 0 if exitstatus
+    bundle! "install"
 
     expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
     expect(bundled_app("vendor/cache/activesupport-2.3.5.gem")).to exist
   end
 
   it "ensures that a successful bundle update does not delete gems for other platforms" do
-    bundle "update"
-
-    expect(exitstatus).to eq 0 if exitstatus
+    bundle! "update", :all => bundle_update_requires_all?
 
     expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
     expect(bundled_app("vendor/cache/activesupport-2.3.5.gem")).to exist

--- a/spec/commands/check_spec.rb
+++ b/spec/commands/check_spec.rb
@@ -210,7 +210,6 @@ RSpec.describe "bundle check" do
     3.times do
       bundle :check
       expect(out).to eq(last_out)
-      expect(err).to lack_errors
     end
   end
 
@@ -329,9 +328,8 @@ RSpec.describe "bundle check" do
     context "is newer" do
       it "does not change the lock but warns" do
         lockfile lock_with(Bundler::VERSION.succ)
-        bundle :check
-        expect(out).to include("the running version of Bundler (#{Bundler::VERSION}) is older than the version that created the lockfile (#{Bundler::VERSION.succ})")
-        expect(err).to lack_errors
+        bundle! :check
+        expect(last_command.bundler_err).to include("the running version of Bundler (#{Bundler::VERSION}) is older than the version that created the lockfile (#{Bundler::VERSION.succ})")
         lockfile_should_be lock_with(Bundler::VERSION.succ)
       end
     end

--- a/spec/commands/clean_spec.rb
+++ b/spec/commands/clean_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe "bundle clean" do
       gem "foo"
     G
 
-    bundle "install --path vendor/bundle --no-clean"
+    bundle! "install --path vendor/bundle --no-clean"
 
     gemfile <<-G
       source "file://#{gem_repo1}"
@@ -88,9 +88,9 @@ RSpec.describe "bundle clean" do
       gem "rack", "0.9.1"
       gem "foo"
     G
-    bundle "install"
+    bundle! "update rack"
 
-    bundle :clean
+    bundle! :clean
 
     expect(out).to include("Removing rack (1.0.0)")
 
@@ -195,13 +195,13 @@ RSpec.describe "bundle clean" do
       end
     G
 
-    bundle "install --path vendor/bundle"
+    bundle! "install --path vendor/bundle"
 
     update_git "foo", :path => lib_path("foo-bar")
     revision2 = revision_for(lib_path("foo-bar"))
 
-    bundle "update"
-    bundle :clean
+    bundle! "update", :all => bundle_update_requires_all?
+    bundle! :clean
 
     expect(out).to include("Removing foo-bar (#{revision[0..11]})")
 
@@ -366,13 +366,13 @@ RSpec.describe "bundle clean" do
 
       gem "foo"
     G
-    bundle "install --path vendor/bundle --clean"
+    bundle! "install --path vendor/bundle --clean"
 
     update_repo2 do
       build_gem "foo", "1.0.1"
     end
 
-    bundle "update"
+    bundle! "update", :all => bundle_update_requires_all?
 
     should_have_gems "foo-1.0.1"
     should_not_have_gems "foo-1.0"
@@ -405,13 +405,13 @@ RSpec.describe "bundle clean" do
 
       gem "foo"
     G
-    bundle "install --path vendor/bundle"
+    bundle! "install --path vendor/bundle"
 
     update_repo2 do
       build_gem "foo", "1.0.1"
     end
 
-    bundle :update
+    bundle! :update, :all => bundle_update_requires_all?
     should_have_gems "foo-1.0", "foo-1.0.1"
   end
 
@@ -423,14 +423,14 @@ RSpec.describe "bundle clean" do
 
       gem "foo"
     G
-    bundle "install"
+    bundle! "install"
 
     update_repo2 do
       build_gem "foo", "1.0.1"
     end
-    bundle :update
+    bundle! :update, :all => bundle_update_requires_all?
 
-    sys_exec "gem list"
+    sys_exec! "gem list"
     expect(out).to include("foo (1.0.1, 1.0)")
   end
 

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -539,7 +539,7 @@ RSpec.describe "bundle exec" do
       end
     end
 
-    context "the executable is empty" do
+    context "the executable is empty", :bundler => "< 2" do
       let(:executable) { "" }
 
       let(:exit_code) { 0 }
@@ -554,13 +554,32 @@ RSpec.describe "bundle exec" do
       end
     end
 
-    context "the executable raises" do
+    context "the executable is empty", :bundler => "2" do
+      let(:executable) { "" }
+
+      let(:exit_code) { 0 }
+      let(:expected_err) { "#{path} is empty" }
+      let(:expected) { "" }
+      it_behaves_like "it runs"
+    end
+
+    context "the executable raises", :bundler => "< 2" do
       let(:executable) { super() << "\nraise 'ERROR'" }
       let(:exit_code) { 1 }
       let(:expected) { super() << "\nbundler: failed to load command: #{path} (#{path})" }
       let(:expected_err) do
         "RuntimeError: ERROR\n  #{path}:10" +
           (Bundler.current_ruby.ruby_18? ? "" : ":in `<top (required)>'")
+      end
+      it_behaves_like "it runs"
+    end
+
+    context "the executable raises", :bundler => "2" do
+      let(:executable) { super() << "\nraise 'ERROR'" }
+      let(:exit_code) { 1 }
+      let(:expected_err) do
+        "bundler: failed to load command: #{path} (#{path})" \
+        "\nRuntimeError: ERROR\n  #{path}:10:in `<top (required)>'"
       end
       it_behaves_like "it runs"
     end

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -225,7 +225,7 @@ RSpec.describe "bundle exec" do
     [true, false].each do |l|
       bundle! "config disable_exec_load #{l}"
       bundle "exec rackup"
-      expect(err).to include "can't find executable rackup for gem rack. rack is not currently included in the bundle, perhaps you meant to add it to your Gemfile?"
+      expect(last_command.stderr).to include "can't find executable rackup for gem rack. rack is not currently included in the bundle, perhaps you meant to add it to your Gemfile?"
     end
   end
 
@@ -239,7 +239,7 @@ RSpec.describe "bundle exec" do
     [true, false].each do |l|
       bundle! "config disable_exec_load #{l}"
       bundle "exec rackup"
-      expect(err).to include "rack is not part of the bundle. Add it to your Gemfile."
+      expect(last_command.stderr).to include "rack is not part of the bundle. Add it to your Gemfile."
     end
   end
 
@@ -519,8 +519,8 @@ RSpec.describe "bundle exec" do
       it "like a normally executed executable" do
         subject
         expect(exitstatus).to eq(exit_code) if exitstatus
-        expect(err).to eq(expected_err)
-        expect(out).to eq(expected)
+        expect(last_command.stderr).to eq(expected_err)
+        expect(last_command.stdout).to eq(expected)
       end
     end
 
@@ -730,7 +730,7 @@ __FILE__: #{path.to_s.inspect}
 
         # sanity check that we get the newer, custom version without bundler
         sys_exec("#{Gem.ruby} #{file}")
-        expect(err).to include("custom openssl should not be loaded")
+        expect(last_command.stderr).to include("custom openssl should not be loaded")
       end
     end
   end

--- a/spec/commands/init_spec.rb
+++ b/spec/commands/init_spec.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 
 RSpec.describe "bundle init" do
-  it "generates a Gemfile" do
-    bundle :init
-    expect(bundled_app("Gemfile")).to exist
+  it "generates a Gemfile", :bundler => "< 2" do
+    bundle! :init
+    expect(out).to include("Writing new Gemfile")
+    expect(bundled_app("Gemfile")).to be_file
   end
 
-  it "prints a message to the user" do
-    bundle :init
-    expect(out).to include("Writing new Gemfile")
+  it "generates a gems.rb", :bundler => "2" do
+    bundle! :init
+    expect(out).to include("Writing new gems.rb")
+    expect(bundled_app("gems.rb")).to be_file
   end
 
   context "when a Gemfile already exists" do
@@ -28,6 +30,23 @@ RSpec.describe "bundle init" do
     end
   end
 
+  context "when a gems.rb already exists" do
+    before do
+      create_file "gems.rb", <<-G
+        gem "rails"
+      G
+    end
+
+    it "does not change existing gem.rb files" do
+      expect { bundle :init }.not_to change { File.read(bundled_app("gems.rb")) }
+    end
+
+    it "notifies the user that an existing gems.rb already exists" do
+      bundle :init
+      expect(out).to include("gems.rb already exists")
+    end
+  end
+
   context "given --gemspec option" do
     let(:spec_file) { tmp.join("test.gemspec") }
 
@@ -44,7 +63,11 @@ RSpec.describe "bundle init" do
 
       bundle :init, :gemspec => spec_file
 
-      gemfile = bundled_app("Gemfile").read
+      gemfile = if Bundler::VERSION[0, 2] == "1."
+        bundled_app("Gemfile").read
+      else
+        bundled_app("gems.rb").read
+      end
       expect(gemfile).to match(%r{source 'https://rubygems.org'})
       expect(gemfile.scan(/gem "rack", "= 1.0.1"/).size).to eq(1)
       expect(gemfile.scan(/gem "rspec", "= 1.2"/).size).to eq(1)
@@ -63,7 +86,7 @@ RSpec.describe "bundle init" do
         end
 
         bundle :init, :gemspec => spec_file
-        expect(out).to include("There was an error while loading `test.gemspec`")
+        expect(last_command.bundler_err).to include("There was an error while loading `test.gemspec`")
       end
     end
   end

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -16,8 +16,7 @@ RSpec.describe "bundle install with gem sources" do
         raise StandardError, "FAIL"
       G
 
-      expect(err).to lack_errors
-      expect(out).to match(/StandardError, "FAIL"/)
+      expect(last_command.bundler_err).to include('StandardError, "FAIL"')
       expect(bundled_app("Gemfile.lock")).not_to exist
     end
 

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -785,22 +785,22 @@ RSpec.describe "bundle gem" do
 
     it "fails gracefully with a ." do
       bundle "gem foo.gemspec"
-      expect(out).to end_with("Invalid gem name foo.gemspec -- `Foo.gemspec` is an invalid constant name")
+      expect(last_command.bundler_err).to end_with("Invalid gem name foo.gemspec -- `Foo.gemspec` is an invalid constant name")
     end
 
     it "fails gracefully with a ^" do
       bundle "gem ^"
-      expect(out).to end_with("Invalid gem name ^ -- `^` is an invalid constant name")
+      expect(last_command.bundler_err).to end_with("Invalid gem name ^ -- `^` is an invalid constant name")
     end
 
     it "fails gracefully with a space" do
       bundle "gem 'foo bar'"
-      expect(out).to end_with("Invalid gem name foo bar -- `Foo bar` is an invalid constant name")
+      expect(last_command.bundler_err).to end_with("Invalid gem name foo bar -- `Foo bar` is an invalid constant name")
     end
 
     it "fails gracefully when multiple names are passed" do
       bundle "gem foo bar baz"
-      expect(out).to eq(<<-E.strip)
+      expect(last_command.bundler_err).to eq(<<-E.strip)
 ERROR: "bundle gem" was called with arguments ["foo", "bar", "baz"]
 Usage: "bundle gem GEM [OPTIONS]"
       E
@@ -890,8 +890,8 @@ Usage: "bundle gem GEM [OPTIONS]"
       in_app_root do
         FileUtils.touch("conflict-foobar")
       end
-      output = bundle "gem conflict-foobar"
-      expect(output).to include("Errno::EEXIST")
+      bundle "gem conflict-foobar"
+      expect(last_command.bundler_err).to include("Errno::EEXIST")
       expect(exitstatus).to eql(32) if exitstatus
     end
   end
@@ -901,8 +901,8 @@ Usage: "bundle gem GEM [OPTIONS]"
       in_app_root do
         FileUtils.mkdir_p("conflict-foobar/Gemfile")
       end
-      output = bundle "gem conflict-foobar"
-      expect(output).to include("Errno::EISDIR")
+      bundle "gem conflict-foobar"
+      expect(last_command.bundler_err).to include("Errno::EISDIR")
       expect(exitstatus).to eql(32) if exitstatus
     end
   end

--- a/spec/commands/package_spec.rb
+++ b/spec/commands/package_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe "bundle package" do
         gem 'rack'
       D
 
-      bundle "package --no-install"
+      bundle! "package --no-install"
 
       expect(the_bundle).not_to include_gems "rack 1.0.0"
       expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
@@ -174,8 +174,8 @@ RSpec.describe "bundle package" do
         gem 'rack'
       D
 
-      bundle "package --no-install"
-      bundle "install"
+      bundle! "package --no-install"
+      bundle! "install"
 
       expect(the_bundle).to include_gems "rack 1.0.0"
     end

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -414,11 +414,18 @@ RSpec.describe "bundle update when a gem depends on a newer version of bundler" 
     G
   end
 
-  it "should explain that bundler conflicted" do
+  it "should explain that bundler conflicted", :bundler => "< 2" do
     bundle "update", :all => bundle_update_requires_all?
     expect(last_command.stdboth).not_to match(/in snapshot/i)
     expect(last_command.bundler_err).to match(/current Bundler version/i).
       and match(/perhaps you need to update bundler/i)
+  end
+
+  it "should warn that the newer version of Bundler would conflict", :bundler => "2" do
+    bundle! "update", :all => true
+    expect(last_command.bundler_err).to include("rails (3.0.1) has dependency bundler").
+      and include("so the dependency is being ignored")
+    expect(the_bundle).to include_gem "rails 3.0.1"
   end
 end
 

--- a/spec/commands/version_spec.rb
+++ b/spec/commands/version_spec.rb
@@ -17,10 +17,8 @@ RSpec.describe "bundle version" do
 
   context "with version" do
     it "outputs the version with build metadata" do
-      date = Bundler::BuildMetadata.built_at
-      git_commit_sha = Bundler::BuildMetadata.git_commit_sha
       bundle! "version"
-      expect(out).to eq("Bundler version #{Bundler::VERSION} (#{date} commit #{git_commit_sha})")
+      expect(out).to match(/\ABundler version #{Regexp.escape(Bundler::VERSION)} \(\d{4}-\d{2}-\d{2} commit [a-fA-F0-9]{7,}\)\z/)
     end
   end
 end

--- a/spec/install/allow_offline_install_spec.rb
+++ b/spec/install/allow_offline_install_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe "bundle install with :allow_offline_install" do
         gem "rack-obama"
       G
 
-      bundle! :update, :artifice => "fail"
-      expect(out).to include("Using the cached data for the new index because of a network error")
+      bundle! :update, :artifice => "fail", :all => true
+      expect(last_command.stdboth).to include "Using the cached data for the new index because of a network error"
 
       expect(the_bundle).to include_gems("rack-obama 1.0", "rack 1.0.0")
     end
@@ -75,7 +75,7 @@ RSpec.describe "bundle install with :allow_offline_install" do
         gem "a", :git => #{git.path.to_s.dump}
       G
 
-      break_git_remote_ops! { bundle! :update }
+      break_git_remote_ops! { bundle! :update, :all => true }
       expect(out).to include("Using cached git data because of network errors")
       expect(the_bundle).to be_locked
 

--- a/spec/install/bundler_spec.rb
+++ b/spec/install/bundler_spec.rb
@@ -37,8 +37,6 @@ RSpec.describe "bundle install" do
       G
 
       nice_error = <<-E.strip.gsub(/^ {8}/, "")
-        Fetching source index from file:#{gem_repo2}/
-        Resolving dependencies...
         Bundler could not find compatible versions for gem "bundler":
           In Gemfile:
             bundler (= 0.9.2)
@@ -50,7 +48,7 @@ RSpec.describe "bundle install" do
 
         Could not find gem 'bundler (= 0.9.2)' in any of the sources
         E
-      expect(out).to eq(nice_error)
+      expect(last_command.bundler_err).to include(nice_error)
     end
 
     it "works for gems with multiple versions in its dependencies" do
@@ -98,8 +96,6 @@ RSpec.describe "bundle install" do
       G
 
       nice_error = <<-E.strip.gsub(/^ {8}/, "")
-        Fetching source index from file:#{gem_repo2}/
-        Resolving dependencies...
         Bundler could not find compatible versions for gem "activesupport":
           In Gemfile:
             activemerchant was resolved to 1.0, which depends on
@@ -108,7 +104,7 @@ RSpec.describe "bundle install" do
             rails_fail was resolved to 1.0, which depends on
               activesupport (= 1.2.3)
       E
-      expect(out).to include(nice_error)
+      expect(last_command.bundler_err).to include(nice_error)
     end
 
     it "causes a conflict if a child dependency conflicts with the Gemfile" do
@@ -119,8 +115,6 @@ RSpec.describe "bundle install" do
       G
 
       nice_error = <<-E.strip.gsub(/^ {8}/, "")
-        Fetching source index from file:#{gem_repo2}/
-        Resolving dependencies...
         Bundler could not find compatible versions for gem "activesupport":
           In Gemfile:
             activesupport (= 2.3.5)
@@ -128,7 +122,7 @@ RSpec.describe "bundle install" do
             rails_fail was resolved to 1.0, which depends on
               activesupport (= 1.2.3)
       E
-      expect(out).to include(nice_error)
+      expect(last_command.bundler_err).to include(nice_error)
     end
 
     it "can install dependencies with newer bundler version" do

--- a/spec/install/failure_spec.rb
+++ b/spec/install/failure_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "bundle install" do
         source "file:#{gem_repo2}"
         gem "rails"
       G
-      expect(out).to end_with(<<-M.strip)
+      expect(last_command.bundler_err).to end_with(<<-M.strip)
 An error occurred while installing activesupport (2.3.2), and Bundler cannot continue.
 Make sure that `gem install activesupport -v '2.3.2'` succeeds before bundling.
 

--- a/spec/install/gemfile/gemspec_spec.rb
+++ b/spec/install/gemfile/gemspec_spec.rb
@@ -57,11 +57,11 @@ RSpec.describe "bundle install from an existing gemspec" do
   it "should raise if there are no gemspecs available" do
     build_lib("foo", :path => tmp.join("foo"), :gemspec => false)
 
-    error = install_gemfile(<<-G)
+    install_gemfile(<<-G)
       source "file://#{gem_repo2}"
       gemspec :path => '#{tmp.join("foo")}'
     G
-    expect(error).to match(/There are no gemspecs at #{tmp.join('foo')}/)
+    expect(last_command.bundler_err).to match(/There are no gemspecs at #{tmp.join('foo')}/)
   end
 
   it "should raise if there are too many gemspecs available" do
@@ -69,11 +69,11 @@ RSpec.describe "bundle install from an existing gemspec" do
       s.write("foo2.gemspec", build_spec("foo", "4.0").first.to_ruby)
     end
 
-    error = install_gemfile(<<-G)
+    install_gemfile(<<-G)
       source "file://#{gem_repo2}"
       gemspec :path => '#{tmp.join("foo")}'
     G
-    expect(error).to match(/There are multiple gemspecs at #{tmp.join('foo')}/)
+    expect(last_command.bundler_err).to match(/There are multiple gemspecs at #{tmp.join('foo')}/)
   end
 
   it "should pick a specific gemspec" do
@@ -188,7 +188,7 @@ RSpec.describe "bundle install from an existing gemspec" do
     install_gemfile <<-G
       gemspec :path => '#{tmp.join("foo")}'
     G
-    expect(@err).not_to match(/ahh/)
+    expect(last_command.stdboth).not_to include("ahh")
   end
 
   it "allows the gemspec to activate other gems" do

--- a/spec/install/gemfile/groups_spec.rb
+++ b/spec/install/gemfile/groups_spec.rb
@@ -363,8 +363,8 @@ RSpec.describe "bundle install with groups" do
 
     it "does not hit the remote a second time" do
       FileUtils.rm_rf gem_repo2
-      bundle! "install --without rack"
-      expect(out).not_to include "Fetching"
+      bundle! "install --without rack", :verbose => true
+      expect(last_command.stdboth).not_to match(/fetching/i)
     end
   end
 end

--- a/spec/install/gems/compact_index_spec.rb
+++ b/spec/install/gems/compact_index_spec.rb
@@ -248,7 +248,7 @@ The checksum of /versions does not match the checksum provided by the server! So
         gem "rack"
       G
 
-      bundle "update --full-index", :artifice => "compact_index"
+      bundle! "update --full-index", :artifice => "compact_index", :all => bundle_update_requires_all?
       expect(out).to include("Fetching source index from #{source_uri}")
       expect(the_bundle).to include_gems "rack 1.0.0"
     end

--- a/spec/install/gems/compact_index_spec.rb
+++ b/spec/install/gems/compact_index_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "compact index api" do
     # can't use `include_gems` here since the `require` will conflict on a
     # case-insensitive FS
     run! "Bundler.require; puts Gem.loaded_specs.values_at('rack', 'Rack').map(&:full_name)"
-    expect(out).to eq("rack-1.0\nRack-0.1")
+    expect(last_command.stdout).to eq("rack-1.0\nRack-0.1")
   end
 
   it "should handle multiple gem dependencies on the same gem" do

--- a/spec/install/gems/dependency_api_spec.rb
+++ b/spec/install/gems/dependency_api_spec.rb
@@ -238,7 +238,7 @@ RSpec.describe "gemcutter's dependency API" do
         gem "rack"
       G
 
-      bundle "update --full-index", :artifice => "endpoint"
+      bundle! "update --full-index", :artifice => "endpoint", :all => bundle_update_requires_all?
       expect(out).to include("Fetching source index from #{source_uri}")
       expect(the_bundle).to include_gems "rack 1.0.0"
     end

--- a/spec/install/gems/flex_spec.rb
+++ b/spec/install/gems/flex_spec.rb
@@ -193,8 +193,6 @@ RSpec.describe "bundle flex_install" do
 
     it "suggests bundle update when the Gemfile requires different versions than the lock" do
       nice_error = <<-E.strip.gsub(/^ {8}/, "")
-        Fetching source index from file:#{gem_repo2}/
-        Resolving dependencies...
         Bundler could not find compatible versions for gem "rack":
           In snapshot (Gemfile.lock):
             rack (= 0.9.1)
@@ -211,7 +209,7 @@ RSpec.describe "bundle flex_install" do
       E
 
       bundle :install, :retry => 0
-      expect(out).to eq(nice_error)
+      expect(last_command.bundler_err).to end_with(nice_error)
     end
   end
 

--- a/spec/install/gems/resolving_spec.rb
+++ b/spec/install/gems/resolving_spec.rb
@@ -140,9 +140,6 @@ RSpec.describe "bundle install with install-time dependencies" do
           expect(out).to_not include("Gem::InstallError: require_ruby requires Ruby version > 9000")
 
           nice_error = strip_whitespace(<<-E).strip
-            Fetching gem metadata from http://localgemserver.test/.
-            Fetching version metadata from http://localgemserver.test/
-            Resolving dependencies...
             Bundler could not find compatible versions for gem "ruby\0":
               In Gemfile:
                 ruby\0 (#{error_message_requirement})
@@ -152,7 +149,7 @@ RSpec.describe "bundle install with install-time dependencies" do
 
             Could not find gem 'ruby\0 (> 9000)', which is required by gem 'require_ruby', in any of the sources.
           E
-          expect(out).to eq(nice_error)
+          expect(last_command.bundler_err).to end_with(nice_error)
         end
       end
 

--- a/spec/install/gems/standalone_spec.rb
+++ b/spec/install/gems/standalone_spec.rb
@@ -171,8 +171,8 @@ RSpec.shared_examples "bundle install --standalone" do
         RUBY
       end
 
-      expect(out).to eq("2.3.2")
-      expect(err).to eq("ZOMG LOAD ERROR")
+      expect(last_command.stdout).to eq("2.3.2")
+      expect(last_command.stderr).to eq("ZOMG LOAD ERROR")
     end
 
     it "allows --without to limit the groups used in a standalone" do
@@ -189,8 +189,8 @@ RSpec.shared_examples "bundle install --standalone" do
         RUBY
       end
 
-      expect(out).to eq("2.3.2")
-      expect(err).to eq("ZOMG LOAD ERROR")
+      expect(last_command.stdout).to eq("2.3.2")
+      expect(last_command.stderr).to eq("ZOMG LOAD ERROR")
     end
 
     it "allows --path to change the location of the standalone bundle" do
@@ -206,7 +206,7 @@ RSpec.shared_examples "bundle install --standalone" do
         RUBY
       end
 
-      expect(out).to eq("2.3.2")
+      expect(last_command.stdout).to eq("2.3.2")
     end
 
     it "allows remembered --without to limit the groups used in a standalone" do
@@ -224,8 +224,8 @@ RSpec.shared_examples "bundle install --standalone" do
         RUBY
       end
 
-      expect(out).to eq("2.3.2")
-      expect(err).to eq("ZOMG LOAD ERROR")
+      expect(last_command.stdout).to eq("2.3.2")
+      expect(last_command.stderr).to eq("ZOMG LOAD ERROR")
     end
   end
 

--- a/spec/install/git_spec.rb
+++ b/spec/install/git_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "bundle install" do
         gem "foo", :git => "#{lib_path("foo")}"
       G
 
-      bundle :install
+      bundle! :install
       expect(out).to include("Using foo 1.0 from #{lib_path("foo")} (at master@#{revision_for(lib_path("foo"))[0..6]})")
       expect(the_bundle).to include_gems "foo 1.0", :source => "git@#{lib_path("foo")}"
     end
@@ -31,7 +31,7 @@ RSpec.describe "bundle install" do
 
       update_git "foo", "4.0", :path => lib_path("foo"), :gemspec => true
 
-      bundle! :update
+      bundle! :update, :all => bundle_update_requires_all?
       expect(out).to include("Using foo 2.0 (was 1.0) from #{lib_path("foo")} (at master~2@#{rev2})")
       expect(the_bundle).to include_gems "foo 2.0", :source => "git@#{lib_path("foo")}"
     end

--- a/spec/install/post_bundle_message_spec.rb
+++ b/spec/install/post_bundle_message_spec.rb
@@ -160,28 +160,28 @@ RSpec.describe "post bundle message" do
 
   describe "for bundle update" do
     it "without any options" do
-      bundle :update
+      bundle! :update, :all => bundle_update_requires_all?
       expect(out).not_to include("Gems in the groups")
       expect(out).to include(bundle_updated_message)
     end
 
     it "with --without one group" do
-      bundle :install, :without => :emo
-      bundle :update
+      bundle! :install, :without => :emo
+      bundle! :update, :all => bundle_update_requires_all?
       expect(out).to include("Gems in the group emo were not installed")
       expect(out).to include(bundle_updated_message)
     end
 
     it "with --without two groups" do
-      bundle "install --without emo test"
-      bundle :update
+      bundle! "install --without emo test"
+      bundle! :update, :all => bundle_update_requires_all?
       expect(out).to include("Gems in the groups emo and test were not installed")
       expect(out).to include(bundle_updated_message)
     end
 
     it "with --without more groups" do
-      bundle "install --without emo obama test"
-      bundle :update
+      bundle! "install --without emo obama test"
+      bundle! :update, :all => bundle_update_requires_all?
       expect(out).to include("Gems in the groups emo, obama and test were not installed")
       expect(out).to include(bundle_updated_message)
     end

--- a/spec/other/cli_dispatch_spec.rb
+++ b/spec/other/cli_dispatch_spec.rb
@@ -3,14 +3,14 @@
 RSpec.describe "bundle command names" do
   it "work when given fully" do
     bundle "install"
-    expect(err).to eq("Could not locate Gemfile")
-    expect(out).not_to include("Ambiguous command")
+    expect(last_command.bundler_err).to eq("Could not locate Gemfile")
+    expect(last_command.stdboth).not_to include("Ambiguous command")
   end
 
   it "work when not ambiguous" do
     bundle "ins"
-    expect(err).to eq("Could not locate Gemfile")
-    expect(out).not_to include("Ambiguous command")
+    expect(last_command.bundler_err).to eq("Could not locate Gemfile")
+    expect(last_command.stdboth).not_to include("Ambiguous command")
   end
 
   it "print a friendly error when ambiguous" do

--- a/spec/other/cli_dispatch_spec.rb
+++ b/spec/other/cli_dispatch_spec.rb
@@ -3,19 +3,18 @@
 RSpec.describe "bundle command names" do
   it "work when given fully" do
     bundle "install"
-    expect(err).to lack_errors
-    expect(out).not_to match(/Ambiguous command/)
+    expect(err).to eq("Could not locate Gemfile")
+    expect(out).not_to include("Ambiguous command")
   end
 
   it "work when not ambiguous" do
     bundle "ins"
-    expect(err).to lack_errors
-    expect(out).not_to match(/Ambiguous command/)
+    expect(err).to eq("Could not locate Gemfile")
+    expect(out).not_to include("Ambiguous command")
   end
 
   it "print a friendly error when ambiguous" do
     bundle "in"
-    expect(err).to lack_errors
-    expect(out).to match(/Ambiguous command/)
+    expect(last_command.bundler_err).to eq("Ambiguous command in matches [info, init, inject, install]")
   end
 end

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-RSpec.describe "major deprecations" do
-  let(:warnings) { out } # change to err in 2.0
+RSpec.describe "major deprecations", :bundler => "< 2" do
+  let(:warnings) { last_command.bundler_err } # change to err in 2.0
   let(:warnings_without_version_messages) { warnings.gsub(/#{Spec::Matchers::MAJOR_DEPRECATION}Bundler will only support ruby(gems)? >= .*/, "") }
 
   context "in a .99 version" do

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "major deprecations", :bundler => "< 2" do
   describe "bundle_ruby" do
     it "prints a deprecation" do
       bundle_ruby
-      out.gsub! "\nruby #{RUBY_VERSION}", ""
+      warnings.gsub! "\nruby #{RUBY_VERSION}", ""
       expect(warnings).to have_major_deprecation "the bundle_ruby executable has been removed in favor of `bundle platform --ruby`"
     end
   end
@@ -255,14 +255,14 @@ The :bitbucket git source is deprecated, and will be removed in Bundler 2.0. Add
 
   context "bundle list" do
     it "prints a deprecation warning" do
-      install_gemfile <<-G
+      install_gemfile! <<-G
         source "file://#{gem_repo1}"
         gem "rack"
       G
 
-      bundle :list
+      bundle! :list
 
-      out.gsub!(/gems included.*?\[DEPRECATED/im, "[DEPRECATED")
+      warnings.gsub!(/gems included.*?\[DEPRECATED/im, "[DEPRECATED")
 
       expect(warnings).to have_major_deprecation("use `bundle show` instead of `bundle list`")
     end

--- a/spec/other/platform_spec.rb
+++ b/spec/other/platform_spec.rb
@@ -492,7 +492,7 @@ G
         build_gem "activesupport", "3.0"
       end
 
-      bundle "update"
+      bundle "update", :all => bundle_update_requires_all?
       expect(the_bundle).to include_gems "rack 1.2", "rack-obama 1.0", "activesupport 3.0"
     end
 
@@ -509,7 +509,7 @@ G
           build_gem "activesupport", "3.0"
         end
 
-        bundle "update"
+        bundle "update", :all => bundle_update_requires_all?
         expect(the_bundle).to include_gems "rack 1.2", "rack-obama 1.0", "activesupport 3.0"
       end
     end
@@ -526,7 +526,7 @@ G
         build_gem "activesupport", "3.0"
       end
 
-      bundle :update
+      bundle :update, :all => bundle_update_requires_all?
       should_be_ruby_version_incorrect
     end
 
@@ -542,7 +542,7 @@ G
         build_gem "activesupport", "3.0"
       end
 
-      bundle :update
+      bundle :update, :all => bundle_update_requires_all?
       should_be_engine_incorrect
     end
 
@@ -559,7 +559,7 @@ G
           build_gem "activesupport", "3.0"
         end
 
-        bundle :update
+        bundle :update, :all => bundle_update_requires_all?
         should_be_engine_version_incorrect
       end
     end
@@ -575,7 +575,7 @@ G
         build_gem "activesupport", "3.0"
       end
 
-      bundle :update
+      bundle :update, :all => bundle_update_requires_all?
       should_be_patchlevel_incorrect
     end
   end

--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe "The library itself" do
         if Bundler.rubygems.provides?(">= 2.4")
           # older rubygems have weird warnings, and we won't actually be using them
           # to build the gem for releases anyways
-          expect(err).to be_empty, "bundler should build as a gem without warnings, but\n#{err}"
+          expect(last_command.stderr).to be_empty, "bundler should build as a gem without warnings, but\n#{err}"
         end
       ensure
         # clean up the .gem generated
@@ -233,8 +233,7 @@ RSpec.describe "The library itself" do
         end
       end
 
-      expect(@err.split("\n")).to be_well_formed
-      expect(@out.split("\n")).to be_well_formed
+      expect(last_command.stdboth.split("\n")).to be_well_formed
     end
   end
 end

--- a/spec/realworld/edgecases_spec.rb
+++ b/spec/realworld/edgecases_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "real world edgecases", :realworld => true, :sometimes => true do
       gem "gxapi_rails", "< 0.1.0" # 0.1.0 was released way after the test was written
       gem 'rack-cache', '1.2.0' # last version that works on Ruby 1.9
     G
-    bundle :lock
+    bundle! :lock
     expect(lockfile).to include("gxapi_rails (0.0.6)")
   end
 
@@ -92,7 +92,7 @@ RSpec.describe "real world edgecases", :realworld => true, :sometimes => true do
       gem "activerecord", "~> 3.0"
       gem "builder", "~> 2.1.2"
     G
-    bundle :lock
+    bundle! :lock
     expect(lockfile).to include(rubygems_version("i18n", "~> 0.6.0"))
     expect(lockfile).to include(rubygems_version("activesupport", "~> 3.0"))
   end
@@ -223,9 +223,6 @@ RSpec.describe "real world edgecases", :realworld => true, :sometimes => true do
       DEPENDENCIES
         paperclip (~> 5.1.0)
         rails (~> 4.2.7.1)
-
-      BUNDLED WITH
-         1.13.1
     L
 
     bundle! "lock --update paperclip"
@@ -250,6 +247,7 @@ RSpec.describe "real world edgecases", :realworld => true, :sometimes => true do
   it "checks out git repos when the lockfile is corrupted" do
     gemfile <<-G
       source "https://rubygems.org"
+      git_source(:github) {|repo| "https://github.com/\#{repo}.git" }
 
       gem 'activerecord',  :github => 'carlhuda/rails-bundler-test', :branch => 'master'
       gem 'activesupport', :github => 'carlhuda/rails-bundler-test', :branch => 'master'
@@ -258,7 +256,7 @@ RSpec.describe "real world edgecases", :realworld => true, :sometimes => true do
 
     lockfile <<-L
       GIT
-        remote: git://github.com/carlhuda/rails-bundler-test.git
+        remote: https://github.com/carlhuda/rails-bundler-test.git
         revision: 369e28a87419565f1940815219ea9200474589d4
         branch: master
         specs:
@@ -285,7 +283,7 @@ RSpec.describe "real world edgecases", :realworld => true, :sometimes => true do
             multi_json (~> 1.0)
 
       GIT
-        remote: git://github.com/carlhuda/rails-bundler-test.git
+        remote: https://github.com/carlhuda/rails-bundler-test.git
         revision: 369e28a87419565f1940815219ea9200474589d4
         branch: master
         specs:
@@ -312,7 +310,7 @@ RSpec.describe "real world edgecases", :realworld => true, :sometimes => true do
             multi_json (~> 1.0)
 
       GIT
-        remote: git://github.com/carlhuda/rails-bundler-test.git
+        remote: https://github.com/carlhuda/rails-bundler-test.git
         revision: 369e28a87419565f1940815219ea9200474589d4
         branch: master
         specs:
@@ -369,9 +367,8 @@ RSpec.describe "real world edgecases", :realworld => true, :sometimes => true do
         activesupport!
     L
 
-    bundle :lock
-    expect(err).to eq("")
-    expect(exitstatus).to eq(0) if exitstatus
+    bundle! :lock
+    expect(last_command.stderr).to lack_errors
   end
 
   it "outputs a helpful error message when gems have invalid gemspecs" do

--- a/spec/realworld/mirror_probe_spec.rb
+++ b/spec/realworld/mirror_probe_spec.rb
@@ -87,12 +87,13 @@ RSpec.describe "fetching dependencies with a not available mirror", :realworld =
 
       bundle :install, :artifice => nil
 
-      expect(out).to eq "Fetching source index from #{mirror}/
-
+      expect(last_command.stdout).to include "Fetching source index from #{mirror}/"
+      expect(last_command.bundler_err).to include <<-EOS.strip
 Retrying fetcher due to error (2/4): Bundler::HTTPError Could not fetch specs from #{mirror}/
 Retrying fetcher due to error (3/4): Bundler::HTTPError Could not fetch specs from #{mirror}/
 Retrying fetcher due to error (4/4): Bundler::HTTPError Could not fetch specs from #{mirror}/
-Could not fetch specs from #{mirror}/"
+Could not fetch specs from #{mirror}/
+      EOS
     end
   end
 

--- a/spec/realworld/parallel_spec.rb
+++ b/spec/realworld/parallel_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "parallel", :realworld => true, :sometimes => true do
       gem 'i18n', '~> 0.6.0' # Because 0.7+ requires Ruby 1.9.3+
     G
 
-    bundle :update, :jobs => 4, :env => { "DEBUG" => "1" }
+    bundle :update, :jobs => 4, :env => { "DEBUG" => "1" }, :all => bundle_update_requires_all?
 
     if Bundler.rubygems.provides?(">= 2.1.0")
       expect(out).to match(/[1-3]: /)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -111,14 +111,14 @@ RSpec.configure do |config|
     reset!
     system_gems []
     in_app_root
-    @all_output = String.new
+    @command_executions = []
   end
 
   config.after :each do |example|
-    @all_output.strip!
-    if example.exception && !@all_output.empty?
-      warn @all_output unless config.formatters.grep(RSpec::Core::Formatters::DocumentationFormatter).empty?
-      message = example.exception.message + "\n\nCommands:\n#{@all_output}"
+    all_output = @command_executions.map(&:to_s_verbose).join("\n\n")
+    if example.exception && !all_output.empty?
+      warn all_output unless config.formatters.grep(RSpec::Core::Formatters::DocumentationFormatter).empty?
+      message = example.exception.message + "\n\nCommands:\n#{all_output}"
       (class << example.exception; self; end).send(:define_method, :message) do
         message
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -93,6 +93,7 @@ RSpec.configure do |config|
   config.filter_run_excluding :rubygems => LessThanProc.with(Gem::VERSION)
   config.filter_run_excluding :git => LessThanProc.with(git_version)
   config.filter_run_excluding :rubygems_master => (ENV["RGV"] != "master")
+  config.filter_run_excluding :bundler => LessThanProc.with(Bundler::VERSION.split(".")[0, 2].join("."))
 
   config.filter_run_when_matching :focus unless ENV["CI"]
 

--- a/spec/support/command_execution.rb
+++ b/spec/support/command_execution.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+require "support/helpers"
+require "support/path"
+
+module Spec
+  CommandExecution = Struct.new(:command, :working_directory, :exitstatus, :stdout, :stderr) do
+    include RSpec::Matchers::Composable
+
+    def to_s
+      "$ #{command.strip}"
+    end
+    alias_method :inspect, :to_s
+
+    def stdboth
+      @stdboth ||= [stderr, stdout].join("\n").strip
+    end
+
+    def bundler_err
+      if Bundler::VERSION.start_with?("1.")
+        stdout
+      else
+        stderr
+      end
+    end
+
+    def to_s_verbose
+      [
+        to_s,
+        stdout,
+        stderr,
+        exitstatus ? "# $? => #{exitstatus}" : "",
+      ].reject(&:empty?).join("\n")
+    end
+
+    def success?
+      return true unless exitstatus
+      exitstatus == 0
+    end
+  end
+end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -42,7 +42,7 @@ module Spec
     end
 
     def err
-      last_command.bundler_err
+      last_command.stderr
     end
 
     def exitstatus

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -20,21 +20,37 @@ module Spec
     def self.bang(method)
       define_method("#{method}!") do |*args, &blk|
         send(method, *args, &blk).tap do
-          if exitstatus && exitstatus != 0
-            error = out + "\n" + err
-            error.strip!
+          unless last_command.success?
             raise RuntimeError,
-              "Invoking #{method}!(#{args.map(&:inspect).join(", ")}) failed:\n#{error}",
+              "Invoking #{method}!(#{args.map(&:inspect).join(", ")}) failed:\n#{last_command.stdboth}",
               caller.drop_while {|bt| bt.start_with?(__FILE__) }
           end
         end
       end
     end
 
-    attr_reader :out, :err, :exitstatus
-
     def the_bundle(*args)
       TheBundle.new(*args)
+    end
+
+    def last_command
+      @command_executions.last || raise("There is no last command")
+    end
+
+    def out
+      last_command.stdboth
+    end
+
+    def err
+      last_command.bundler_err
+    end
+
+    def exitstatus
+      last_command.exitstatus
+    end
+
+    def bundle_update_requires_all?
+      !Bundler::VERSION.start_with?("1.")
     end
 
     def in_app_root(&blk)
@@ -53,7 +69,7 @@ module Spec
       opts = args.last.is_a?(Hash) ? args.pop : {}
       groups = args.map(&:inspect).join(", ")
       setup = "require 'rubygems' ; require 'bundler' ; Bundler.setup(#{groups})\n"
-      @out = ruby(setup + cmd, opts)
+      ruby(setup + cmd, opts)
     end
     bang :run
 
@@ -173,24 +189,20 @@ module Spec
     bang :gem_command
 
     def sys_exec(cmd)
+      command_execution = CommandExecution.new(cmd.to_s, Dir.pwd)
+
       Open3.popen3(cmd.to_s) do |stdin, stdout, stderr, wait_thr|
         yield stdin, stdout, wait_thr if block_given?
         stdin.close
 
-        @exitstatus = wait_thr && wait_thr.value.exitstatus
-        @out = Thread.new { stdout.read }.value.strip
-        @err = Thread.new { stderr.read }.value.strip
+        command_execution.exitstatus = wait_thr && wait_thr.value.exitstatus
+        command_execution.stdout = Thread.new { stdout.read }.value.strip
+        command_execution.stderr = Thread.new { stderr.read }.value.strip
       end
 
-      (@all_output ||= String.new) << [
-        "$ #{cmd.to_s.strip}",
-        out,
-        err,
-        @exitstatus ? "# $? => #{@exitstatus}" : "",
-        "\n",
-      ].reject(&:empty?).join("\n")
+      (@command_executions ||= []) << command_execution
 
-      @out
+      command_execution.stdout
     end
     bang :sys_exec
 

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -140,8 +140,8 @@ module Spec
           rescue => e
             next "#{name} is not installed:\n#{indent(e)}"
           end
-          out.gsub!(/#{MAJOR_DEPRECATION}.*$/, "")
-          actual_version, actual_platform = out.strip.split(/\s+/, 2)
+          last_command.stdout.gsub!(/#{MAJOR_DEPRECATION}.*$/, "")
+          actual_version, actual_platform = last_command.stdout.strip.split(/\s+/, 2)
           unless Gem::Version.new(actual_version) == Gem::Version.new(version)
             next "#{name} was expected to be at version #{version} but was #{actual_version}"
           end
@@ -155,8 +155,8 @@ module Spec
           rescue
             next "#{name} does not have a source defined:\n#{indent(e)}"
           end
-          out.gsub!(/#{MAJOR_DEPRECATION}.*$/, "")
-          unless out.strip == source
+          last_command.stdout.gsub!(/#{MAJOR_DEPRECATION}.*$/, "")
+          unless last_command.stdout.strip == source
             next "Expected #{name} (#{version}) to be installed from `#{source}`, was actually from `#{out}`"
           end
         end.compact
@@ -181,9 +181,9 @@ module Spec
           rescue => e
             next "checking for #{name} failed:\n#{e}"
           end
-          next if out == "WIN"
+          next if last_command.stdout == "WIN"
           next "expected #{name} to not be installed, but it was" if version.nil?
-          if Gem::Version.new(out) == Gem::Version.new(version)
+          if Gem::Version.new(last_command.stdout) == Gem::Version.new(version)
             next "expected #{name} (#{version}) not to be installed, but it was"
           end
         end.compact

--- a/spec/update/gems/post_install_spec.rb
+++ b/spec/update/gems/post_install_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "bundle update" do
         gem 'thin'
       G
 
-      bundle! :update
+      bundle! :update, :all => bundle_update_requires_all?
     end
 
     it_behaves_like "a post-install message outputter"
@@ -67,7 +67,7 @@ RSpec.describe "bundle update" do
         gem 'thin'
       G
 
-      bundle! :update
+      bundle! :update, :all => bundle_update_requires_all?
     end
 
     it_behaves_like "a post-install message outputter"

--- a/spec/update/git_spec.rb
+++ b/spec/update/git_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "bundle update" do
         s.write "lib/foo.rb", "FOO = '1.1'"
       end
 
-      bundle "update"
+      bundle "update", :all => bundle_update_requires_all?
 
       expect(the_bundle).to include_gems "foo 1.1"
     end
@@ -112,7 +112,7 @@ RSpec.describe "bundle update" do
         gem 'foo', :git => "#{@remote.path}", :tag => "fubar"
       G
 
-      bundle "update"
+      bundle "update", :all => bundle_update_requires_all?
       expect(exitstatus).to eq(0) if exitstatus
     end
 
@@ -186,8 +186,9 @@ RSpec.describe "bundle update" do
 
       lib_path("foo-1.0").join(".git").rmtree
 
-      bundle :update
-      expect(out).to include(lib_path("foo-1.0").to_s)
+      bundle :update, :all => bundle_update_requires_all?
+      expect(last_command.bundler_err).to include(lib_path("foo-1.0").to_s).
+        and match(/Git error: command `git fetch.+has failed/)
     end
 
     it "should not explode on invalid revision on update of gem by name" do
@@ -227,7 +228,7 @@ RSpec.describe "bundle update" do
           rails!
       G
 
-      bundle "update"
+      bundle "update", :all => bundle_update_requires_all?
       expect(out).to include("Using rails 3.0 (was 2.3.2) from #{lib_path("rails")} (at master@#{revision_for(lib_path("rails"))[0..6]})")
     end
   end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was we have all these _amazing_ Bundler 2.0 features hidden behind feature flags. But we weren't testing all of bundler in that 2.0 mode.

### Was was your diagnosis of the problem?

My diagnosis was we needed to get the bundler 2 specs running, and passing!

### What is your fix for the problem, implemented in this PR?

My fix is to add a travis build entry to change `version.rb` to a 2.0 version and run the tests!

### Why did you choose this fix out of the possible options?

I chose this fix because it will completely imitate what happens once we change the version on `master`, and by keeping the test suite passing on both 1.0 and 2.0 modes, we'll be in a position to release a 1.16 to which we'll be able to (relatively easily) backport fixes that land after master switches to completely target 2.0.