### PR TITLE
No longer automatically subtract 1 from user-specified `--jobs`

### DIFF
--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -165,7 +165,7 @@ module Bundler
       load_plugins
       force = options["force"]
       jobs = 1
-      jobs = [Bundler.settings[:jobs].to_i - 1, 1].max if can_install_in_parallel?
+      jobs = [Bundler.settings[:jobs].to_i, 1].max if can_install_in_parallel?
       install_in_parallel jobs, options[:standalone], force
     end
 

--- a/lib/bundler/installer/parallel_installer.rb
+++ b/lib/bundler/installer/parallel_installer.rb
@@ -79,7 +79,7 @@ module Bundler
 
     # Returns max number of threads machine can handle with a min of 1
     def self.max_threads
-      [Bundler.settings[:jobs].to_i - 1, 1].max
+      [Bundler.settings[:jobs].to_i, 1].max
     end
 
     attr_reader :size

--- a/spec/realworld/parallel_spec.rb
+++ b/spec/realworld/parallel_spec.rb
@@ -9,10 +9,11 @@ RSpec.describe "parallel", :realworld => true, :sometimes => true do
       gem 'i18n', '~> 0.6.0' # Because 0.7+ requires Ruby 1.9.3+
     G
 
-    bundle :install, :jobs => 4, :env => { "DEBUG" => "1" }
+    bundle :install, :jobs => 2, :env => { "DEBUG" => "1" }
 
     if Bundler.rubygems.provides?(">= 2.1.0")
-      expect(out).to match(/[1-3]: /)
+      expect(out).to match(/^0: /)
+      expect(out).to match(/^1: /)
     else
       expect(out).to include("is not threadsafe")
     end
@@ -24,7 +25,7 @@ RSpec.describe "parallel", :realworld => true, :sometimes => true do
     expect(out).to match(/faker/)
 
     bundle "config jobs"
-    expect(out).to match(/: "4"/)
+    expect(out).to match(/: "2"/)
   end
 
   it "updates" do
@@ -41,10 +42,11 @@ RSpec.describe "parallel", :realworld => true, :sometimes => true do
       gem 'i18n', '~> 0.6.0' # Because 0.7+ requires Ruby 1.9.3+
     G
 
-    bundle :update, :jobs => 4, :env => { "DEBUG" => "1" }
+    bundle :update, :jobs => 2, :env => { "DEBUG" => "1" }
 
     if Bundler.rubygems.provides?(">= 2.1.0")
-      expect(out).to match(/[1-3]: /)
+      expect(out).to match(/^0: /)
+      expect(out).to match(/^1: /)
     else
       expect(out).to include("is not threadsafe")
     end
@@ -56,7 +58,7 @@ RSpec.describe "parallel", :realworld => true, :sometimes => true do
     expect(out).to match(/faker/)
 
     bundle "config jobs"
-    expect(out).to match(/: "4"/)
+    expect(out).to match(/: "2"/)
   end
 
   it "works with --standalone" do


### PR DESCRIPTION
This argument comes in two parts, but luckily, the first one is both easier to understand and hopefully to agree with.

Background: Bundler 1.4.0 added support for parallel installation via the `--jobs` param.  Soon after, [this blog post](http://archlever.blogspot.com/2013/09/lies-damned-lies-and-truths-backed-by.html) (probably greatly amplified by [this Thoughtbot blog post](https://robots.thoughtbot.com/parallel-gem-installing-using-bundler)) popularized the recommendation "set `--jobs` to `nproc - 1`".

Not long after, probably also inspired by the popularity of this tip, this "n - 1 jobs" advice got codified into Bundler itself: https://github.com/bundler/bundler/commit/66acd02de593a6c7ee271bcbce3917eb3a01825a

However, my assertion here is _Bundler should not do that_.

The first argument (the easy one) is just that it's not doing what the user asks for.  For all the people following the (seemingly popular) tip to set their jobs to `nproc - 1`, they're actually ending up with the probably-worse `- 2`.  Even worse than that, if a user does a conservative `--jobs 2`, they're getting _no benefit_ — Bundler is quietly taking their parallelization back down to "no parallelization".

Hopefully that's a sufficient argument on its own, but the part II is that this blanket advice is probably out-of-date anyway.

Using [this script](https://gist.github.com/tjschuck/ca1d37a8869d1cc01313171b4b318094), I repeatedly installed 29 gems (installing them to a `vendor/` dir and deleting it in between runs).  I averaged the time over 10 runs per --jobs value, but the trend holds regardless of how many runs you do.

Note that these numbers are for a machine with 2 physical cores and 4 virtual ones (a Mac, reporting 2 and 4 respectively from `sysctl -n hw.physicalcpu` and `sysctl -n hw.ncpu`, the latter corresponding to Linux's `nproc`).

```
~/Code/tmp/bundler_jobs_bench ☠  ./bundler_jobs_bench.sh

Installing 29 gems repeatedly...

===============================================
Using Bundler version 1.15.1 (current release version)
===============================================

--jobs 1  5.58435780 seconds on average (across 10 runs)
--jobs 2  5.35010690 seconds on average (across 10 runs)
--jobs 3  3.93493610 seconds on average (across 10 runs)
--jobs 4  3.86082760 seconds on average (across 10 runs)
--jobs 5  3.24673650 seconds on average (across 10 runs)
--jobs 6  3.49340190 seconds on average (across 10 runs)
--jobs 7  3.26473430 seconds on average (across 10 runs)
--jobs 8  3.34560500 seconds on average (across 10 runs)

===============================================
Using development version (no more n - 1 jobs)
===============================================

--jobs 1  4.32629540 seconds on average (across 10 runs)
--jobs 2  3.48100690 seconds on average (across 10 runs)
--jobs 3  3.30937880 seconds on average (across 10 runs)
--jobs 4  3.30868200 seconds on average (across 10 runs)
--jobs 5  3.54932920 seconds on average (across 10 runs)
--jobs 6  3.36123440 seconds on average (across 10 runs)
--jobs 7  3.96490630 seconds on average (across 10 runs)
--jobs 8  3.39955640 seconds on average (across 10 runs)
```

From the above, you can see:

1. In the first block, no notable change between `--jobs 1` and `--jobs 2` — that's because they're currently the same.

2. In both, a best time corresponding to the value that (effectively) matches nproc, _not_ nproc - 1.

3. Regardless of nproc coming out best in this run, there is close enough performance among the range of `nproc - 1` through to `nproc * 2` that it doesn't seem like anything in particular (like the `- 1` removed in this commit) should be codified — people seeking to particularly optimize their bundler runtimes should do their own tweaking of the value, and it should be respected as given.