### PR TITLE
Remove `require "spec_helper"` from spec files

### DIFF
--- a/spec/bundler/stub_specification_spec.rb
+++ b/spec/bundler/stub_specification_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe Bundler::StubSpecification do
   let(:gemspec) do

--- a/spec/bundler/ui/shell_spec.rb
+++ b/spec/bundler/ui/shell_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 RSpec.describe Bundler::UI::Shell do
   subject { described_class.new }

--- a/spec/install/gemfile/install_if.rb
+++ b/spec/install/gemfile/install_if.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "spec_helper"
 
 describe "bundle install with install_if conditionals" do
   it "follows the install_if DSL" do


### PR DESCRIPTION
Follow up of #5634.

Since `--require spec_helper` is specified in the .rspec file, This PR will remove redundancy.