### PR TITLE
[Settings] Print pretty values for settings as their converted values, rather than strings

### DIFF
--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -67,15 +67,7 @@ module Bundler
                 nil
               end end end end end
 
-      if value.nil?
-        nil
-      elsif is_bool(name) || value == "false"
-        to_bool(value)
-      elsif is_num(name)
-        value.to_i
-      else
-        value
-      end
+      converted_value(value, name)
     end
 
     def []=(key, value)
@@ -167,15 +159,15 @@ module Bundler
 
       locations = []
       if @local_config.key?(key)
-        locations << "Set for your local app (#{local_config_file}): #{@local_config[key].inspect}"
+        locations << "Set for your local app (#{local_config_file}): #{converted_value(@local_config[key], exposed_key).inspect}"
       end
 
       if value = ENV[key]
-        locations << "Set via #{key}: #{value.inspect}"
+        locations << "Set via #{key}: #{converted_value(value, exposed_key).inspect}"
       end
 
       if @global_config.key?(key)
-        locations << "Set for the current user (#{global_config_file}): #{@global_config[key].inspect}"
+        locations << "Set for the current user (#{global_config_file}): #{converted_value(@global_config[key], exposed_key).inspect}"
       end
 
       return ["You have not configured a value for `#{exposed_key}`"] if locations.empty?
@@ -282,6 +274,18 @@ module Bundler
       end
 
       value
+    end
+
+    def converted_value(value, key)
+      if value.nil?
+        nil
+      elsif is_bool(key) || value == "false"
+        to_bool(value)
+      elsif is_num(key)
+        value.to_i
+      else
+        value
+      end
     end
 
     def global_config_file

--- a/spec/bundler/settings_spec.rb
+++ b/spec/bundler/settings_spec.rb
@@ -150,6 +150,16 @@ that would suck --ehhh=oh geez it looks like i might have broken bundler somehow
     end
   end
 
+  describe "#pretty_values_for" do
+    it "prints the converted value rather than the raw string" do
+      bool_key = described_class::BOOL_KEYS.first
+      settings[bool_key] = false
+      expect(subject.pretty_values_for(bool_key)).to eq [
+        "Set for your local app (#{bundled_app("config")}): false",
+      ]
+    end
+  end
+
   describe "#mirror_for" do
     let(:uri) { URI("https://rubygems.org/") }
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was `bundle config` would print bool keys as strings (i.e. `true` was printed as `"true"`)

### Was was your diagnosis of the problem?

My diagnosis was we needed to convert the values before formatting them

### What is your fix for the problem, implemented in this PR?

My fix extracts the conversion method, and calls it in `pretty_values_for`
