### PR TITLE
Add explicit nil proxy arguments - Fixes no_proxy support

### DIFF
--- a/lib/bundler/vendor/net-http-persistent/lib/net/http/persistent.rb
+++ b/lib/bundler/vendor/net-http-persistent/lib/net/http/persistent.rb
@@ -616,6 +616,8 @@ class Bundler::Persistent::Net::HTTP::Persistent
     if @proxy_uri and not proxy_bypass? uri.host, uri.port then
       connection_id << @proxy_connection_id
       net_http_args.concat @proxy_args
+    else
+      net_http_args.concat [nil, nil, nil, nil]
     end
 
     connection = connections[connection_id]

--- a/spec/bundler/fetcher_spec.rb
+++ b/spec/bundler/fetcher_spec.rb
@@ -69,6 +69,21 @@ RSpec.describe Bundler::Fetcher do
         expect(fetcher.send(:connection).override_headers["X-Gemfile-Source"]).to be_nil
       end
     end
+
+    context "when there are proxy environment variable(s) set" do
+      it "consider http_proxy" do
+        with_env_vars("HTTP_PROXY" => "http://proxy-example3.com") do
+          expect(fetcher.http_proxy).to match("http://proxy-example3.com")
+        end
+      end
+      it "consider no_proxy" do
+        with_env_vars("HTTP_PROXY" => "http://proxy-example4.com", "NO_PROXY" => ".example.com,.example.net") do
+          expect(
+            fetcher.send(:connection).no_proxy
+          ).to eq([".example.com", ".example.net"])
+        end
+      end
+    end
   end
 
   describe "#user_agent" do


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

When the `no_proxy` environment variable is configured it is not being honored and requests for hosts that are present in the list will be sent through the proxy defined via `http_proxy` and `https_proxy`.

Ultimately this means that a user utilizing the `http_proxy`, `https_proxy`, and `no_proxy` environment variables will unable to access an internal RubyGems source.

### Was was your diagnosis of the problem?

The underlying `net-http-persistent` gem currently does not explicitly pass in nil arguments when a host matches a value within `no_proxy`, so when `Net::HTTP.new()` is called, it will fall back an utilize the values defined in `http_proxy` and `https_proxy`.

https://github.com/drbrain/net-http-persistent/pull/88 has been submitted to add the explicit nil argument to be defined.

### What is your fix for the problem, implemented in this PR?

Adding explicit nil arguments for the proxy definition for `Net::HTTP.new()` as defined by the documentation.

https://ruby-doc.org/stdlib-2.4.1/libdoc/net/http/rdoc/Net/HTTP.html#method-c-new

### Why did you choose this fix out of the possible options?

Per the discussion in https://github.com/bundler/bundler/issues/5781, as Bundler is currently stuck to v2.9.4 of `net-http-persistent` for now, it would be best addressed by a change to the vendored code.

A PR has been submitted to `net-http-persistent` which can be pulled into Bundler when v3.x will be integrated.
