### PR TITLE
Avoid hitting RubyGems remotes when all missing gems are in --without groups

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -593,6 +593,9 @@ module Bundler
 
       # order here matters, since Index#== is checking source.specs.include?(locked_index)
       locked_index != source.specs
+    rescue PathError, GitError => e
+      Bundler.ui.debug "Assuming that #{source} has not changed since fetching its specs errored (#{e})"
+      false
     end
 
     # Get all locals and override their matching sources.
@@ -770,7 +773,19 @@ module Bundler
 
         # Path sources have special logic
         if s.source.instance_of?(Source::Path) || s.source.instance_of?(Source::Gemspec)
-          other = s.source.specs[s].first
+          other_sources_specs = begin
+            s.source.specs
+          rescue PathError, GitError
+            # if we won't need the source (according to the lockfile),
+            # don't error if the path/git source isn't available
+            next if @locked_specs.
+                    for(requested_dependencies, [], false, true, false).
+                    none? {|locked_spec| locked_spec.source == s.source }
+
+            raise
+          end
+
+          other = other_sources_specs[s].first
 
           # If the spec is no longer in the path source, unlock it. This
           # commonly happens if the version changed in the gemspec

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -167,8 +167,7 @@ module Bundler
                              "to a different version of #{locked_gem} that hasn't been removed in order to install."
         end
         unless specs["bundler"].any?
-          local = Bundler.settings[:frozen] ? rubygems_index : index
-          bundler = local.search(Gem::Dependency.new("bundler", VERSION)).last
+          bundler = rubygems_index.search(Gem::Dependency.new("bundler", VERSION)).last
           specs["bundler"] = bundler if bundler
         end
 
@@ -194,9 +193,9 @@ module Bundler
       missing
     end
 
-    def missing_dependencies?
+    def missing_specs?
       missing = []
-      resolve.materialize(current_dependencies, missing)
+      resolve.materialize(requested_dependencies, missing)
       return false if missing.empty?
       Bundler.ui.debug "The definition is missing #{missing.map(&:full_name)}"
       true

--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -231,7 +231,7 @@ module Bundler
 
     def resolve_if_needed(options)
       if !options["update"] && !options[:inline] && !options["force"] && Bundler.default_lockfile.file?
-        return if @definition.nothing_changed? && !@definition.missing_dependencies?
+        return if @definition.nothing_changed? && !@definition.missing_specs?
       end
 
       options["local"] ? @definition.resolve_with_cache! : @definition.resolve_remotely!

--- a/lib/bundler/spec_set.rb
+++ b/lib/bundler/spec_set.rb
@@ -76,7 +76,7 @@ module Bundler
     end
 
     def materialize(deps, missing_specs = nil)
-      materialized = self.for(deps, [], false, true, missing_specs).to_a
+      materialized = self.for(deps, [], false, true, !missing_specs).to_a
       deps = materialized.map(&:name).uniq
       materialized.map! do |s|
         next s unless s.is_a?(LazySpecification)

--- a/spec/install/deploy_spec.rb
+++ b/spec/install/deploy_spec.rb
@@ -135,6 +135,35 @@ RSpec.describe "install with --deployment or --frozen" do
       expect(out).not_to include("You have changed in the Gemfile")
     end
 
+    it "works if a path gem is missing but is in a without group" do
+      build_lib "path_gem"
+      install_gemfile! <<-G
+        source "file://#{gem_repo1}"
+        gem "rake"
+        gem "path_gem", :path => "#{lib_path("path_gem-1.0")}", :group => :development
+      G
+      expect(the_bundle).to include_gems "path_gem 1.0"
+      FileUtils.rm_r lib_path("path_gem-1.0")
+
+      bundle! :install, :path => ".bundle", :without => "development", :deployment => true, :env => { :DEBUG => "1" }
+      run! "puts :WIN"
+      expect(out).to eq("WIN")
+    end
+
+    it "explodes if a path gem is missing" do
+      build_lib "path_gem"
+      install_gemfile! <<-G
+        source "file://#{gem_repo1}"
+        gem "rake"
+        gem "path_gem", :path => "#{lib_path("path_gem-1.0")}", :group => :development
+      G
+      expect(the_bundle).to include_gems "path_gem 1.0"
+      FileUtils.rm_r lib_path("path_gem-1.0")
+
+      bundle :install, :path => ".bundle", :deployment => true
+      expect(out).to include("The path `#{lib_path("path_gem-1.0")}` does not exist.")
+    end
+
     it "can have --frozen set via an environment variable" do
       gemfile <<-G
         source "file://#{gem_repo1}"

--- a/spec/install/gemfile/groups_spec.rb
+++ b/spec/install/gemfile/groups_spec.rb
@@ -363,8 +363,8 @@ RSpec.describe "bundle install with groups" do
 
     it "does not hit the remote a second time" do
       FileUtils.rm_rf gem_repo2
-      bundle "install --without rack"
-      expect(err).to lack_errors
+      bundle! "install --without rack"
+      expect(out).not_to include "Fetching"
     end
   end
 end

--- a/spec/install/git_spec.rb
+++ b/spec/install/git_spec.rb
@@ -36,8 +36,8 @@ RSpec.describe "bundle install" do
       expect(the_bundle).to include_gems "foo 2.0", :source => "git@#{lib_path("foo")}"
     end
 
-    it "should check out git repos that are missing but not being installed" do
-      build_git "foo"
+    it "should allows git repos that are missing but not being installed" do
+      revision = build_git("foo").ref_for("HEAD")
 
       gemfile <<-G
         gem "foo", :git => "file://#{lib_path("foo-1.0")}", :group => :development
@@ -46,6 +46,7 @@ RSpec.describe "bundle install" do
       lockfile <<-L
         GIT
           remote: file://#{lib_path("foo-1.0")}
+          revision: #{revision}
           specs:
             foo (1.0)
 
@@ -56,10 +57,9 @@ RSpec.describe "bundle install" do
           foo!
       L
 
-      bundle "install --path=vendor/bundle --without development"
+      bundle! "install --path=vendor/bundle --without development"
 
       expect(out).to include("Bundle complete!")
-      expect(vendored_gems("bundler/gems/foo-1.0-#{revision_for(lib_path("foo-1.0"))[0..11]}")).to be_directory
     end
   end
 end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was we would attempt to fetch dependency info from a RubyGems remote even when it was only needed for gems whose groups were excluded.

### Was was your diagnosis of the problem?

My diagnosis was that the test we had for this case was insufficient, since it checked only that `stderr` was empty, and since Bundler 1 prints errors to `stdout`... it went undetected for a year.

### What is your fix for the problem, implemented in this PR?

My fix is to only report that deps are missing when they are either requested or are path/git/gemspec-sourced.

### Why did you choose this fix out of the possible options?

I chose this fix because it keeps the behavior of always ensuring all git repos are checked out.