### PR TITLE
[2.0] Stop remembering CLI options in Bundler 2

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -231,7 +231,7 @@ module Bundler
 
     def app_cache(custom_path = nil)
       path = custom_path || root
-      path.join(settings.app_cache_path)
+      Pathname.new(path).join(settings.app_cache_path)
     end
 
     def tmp(name = Process.pid.to_s)

--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -60,8 +60,6 @@ module Bundler
   autoload :VersionRanges,          "bundler/version_ranges"
 
   class << self
-    attr_writer :bundle_path
-
     def configure
       @configured ||= configure_gem_home_and_path
     end

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -52,7 +52,7 @@ module Bundler
       end
     end
 
-    def self.forgotten_option(*args, &blk)
+    def self.deprecated_option(*args, &blk)
       return if Bundler.feature_flag.forget_cli_options?
       method_option(*args, &blk)
     end
@@ -152,13 +152,13 @@ module Bundler
 
       If the bundle has already been installed, bundler will tell you so and then exit.
     D
-    forgotten_option "binstubs", :type => :string, :lazy_default => "bin", :banner =>
+    deprecated_option "binstubs", :type => :string, :lazy_default => "bin", :banner =>
       "Generate bin stubs for bundled gems to ./bin"
     method_option "clean", :type => :boolean, :banner =>
       "Run bundle clean automatically after install"
-    forgotten_option "deployment", :type => :boolean, :banner =>
+    deprecated_option "deployment", :type => :boolean, :banner =>
       "Install using defaults tuned for deployment environments"
-    forgotten_option "frozen", :type => :boolean, :banner =>
+    deprecated_option "frozen", :type => :boolean, :banner =>
       "Do not allow the Gemfile.lock to be updated after this install"
     method_option "full-index", :type => :boolean, :banner =>
       "Fall back to using the single-file index of all gems"
@@ -168,28 +168,28 @@ module Bundler
       "Specify the number of jobs to run in parallel"
     method_option "local", :type => :boolean, :banner =>
       "Do not attempt to fetch gems remotely and use the gem cache instead"
-    forgotten_option "no-cache", :type => :boolean, :banner =>
+    deprecated_option "no-cache", :type => :boolean, :banner =>
       "Don't update the existing gem cache."
     method_option "force", :type => :boolean, :banner =>
       "Force downloading every gem."
     method_option "no-prune", :type => :boolean, :banner =>
       "Don't remove stale gems from the cache."
-    forgotten_option "path", :type => :string, :banner =>
+    deprecated_option "path", :type => :string, :banner =>
       "Specify a different path than the system default ($BUNDLE_PATH or $GEM_HOME). Bundler will remember this value for future installs on this machine"
     method_option "quiet", :type => :boolean, :banner =>
       "Only output warnings and errors."
-    forgotten_option "shebang", :type => :string, :banner =>
+    deprecated_option "shebang", :type => :string, :banner =>
       "Specify a different shebang executable name than the default (usually 'ruby')"
     method_option "standalone", :type => :array, :lazy_default => [], :banner =>
       "Make a bundle that can work without the Bundler runtime"
-    forgotten_option "system", :type => :boolean, :banner =>
+    deprecated_option "system", :type => :boolean, :banner =>
       "Install to the system location ($BUNDLE_PATH or $GEM_HOME) even if the bundle was previously installed somewhere else for this application"
     method_option "trust-policy", :alias => "P", :type => :string, :banner =>
       "Gem trust policy (like gem install -P). Must be one of " +
         Bundler.rubygems.security_policy_keys.join("|")
-    forgotten_option "without", :type => :array, :banner =>
+    deprecated_option "without", :type => :array, :banner =>
       "Exclude gems that are part of the specified named group."
-    forgotten_option "with", :type => :array, :banner =>
+    deprecated_option "with", :type => :array, :banner =>
       "Include gems that are part of the specified named group."
     map "i" => "install"
     def install

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -154,7 +154,7 @@ module Bundler
     D
     deprecated_option "binstubs", :type => :string, :lazy_default => "bin", :banner =>
       "Generate bin stubs for bundled gems to ./bin"
-    method_option "clean", :type => :boolean, :banner =>
+    deprecated_option "clean", :type => :boolean, :banner =>
       "Run bundle clean automatically after install"
     deprecated_option "deployment", :type => :boolean, :banner =>
       "Install using defaults tuned for deployment environments"

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -30,7 +30,7 @@ module Bundler
         Bundler.reset_paths!
       end
 
-      Bundler.settings[:retry] = options[:retry] if options[:retry]
+      Bundler.settings.set_command_option_if_given :retry, options[:retry]
 
       current_cmd = args.last[:current_command].name
       auto_install if AUTO_INSTALL_CMDS.include?(current_cmd)
@@ -38,7 +38,6 @@ module Bundler
       raise InvalidOption, e.message
     ensure
       self.options ||= {}
-      Bundler.settings.cli_flags_given = !options.empty?
       unprinted_warnings = Bundler.ui.unprinted_warnings
       Bundler.ui = UI::Shell.new(options)
       Bundler.ui.level = "debug" if options["verbose"]

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -117,7 +117,7 @@ module Bundler
       Gemfile to a gem with a gemspec, the --gemspec option will automatically add each
       dependency listed in the gemspec file to the newly created Gemfile.
     D
-    method_option "gemspec", :type => :string, :banner => "Use the specified .gemspec to create the Gemfile"
+    deprecated_option "gemspec", :type => :string, :banner => "Use the specified .gemspec to create the Gemfile"
     def init
       require "bundler/cli/init"
       Init.new(options.dup).run

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -173,7 +173,7 @@ module Bundler
     method_option "redownload", :type => :boolean, :aliases =>
       [Bundler.feature_flag.forget_cli_options? ? nil : "--force"].compact, :banner =>
       "Force downloading every gem."
-    method_option "no-prune", :type => :boolean, :banner =>
+    deprecated_option "no-prune", :type => :boolean, :banner =>
       "Don't remove stale gems from the cache."
     deprecated_option "path", :type => :string, :banner =>
       "Specify a different path than the system default ($BUNDLE_PATH or $GEM_HOME). Bundler will remember this value for future installs on this machine"

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -52,6 +52,11 @@ module Bundler
       end
     end
 
+    def self.forgotten_option(*args, &blk)
+      return if Bundler.feature_flag.forget_cli_options?
+      method_option(*args, &blk)
+    end
+
     check_unknown_options!(:except => [:config, :exec])
     stop_on_unknown_option! :exec
 
@@ -129,7 +134,7 @@ module Bundler
     method_option "gemfile", :type => :string, :banner =>
       "Use the specified gemfile instead of Gemfile"
     method_option "path", :type => :string, :banner =>
-      "Specify a different path than the system default ($BUNDLE_PATH or $GEM_HOME). Bundler will remember this value for future installs on this machine"
+      "Specify a different path than the system default ($BUNDLE_PATH or $GEM_HOME).#{" Bundler will remember this value for future installs on this machine" unless Bundler.feature_flag.forget_cli_options?}"
     map "c" => "check"
     def check
       require "bundler/cli/check"
@@ -147,13 +152,13 @@ module Bundler
 
       If the bundle has already been installed, bundler will tell you so and then exit.
     D
-    method_option "binstubs", :type => :string, :lazy_default => "bin", :banner =>
+    forgotten_option "binstubs", :type => :string, :lazy_default => "bin", :banner =>
       "Generate bin stubs for bundled gems to ./bin"
     method_option "clean", :type => :boolean, :banner =>
       "Run bundle clean automatically after install"
-    method_option "deployment", :type => :boolean, :banner =>
+    forgotten_option "deployment", :type => :boolean, :banner =>
       "Install using defaults tuned for deployment environments"
-    method_option "frozen", :type => :boolean, :banner =>
+    forgotten_option "frozen", :type => :boolean, :banner =>
       "Do not allow the Gemfile.lock to be updated after this install"
     method_option "full-index", :type => :boolean, :banner =>
       "Fall back to using the single-file index of all gems"
@@ -163,28 +168,28 @@ module Bundler
       "Specify the number of jobs to run in parallel"
     method_option "local", :type => :boolean, :banner =>
       "Do not attempt to fetch gems remotely and use the gem cache instead"
-    method_option "no-cache", :type => :boolean, :banner =>
+    forgotten_option "no-cache", :type => :boolean, :banner =>
       "Don't update the existing gem cache."
     method_option "force", :type => :boolean, :banner =>
       "Force downloading every gem."
     method_option "no-prune", :type => :boolean, :banner =>
       "Don't remove stale gems from the cache."
-    method_option "path", :type => :string, :banner =>
+    forgotten_option "path", :type => :string, :banner =>
       "Specify a different path than the system default ($BUNDLE_PATH or $GEM_HOME). Bundler will remember this value for future installs on this machine"
     method_option "quiet", :type => :boolean, :banner =>
       "Only output warnings and errors."
-    method_option "shebang", :type => :string, :banner =>
+    forgotten_option "shebang", :type => :string, :banner =>
       "Specify a different shebang executable name than the default (usually 'ruby')"
     method_option "standalone", :type => :array, :lazy_default => [], :banner =>
       "Make a bundle that can work without the Bundler runtime"
-    method_option "system", :type => :boolean, :banner =>
+    forgotten_option "system", :type => :boolean, :banner =>
       "Install to the system location ($BUNDLE_PATH or $GEM_HOME) even if the bundle was previously installed somewhere else for this application"
     method_option "trust-policy", :alias => "P", :type => :string, :banner =>
       "Gem trust policy (like gem install -P). Must be one of " +
         Bundler.rubygems.security_policy_keys.join("|")
-    method_option "without", :type => :array, :banner =>
+    forgotten_option "without", :type => :array, :banner =>
       "Exclude gems that are part of the specified named group."
-    method_option "with", :type => :array, :banner =>
+    forgotten_option "with", :type => :array, :banner =>
       "Include gems that are part of the specified named group."
     map "i" => "install"
     def install

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -170,7 +170,8 @@ module Bundler
       "Do not attempt to fetch gems remotely and use the gem cache instead"
     deprecated_option "no-cache", :type => :boolean, :banner =>
       "Don't update the existing gem cache."
-    method_option "force", :type => :boolean, :banner =>
+    method_option "redownload", :type => :boolean, :aliases =>
+      [Bundler.feature_flag.forget_cli_options? ? nil : "--force"].compact, :banner =>
       "Force downloading every gem."
     method_option "no-prune", :type => :boolean, :banner =>
       "Don't remove stale gems from the cache."

--- a/lib/bundler/cli/binstubs.rb
+++ b/lib/bundler/cli/binstubs.rb
@@ -12,9 +12,10 @@ module Bundler
 
     def run
       Bundler.definition.validate_runtime!
-      Bundler.settings[:bin] = options["path"] if options["path"]
-      Bundler.settings[:bin] = nil if options["path"] && options["path"].empty?
-      Bundler.settings[:shebang] = options["shebang"] if options["shebang"]
+      path_option = options["path"]
+      path_option = nil if path_option && path_option.empty?
+      Bundler.settings.set_command_option :bin, path_option if options["path"]
+      Bundler.settings.set_command_option_if_given :shebang, options["shebang"]
       installer = Installer.new(Bundler.root, Bundler.definition)
 
       if gems.empty?

--- a/lib/bundler/cli/cache.rb
+++ b/lib/bundler/cli/cache.rb
@@ -11,9 +11,9 @@ module Bundler
       Bundler.definition.validate_runtime!
       Bundler.definition.resolve_with_cache!
       setup_cache_all
-      Bundler.settings[:cache_all_platforms] = options["all-platforms"] if options.key?("all-platforms")
+      Bundler.settings.set_command_option_if_given :cache_all_platforms, options["all-platforms"]
       Bundler.load.cache
-      Bundler.settings[:no_prune] = true if options["no-prune"]
+      Bundler.settings.set_command_option_if_given :no_prune, options["no-prune"]
       Bundler.load.lock
     rescue GemNotFound => e
       Bundler.ui.error(e.message)
@@ -24,7 +24,7 @@ module Bundler
   private
 
     def setup_cache_all
-      Bundler.settings[:cache_all] = options[:all] if options.key?("all")
+      Bundler.settings.set_command_option_if_given :cache_all, options[:all]
 
       if Bundler.definition.has_local_dependencies? && !Bundler.settings[:cache_all]
         Bundler.ui.warn "Your Gemfile contains path and git dependencies. If you want "    \

--- a/lib/bundler/cli/check.rb
+++ b/lib/bundler/cli/check.rb
@@ -9,9 +9,9 @@ module Bundler
     end
 
     def run
-      if options[:path]
-        Bundler.settings[:path] = File.expand_path(options[:path])
-        Bundler.settings[:disable_shared_gems] = true
+      if path = options[:path]
+        Bundler.settings.set_command_option :path, path
+        Bundler.settings.set_command_option :disable_shared_gems, true
       end
 
       begin

--- a/lib/bundler/cli/clean.rb
+++ b/lib/bundler/cli/clean.rb
@@ -17,10 +17,9 @@ module Bundler
 
     def require_path_or_force
       if !Bundler.settings[:path] && !options[:force]
-        Bundler.ui.error "Cleaning all the gems on your system is dangerous! " \
+        raise InvalidOption, "Cleaning all the gems on your system is dangerous! " \
           "If you're sure you want to remove every system gem not in this " \
           "bundle, run `bundle clean --force`."
-        exit 1
       end
     end
   end

--- a/lib/bundler/cli/common.rb
+++ b/lib/bundler/cli/common.rb
@@ -15,12 +15,12 @@ module Bundler
     end
 
     def self.output_without_groups_message
-      return unless Bundler.settings.without.any?
+      return if Bundler.settings[:without].empty?
       Bundler.ui.confirm without_groups_message
     end
 
     def self.without_groups_message
-      groups = Bundler.settings.without
+      groups = Bundler.settings[:without]
       group_list = [groups[0...-1].join(", "), groups[-1..-1]].
         reject {|s| s.to_s.empty? }.join(" and ")
       group_str = (groups.size == 1) ? "group" : "groups"

--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -78,8 +78,8 @@ module Bundler
       Bundler.ui.confirm "Bundle complete! #{dependencies_count_for(definition)}, #{gems_installed_for(definition)}."
       Bundler::CLI::Common.output_without_groups_message
 
-      if Bundler.settings[:path]
-        absolute_path = File.expand_path(Bundler.settings[:path])
+      if path = Bundler.settings[:path]
+        absolute_path = File.expand_path(path)
         relative_path = absolute_path.sub(File.expand_path(".") + File::SEPARATOR, "." + File::SEPARATOR)
         Bundler.ui.confirm "Bundled gems are installed into #{relative_path}."
       else

--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -194,6 +194,8 @@ module Bundler
 
       disable_shared_gems = Bundler.settings[:path] ? true : nil
       Bundler.settings.set_command_option :disable_shared_gems, disable_shared_gems unless Bundler.settings[:disable_shared_gems] == disable_shared_gems
+
+      options[:force] = options[:redownload]
     end
 
     def warn_ambiguous_gems

--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -132,14 +132,10 @@ module Bundler
     end
 
     def check_for_group_conflicts
-      if options[:without] && options[:with]
-        conflicting_groups = options[:without] & options[:with]
-        unless conflicting_groups.empty?
-          Bundler.ui.error "You can't list a group in both, --with and --without." \
-          " The offending groups are: #{conflicting_groups.join(", ")}."
-          exit 1
-        end
-      end
+      conflicting_groups = Bundler.settings[:without] & Bundler.settings[:with]
+      return if conflicting_groups.empty?
+      raise InvalidOption, "You can't list a group in both with and without." \
+        " The offending groups are: #{conflicting_groups.join(", ")}."
     end
 
     def check_for_options_conflicts

--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -54,7 +54,7 @@ module Bundler
 
       # When install is called with --no-deployment, disable deployment mode
       if options[:deployment] == false
-        Bundler.settings.delete(:frozen)
+        Bundler.settings.set_command_option :frozen, nil
         options[:system] = true
       end
 
@@ -177,7 +177,7 @@ module Bundler
     end
 
     def normalize_settings
-      Bundler.settings.delete(:path) if options[:system]
+      Bundler.settings.set_command_option :path, nil if options[:system]
       Bundler.settings.set_command_option :path, "vendor/bundle" if options[:deployment]
       Bundler.settings.set_command_option_if_given :path, options["path"]
       Bundler.settings.set_command_option :path, "bundle" if options["standalone"] && Bundler.settings[:path].nil?

--- a/lib/bundler/cli/package.rb
+++ b/lib/bundler/cli/package.rb
@@ -10,9 +10,9 @@ module Bundler
 
     def run
       Bundler.ui.level = "error" if options[:quiet]
-      Bundler.settings[:path] = File.expand_path(options[:path]) if options[:path]
-      Bundler.settings[:cache_all_platforms] = options["all-platforms"] if options.key?("all-platforms")
-      Bundler.settings[:cache_path] = options["cache-path"] if options.key?("cache-path")
+      Bundler.settings.set_command_option_if_given :path, options[:path]
+      Bundler.settings.set_command_option_if_given :cache_all_platforms, options["all-platforms"]
+      Bundler.settings.set_command_option_if_given :cache_path, options["cache-path"]
 
       setup_cache_all
       install
@@ -35,7 +35,7 @@ module Bundler
     end
 
     def setup_cache_all
-      Bundler.settings[:cache_all] = options[:all] if options.key?("all")
+      Bundler.settings.set_command_option_if_given :cache_all, options[:all]
 
       if Bundler.definition.has_local_dependencies? && !Bundler.settings[:cache_all]
         Bundler.ui.warn "Your Gemfile contains path and git dependencies. If you want "    \

--- a/lib/bundler/cli/package.rb
+++ b/lib/bundler/cli/package.rb
@@ -18,7 +18,7 @@ module Bundler
       install
 
       # TODO: move cache contents here now that all bundles are locked
-      custom_path = Pathname.new(options[:path]) if options[:path]
+      custom_path = Bundler.settings[:path] if options[:path]
       Bundler.load.cache(custom_path)
     end
 

--- a/lib/bundler/cli/update.rb
+++ b/lib/bundler/cli/update.rb
@@ -56,7 +56,7 @@ module Bundler
       opts["update"] = true
       opts["local"] = options[:local]
 
-      Bundler.settings[:jobs] = opts["jobs"] if opts["jobs"]
+      Bundler.settings.set_command_option_if_given :jobs, opts["jobs"]
 
       Bundler.definition.validate_runtime!
       installer = Installer.install Bundler.root, Bundler.definition, opts

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -920,7 +920,7 @@ module Bundler
     end
 
     def requested_groups
-      groups - Bundler.settings.without - @optional_groups + Bundler.settings.with
+      groups - Bundler.settings[:without] - @optional_groups + Bundler.settings[:with]
     end
 
     def lockfiles_equal?(current, proposed, preserve_unknown_sections)

--- a/lib/bundler/endpoint_specification.rb
+++ b/lib/bundler/endpoint_specification.rb
@@ -15,6 +15,9 @@ module Bundler
       @platform     = platform
       @dependencies = dependencies.map {|dep, reqs| build_dependency(dep, reqs) }
 
+      @loaded_from          = nil
+      @remote_specification = nil
+
       parse_metadata(metadata)
     end
 

--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -46,6 +46,7 @@ module Bundler
     settings_flag(:suppress_install_using_messages) { bundler_2_mode? }
     settings_flag(:unlock_source_unlocks_spec) { !bundler_2_mode? }
     settings_flag(:update_requires_all_flag) { bundler_2_mode? }
+    settings_flag(:forget_cli_options) { bundler_2_mode? }
 
     settings_option(:default_cli_command) { bundler_2_mode? ? :cli_help : :install }
 

--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -34,6 +34,7 @@ module Bundler
     settings_flag(:deployment_means_frozen) { bundler_2_mode? }
     settings_flag(:disable_multisource) { bundler_2_mode? }
     settings_flag(:error_on_stderr) { bundler_2_mode? }
+    settings_flag(:forget_cli_options) { bundler_2_mode? }
     settings_flag(:global_gem_cache) { bundler_2_mode? }
     settings_flag(:init_gems_rb) { bundler_2_mode? }
     settings_flag(:lockfile_uses_separate_rubygems_sources) { bundler_2_mode? }
@@ -46,7 +47,6 @@ module Bundler
     settings_flag(:suppress_install_using_messages) { bundler_2_mode? }
     settings_flag(:unlock_source_unlocks_spec) { !bundler_2_mode? }
     settings_flag(:update_requires_all_flag) { bundler_2_mode? }
-    settings_flag(:forget_cli_options) { bundler_2_mode? }
 
     settings_option(:default_cli_command) { bundler_2_mode? ? :cli_help : :install }
 

--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -151,7 +151,10 @@ module Bundler
     def generate_standalone_bundler_executable_stubs(spec)
       # double-assignment to avoid warnings about variables that will be used by ERB
       bin_path = Bundler.bin_path
-      standalone_path = standalone_path = Bundler.root.join(Bundler.settings[:path]).relative_path_from(bin_path)
+      unless path = Bundler.settings[:path]
+        raise "Can't standalone without a path set"
+      end
+      standalone_path = standalone_path = Bundler.root.join(path).relative_path_from(bin_path)
       template = File.read(File.expand_path("../templates/Executable.standalone", __FILE__))
       ruby_command = ruby_command = Thor::Util.ruby_command
 

--- a/lib/bundler/installer/gem_installer.rb
+++ b/lib/bundler/installer/gem_installer.rb
@@ -66,6 +66,7 @@ module Bundler
     end
 
     def generate_executable_stubs
+      return if Bundler.feature_flag.forget_cli_options?
       return if Bundler.settings[:inline]
       if Bundler.settings[:bin] && standalone
         installer.generate_standalone_bundler_executable_stubs(spec)

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -131,10 +131,6 @@ module Bundler
       end
     end
 
-    def delete(key)
-      @local_config.delete(key_for(key))
-    end
-
     def set_global(key, value)
       set_key(key, value, @global_config, global_config_file)
     end

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -278,7 +278,8 @@ module Bundler
 
     def array_to_s(array)
       array = Array(array)
-      array.empty? ? nil : array.join(":").tr(" ", ":")
+      return nil if array.empty?
+      array.join(":").tr(" ", ":")
     end
 
     def set_key(key, value, hash, file)

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -172,6 +172,7 @@ module Bundler
     def locations(key)
       key = key_for(key)
       locations = {}
+      locations[:temporary] = @temporary[key] if @temporary.key?(key)
       locations[:local]  = @local_config[key] if @local_config.key?(key)
       locations[:env]    = ENV[key] if ENV[key]
       locations[:global] = @global_config[key] if @global_config.key?(key)
@@ -183,6 +184,11 @@ module Bundler
       key = key_for(exposed_key)
 
       locations = []
+
+      if @temporary.key?(key)
+        locations << "Set for the current command: #{converted_value(@temporary[key], exposed_key).inspect}"
+      end
+
       if @local_config.key?(key)
         locations << "Set for your local app (#{local_config_file}): #{converted_value(@local_config[key], exposed_key).inspect}"
       end
@@ -271,7 +277,8 @@ module Bundler
     end
 
     def array_to_s(array)
-      array.empty? ? nil : array.join(":")
+      array = Array(array)
+      array.empty? ? nil : array.join(":").tr(" ", ":")
     end
 
     def set_key(key, value, hash, file)

--- a/lib/bundler/source/git/git_proxy.rb
+++ b/lib/bundler/source/git/git_proxy.rb
@@ -153,7 +153,7 @@ module Bundler
         end
 
         def git_retry(command)
-          Bundler::Retry.new("`git #{command}`", GitNotAllowedError).attempts do
+          Bundler::Retry.new("`git #{URICredentialsFilter.credential_filtered_string(command, uri)}`", GitNotAllowedError).attempts do
             git(command)
           end
         end

--- a/lib/bundler/yaml_serializer.rb
+++ b/lib/bundler/yaml_serializer.rb
@@ -37,7 +37,7 @@ module Bundler
     HASH_REGEX = /
       ^
       ([ ]*) # indentations
-      (.*) # key
+      (.+) # key
       (?::(?=(?:\s|$))) # :  (without the lookahead the #key includes this when : is present in value)
       [ ]?
       (?: !\s)? # optional exclamation mark found with ruby 1.9.3
@@ -54,10 +54,10 @@ module Bundler
       last_empty_key = nil
       str.split(/\r?\n/).each do |line|
         if match = HASH_REGEX.match(line)
-          indent, key, _, val = match.captures
+          indent, key, quote, val = match.captures
           key = convert_to_backward_compatible_key(key)
           depth = indent.scan(/  /).length
-          if val.empty?
+          if quote.empty? && val.empty?
             new_hash = {}
             stack[depth][key] = new_hash
             stack[depth + 1] = new_hash

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -71,6 +71,9 @@ The options that can be configured are:
 * `without`:
    A space-separated list of groups referencing gems to skip during installation.
 
+* `with`:
+  A space-separated list of groups referencing gems to include during installation.
+
 ## BUILD OPTIONS
 
 You can use `bundle config` to give bundler the flags to pass to the gem
@@ -253,6 +256,8 @@ learn more about their operation in [bundle install(1)][bundle-install].
    and disallow passing no options to `bundle update`.
 * `user_agent` (`BUNDLE_USER_AGENT`):
    The custom user agent fragment Bundler includes in API requests.
+* `with` (`BUNDLE_WITH`):
+   A `:`-separated list of groups whose gems bundler should install.
 * `without` (`BUNDLE_WITHOUT`):
    A `:`-separated list of groups whose gems bundler should not install.
 

--- a/spec/bundler/installer/gem_installer_spec.rb
+++ b/spec/bundler/installer/gem_installer_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Bundler::GemInstaller do
     it "invokes install method with build_args", :rubygems => ">= 2" do
       allow(Bundler.settings).to receive(:[]).with(:bin)
       allow(Bundler.settings).to receive(:[]).with(:inline)
+      allow(Bundler.settings).to receive(:[]).with(:forget_cli_options)
       allow(Bundler.settings).to receive(:[]).with("build.dummy").and_return("--with-dummy-config=dummy")
       expect(spec_source).to receive(:install).with(spec, :force => false, :ensure_builtin_gems_cached => false, :build_args => ["--with-dummy-config=dummy"])
       subject.install_from_spec

--- a/spec/bundler/settings_spec.rb
+++ b/spec/bundler/settings_spec.rb
@@ -170,7 +170,7 @@ that would suck --ehhh=oh geez it looks like i might have broken bundler somehow
   describe "#pretty_values_for" do
     it "prints the converted value rather than the raw string" do
       bool_key = described_class::BOOL_KEYS.first
-      settings[bool_key] = false
+      settings.set_local(bool_key, "false")
       expect(subject.pretty_values_for(bool_key)).to eq [
         "Set for your local app (#{bundled_app("config")}): false",
       ]

--- a/spec/bundler/source/git/git_proxy_spec.rb
+++ b/spec/bundler/source/git/git_proxy_spec.rb
@@ -6,25 +6,25 @@ RSpec.describe Bundler::Source::Git::GitProxy do
 
   context "with configured credentials" do
     it "adds username and password to URI" do
-      Bundler.settings[uri] = "u:p"
+      Bundler.settings.temporary(uri => "u:p")
       expect(subject).to receive(:git_retry).with(match("https://u:p@github.com/bundler/bundler.git"))
       subject.checkout
     end
 
     it "adds username and password to URI for host" do
-      Bundler.settings["github.com"] = "u:p"
+      Bundler.settings.temporary("github.com" => "u:p")
       expect(subject).to receive(:git_retry).with(match("https://u:p@github.com/bundler/bundler.git"))
       subject.checkout
     end
 
     it "does not add username and password to mismatched URI" do
-      Bundler.settings["https://u:p@github.com/bundler/bundler-mismatch.git"] = "u:p"
+      Bundler.settings.temporary("https://u:p@github.com/bundler/bundler-mismatch.git" => "u:p")
       expect(subject).to receive(:git_retry).with(match(uri))
       subject.checkout
     end
 
     it "keeps original userinfo" do
-      Bundler.settings["github.com"] = "u:p"
+      Bundler.settings.temporary("github.com" => "u:p")
       original = "https://orig:info@github.com/bundler/bundler.git"
       subject = described_class.new(Pathname("path"), original, "HEAD")
       expect(subject).to receive(:git_retry).with(match(original))

--- a/spec/bundler/source/rubygems/remote_spec.rb
+++ b/spec/bundler/source/rubygems/remote_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Bundler::Source::Rubygems::Remote do
       end
 
       it "applies configured credentials" do
-        Bundler.settings[uri_no_auth.to_s] = credentials
+        Bundler.settings.temporary(uri_no_auth.to_s => credentials)
         expect(remote(uri_no_auth).uri).to eq(uri_with_auth)
       end
     end
@@ -33,7 +33,7 @@ RSpec.describe Bundler::Source::Rubygems::Remote do
       end
 
       it "does not apply given credentials" do
-        Bundler.settings[uri_no_auth.to_s] = credentials
+        Bundler.settings.temporary(uri_no_auth.to_s => credentials)
         expect(remote(uri_no_auth).anonymized_uri).to eq(uri_no_auth)
       end
     end
@@ -44,7 +44,7 @@ RSpec.describe Bundler::Source::Rubygems::Remote do
       end
 
       it "only applies the given user" do
-        Bundler.settings[uri_no_auth.to_s] = credentials
+        Bundler.settings.temporary(uri_no_auth.to_s => credentials)
         expect(remote(uri_no_auth).cache_slug).to eq("gems.example.com.username.443.MD5HEX(gems.example.com.username.443./)")
       end
     end
@@ -57,7 +57,7 @@ RSpec.describe Bundler::Source::Rubygems::Remote do
       end
 
       it "does not apply configured credentials" do
-        Bundler.settings[uri_no_auth.to_s] = "other:stuff"
+        Bundler.settings.temporary(uri_no_auth.to_s => "other:stuff")
         expect(remote(uri_with_auth).uri).to eq(uri_with_auth)
       end
     end
@@ -68,7 +68,7 @@ RSpec.describe Bundler::Source::Rubygems::Remote do
       end
 
       it "does not apply given credentials" do
-        Bundler.settings[uri_no_auth.to_s] = "other:stuff"
+        Bundler.settings.temporary(uri_no_auth.to_s => "other:stuff")
         expect(remote(uri_with_auth).anonymized_uri).to eq(uri_no_auth)
       end
     end
@@ -79,7 +79,7 @@ RSpec.describe Bundler::Source::Rubygems::Remote do
       end
 
       it "does not apply given credentials" do
-        Bundler.settings[uri_with_auth.to_s] = credentials
+        Bundler.settings.temporary(uri_with_auth.to_s => credentials)
         expect(remote(uri_with_auth).cache_slug).to eq("gems.example.com.username.443.MD5HEX(gems.example.com.username.443./)")
       end
     end
@@ -106,7 +106,7 @@ RSpec.describe Bundler::Source::Rubygems::Remote do
     let(:mirror_uri_with_auth) { URI("https://username:password@rubygems-mirror.org/") }
     let(:mirror_uri_no_auth) { URI("https://rubygems-mirror.org/") }
 
-    before { Bundler.settings["mirror.https://rubygems.org/"] = mirror_uri_with_auth.to_s }
+    before { Bundler.settings.set_local("mirror.https://rubygems.org/", mirror_uri_with_auth.to_s) }
 
     specify "#uri returns the mirror URI with credentials" do
       expect(remote(uri).uri).to eq(mirror_uri_with_auth)
@@ -131,8 +131,8 @@ RSpec.describe Bundler::Source::Rubygems::Remote do
     let(:mirror_uri_no_auth) { URI("https://rubygems-mirror.org/") }
 
     before do
-      Bundler.settings["mirror.https://rubygems.org/"] = mirror_uri_no_auth.to_s
-      Bundler.settings[mirror_uri_no_auth.to_s] = credentials
+      Bundler.settings.temporary("mirror.https://rubygems.org/" => mirror_uri_no_auth.to_s)
+      Bundler.settings.temporary(mirror_uri_no_auth.to_s => credentials)
     end
 
     specify "#uri returns the mirror URI with credentials" do

--- a/spec/bundler/source_list_spec.rb
+++ b/spec/bundler/source_list_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Bundler::SourceList do
         end
 
         it "ignores git protocols on request" do
-          Bundler.settings["git.allow_insecure"] = true
+          Bundler.settings.temporary(:"git.allow_insecure" => true)
           expect(Bundler.ui).to_not receive(:warn).with(msg)
           source_list.add_git_source("uri" => "git://existing-git.org/path.git")
         end

--- a/spec/bundler/yaml_serializer_spec.rb
+++ b/spec/bundler/yaml_serializer_spec.rb
@@ -156,6 +156,7 @@ RSpec.describe Bundler::YAMLSerializer do
         "a_joke" => {
           "my-stand" => "I can totally keep secrets",
           "but" => "The people I tell them to can't :P",
+          "wouldn't it be funny if this string were empty?" => "",
         },
         "more" => {
           "first" => [

--- a/spec/cache/git_spec.rb
+++ b/spec/cache/git_spec.rb
@@ -100,7 +100,7 @@ end
         gem "foo", :git => '#{lib_path("foo-1.0")}'
       G
 
-      bundle "#{cmd} --all"
+      bundle! cmd, forgotten_command_line_options([:all, :cache_all] => true)
 
       update_git "foo" do |s|
         s.write "lib/foo.rb", "puts :CACHE"
@@ -187,8 +187,8 @@ end
         gem "foo", :git => '#{lib_path("foo-1.0")}'
       G
 
-      bundle "#{cmd} --all"
-      bundle "#{cmd}"
+      bundle cmd, forgotten_command_line_options([:all, :cache_all] => true)
+      bundle cmd
 
       expect(out).not_to include("Your Gemfile contains path and git dependencies.")
     end
@@ -204,7 +204,7 @@ end
       install_gemfile <<-G
         gem "foo", :git => '#{lib_path("foo-1.0")}'
       G
-      bundle "#{cmd} --all"
+      bundle cmd, forgotten_command_line_options([:all, :cache_all] => true)
 
       ref = git.ref_for("master", 11)
       gemspec = bundled_app("vendor/cache/foo-1.0-#{ref}/foo.gemspec").read

--- a/spec/cache/path_spec.rb
+++ b/spec/cache/path_spec.rb
@@ -9,7 +9,7 @@
         gem "foo", :path => '#{bundled_app("lib/foo")}'
       G
 
-      bundle "#{cmd} --all"
+      bundle cmd, forgotten_command_line_options([:all, :cache_all] => true)
       expect(bundled_app("vendor/cache/foo-1.0")).not_to exist
       expect(the_bundle).to include_gems "foo 1.0"
     end
@@ -21,7 +21,7 @@
         gem "foo", :path => '#{lib_path("foo-1.0")}'
       G
 
-      bundle "#{cmd} --all"
+      bundle cmd, forgotten_command_line_options([:all, :cache_all] => true)
       expect(bundled_app("vendor/cache/foo-1.0")).to exist
       expect(bundled_app("vendor/cache/foo-1.0/.bundlecache")).to be_file
 
@@ -39,7 +39,7 @@
         gem "#{libname}", :path => '#{libpath}'
       G
 
-      bundle "#{cmd} --all"
+      bundle cmd, forgotten_command_line_options([:all, :cache_all] => true)
       expect(bundled_app("vendor/cache/#{libname}")).to exist
       expect(bundled_app("vendor/cache/#{libname}/.bundlecache")).to be_file
 
@@ -54,13 +54,13 @@
         gem "foo", :path => '#{lib_path("foo-1.0")}'
       G
 
-      bundle "#{cmd} --all"
+      bundle cmd, forgotten_command_line_options([:all, :cache_all] => true)
 
       build_lib "foo" do |s|
         s.write "lib/foo.rb", "puts :CACHE"
       end
 
-      bundle "#{cmd} --all"
+      bundle cmd, forgotten_command_line_options([:all, :cache_all] => true)
 
       expect(bundled_app("vendor/cache/foo-1.0")).to exist
       FileUtils.rm_rf lib_path("foo-1.0")
@@ -76,13 +76,13 @@
         gem "foo", :path => '#{lib_path("foo-1.0")}'
       G
 
-      bundle "#{cmd} --all"
+      bundle cmd, forgotten_command_line_options([:all, :cache_all] => true)
 
       install_gemfile <<-G
         gem "bar", :path => '#{lib_path("bar-1.0")}'
       G
 
-      bundle "#{cmd} --all"
+      bundle cmd, forgotten_command_line_options([:all, :cache_all] => true)
       expect(bundled_app("vendor/cache/bar-1.0")).not_to exist
     end
 
@@ -105,7 +105,7 @@
         gem "foo", :path => '#{lib_path("foo-1.0")}'
       G
 
-      bundle "#{cmd} --all"
+      bundle cmd, forgotten_command_line_options([:all, :cache_all] => true)
       build_lib "bar"
 
       install_gemfile <<-G
@@ -124,7 +124,7 @@
         gem "foo", :path => '#{lib_path("foo-1.0")}'
       G
 
-      bundle "#{cmd} --all"
+      bundle cmd, forgotten_command_line_options([:all, :cache_all] => true)
       build_lib "baz"
 
       gemfile <<-G

--- a/spec/commands/binstubs_spec.rb
+++ b/spec/commands/binstubs_spec.rb
@@ -150,8 +150,8 @@ RSpec.describe "bundle binstubs <gem>" do
         gem "rails"
       G
 
-      bundle "binstubs rack --path exec"
-      bundle :install
+      bundle! "binstubs rack", forgotten_command_line_options([:path, :bin] => "exec")
+      bundle! :install
 
       expect(bundled_app("exec/rails")).to exist
     end
@@ -159,15 +159,16 @@ RSpec.describe "bundle binstubs <gem>" do
 
   context "after installing with --standalone" do
     before do
-      install_gemfile <<-G
+      install_gemfile! <<-G
         source "file://#{gem_repo1}"
         gem "rack"
       G
-      bundle "install --standalone"
+      forgotten_command_line_options(:path => "bundle")
+      bundle! "install", :standalone => true
     end
 
     it "includes the standalone path" do
-      bundle "binstubs rack --standalone"
+      bundle! "binstubs rack", :standalone => true
       standalone_line = File.read(bundled_app("bin/rackup")).each_line.find {|line| line.include? "$:.unshift" }.strip
       expect(standalone_line).to eq %($:.unshift File.expand_path "../../bundle", path.realpath)
     end

--- a/spec/commands/binstubs_spec.rb
+++ b/spec/commands/binstubs_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe "bundle binstubs <gem>" do
       expect(bundled_app("exec/rackup")).to exist
     end
 
-    it "setting is saved for bundle install" do
+    it "setting is saved for bundle install", :bundler => "< 2" do
       install_gemfile <<-G
         source "file://#{gem_repo1}"
         gem "rack"

--- a/spec/commands/check_spec.rb
+++ b/spec/commands/check_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe "bundle check" do
       gem "rack", :group => :foo
     G
 
-    bundle "install --without foo"
+    bundle :install, forgotten_command_line_options(:without => "foo")
 
     gemfile <<-G
       source "file://#{gem_repo1}"
@@ -238,7 +238,7 @@ RSpec.describe "bundle check" do
     expect(last_command).to be_failure
   end
 
-  context "--path" do
+  context "--path", :bundler => "< 2" do
     before do
       gemfile <<-G
         source "file://#{gem_repo1}"
@@ -250,8 +250,7 @@ RSpec.describe "bundle check" do
     end
 
     it "returns success" do
-      bundle "check --path vendor/bundle"
-      expect(exitstatus).to eq(0) if exitstatus
+      bundle! "check --path vendor/bundle"
       expect(out).to include("The Gemfile's dependencies are satisfied")
     end
 

--- a/spec/commands/check_spec.rb
+++ b/spec/commands/check_spec.rb
@@ -231,7 +231,7 @@ RSpec.describe "bundle check" do
       gem "foo"
     G
 
-    bundle! "install", forgotten_command_line_options([:deployment, :frozen] => true)
+    bundle! "install", forgotten_command_line_options(:deployment => true)
     FileUtils.rm(bundled_app("Gemfile.lock"))
 
     bundle :check

--- a/spec/commands/check_spec.rb
+++ b/spec/commands/check_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe "bundle check" do
     expect(out).to include("Bundler can't satisfy your Gemfile's dependencies.")
   end
 
-  it "remembers --without option from install" do
+  it "remembers --without option from install", :bundler => "< 2" do
     gemfile <<-G
       source "file://#{gem_repo1}"
       group :foo do
@@ -100,9 +100,21 @@ RSpec.describe "bundle check" do
       end
     G
 
-    bundle "install --without foo"
-    bundle "check"
-    expect(exitstatus).to eq(0) if exitstatus
+    bundle! "install --without foo"
+    bundle! "check"
+    expect(out).to include("The Gemfile's dependencies are satisfied")
+  end
+
+  it "uses the without setting" do
+    bundle! "config without foo"
+    install_gemfile! <<-G
+      source "file://#{gem_repo1}"
+      group :foo do
+        gem "rack"
+      end
+    G
+
+    bundle! "check"
     expect(out).to include("The Gemfile's dependencies are satisfied")
   end
 
@@ -219,8 +231,7 @@ RSpec.describe "bundle check" do
       gem "foo"
     G
 
-    bundle! "config deployment true"
-    bundle! :install
+    bundle! "install", forgotten_command_line_options([:deployment, :frozen] => true)
     FileUtils.rm(bundled_app("Gemfile.lock"))
 
     bundle :check
@@ -244,10 +255,9 @@ RSpec.describe "bundle check" do
       expect(out).to include("The Gemfile's dependencies are satisfied")
     end
 
-    it "should write to .bundle/config" do
+    it "should write to .bundle/config", :bundler => "< 2" do
       bundle "check --path vendor/bundle"
-      bundle "check"
-      expect(exitstatus).to eq(0) if exitstatus
+      bundle! "check"
     end
   end
 

--- a/spec/commands/clean_spec.rb
+++ b/spec/commands/clean_spec.rb
@@ -25,16 +25,16 @@ RSpec.describe "bundle clean" do
       gem "foo"
     G
 
-    bundle "install --path vendor/bundle --no-clean"
+    bundle! "install", forgotten_command_line_options(:path => "vendor/bundle", :clean => false)
 
     gemfile <<-G
       source "file://#{gem_repo1}"
 
       gem "thin"
     G
-    bundle "install"
+    bundle! "install"
 
-    bundle :clean
+    bundle! :clean
 
     expect(out).to include("Removing foo (1.0)")
 
@@ -52,7 +52,7 @@ RSpec.describe "bundle clean" do
       gem "foo"
     G
 
-    bundle "install --path vendor/bundle --no-clean"
+    bundle "install", forgotten_command_line_options(:path => "vendor/bundle", :clean => false)
 
     gemfile <<-G
       source "file://#{gem_repo1}"
@@ -80,7 +80,7 @@ RSpec.describe "bundle clean" do
       gem "foo"
     G
 
-    bundle! "install --path vendor/bundle --no-clean"
+    bundle! "install", forgotten_command_line_options(:path => "vendor/bundle", :clean => false)
 
     gemfile <<-G
       source "file://#{gem_repo1}"
@@ -111,8 +111,8 @@ RSpec.describe "bundle clean" do
       end
     G
 
-    bundle "install --path vendor/bundle"
-    bundle "install --without test_group"
+    bundle "install", forgotten_command_line_options(:path => "vendor/bundle")
+    bundle "install", forgotten_command_line_options(:without => "test_group")
     bundle :clean
 
     expect(out).to include("Removing rack (1.0.0)")
@@ -137,7 +137,7 @@ RSpec.describe "bundle clean" do
       end
     G
 
-    bundle "install --path vendor/bundle"
+    bundle "install", forgotten_command_line_options(:path => "vendor/bundle")
 
     bundle :clean
 
@@ -159,7 +159,7 @@ RSpec.describe "bundle clean" do
       end
     G
 
-    bundle "install --path vendor/bundle"
+    bundle "install", forgotten_command_line_options(:path => "vendor/bundle")
 
     gemfile <<-G
       source "file://#{gem_repo1}"
@@ -195,7 +195,7 @@ RSpec.describe "bundle clean" do
       end
     G
 
-    bundle! "install --path vendor/bundle"
+    bundle! "install", forgotten_command_line_options(:path => "vendor/bundle")
 
     update_git "foo", :path => lib_path("foo-bar")
     revision2 = revision_for(lib_path("foo-bar"))
@@ -225,7 +225,7 @@ RSpec.describe "bundle clean" do
       gem "activesupport", :git => "#{lib_path("rails")}", :ref => '#{revision}'
     G
 
-    bundle "install --path vendor/bundle"
+    bundle "install", forgotten_command_line_options(:path => "vendor/bundle")
     bundle :clean
     expect(out).to include("")
 
@@ -247,7 +247,7 @@ RSpec.describe "bundle clean" do
         end
       end
     G
-    bundle "install --path vendor/bundle --without test"
+    bundle "install", forgotten_command_line_options(:path => "vendor/bundle", :without => "test")
 
     bundle :clean
 
@@ -268,7 +268,7 @@ RSpec.describe "bundle clean" do
       end
     G
 
-    bundle "install --path vendor/bundle --without development"
+    bundle "install", forgotten_command_line_options(:path => "vendor/bundle", :without => "development")
 
     bundle :clean
     expect(exitstatus).to eq(0) if exitstatus
@@ -283,7 +283,7 @@ RSpec.describe "bundle clean" do
 
     bundle :clean
 
-    expect(exitstatus).to eq(1) if exitstatus
+    expect(exitstatus).to eq(15) if exitstatus
     expect(out).to include("--force")
   end
 
@@ -296,7 +296,7 @@ RSpec.describe "bundle clean" do
       gem "foo"
     G
 
-    bundle "install --path vendor/bundle"
+    bundle "install", forgotten_command_line_options(:path => "vendor/bundle")
 
     gemfile <<-G
       source "file://#{gem_repo1}"
@@ -345,7 +345,7 @@ RSpec.describe "bundle clean" do
       gem "thin"
       gem "rack"
     G
-    bundle "install --path vendor/bundle --clean"
+    bundle "install", forgotten_command_line_options(:path => "vendor/bundle", :clean => true)
 
     gemfile <<-G
       source "file://#{gem_repo1}"
@@ -366,7 +366,7 @@ RSpec.describe "bundle clean" do
 
       gem "foo"
     G
-    bundle! "install --path vendor/bundle --clean"
+    bundle! "install", forgotten_command_line_options(:path => "vendor/bundle", :clean => true)
 
     update_repo2 do
       build_gem "foo", "1.0.1"
@@ -385,7 +385,7 @@ RSpec.describe "bundle clean" do
       gem "thin"
       gem "rack"
     G
-    bundle "install --path vendor/bundle"
+    bundle "install", forgotten_command_line_options(:path => "vendor/bundle")
 
     gemfile <<-G
       source "file://#{gem_repo1}"
@@ -405,7 +405,7 @@ RSpec.describe "bundle clean" do
 
       gem "foo"
     G
-    bundle! "install --path vendor/bundle"
+    bundle! "install", forgotten_command_line_options(:path => "vendor/bundle")
 
     update_repo2 do
       build_gem "foo", "1.0.1"
@@ -501,7 +501,7 @@ RSpec.describe "bundle clean" do
       gem "foo", :git => "#{lib_path("foo-1.0")}"
     G
 
-    bundle "install --path vendor/bundle"
+    bundle "install", forgotten_command_line_options(:path => "vendor/bundle")
 
     # mimic 7 length git revisions in Gemfile.lock
     gemfile_lock = File.read(bundled_app("Gemfile.lock")).split("\n")
@@ -512,7 +512,7 @@ RSpec.describe "bundle clean" do
       file.print gemfile_lock.join("\n")
     end
 
-    bundle "install --path vendor/bundle"
+    bundle "install", forgotten_command_line_options(:path => "vendor/bundle")
 
     bundle :clean
 
@@ -560,10 +560,8 @@ RSpec.describe "bundle clean" do
       gem "bar", "1.0", :path => "#{relative_path}"
     G
 
-    bundle "install --path vendor/bundle"
-    bundle :clean
-
-    expect(exitstatus).to eq(0) if exitstatus
+    bundle "install", forgotten_command_line_options(:path => "vendor/bundle")
+    bundle! :clean
   end
 
   it "doesn't remove gems in dry-run mode with path set" do
@@ -574,7 +572,7 @@ RSpec.describe "bundle clean" do
       gem "foo"
     G
 
-    bundle "install --path vendor/bundle --no-clean"
+    bundle "install", forgotten_command_line_options(:path => "vendor/bundle", :clean => false)
 
     gemfile <<-G
       source "file://#{gem_repo1}"
@@ -602,7 +600,7 @@ RSpec.describe "bundle clean" do
       gem "foo"
     G
 
-    bundle "install --path vendor/bundle --no-clean"
+    bundle "install", forgotten_command_line_options(:path => "vendor/bundle", :clean => false)
 
     gemfile <<-G
       source "file://#{gem_repo1}"
@@ -632,7 +630,7 @@ RSpec.describe "bundle clean" do
       gem "foo"
     G
 
-    bundle "install --path vendor/bundle --no-clean"
+    bundle "install", forgotten_command_line_options(:path => "vendor/bundle", :clean => false)
     bundle "config dry_run false"
 
     gemfile <<-G
@@ -662,7 +660,7 @@ RSpec.describe "bundle clean" do
       gem "foo"
     G
 
-    bundle "install --path vendor/bundle --no-clean"
+    bundle "install", forgotten_command_line_options(:path => "vendor/bundle", :clean => false)
 
     gemfile <<-G
       source "file://#{gem_repo1}"
@@ -689,7 +687,7 @@ RSpec.describe "bundle clean" do
       gem "very_simple_git_binary", :git => "#{lib_path("very_simple_git_binary-1.0")}", :ref => "#{revision}"
     G
 
-    bundle! "install --path vendor/bundle"
+    bundle! "install", forgotten_command_line_options(:path => "vendor/bundle")
     expect(vendored_gems("bundler/gems/extensions")).to exist
     expect(vendored_gems("bundler/gems/very_simple_git_binary-1.0-#{revision[0..11]}")).to exist
 

--- a/spec/commands/clean_spec.rb
+++ b/spec/commands/clean_spec.rb
@@ -338,7 +338,7 @@ RSpec.describe "bundle clean" do
     expect(out).to include("thin (1.0)")
   end
 
-  it "--clean should override the bundle setting on install" do
+  it "--clean should override the bundle setting on install", :bundler => "< 2" do
     gemfile <<-G
       source "file://#{gem_repo1}"
 
@@ -358,7 +358,7 @@ RSpec.describe "bundle clean" do
     should_not_have_gems "thin-1.0"
   end
 
-  it "--clean should override the bundle setting on update" do
+  it "--clean should override the bundle setting on update", :bundler => "< 2" do
     build_repo2
 
     gemfile <<-G

--- a/spec/commands/config_spec.rb
+++ b/spec/commands/config_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe ".bundle/config" do
   describe "BUNDLE_APP_CONFIG" do
     it "can be moved with an environment variable" do
       ENV["BUNDLE_APP_CONFIG"] = tmp("foo/bar").to_s
-      bundle "install --path vendor/bundle"
+      bundle "install", forgotten_command_line_options(:path => "vendor/bundle")
 
       expect(bundled_app(".bundle")).not_to exist
       expect(tmp("foo/bar/config")).to exist
@@ -57,7 +57,7 @@ RSpec.describe ".bundle/config" do
       Dir.chdir bundled_app("omg")
 
       ENV["BUNDLE_APP_CONFIG"] = "../foo"
-      bundle "install --path vendor/bundle"
+      bundle "install", forgotten_command_line_options(:path => "vendor/bundle")
 
       expect(bundled_app(".bundle")).not_to exist
       expect(bundled_app("../foo/config")).to exist

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe "bundle exec" do
   end
 
   it "handles gems installed with --without" do
-    install_gemfile <<-G, :without => :middleware
+    install_gemfile <<-G, forgotten_command_line_options(:without => "middleware")
       source "file://#{gem_repo1}"
       gem "rack" # rack 0.9.1 and 1.0 exist
 

--- a/spec/commands/init_spec.rb
+++ b/spec/commands/init_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "bundle init" do
     end
   end
 
-  context "given --gemspec option" do
+  context "given --gemspec option", :bundler => "< 2" do
     let(:spec_file) { tmp.join("test.gemspec") }
 
     it "should generate from an existing gemspec" do
@@ -116,7 +116,7 @@ RSpec.describe "bundle init" do
       end
     end
 
-    context "given --gemspec option" do
+    context "given --gemspec option", :bundler => "< 2" do
       let(:spec_file) { tmp.join("test.gemspec") }
 
       before do

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -261,21 +261,21 @@ RSpec.describe "bundle install with gem sources" do
       end
 
       it "works" do
-        bundle "install --path vendor"
+        bundle "install", forgotten_command_line_options(:path => "vendor")
         expect(the_bundle).to include_gems "rack 1.0"
       end
 
-      it "allows running bundle install --system without deleting foo" do
-        bundle "install --path vendor"
-        bundle "install --system"
+      it "allows running bundle install --system without deleting foo", :bundler => "< 2" do
+        bundle "install", forgotten_command_line_options(:path => "vendor")
+        bundle "install", forgotten_command_line_options(:system => true)
         FileUtils.rm_rf(bundled_app("vendor"))
         expect(the_bundle).to include_gems "rack 1.0"
       end
 
-      it "allows running bundle install --system after deleting foo" do
-        bundle "install --path vendor"
+      it "allows running bundle install --system after deleting foo", :bundler => "< 2" do
+        bundle "install", forgotten_command_line_options(:path => "vendor")
         FileUtils.rm_rf(bundled_app("vendor"))
-        bundle "install --system"
+        bundle "install", forgotten_command_line_options(:system => true)
         expect(the_bundle).to include_gems "rack 1.0"
       end
     end
@@ -486,7 +486,7 @@ RSpec.describe "bundle install with gem sources" do
     it "should display a proper message to explain the problem" do
       FileUtils.chmod(0o500, bundled_app("vendor"))
 
-      bundle :install, :path => "vendor"
+      bundle :install, forgotten_command_line_options(:path => "vendor")
       expect(out).to include(bundled_app("vendor").to_s)
       expect(out).to include("grant write permissions")
     end

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -407,7 +407,7 @@ RSpec.describe "bundle outdated" do
 
   context "after bundle install --deployment", :bundler => "< 2" do
     before do
-      install_gemfile <<-G, :deployment => true
+      install_gemfile <<-G, forgotten_command_line_options([:deployment, :frozen] => true)
         source "file://#{gem_repo2}"
 
         gem "rack"

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -407,7 +407,7 @@ RSpec.describe "bundle outdated" do
 
   context "after bundle install --deployment", :bundler => "< 2" do
     before do
-      install_gemfile <<-G, forgotten_command_line_options([:deployment, :frozen] => true)
+      install_gemfile <<-G, forgotten_command_line_options(:deployment => true)
         source "file://#{gem_repo2}"
 
         gem "rack"

--- a/spec/commands/package_spec.rb
+++ b/spec/commands/package_spec.rb
@@ -250,7 +250,7 @@ RSpec.describe "bundle install with gem sources" do
       simulate_new_machine
       FileUtils.rm_rf gem_repo2
 
-      bundle! :install, forgotten_command_line_options([:deployment, :frozen] => true, :path => "vendor/bundle")
+      bundle! :install, forgotten_command_line_options(:deployment => true, :path => "vendor/bundle")
       expect(the_bundle).to include_gems "rack 1.0.0"
     end
 

--- a/spec/commands/package_spec.rb
+++ b/spec/commands/package_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe "bundle package" do
         gem 'rack'
       D
 
-      bundle "package --path=#{bundled_app("test")}"
+      bundle! :package, forgotten_command_line_options(:path => bundled_app("test"))
 
       expect(the_bundle).to include_gems "rack 1.0.0"
       expect(bundled_app("test/vendor/cache/")).to exist
@@ -202,7 +202,7 @@ RSpec.describe "bundle package" do
       bundle "install"
     end
 
-    subject { bundle "package --frozen" }
+    subject { bundle :package, forgotten_command_line_options(:frozen => true) }
 
     it "tries to install with frozen" do
       bundle! "config deployment true"
@@ -241,16 +241,16 @@ RSpec.describe "bundle install with gem sources" do
 
     it "does not hit the remote at all" do
       build_repo2
-      install_gemfile <<-G
+      install_gemfile! <<-G
         source "file://#{gem_repo2}"
         gem "rack"
       G
 
-      bundle :pack
+      bundle! :pack
       simulate_new_machine
       FileUtils.rm_rf gem_repo2
 
-      bundle "install --deployment"
+      bundle! :install, forgotten_command_line_options([:deployment, :frozen] => true, :path => "vendor/bundle")
       expect(the_bundle).to include_gems "rack 1.0.0"
     end
 

--- a/spec/commands/package_spec.rb
+++ b/spec/commands/package_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe "bundle package" do
     end
   end
 
-  context "with --path" do
+  context "with --path", :bundler => "< 2" do
     it "sets root directory for gems" do
       gemfile <<-D
         source "file://#{gem_repo1}"

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -202,9 +202,9 @@ RSpec.describe "bundle update" do
       bundle! "install --deployment"
       bundle "update", :all => bundle_update_requires_all?
 
+      expect(last_command).to be_failure
       expect(out).to match(/You are trying to install in deployment mode after changing.your Gemfile/m)
       expect(out).to match(/freeze \nby running `bundle install --no-deployment`./m)
-      expect(exitstatus).not_to eq(0) if exitstatus
     end
 
     it "should suggest different command when frozen is set globally", :bundler => "< 2" do

--- a/spec/install/binstubs_spec.rb
+++ b/spec/install/binstubs_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "bundle install" do
     end
   end
 
-  describe "when multiple gems contain the same exe" do
+  describe "when multiple gems contain the same exe", :bundler => "< 2" do
     before do
       build_repo2 do
         build_gem "fake", "14" do |s|

--- a/spec/install/deploy_spec.rb
+++ b/spec/install/deploy_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "install with --deployment or --frozen" do
       simulate_new_machine
       bundle! :install,
         forgotten_command_line_options(:gemfile => "#{tmp}/bundled_app/Gemfile",
-                                       [:deployment, :frozen] => true,
+                                       :deployment => true,
                                        :path => "vendor/bundle")
     end
     expect(the_bundle).to include_gems "rack 1.0"
@@ -61,7 +61,7 @@ RSpec.describe "install with --deployment or --frozen" do
       end
     G
     bundle :install
-    bundle! :install, forgotten_command_line_options([:deployment, :frozen] => true, :without => "test")
+    bundle! :install, forgotten_command_line_options(:deployment => true, :without => "test")
   end
 
   it "works when you bundle exec bundle" do
@@ -79,7 +79,7 @@ RSpec.describe "install with --deployment or --frozen" do
     G
 
     bundle! :install
-    bundle! :install, forgotten_command_line_options([:deployment, :frozen] => true)
+    bundle! :install, forgotten_command_line_options(:deployment => true)
   end
 
   it "works when there are credentials in the source URL" do
@@ -89,7 +89,7 @@ RSpec.describe "install with --deployment or --frozen" do
       gem "rack-obama", ">= 1.0"
     G
 
-    bundle! :install, forgotten_command_line_options([:deployment, :frozen] => true).merge(:artifice => "endpoint_strict_basic_authentication")
+    bundle! :install, forgotten_command_line_options(:deployment => true).merge(:artifice => "endpoint_strict_basic_authentication")
   end
 
   it "works with sources given by a block" do
@@ -99,7 +99,7 @@ RSpec.describe "install with --deployment or --frozen" do
       end
     G
 
-    bundle! :install, forgotten_command_line_options([:deployment, :frozen] => true)
+    bundle! :install, forgotten_command_line_options(:deployment => true)
 
     expect(the_bundle).to include_gems "rack 1.0"
   end
@@ -128,7 +128,7 @@ RSpec.describe "install with --deployment or --frozen" do
         gem "rack-obama"
       G
 
-      bundle :install, forgotten_command_line_options([:deployment, :frozen] => true)
+      bundle :install, forgotten_command_line_options(:deployment => true)
       expect(out).to include("deployment mode")
       expect(out).to include("You have added to the Gemfile")
       expect(out).to include("* rack-obama")
@@ -146,7 +146,7 @@ RSpec.describe "install with --deployment or --frozen" do
       expect(the_bundle).to include_gems "path_gem 1.0"
       FileUtils.rm_r lib_path("path_gem-1.0")
 
-      bundle! :install, forgotten_command_line_options(:path => ".bundle", :without => "development", [:deployment, :frozen] => true).merge(:env => { :DEBUG => "1" })
+      bundle! :install, forgotten_command_line_options(:path => ".bundle", :without => "development", :deployment => true).merge(:env => { :DEBUG => "1" })
       run! "puts :WIN"
       expect(out).to eq("WIN")
     end
@@ -161,7 +161,7 @@ RSpec.describe "install with --deployment or --frozen" do
       expect(the_bundle).to include_gems "path_gem 1.0"
       FileUtils.rm_r lib_path("path_gem-1.0")
 
-      bundle :install, forgotten_command_line_options(:path => ".bundle", [:deployment, :frozen] => true)
+      bundle :install, forgotten_command_line_options(:path => ".bundle", :deployment => true)
       expect(out).to include("The path `#{lib_path("path_gem-1.0")}` does not exist.")
     end
 
@@ -212,7 +212,7 @@ RSpec.describe "install with --deployment or --frozen" do
       expect(out).not_to include("* rack-obama")
     end
 
-    it "explodes with the --frozen flag if you make a change and don't check in the lockfile" do
+    it "explodes with the --frozen flag if you make a change and don't check in the lockfile", :bundler => "< 2" do
       gemfile <<-G
         source "file://#{gem_repo1}"
         gem "rack"
@@ -233,7 +233,7 @@ RSpec.describe "install with --deployment or --frozen" do
         gem "activesupport"
       G
 
-      bundle :install, forgotten_command_line_options([:deployment, :frozen] => true)
+      bundle :install, forgotten_command_line_options(:deployment => true)
       expect(out).to include("deployment mode")
       expect(out).to include("You have added to the Gemfile:\n* activesupport\n\n")
       expect(out).to include("You have deleted from the Gemfile:\n* rack")
@@ -246,7 +246,7 @@ RSpec.describe "install with --deployment or --frozen" do
         gem "rack", :git => "git://hubz.com"
       G
 
-      bundle :install, forgotten_command_line_options([:deployment, :frozen] => true)
+      bundle :install, forgotten_command_line_options(:deployment => true)
       expect(out).to include("deployment mode")
       expect(out).to include("You have added to the Gemfile:\n* source: git://hubz.com (at master)")
       expect(out).not_to include("You have changed in the Gemfile")
@@ -265,7 +265,7 @@ RSpec.describe "install with --deployment or --frozen" do
         gem "rack"
       G
 
-      bundle :install, forgotten_command_line_options([:deployment, :frozen] => true)
+      bundle :install, forgotten_command_line_options(:deployment => true)
       expect(out).to include("deployment mode")
       expect(out).to include("You have deleted from the Gemfile:\n* source: #{lib_path("rack-1.0")} (at master@#{revision_for(lib_path("rack-1.0"))[0..6]}")
       expect(out).not_to include("You have added to the Gemfile")
@@ -288,7 +288,7 @@ RSpec.describe "install with --deployment or --frozen" do
         gem "foo", :git => "#{lib_path("rack")}"
       G
 
-      bundle :install, forgotten_command_line_options([:deployment, :frozen] => true)
+      bundle :install, forgotten_command_line_options(:deployment => true)
       expect(out).to include("deployment mode")
       expect(out).to include("You have changed in the Gemfile:\n* rack from `no specified source` to `#{lib_path("rack")} (at master@#{revision_for(lib_path("rack"))[0..6]})`")
       expect(out).not_to include("You have added to the Gemfile")
@@ -336,7 +336,7 @@ You have deleted from the Gemfile:
       expect(out).to include("Updating files in vendor/cache")
 
       simulate_new_machine
-      bundle! "install --verbose", forgotten_command_line_options([:deployment, :frozen] => true)
+      bundle! "install --verbose", forgotten_command_line_options(:deployment => true)
       expect(out).not_to include("You are trying to install in deployment mode after changing your Gemfile")
       expect(out).not_to include("You have added to the Gemfile")
       expect(out).not_to include("You have deleted from the Gemfile")

--- a/spec/install/deploy_spec.rb
+++ b/spec/install/deploy_spec.rb
@@ -8,29 +8,31 @@ RSpec.describe "install with --deployment or --frozen" do
     G
   end
 
-  it "fails without a lockfile and says that --deployment requires a lock" do
-    bundle "install --deployment"
-    expect(out).to include("The --deployment flag requires a Gemfile.lock")
-  end
+  context "with CLI flags", :bundler => "< 2" do
+    it "fails without a lockfile and says that --deployment requires a lock" do
+      bundle "install --deployment"
+      expect(out).to include("The --deployment flag requires a Gemfile.lock")
+    end
 
-  it "fails without a lockfile and says that --frozen requires a lock" do
-    bundle "install --frozen"
-    expect(out).to include("The --frozen flag requires a Gemfile.lock")
-  end
+    it "fails without a lockfile and says that --frozen requires a lock" do
+      bundle "install --frozen"
+      expect(out).to include("The --frozen flag requires a Gemfile.lock")
+    end
 
-  it "disallows --deployment --system" do
-    bundle "install --deployment --system"
-    expect(out).to include("You have specified both --deployment")
-    expect(out).to include("Please choose only one option")
-    expect(exitstatus).to eq(15) if exitstatus
-  end
+    it "disallows --deployment --system" do
+      bundle "install --deployment --system"
+      expect(out).to include("You have specified both --deployment")
+      expect(out).to include("Please choose only one option")
+      expect(exitstatus).to eq(15) if exitstatus
+    end
 
-  it "disallows --deployment --path --system" do
-    bundle "install --deployment --path . --system"
-    expect(out).to include("You have specified both --path")
-    expect(out).to include("as well as --system")
-    expect(out).to include("Please choose only one option")
-    expect(exitstatus).to eq(15) if exitstatus
+    it "disallows --deployment --path --system" do
+      bundle "install --deployment --path . --system"
+      expect(out).to include("You have specified both --path")
+      expect(out).to include("as well as --system")
+      expect(out).to include("Please choose only one option")
+      expect(exitstatus).to eq(15) if exitstatus
+    end
   end
 
   it "works after you try to deploy without a lock" do
@@ -60,15 +62,13 @@ RSpec.describe "install with --deployment or --frozen" do
       end
     G
     bundle :install
-    bundle "install --deployment --without test"
-    expect(exitstatus).to eq(0) if exitstatus
+    bundle! :install, forgotten_command_line_options([:deployment, :frozen] => true, :without => "test")
   end
 
   it "works when you bundle exec bundle" do
     bundle :install
     bundle "install --deployment"
-    bundle "exec bundle check"
-    expect(exitstatus).to eq(0) if exitstatus
+    bundle! "exec bundle check"
   end
 
   it "works when using path gems from the same path and the version is specified" do
@@ -90,9 +90,7 @@ RSpec.describe "install with --deployment or --frozen" do
       gem "rack-obama", ">= 1.0"
     G
 
-    bundle "install --deployment", :artifice => "endpoint_strict_basic_authentication"
-
-    expect(exitstatus).to eq(0) if exitstatus
+    bundle! :install, forgotten_command_line_options([:deployment, :frozen] => true).merge(:artifice => "endpoint_strict_basic_authentication")
   end
 
   it "works with sources given by a block" do
@@ -102,7 +100,7 @@ RSpec.describe "install with --deployment or --frozen" do
       end
     G
 
-    bundle! "install --deployment"
+    bundle! :install, forgotten_command_line_options([:deployment, :frozen] => true)
 
     expect(the_bundle).to include_gems "rack 1.0"
   end

--- a/spec/install/deploy_spec.rb
+++ b/spec/install/deploy_spec.rb
@@ -33,13 +33,12 @@ RSpec.describe "install with --deployment or --frozen" do
       expect(out).to include("Please choose only one option")
       expect(exitstatus).to eq(15) if exitstatus
     end
-  end
 
-  it "works after you try to deploy without a lock" do
-    bundle "install --deployment"
-    bundle :install
-    expect(exitstatus).to eq(0) if exitstatus
-    expect(the_bundle).to include_gems "rack 1.0"
+    it "works after you try to deploy without a lock" do
+      bundle "install --deployment"
+      bundle! :install
+      expect(the_bundle).to include_gems "rack 1.0"
+    end
   end
 
   it "still works if you are not in the app directory and specify --gemfile" do
@@ -80,7 +79,7 @@ RSpec.describe "install with --deployment or --frozen" do
     G
 
     bundle! :install
-    bundle! "install --deployment"
+    bundle! :install, forgotten_command_line_options([:deployment, :frozen] => true)
   end
 
   it "works when there are credentials in the source URL" do
@@ -110,14 +109,16 @@ RSpec.describe "install with --deployment or --frozen" do
       bundle "install"
     end
 
-    it "works with the --deployment flag if you didn't change anything" do
-      bundle "install --deployment"
-      expect(exitstatus).to eq(0) if exitstatus
+    it "works with the --deployment flag if you didn't change anything", :bundler => "< 2" do
+      bundle! "install --deployment"
     end
 
-    it "works with the --frozen flag if you didn't change anything" do
-      bundle "install --frozen"
-      expect(exitstatus).to eq(0) if exitstatus
+    it "works with the --frozen flag if you didn't change anything", :bundler => "< 2" do
+      bundle! "install --frozen"
+    end
+
+    it "works with BUNDLE_FROZEN if you didn't change anything" do
+      bundle! :install, :env => { "BUNDLE_FROZEN" => "true" }
     end
 
     it "explodes with the --deployment flag if you make a change and don't check in the lockfile" do
@@ -127,7 +128,7 @@ RSpec.describe "install with --deployment or --frozen" do
         gem "rack-obama"
       G
 
-      bundle "install --deployment"
+      bundle :install, forgotten_command_line_options([:deployment, :frozen] => true)
       expect(out).to include("deployment mode")
       expect(out).to include("You have added to the Gemfile")
       expect(out).to include("* rack-obama")
@@ -160,7 +161,7 @@ RSpec.describe "install with --deployment or --frozen" do
       expect(the_bundle).to include_gems "path_gem 1.0"
       FileUtils.rm_r lib_path("path_gem-1.0")
 
-      bundle :install, :path => ".bundle", :deployment => true
+      bundle :install, forgotten_command_line_options(:path => ".bundle", [:deployment, :frozen] => true)
       expect(out).to include("The path `#{lib_path("path_gem-1.0")}` does not exist.")
     end
 
@@ -218,7 +219,7 @@ RSpec.describe "install with --deployment or --frozen" do
         gem "rack-obama", "1.1"
       G
 
-      bundle "install --frozen"
+      bundle :install, forgotten_command_line_options(:frozen => true)
       expect(out).to include("deployment mode")
       expect(out).to include("You have added to the Gemfile")
       expect(out).to include("* rack-obama (= 1.1)")
@@ -232,7 +233,7 @@ RSpec.describe "install with --deployment or --frozen" do
         gem "activesupport"
       G
 
-      bundle "install --deployment"
+      bundle :install, forgotten_command_line_options([:deployment, :frozen] => true)
       expect(out).to include("deployment mode")
       expect(out).to include("You have added to the Gemfile:\n* activesupport\n\n")
       expect(out).to include("You have deleted from the Gemfile:\n* rack")
@@ -245,7 +246,7 @@ RSpec.describe "install with --deployment or --frozen" do
         gem "rack", :git => "git://hubz.com"
       G
 
-      bundle "install --deployment"
+      bundle :install, forgotten_command_line_options([:deployment, :frozen] => true)
       expect(out).to include("deployment mode")
       expect(out).to include("You have added to the Gemfile:\n* source: git://hubz.com (at master)")
       expect(out).not_to include("You have changed in the Gemfile")
@@ -264,7 +265,7 @@ RSpec.describe "install with --deployment or --frozen" do
         gem "rack"
       G
 
-      bundle "install --deployment"
+      bundle :install, forgotten_command_line_options([:deployment, :frozen] => true)
       expect(out).to include("deployment mode")
       expect(out).to include("You have deleted from the Gemfile:\n* source: #{lib_path("rack-1.0")} (at master@#{revision_for(lib_path("rack-1.0"))[0..6]}")
       expect(out).not_to include("You have added to the Gemfile")
@@ -287,7 +288,7 @@ RSpec.describe "install with --deployment or --frozen" do
         gem "foo", :git => "#{lib_path("rack")}"
       G
 
-      bundle "install --deployment"
+      bundle :install, forgotten_command_line_options([:deployment, :frozen] => true)
       expect(out).to include("deployment mode")
       expect(out).to include("You have changed in the Gemfile:\n* rack from `no specified source` to `#{lib_path("rack")} (at master@#{revision_for(lib_path("rack"))[0..6]})`")
       expect(out).not_to include("You have added to the Gemfile")
@@ -335,7 +336,7 @@ You have deleted from the Gemfile:
       expect(out).to include("Updating files in vendor/cache")
 
       simulate_new_machine
-      bundle! "install --deployment --verbose"
+      bundle! "install --verbose", forgotten_command_line_options([:deployment, :frozen] => true)
       expect(out).not_to include("You are trying to install in deployment mode after changing your Gemfile")
       expect(out).not_to include("You have added to the Gemfile")
       expect(out).not_to include("You have deleted from the Gemfile")

--- a/spec/install/deploy_spec.rb
+++ b/spec/install/deploy_spec.rb
@@ -42,10 +42,13 @@ RSpec.describe "install with --deployment or --frozen" do
 
   it "still works if you are not in the app directory and specify --gemfile" do
     bundle "install"
-    Dir.chdir tmp
-    simulate_new_machine
-    bundle "install --gemfile #{tmp}/bundled_app/Gemfile --deployment"
-    Dir.chdir bundled_app
+    Dir.chdir tmp do
+      simulate_new_machine
+      bundle! :install,
+        forgotten_command_line_options(:gemfile => "#{tmp}/bundled_app/Gemfile",
+                                       [:deployment, :frozen] => true,
+                                       :path => "vendor/bundle")
+    end
     expect(the_bundle).to include_gems "rack 1.0"
   end
 
@@ -144,7 +147,7 @@ RSpec.describe "install with --deployment or --frozen" do
       expect(the_bundle).to include_gems "path_gem 1.0"
       FileUtils.rm_r lib_path("path_gem-1.0")
 
-      bundle! :install, :path => ".bundle", :without => "development", :deployment => true, :env => { :DEBUG => "1" }
+      bundle! :install, forgotten_command_line_options(:path => ".bundle", :without => "development", [:deployment, :frozen] => true).merge(:env => { :DEBUG => "1" })
       run! "puts :WIN"
       expect(out).to eq("WIN")
     end

--- a/spec/install/force_spec.rb
+++ b/spec/install/force_spec.rb
@@ -1,59 +1,61 @@
 # frozen_string_literal: true
 
 RSpec.describe "bundle install" do
-  describe "with --force" do
-    before :each do
-      gemfile <<-G
-        source "file://#{gem_repo1}"
-        gem "rack"
-      G
-    end
-
-    it "re-installs installed gems" do
-      rack_lib = default_bundle_path("gems/rack-1.0.0/lib/rack.rb")
-
-      bundle "install"
-      rack_lib.open("w") {|f| f.write("blah blah blah") }
-      bundle "install --force"
-
-      expect(exitstatus).to eq(0) if exitstatus
-      expect(out).to include "Installing rack 1.0.0"
-      expect(rack_lib.open(&:read)).to eq("RACK = '1.0.0'\n")
-      expect(the_bundle).to include_gems "rack 1.0.0"
-    end
-
-    it "works on first bundle install" do
-      bundle "install --force"
-
-      expect(exitstatus).to eq(0) if exitstatus
-      expect(out).to include "Installing rack 1.0.0"
-      expect(the_bundle).to include_gems "rack 1.0.0"
-    end
-
-    context "with a git gem" do
-      let!(:ref) { build_git("foo", "1.0").ref_for("HEAD", 11) }
-
-      before do
+  %w[force redownload].each do |flag|
+    describe_opts = {}
+    describe_opts[:bundler] = "< 2" if flag == "force"
+    describe "with --#{flag}", describe_opts do
+      before :each do
         gemfile <<-G
-          gem "foo", :git => "#{lib_path("foo-1.0")}"
+          source "file://#{gem_repo1}"
+          gem "rack"
         G
       end
 
       it "re-installs installed gems" do
-        foo_lib = default_bundle_path("bundler/gems/foo-1.0-#{ref}/lib/foo.rb")
+        rack_lib = default_bundle_path("gems/rack-1.0.0/lib/rack.rb")
 
-        bundle! "install"
-        foo_lib.open("w") {|f| f.write("blah blah blah") }
-        bundle! "install --force"
+        bundle! :install
+        rack_lib.open("w") {|f| f.write("blah blah blah") }
+        bundle! :install, flag => true
 
-        expect(foo_lib.open(&:read)).to eq("FOO = '1.0'\n")
-        expect(the_bundle).to include_gems "foo 1.0"
+        expect(out).to include "Installing rack 1.0.0"
+        expect(rack_lib.open(&:read)).to eq("RACK = '1.0.0'\n")
+        expect(the_bundle).to include_gems "rack 1.0.0"
       end
 
       it "works on first bundle install" do
-        bundle! "install --force"
+        bundle! :install, flag => true
 
-        expect(the_bundle).to include_gems "foo 1.0"
+        expect(out).to include "Installing rack 1.0.0"
+        expect(the_bundle).to include_gems "rack 1.0.0"
+      end
+
+      context "with a git gem" do
+        let!(:ref) { build_git("foo", "1.0").ref_for("HEAD", 11) }
+
+        before do
+          gemfile <<-G
+            gem "foo", :git => "#{lib_path("foo-1.0")}"
+          G
+        end
+
+        it "re-installs installed gems" do
+          foo_lib = default_bundle_path("bundler/gems/foo-1.0-#{ref}/lib/foo.rb")
+
+          bundle! :install
+          foo_lib.open("w") {|f| f.write("blah blah blah") }
+          bundle! :install, flag => true
+
+          expect(foo_lib.open(&:read)).to eq("FOO = '1.0'\n")
+          expect(the_bundle).to include_gems "foo 1.0"
+        end
+
+        it "works on first bundle install" do
+          bundle! :install, flag => true
+
+          expect(the_bundle).to include_gems "foo 1.0"
+        end
       end
     end
   end

--- a/spec/install/gemfile/eval_gemfile_spec.rb
+++ b/spec/install/gemfile/eval_gemfile_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "bundle install with gemfile that uses eval_gemfile" do
     # parsed lockfile and the evaluated gemfile.
     it "bundles with --deployment" do
       bundle! :install
-      bundle! :install, forgotten_command_line_options([:deployment, :frozen] => true)
+      bundle! :install, forgotten_command_line_options(:deployment => true)
     end
   end
 

--- a/spec/install/gemfile/eval_gemfile_spec.rb
+++ b/spec/install/gemfile/eval_gemfile_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "bundle install with gemfile that uses eval_gemfile" do
     # parsed lockfile and the evaluated gemfile.
     it "bundles with --deployment" do
       bundle! :install
-      bundle! "install --deployment"
+      bundle! :install, forgotten_command_line_options([:deployment, :frozen] => true)
     end
   end
 

--- a/spec/install/gemfile/gemspec_spec.rb
+++ b/spec/install/gemfile/gemspec_spec.rb
@@ -272,7 +272,7 @@ RSpec.describe "bundle install from an existing gemspec" do
           s.add_dependency "activesupport", ">= 1.0.1"
         end
 
-        bundle "install --deployment"
+        bundle :install, forgotten_command_line_options([:deployment, :frozen] => true)
 
         expect(out).to include("changed")
       end

--- a/spec/install/gemfile/gemspec_spec.rb
+++ b/spec/install/gemfile/gemspec_spec.rb
@@ -272,7 +272,7 @@ RSpec.describe "bundle install from an existing gemspec" do
           s.add_dependency "activesupport", ">= 1.0.1"
         end
 
-        bundle :install, forgotten_command_line_options([:deployment, :frozen] => true)
+        bundle :install, forgotten_command_line_options(:deployment => true)
 
         expect(out).to include("changed")
       end

--- a/spec/install/gemfile/gemspec_spec.rb
+++ b/spec/install/gemfile/gemspec_spec.rb
@@ -651,7 +651,7 @@ RSpec.describe "bundle install from an existing gemspec" do
     it "installs the ruby platform gemspec and skips dev deps with --without development" do
       simulate_platform "ruby"
 
-      install_gemfile! <<-G, :without => "development"
+      install_gemfile! <<-G, forgotten_command_line_options(:without => "development")
         source "file://#{gem_repo1}"
         gemspec :path => '#{tmp.join("foo")}', :name => 'foo'
       G

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -1022,8 +1022,7 @@ RSpec.describe "bundle install with git sources" do
 
       simulate_new_machine
 
-      bundle "install --deployment"
-      expect(exitstatus).to eq(0) if exitstatus
+      bundle! :install, forgotten_command_line_options([:deployment, :frozen] => true)
     end
   end
 

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -1022,7 +1022,7 @@ RSpec.describe "bundle install with git sources" do
 
       simulate_new_machine
 
-      bundle! :install, forgotten_command_line_options([:deployment, :frozen] => true)
+      bundle! :install, forgotten_command_line_options(:deployment => true)
     end
   end
 

--- a/spec/install/gemfile/groups_spec.rb
+++ b/spec/install/gemfile/groups_spec.rb
@@ -198,15 +198,29 @@ RSpec.describe "bundle install with groups" do
         expect(the_bundle).to include_gems "activesupport 2.3.5"
       end
 
-      it "does remove groups from with when passed at without" do
+      it "does remove groups from with when passed at --without", :bundler => "< 2" do
         bundle :install, forgotten_command_line_options(:with => "debugging")
         bundle :install, forgotten_command_line_options(:without => "debugging")
-        expect(the_bundle).not_to include_gems "thin 1.0"
+        expect(the_bundle).not_to include_gem "thin 1.0"
       end
 
-      it "errors out when passing a group to with and without" do
+      it "errors out when passing a group to with and without via CLI flags", :bundler => "< 2" do
         bundle :install, forgotten_command_line_options(:with => "emo debugging", :without => "emo")
+        expect(last_command).to be_failure
         expect(out).to include("The offending groups are: emo")
+      end
+
+      it "allows the BUNDLE_WITH setting to override BUNDLE_WITHOUT" do
+        bundle! "config --local with debugging"
+
+        bundle! :install
+        expect(the_bundle).to include_gem "thin 1.0"
+
+        bundle! "config --local without debugging"
+        expect(the_bundle).to include_gem "thin 1.0"
+
+        bundle! :install
+        expect(the_bundle).to include_gem "thin 1.0"
       end
 
       it "can add and remove a group at the same time" do

--- a/spec/install/gemfile/groups_spec.rb
+++ b/spec/install/gemfile/groups_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "bundle install with groups" do
       end
 
       it "installs gems in the default group" do
-        bundle :install, :without => "emo"
+        bundle! :install, forgotten_command_line_options(:without => "emo")
         expect(the_bundle).to include_gems "rack 1.0.0", :groups => [:default]
       end
 
@@ -96,20 +96,20 @@ RSpec.describe "bundle install with groups" do
       end
 
       it "does not install gems from the previously excluded group" do
-        bundle :install, :without => "emo"
+        bundle :install, forgotten_command_line_options(:without => "emo")
         expect(the_bundle).not_to include_gems "activesupport 2.3.5"
         bundle :install
         expect(the_bundle).not_to include_gems "activesupport 2.3.5"
       end
 
       it "does not say it installed gems from the excluded group" do
-        bundle :install, :without => "emo"
+        bundle! :install, forgotten_command_line_options(:without => "emo")
         expect(out).not_to include("activesupport")
       end
 
       it "allows Bundler.setup for specific groups" do
-        bundle :install, :without => "emo"
-        run("require 'rack'; puts RACK", :default)
+        bundle :install, forgotten_command_line_options(:without => "emo")
+        run!("require 'rack'; puts RACK", :default)
         expect(out).to eq("1.0.0")
       end
 
@@ -122,15 +122,15 @@ RSpec.describe "bundle install with groups" do
           end
         G
 
-        bundle :install, :without => "emo"
+        bundle :install, forgotten_command_line_options(:without => "emo")
         expect(the_bundle).to include_gems "activesupport 2.3.2", :groups => [:default]
       end
 
       it "still works on a different machine and excludes gems" do
-        bundle :install, :without => "emo"
+        bundle :install, forgotten_command_line_options(:without => "emo")
 
         simulate_new_machine
-        bundle :install, :without => "emo"
+        bundle :install, forgotten_command_line_options(:without => "emo")
 
         expect(the_bundle).to include_gems "rack 1.0.0", :groups => [:default]
         expect(the_bundle).not_to include_gems "activesupport 2.3.5", :groups => [:default]
@@ -149,14 +149,14 @@ RSpec.describe "bundle install with groups" do
       end
 
       it "clears without when passed an empty list" do
-        bundle :install, :without => "emo"
+        bundle :install, forgotten_command_line_options(:without => "emo")
 
-        bundle 'install --without ""'
+        bundle :install, forgotten_command_line_options(:without => "")
         expect(the_bundle).to include_gems "activesupport 2.3.5"
       end
 
       it "doesn't clear without when nothing is passed" do
-        bundle :install, :without => "emo"
+        bundle :install, forgotten_command_line_options(:without => "emo")
 
         bundle :install
         expect(the_bundle).not_to include_gems "activesupport 2.3.5"
@@ -168,12 +168,12 @@ RSpec.describe "bundle install with groups" do
       end
 
       it "does install gems from the optional group when requested" do
-        bundle :install, :with => "debugging"
+        bundle :install, forgotten_command_line_options(:with => "debugging")
         expect(the_bundle).to include_gems "thin 1.0"
       end
 
       it "does install gems from the previously requested group" do
-        bundle :install, :with => "debugging"
+        bundle :install, forgotten_command_line_options(:with => "debugging")
         expect(the_bundle).to include_gems "thin 1.0"
         bundle :install
         expect(the_bundle).to include_gems "thin 1.0"
@@ -187,8 +187,8 @@ RSpec.describe "bundle install with groups" do
       end
 
       it "clears with when passed an empty list" do
-        bundle :install, :with => "debugging"
-        bundle 'install --with ""'
+        bundle :install, forgotten_command_line_options(:with => "debugging")
+        bundle :install, forgotten_command_line_options(:with => "")
         expect(the_bundle).not_to include_gems "thin 1.0"
       end
 
@@ -210,7 +210,7 @@ RSpec.describe "bundle install with groups" do
       end
 
       it "can add and remove a group at the same time" do
-        bundle :install, :with => "debugging", :without => "emo"
+        bundle :install, forgotten_command_line_options(:with => "debugging", :without => "emo")
         expect(the_bundle).to include_gems "thin 1.0"
         expect(the_bundle).not_to include_gems "activesupport 2.3.5"
       end
@@ -238,12 +238,12 @@ RSpec.describe "bundle install with groups" do
       end
 
       it "installs gems in the default group" do
-        bundle :install, :without => "emo lolercoaster"
+        bundle! :install, forgotten_command_line_options(:without => "emo lolercoaster")
         expect(the_bundle).to include_gems "rack 1.0.0"
       end
 
       it "installs the gem if any of its groups are installed" do
-        bundle "install --without emo"
+        bundle! :install, forgotten_command_line_options(:without => "emo")
         expect(the_bundle).to include_gems "rack 1.0.0", "activesupport 2.3.5"
       end
 
@@ -299,12 +299,12 @@ RSpec.describe "bundle install with groups" do
       end
 
       it "installs gems in the default group" do
-        bundle :install, :without => "emo lolercoaster"
+        bundle! :install, forgotten_command_line_options(:without => "emo lolercoaster")
         expect(the_bundle).to include_gems "rack 1.0.0"
       end
 
       it "installs the gem if any of its groups are installed" do
-        bundle "install --without emo"
+        bundle! :install, forgotten_command_line_options(:without => "emo")
         expect(the_bundle).to include_gems "rack 1.0.0", "activesupport 2.3.5"
       end
     end
@@ -339,7 +339,7 @@ RSpec.describe "bundle install with groups" do
     before(:each) do
       build_repo2
       system_gems "rack-0.9.1" do
-        install_gemfile <<-G, :without => :rack
+        install_gemfile <<-G, forgotten_command_line_options(:without => "rack")
           source "file://#{gem_repo2}"
           gem "rack"
 

--- a/spec/install/gemfile/groups_spec.rb
+++ b/spec/install/gemfile/groups_spec.rb
@@ -193,19 +193,19 @@ RSpec.describe "bundle install with groups" do
       end
 
       it "does remove groups from without when passed at with" do
-        bundle :install, :without => "emo"
-        bundle :install, :with => "emo"
+        bundle :install, forgotten_command_line_options(:without => "emo")
+        bundle :install, forgotten_command_line_options(:with => "emo")
         expect(the_bundle).to include_gems "activesupport 2.3.5"
       end
 
       it "does remove groups from with when passed at without" do
-        bundle :install, :with => "debugging"
-        bundle :install, :without => "debugging"
+        bundle :install, forgotten_command_line_options(:with => "debugging")
+        bundle :install, forgotten_command_line_options(:without => "debugging")
         expect(the_bundle).not_to include_gems "thin 1.0"
       end
 
       it "errors out when passing a group to with and without" do
-        bundle :install, :with => "emo debugging", :without => "emo"
+        bundle :install, forgotten_command_line_options(:with => "emo debugging", :without => "emo")
         expect(out).to include("The offending groups are: emo")
       end
 
@@ -216,12 +216,12 @@ RSpec.describe "bundle install with groups" do
       end
 
       it "does have no effect when listing a not optional group in with" do
-        bundle :install, :with => "emo"
+        bundle :install, forgotten_command_line_options(:with => "emo")
         expect(the_bundle).to include_gems "activesupport 2.3.5"
       end
 
       it "does have no effect when listing an optional group in without" do
-        bundle :install, :without => "debugging"
+        bundle :install, forgotten_command_line_options(:without => "debugging")
         expect(the_bundle).not_to include_gems "thin 1.0"
       end
     end
@@ -264,22 +264,22 @@ RSpec.describe "bundle install with groups" do
         end
 
         it "installs the gem w/ option --without emo" do
-          bundle "install --without emo"
+          bundle :install, forgotten_command_line_options(:without => "emo")
           expect(the_bundle).to include_gems "activesupport 2.3.5"
         end
 
         it "installs the gem w/ option --without lolercoaster" do
-          bundle "install --without lolercoaster"
+          bundle :install, forgotten_command_line_options(:without => "lolercoaster")
           expect(the_bundle).to include_gems "activesupport 2.3.5"
         end
 
         it "does not install the gem w/ option --without emo lolercoaster" do
-          bundle "install --without emo lolercoaster"
+          bundle :install, forgotten_command_line_options(:without => "emo lolercoaster")
           expect(the_bundle).not_to include_gems "activesupport 2.3.5"
         end
 
         it "does not install the gem w/ option --without 'emo lolercoaster'" do
-          bundle "install --without 'emo lolercoaster'"
+          bundle :install, forgotten_command_line_options(:without => "'emo lolercoaster'")
           expect(the_bundle).not_to include_gems "activesupport 2.3.5"
         end
       end
@@ -363,7 +363,7 @@ RSpec.describe "bundle install with groups" do
 
     it "does not hit the remote a second time" do
       FileUtils.rm_rf gem_repo2
-      bundle! "install --without rack", :verbose => true
+      bundle! :install, forgotten_command_line_options(:without => "rack").merge(:verbose => true)
       expect(last_command.stdboth).not_to match(/fetching/i)
     end
   end

--- a/spec/install/gemfile/path_spec.rb
+++ b/spec/install/gemfile/path_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe "bundle install with explicit source paths" do
       gem 'foo', :path => File.expand_path("../foo-1.0", __FILE__)
     G
 
-    bundle "install --frozen"
+    bundle! :install, forgotten_command_line_options(:frozen => true)
     expect(exitstatus).to eq(0) if exitstatus
   end
 

--- a/spec/install/gemfile/platform_spec.rb
+++ b/spec/install/gemfile/platform_spec.rb
@@ -120,12 +120,12 @@ RSpec.describe "bundle install across platforms" do
       gem "rack", "1.0.0"
     G
 
-    bundle "install --path vendor/bundle"
+    bundle! :install, forgotten_command_line_options(:path => "vendor/bundle")
 
     new_version = Gem::ConfigMap[:ruby_version] == "1.8" ? "1.9.1" : "1.8"
     FileUtils.mv(vendored_gems, bundled_app("vendor/bundle", Gem.ruby_engine, new_version))
 
-    bundle "install --path vendor/bundle"
+    bundle! :install
     expect(vendored_gems("gems/rack-1.0.0")).to exist
   end
 end

--- a/spec/install/gemfile/sources_spec.rb
+++ b/spec/install/gemfile/sources_spec.rb
@@ -107,9 +107,8 @@ RSpec.describe "bundle install with gems on multiple sources" do
         expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
         expect(bundled_app("vendor/cache/rack-obama-1.0.gem")).to exist
 
-        bundle! "install --deployment"
+        bundle! :install, forgotten_command_line_options([:deployment, :frozen] => true)
 
-        expect(exitstatus).to eq(0) if exitstatus
         expect(the_bundle).to include_gems("rack-obama 1.0.0", "rack 1.0.0")
       end
     end
@@ -498,7 +497,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
           rack
       L
 
-      bundle "install --path ../gems/system"
+      bundle! :install, forgotten_command_line_options(:path => "../gems/system")
 
       # 4. Then we add some new versions...
       update_repo4 do
@@ -517,8 +516,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
       G
 
       # 6. Which should update foo to 0.2, but not the (locked) bar 0.1
-      expect(the_bundle).to include_gems("foo 0.2")
-      expect(the_bundle).to include_gems("bar 0.1")
+      expect(the_bundle).to include_gems("foo 0.2", "bar 0.1")
     end
   end
 

--- a/spec/install/gemfile/sources_spec.rb
+++ b/spec/install/gemfile/sources_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
         expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
         expect(bundled_app("vendor/cache/rack-obama-1.0.gem")).to exist
 
-        bundle! :install, forgotten_command_line_options([:deployment, :frozen] => true)
+        bundle! :install, forgotten_command_line_options(:deployment => true)
 
         expect(the_bundle).to include_gems("rack-obama 1.0.0", "rack 1.0.0")
       end

--- a/spec/install/gems/compact_index_spec.rb
+++ b/spec/install/gems/compact_index_spec.rb
@@ -174,7 +174,7 @@ The checksum of /versions does not match the checksum provided by the server! So
   end
 
   it "falls back when the user's home directory does not exist or is not writable" do
-    ENV["HOME"] = nil
+    ENV["HOME"] = tmp("missing_home").to_s
 
     gemfile <<-G
       source "#{source_uri}"

--- a/spec/install/gems/compact_index_spec.rb
+++ b/spec/install/gems/compact_index_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe "compact index api" do
     G
     bundle! :install, :artifice => "compact_index"
 
-    bundle "install --deployment", :artifice => "compact_index"
+    bundle! :install, forgotten_command_line_options([:deployment, :frozen] => true, :path => "vendor/bundle").merge(:artifice => "compact_index")
     expect(out).to include("Fetching gem metadata from #{source_uri}")
     expect(the_bundle).to include_gems "rack 1.0.0"
   end
@@ -129,9 +129,8 @@ RSpec.describe "compact index api" do
     G
 
     bundle "install", :artifice => "compact_index"
-    bundle "install --deployment", :artifice => "compact_index"
+    bundle! :install, forgotten_command_line_options([:deployment, :frozen] => true).merge(:artifice => "compact_index")
 
-    expect(exitstatus).to eq(0) if exitstatus
     expect(the_bundle).to include_gems("foo 1.0")
   end
 
@@ -508,7 +507,7 @@ The checksum of /versions does not match the checksum provided by the server! So
     expect(the_bundle).to include_gems "rails 2.3.2"
   end
 
-  it "installs the binstubs" do
+  it "installs the binstubs", :bundler => "< 2" do
     gemfile <<-G
       source "#{source_uri}"
       gem "rack"
@@ -520,7 +519,7 @@ The checksum of /versions does not match the checksum provided by the server! So
     expect(out).to eq("1.0.0")
   end
 
-  it "installs the bins when using --path and uses autoclean" do
+  it "installs the bins when using --path and uses autoclean", :bundler => "< 2" do
     gemfile <<-G
       source "#{source_uri}"
       gem "rack"
@@ -531,7 +530,7 @@ The checksum of /versions does not match the checksum provided by the server! So
     expect(vendored_gems("bin/rackup")).to exist
   end
 
-  it "installs the bins when using --path and uses bundle clean" do
+  it "installs the bins when using --path and uses bundle clean", :bundler => "< 2" do
     gemfile <<-G
       source "#{source_uri}"
       gem "rack"

--- a/spec/install/gems/compact_index_spec.rb
+++ b/spec/install/gems/compact_index_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe "compact index api" do
     G
     bundle! :install, :artifice => "compact_index"
 
-    bundle! :install, forgotten_command_line_options([:deployment, :frozen] => true, :path => "vendor/bundle").merge(:artifice => "compact_index")
+    bundle! :install, forgotten_command_line_options(:deployment => true, :path => "vendor/bundle").merge(:artifice => "compact_index")
     expect(out).to include("Fetching gem metadata from #{source_uri}")
     expect(the_bundle).to include_gems "rack 1.0.0"
   end
@@ -129,7 +129,7 @@ RSpec.describe "compact index api" do
     G
 
     bundle "install", :artifice => "compact_index"
-    bundle! :install, forgotten_command_line_options([:deployment, :frozen] => true).merge(:artifice => "compact_index")
+    bundle! :install, forgotten_command_line_options(:deployment => true).merge(:artifice => "compact_index")
 
     expect(the_bundle).to include_gems("foo 1.0")
   end

--- a/spec/install/gems/dependency_api_spec.rb
+++ b/spec/install/gems/dependency_api_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "gemcutter's dependency API" do
     G
     bundle :install, :artifice => "endpoint"
 
-    bundle "install --deployment", :artifice => "endpoint"
+    bundle! :install, forgotten_command_line_options([:deployment, :frozen] => true, :path => "vendor/bundle").merge(:artifice => "endpoint")
     expect(out).to include("Fetching gem metadata from #{source_uri}")
     expect(the_bundle).to include_gems "rack 1.0.0"
   end
@@ -109,9 +109,8 @@ RSpec.describe "gemcutter's dependency API" do
     G
 
     bundle "install", :artifice => "endpoint"
-    bundle "install --deployment", :artifice => "endpoint"
+    bundle! :install, forgotten_command_line_options([:deployment, :frozen] => true).merge(:artifice => "endpoint")
 
-    expect(exitstatus).to eq(0) if exitstatus
     expect(the_bundle).to include_gems("foo 1.0")
   end
 
@@ -497,7 +496,7 @@ RSpec.describe "gemcutter's dependency API" do
     expect(the_bundle).to include_gems "rails 2.3.2"
   end
 
-  it "installs the binstubs" do
+  it "installs the binstubs", :bundler => "< 2" do
     gemfile <<-G
       source "#{source_uri}"
       gem "rack"
@@ -509,7 +508,7 @@ RSpec.describe "gemcutter's dependency API" do
     expect(out).to eq("1.0.0")
   end
 
-  it "installs the bins when using --path and uses autoclean" do
+  it "installs the bins when using --path and uses autoclean", :bundler => "< 2" do
     gemfile <<-G
       source "#{source_uri}"
       gem "rack"
@@ -520,7 +519,7 @@ RSpec.describe "gemcutter's dependency API" do
     expect(vendored_gems("bin/rackup")).to exist
   end
 
-  it "installs the bins when using --path and uses bundle clean" do
+  it "installs the bins when using --path and uses bundle clean", :bundler => "< 2" do
     gemfile <<-G
       source "#{source_uri}"
       gem "rack"

--- a/spec/install/gems/dependency_api_spec.rb
+++ b/spec/install/gems/dependency_api_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "gemcutter's dependency API" do
     G
     bundle :install, :artifice => "endpoint"
 
-    bundle! :install, forgotten_command_line_options([:deployment, :frozen] => true, :path => "vendor/bundle").merge(:artifice => "endpoint")
+    bundle! :install, forgotten_command_line_options(:deployment => true, :path => "vendor/bundle").merge(:artifice => "endpoint")
     expect(out).to include("Fetching gem metadata from #{source_uri}")
     expect(the_bundle).to include_gems "rack 1.0.0"
   end
@@ -109,7 +109,7 @@ RSpec.describe "gemcutter's dependency API" do
     G
 
     bundle "install", :artifice => "endpoint"
-    bundle! :install, forgotten_command_line_options([:deployment, :frozen] => true).merge(:artifice => "endpoint")
+    bundle! :install, forgotten_command_line_options(:deployment => true).merge(:artifice => "endpoint")
 
     expect(the_bundle).to include_gems("foo 1.0")
   end

--- a/spec/install/gems/standalone_spec.rb
+++ b/spec/install/gems/standalone_spec.rb
@@ -255,7 +255,7 @@ RSpec.shared_examples "bundle install --standalone" do
     end
   end
 
-  describe "with --binstubs" do
+  describe "with --binstubs", :bundler => "< 2" do
     before do
       gemfile <<-G
         source "file://#{gem_repo1}"

--- a/spec/install/gems/standalone_spec.rb
+++ b/spec/install/gems/standalone_spec.rb
@@ -50,10 +50,11 @@ RSpec.shared_examples "bundle install --standalone" do
 
   describe "with simple gems" do
     before do
-      install_gemfile <<-G, :standalone => true
+      gemfile <<-G
         source "file://#{gem_repo1}"
         gem "rails"
       G
+      bundle! :install, forgotten_command_line_options(:path => "bundle").merge(:standalone => true)
     end
 
     let(:expected_gems) do
@@ -68,7 +69,7 @@ RSpec.shared_examples "bundle install --standalone" do
 
   describe "with gems with native extension" do
     before do
-      install_gemfile <<-G, :standalone => true
+      install_gemfile <<-G, forgotten_command_line_options(:path => "bundle").merge(:standalone => true)
         source "file://#{gem_repo1}"
         gem "very_simple_binary"
       G
@@ -100,7 +101,7 @@ RSpec.shared_examples "bundle install --standalone" do
           end
         G
       end
-      install_gemfile <<-G, :standalone => true
+      install_gemfile <<-G, forgotten_command_line_options(:path => "bundle").merge(:standalone => true)
         gem "bar", :git => "#{lib_path("bar-1.0")}"
       G
     end
@@ -115,11 +116,12 @@ RSpec.shared_examples "bundle install --standalone" do
     before do
       build_git "devise", "1.0"
 
-      install_gemfile <<-G, :standalone => true
+      gemfile <<-G
         source "file://#{gem_repo1}"
         gem "rails"
         gem "devise", :git => "#{lib_path("devise-1.0")}"
       G
+      bundle! :install, forgotten_command_line_options(:path => "bundle").merge(:standalone => true)
     end
 
     let(:expected_gems) do
@@ -137,7 +139,7 @@ RSpec.shared_examples "bundle install --standalone" do
     before do
       build_git "devise", "1.0"
 
-      install_gemfile <<-G, :standalone => true
+      gemfile <<-G
         source "file://#{gem_repo1}"
         gem "rails"
 
@@ -146,6 +148,7 @@ RSpec.shared_examples "bundle install --standalone" do
           gem "rack-test"
         end
       G
+      bundle! :install, forgotten_command_line_options(:path => "bundle").merge(:standalone => true)
     end
 
     let(:expected_gems) do
@@ -158,7 +161,7 @@ RSpec.shared_examples "bundle install --standalone" do
     include_examples "common functionality"
 
     it "allows creating a standalone file with limited groups" do
-      bundle "install --standalone default"
+      bundle! "install", forgotten_command_line_options(:path => "bundle").merge(:standalone => "default")
 
       Dir.chdir(bundled_app) do
         load_error_ruby <<-RUBY, "spec", :no_lib => true
@@ -176,7 +179,7 @@ RSpec.shared_examples "bundle install --standalone" do
     end
 
     it "allows --without to limit the groups used in a standalone" do
-      bundle "install --standalone --without test"
+      bundle! :install, forgotten_command_line_options(:path => "bundle", :without => "test").merge(:standalone => true)
 
       Dir.chdir(bundled_app) do
         load_error_ruby <<-RUBY, "spec", :no_lib => true
@@ -194,7 +197,7 @@ RSpec.shared_examples "bundle install --standalone" do
     end
 
     it "allows --path to change the location of the standalone bundle" do
-      bundle "install --standalone --path path/to/bundle"
+      bundle! "install", forgotten_command_line_options(:path => "path/to/bundle").merge(:standalone => true)
 
       Dir.chdir(bundled_app) do
         ruby <<-RUBY, :no_lib => true
@@ -210,8 +213,8 @@ RSpec.shared_examples "bundle install --standalone" do
     end
 
     it "allows remembered --without to limit the groups used in a standalone" do
-      bundle "install --without test"
-      bundle "install --standalone"
+      bundle! :install, forgotten_command_line_options(:without => "test")
+      bundle! :install, forgotten_command_line_options(:path => "bundle").merge(:standalone => true)
 
       Dir.chdir(bundled_app) do
         load_error_ruby <<-RUBY, "spec", :no_lib => true
@@ -238,7 +241,7 @@ RSpec.shared_examples "bundle install --standalone" do
           source "#{source_uri}"
           gem "rails"
         G
-        bundle "install --standalone", :artifice => "endpoint"
+        bundle! :install, forgotten_command_line_options(:path => "bundle").merge(:standalone => true, :artifice => "endpoint")
       end
 
       let(:expected_gems) do
@@ -254,10 +257,11 @@ RSpec.shared_examples "bundle install --standalone" do
 
   describe "with --binstubs" do
     before do
-      install_gemfile <<-G, :standalone => true, :binstubs => true
+      gemfile <<-G
         source "file://#{gem_repo1}"
         gem "rails"
       G
+      bundle! :install, forgotten_command_line_options(:path => "bundle").merge(:standalone => true, :binstubs => true)
     end
 
     let(:expected_gems) do

--- a/spec/install/gems/sudo_spec.rb
+++ b/spec/install/gems/sudo_spec.rb
@@ -161,16 +161,9 @@ RSpec.describe "when using sudo", :sudo => true do
       end
     end
 
-    context "when silence_root_warning is passed as an option" do
-      it "skips the warning" do
-        bundle :install, :sudo => true, :silence_root_warning => true
-        expect(out).to_not include(warning)
-      end
-    end
-
     context "when silence_root_warning = false" do
       it "warns against that" do
-        bundle :install, :sudo => true, :silence_root_warning => false
+        bundle :install, :sudo => true, :env => { "BUNDLE_SILENCE_ROOT_WARNING" => "false" }
         expect(out).to include(warning)
       end
     end

--- a/spec/install/git_spec.rb
+++ b/spec/install/git_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "bundle install" do
           foo!
       L
 
-      bundle! "install --path=vendor/bundle --without development"
+      bundle! :install, forgotten_command_line_options(:path => "vendor/bundle", :without => "development")
 
       expect(out).to include("Bundle complete!")
     end

--- a/spec/install/path_spec.rb
+++ b/spec/install/path_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe "bundle install" do
       G
     end
 
-    it "does not use available system gems with bundle --path vendor/bundle" do
-      bundle "install --path vendor/bundle"
+    it "does not use available system gems with bundle --path vendor/bundle", :bundler => "< 2" do
+      bundle! :install, forgotten_command_line_options(:path => "vendor/bundle")
       expect(the_bundle).to include_gems "rack 1.0.0"
     end
 
@@ -41,7 +41,7 @@ RSpec.describe "bundle install" do
       expect(exitstatus).to eq(15) if exitstatus
     end
 
-    it "remembers to disable system gems after the first time with bundle --path vendor/bundle" do
+    it "remembers to disable system gems after the first time with bundle --path vendor/bundle", :bundler => "< 2" do
       bundle "install --path vendor/bundle"
       FileUtils.rm_rf bundled_app("vendor")
       bundle "install"
@@ -74,7 +74,7 @@ RSpec.describe "bundle install" do
     [:env, :global].each do |type|
       it "installs gems to a path if one is specified" do
         set_bundle_path(type, bundled_app("vendor2").to_s)
-        bundle "install --path vendor/bundle"
+        bundle! :install, forgotten_command_line_options(:path => "vendor/bundle")
 
         expect(vendored_gems("gems/rack-1.0.0")).to be_directory
         expect(bundled_app("vendor2")).not_to be_directory
@@ -113,7 +113,7 @@ RSpec.describe "bundle install" do
     end
 
     it "sets BUNDLE_PATH as the first argument to bundle install" do
-      bundle "install --path ./vendor/bundle"
+      bundle! :install, forgotten_command_line_options(:path => "./vendor/bundle")
 
       expect(vendored_gems("gems/rack-1.0.0")).to be_directory
       expect(the_bundle).to include_gems "rack 1.0.0"
@@ -122,7 +122,7 @@ RSpec.describe "bundle install" do
     it "disables system gems when passing a path to install" do
       # This is so that vendored gems can be distributed to others
       build_gem "rack", "1.1.0", :to_system => true
-      bundle "install --path ./vendor/bundle"
+      bundle! :install, forgotten_command_line_options(:path => "./vendor/bundle")
 
       expect(vendored_gems("gems/rack-1.0.0")).to be_directory
       expect(the_bundle).to include_gems "rack 1.0.0"
@@ -138,7 +138,7 @@ RSpec.describe "bundle install" do
         gem "very_simple_binary"
       G
 
-      bundle "install --path ./vendor/bundle"
+      bundle! :install, forgotten_command_line_options(:path => "./vendor/bundle")
 
       expect(vendored_gems("gems/very_simple_binary-1.0")).to be_directory
       expect(vendored_gems("extensions")).to be_directory
@@ -149,7 +149,7 @@ RSpec.describe "bundle install" do
       run "require 'very_simple_binary_c'"
       expect(err).to include("Bundler::GemNotFound")
 
-      bundle "install --path ./vendor/bundle"
+      bundle :install, forgotten_command_line_options(:path => "./vendor/bundle")
 
       expect(vendored_gems("gems/very_simple_binary-1.0")).to be_directory
       expect(vendored_gems("extensions")).to be_directory

--- a/spec/install/path_spec.rb
+++ b/spec/install/path_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "bundle install" do
       dir.mkpath
 
       Dir.chdir(dir) do
-        bundle "install --path vendor/bundle"
+        bundle! :install, forgotten_command_line_options(:path => "vendor/bundle")
         expect(out).to include("installed into ./vendor/bundle")
       end
 
@@ -31,11 +31,11 @@ RSpec.describe "bundle install" do
     end
 
     it "prints a warning to let the user know what has happened with bundle --path vendor/bundle" do
-      bundle "install --path vendor/bundle"
+      bundle! :install, forgotten_command_line_options(:path => "vendor/bundle")
       expect(out).to include("gems are installed into ./vendor")
     end
 
-    it "disallows --path vendor/bundle --system" do
+    it "disallows --path vendor/bundle --system", :bundler => "< 2" do
       bundle "install --path vendor/bundle --system"
       expect(out).to include("Please choose only one option.")
       expect(exitstatus).to eq(15) if exitstatus
@@ -170,7 +170,7 @@ RSpec.describe "bundle install" do
         gem "rack"
       G
 
-      bundle "install --path bundle"
+      bundle :install, forgotten_command_line_options(:path => "bundle")
       expect(out).to match(/file already exists/)
     end
   end

--- a/spec/install/post_bundle_message_spec.rb
+++ b/spec/install/post_bundle_message_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "post bundle message" do
     end
 
     it "with --without one group" do
-      bundle "install --without emo"
+      bundle! :install, forgotten_command_line_options(:without => "emo")
       expect(out).to include(bundle_show_message)
       expect(out).to include("Gems in the group emo were not installed")
       expect(out).to include(bundle_complete_message)
@@ -37,7 +37,7 @@ RSpec.describe "post bundle message" do
     end
 
     it "with --without two groups" do
-      bundle "install --without emo test"
+      bundle! :install, forgotten_command_line_options(:without => "emo test")
       expect(out).to include(bundle_show_message)
       expect(out).to include("Gems in the groups emo and test were not installed")
       expect(out).to include(bundle_complete_message)
@@ -45,7 +45,7 @@ RSpec.describe "post bundle message" do
     end
 
     it "with --without more groups" do
-      bundle "install --without emo obama test"
+      bundle! :install, forgotten_command_line_options(:without => "emo obama test")
       expect(out).to include(bundle_show_message)
       expect(out).to include("Gems in the groups emo, obama and test were not installed")
       expect(out).to include(bundle_complete_message)
@@ -54,43 +54,43 @@ RSpec.describe "post bundle message" do
 
     describe "with --path and" do
       it "without any options" do
-        bundle "install --path vendor"
+        bundle! :install, forgotten_command_line_options(:path => "vendor")
         expect(out).to include(bundle_deployment_message)
         expect(out).to_not include("Gems in the group")
         expect(out).to include(bundle_complete_message)
       end
 
       it "with --without one group" do
-        bundle "install --without emo --path vendor"
+        bundle! :install, forgotten_command_line_options(:without => "emo", :path => "vendor")
         expect(out).to include(bundle_deployment_message)
         expect(out).to include("Gems in the group emo were not installed")
         expect(out).to include(bundle_complete_message)
       end
 
       it "with --without two groups" do
-        bundle "install --without emo test --path vendor"
+        bundle! :install, forgotten_command_line_options(:without => "emo test", :path => "vendor")
         expect(out).to include(bundle_deployment_message)
         expect(out).to include("Gems in the groups emo and test were not installed")
         expect(out).to include(bundle_complete_message)
       end
 
       it "with --without more groups" do
-        bundle "install --without emo obama test --path vendor"
+        bundle! :install, forgotten_command_line_options(:without => "emo obama test", :path => "vendor")
         expect(out).to include(bundle_deployment_message)
         expect(out).to include("Gems in the groups emo, obama and test were not installed")
         expect(out).to include(bundle_complete_message)
       end
 
       it "with an absolute --path inside the cwd" do
-        bundle "install --path #{bundled_app}/cache"
+        bundle! :install, forgotten_command_line_options(:path => bundled_app("cache"))
         expect(out).to include("Bundled gems are installed into ./cache")
         expect(out).to_not include("Gems in the group")
         expect(out).to include(bundle_complete_message)
       end
 
       it "with an absolute --path outside the cwd" do
-        bundle "install --path #{bundled_app}_cache"
-        expect(out).to include("Bundled gems are installed into #{bundled_app}_cache")
+        bundle! :install, forgotten_command_line_options(:path => tmp("not_bundled_app"))
+        expect(out).to include("Bundled gems are installed into #{tmp("not_bundled_app")}")
         expect(out).to_not include("Gems in the group")
         expect(out).to include(bundle_complete_message)
       end

--- a/spec/install/post_bundle_message_spec.rb
+++ b/spec/install/post_bundle_message_spec.rb
@@ -146,8 +146,8 @@ The source does not contain any versions of 'not-a-gem'
     end
 
     it "with --without one group" do
-      bundle "install --without emo"
-      bundle :install
+      bundle! :install, forgotten_command_line_options(:without => "emo")
+      bundle! :install
       expect(out).to include(bundle_show_message)
       expect(out).to include("Gems in the group emo were not installed")
       expect(out).to include(bundle_complete_message)
@@ -155,15 +155,15 @@ The source does not contain any versions of 'not-a-gem'
     end
 
     it "with --without two groups" do
-      bundle "install --without emo test"
-      bundle :install
+      bundle! :install, forgotten_command_line_options(:without => "emo test")
+      bundle! :install
       expect(out).to include(bundle_show_message)
       expect(out).to include("Gems in the groups emo and test were not installed")
       expect(out).to include(bundle_complete_message)
     end
 
     it "with --without more groups" do
-      bundle "install --without emo obama test"
+      bundle! :install, forgotten_command_line_options(:without => "emo obama test")
       bundle :install
       expect(out).to include(bundle_show_message)
       expect(out).to include("Gems in the groups emo, obama and test were not installed")
@@ -179,21 +179,21 @@ The source does not contain any versions of 'not-a-gem'
     end
 
     it "with --without one group" do
-      bundle! :install, :without => :emo
+      bundle! :install, forgotten_command_line_options(:without => "emo")
       bundle! :update, :all => bundle_update_requires_all?
       expect(out).to include("Gems in the group emo were not installed")
       expect(out).to include(bundle_updated_message)
     end
 
     it "with --without two groups" do
-      bundle! "install --without emo test"
+      bundle! :install, forgotten_command_line_options(:without => "emo test")
       bundle! :update, :all => bundle_update_requires_all?
       expect(out).to include("Gems in the groups emo and test were not installed")
       expect(out).to include(bundle_updated_message)
     end
 
     it "with --without more groups" do
-      bundle! "install --without emo obama test"
+      bundle! :install, forgotten_command_line_options(:without => "emo obama test")
       bundle! :update, :all => bundle_update_requires_all?
       expect(out).to include("Gems in the groups emo, obama and test were not installed")
       expect(out).to include(bundle_updated_message)

--- a/spec/lock/lockfile_spec.rb
+++ b/spec/lock/lockfile_spec.rb
@@ -1239,7 +1239,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
       gem "omg", :git => "#{lib_path("omg")}", :branch => 'master'
     G
 
-    bundle "install --path vendor"
+    bundle! :install, forgotten_command_line_options(:path => "vendor")
     expect(the_bundle).to include_gems "omg 1.0"
 
     # Create a Gemfile.lock that has duplicate GIT sections

--- a/spec/plugins/source/example_spec.rb
+++ b/spec/plugins/source/example_spec.rb
@@ -152,8 +152,8 @@ RSpec.describe "real source plugins" do
       end
 
       it "copies repository to vendor cache and uses it even when installed with bundle --path" do
-        bundle "install --path vendor/bundle"
-        bundle "cache --all"
+        bundle! :install, forgotten_command_line_options(:path => "vendor/bundle")
+        bundle! :cache, forgotten_command_line_options([:all, :cache_all] => true)
 
         expect(bundled_app("vendor/cache/a-path-gem-1.0-#{uri_hash}")).to exist
 
@@ -162,8 +162,8 @@ RSpec.describe "real source plugins" do
       end
 
       it "bundler package copies repository to vendor cache" do
-        bundle "install --path vendor/bundle"
-        bundle "package --all"
+        bundle! :install, forgotten_command_line_options(:path => "vendor/bundle")
+        bundle! :package, forgotten_command_line_options([:all, :cache_all] => true)
 
         expect(bundled_app("vendor/cache/a-path-gem-1.0-#{uri_hash}")).to exist
 

--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -173,6 +173,7 @@ RSpec.describe "The library itself" do
       console_command
       default_cli_command
       deployment_means_frozen
+      forget_cli_options
       gem.coc
       gem.mit
       inline
@@ -185,6 +186,7 @@ RSpec.describe "The library itself" do
 
     Bundler::Settings::BOOL_KEYS.each {|k| all_settings[k] << "in Bundler::Settings::BOOL_KEYS" }
     Bundler::Settings::NUMBER_KEYS.each {|k| all_settings[k] << "in Bundler::Settings::NUMBER_KEYS" }
+    Bundler::Settings::ARRAY_KEYS.each {|k| all_settings[k] << "in Bundler::Settings::ARRAY_KEYS" }
 
     Dir.chdir(root) do
       key_pattern = /([a-z\._-]+)/i

--- a/spec/realworld/edgecases_spec.rb
+++ b/spec/realworld/edgecases_spec.rb
@@ -239,7 +239,7 @@ RSpec.describe "real world edgecases", :realworld => true, :sometimes => true do
       gem 'rack', '1.0.1'
     G
 
-    bundle "install --path vendor/bundle"
+    bundle! :install, forgotten_command_line_options(:path => "vendor/bundle")
     expect(err).not_to include("Could not find rake")
     expect(err).to lack_errors
   end

--- a/spec/realworld/parallel_spec.rb
+++ b/spec/realworld/parallel_spec.rb
@@ -22,9 +22,6 @@ RSpec.describe "parallel", :realworld => true, :sometimes => true do
 
     bundle "show faker"
     expect(out).to match(/faker/)
-
-    bundle "config jobs"
-    expect(out).to match(/: "4"/)
   end
 
   it "updates" do
@@ -54,9 +51,6 @@ RSpec.describe "parallel", :realworld => true, :sometimes => true do
 
     bundle "show faker"
     expect(out).to match(/faker/)
-
-    bundle "config jobs"
-    expect(out).to match(/: "4"/)
   end
 
   it "works with --standalone" do

--- a/spec/runtime/executable_spec.rb
+++ b/spec/runtime/executable_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe "Running bin/* commands" do
       gem "activesupport"
     G
 
-    bundle "install --binstubs"
+    bundle! :install, forgotten_command_line_options([:binstubs, :bin] => "bin")
 
     gemfile <<-G
       source "file://#{gem_repo1}"
@@ -135,7 +135,7 @@ RSpec.describe "Running bin/* commands" do
       gem "rack"
     G
 
-    bundle "install --binstubs bin/"
+    bundle! :install, forgotten_command_line_options([:binstubs, :bin] => "bin")
 
     File.open(bundled_app("bin/rackup"), "wb") do |file|
       file.print "OMG"

--- a/spec/runtime/executable_spec.rb
+++ b/spec/runtime/executable_spec.rb
@@ -100,13 +100,13 @@ RSpec.describe "Running bin/* commands" do
   end
 
   it "allows you to stop installing binstubs" do
-    bundle "install --binstubs bin/"
+    bundle! "install --binstubs bin/"
     bundled_app("bin/rackup").rmtree
-    bundle "install --binstubs \"\""
+    bundle! "install --binstubs \"\""
 
     expect(bundled_app("bin/rackup")).not_to exist
 
-    bundle "config bin"
+    bundle! "config bin"
     expect(out).to include("You have not configured a value for `bin`")
   end
 

--- a/spec/runtime/executable_spec.rb
+++ b/spec/runtime/executable_spec.rb
@@ -2,14 +2,14 @@
 
 RSpec.describe "Running bin/* commands" do
   before :each do
-    gemfile <<-G
+    install_gemfile! <<-G
       source "file://#{gem_repo1}"
       gem "rack"
     G
   end
 
   it "runs the bundled command when in the bundle" do
-    bundle "install --binstubs"
+    bundle! "binstubs rack"
 
     build_gem "rack", "2.0", :to_system => true do |s|
       s.executables = "rackup"
@@ -20,7 +20,7 @@ RSpec.describe "Running bin/* commands" do
   end
 
   it "allows the location of the gem stubs to be specified" do
-    bundle "install --binstubs gbin"
+    bundle! "binstubs rack", :path => "gbin"
 
     expect(bundled_app("bin")).not_to exist
     expect(bundled_app("gbin/rackup")).to exist
@@ -30,24 +30,24 @@ RSpec.describe "Running bin/* commands" do
   end
 
   it "allows absolute paths as a specification of where to install bin stubs" do
-    bundle "install --binstubs #{tmp}/bin"
+    bundle! "binstubs rack", :path => tmp("bin")
 
     gembin tmp("bin/rackup")
     expect(out).to eq("1.0.0")
   end
 
   it "uses the default ruby install name when shebang is not specified" do
-    bundle "install --binstubs"
+    bundle! "binstubs rack"
     expect(File.open("bin/rackup").gets).to eq("#!/usr/bin/env #{RbConfig::CONFIG["ruby_install_name"]}\n")
   end
 
   it "allows the name of the shebang executable to be specified" do
-    bundle "install --binstubs --shebang ruby-foo"
+    bundle! "binstubs rack", :shebang => "ruby-foo"
     expect(File.open("bin/rackup").gets).to eq("#!/usr/bin/env ruby-foo\n")
   end
 
   it "runs the bundled command when out of the bundle" do
-    bundle "install --binstubs"
+    bundle! "binstubs rack"
 
     build_gem "rack", "2.0", :to_system => true do |s|
       s.executables = "rackup"
@@ -68,7 +68,7 @@ RSpec.describe "Running bin/* commands" do
       gem "rack", :path => "#{lib_path("rack")}"
     G
 
-    bundle "install --binstubs"
+    bundle! "binstubs rack"
 
     build_gem "rack", "2.0", :to_system => true do |s|
       s.executables = "rackup"
@@ -88,18 +88,18 @@ RSpec.describe "Running bin/* commands" do
       gem "bundler"
     G
 
-    bundle "install --binstubs"
+    bundle "binstubs bundler"
 
     expect(bundled_app("bin/bundle")).not_to exist
   end
 
   it "does not generate bin stubs if the option was not specified" do
-    bundle "install"
+    bundle! "install"
 
     expect(bundled_app("bin/rackup")).not_to exist
   end
 
-  it "allows you to stop installing binstubs" do
+  it "allows you to stop installing binstubs", :bundler => "< 2" do
     bundle! "install --binstubs bin/"
     bundled_app("bin/rackup").rmtree
     bundle! "install --binstubs \"\""
@@ -110,7 +110,7 @@ RSpec.describe "Running bin/* commands" do
     expect(out).to include("You have not configured a value for `bin`")
   end
 
-  it "remembers that the option was specified" do
+  it "remembers that the option was specified", :bundler => "< 2" do
     gemfile <<-G
       source "file://#{gem_repo1}"
       gem "activesupport"
@@ -129,7 +129,7 @@ RSpec.describe "Running bin/* commands" do
     expect(bundled_app("bin/rackup")).to exist
   end
 
-  it "rewrites bins on --binstubs (to maintain backwards compatibility)" do
+  it "rewrites bins on --binstubs (to maintain backwards compatibility)", :bundler => "< 2" do
     gemfile <<-G
       source "file://#{gem_repo1}"
       gem "rack"
@@ -142,6 +142,21 @@ RSpec.describe "Running bin/* commands" do
     end
 
     bundle "install"
+
+    expect(bundled_app("bin/rackup").read).to_not eq("OMG")
+  end
+
+  it "rewrites bins on binstubs (to maintain backwards compatibility)" do
+    install_gemfile! <<-G
+      source "file://#{gem_repo1}"
+      gem "rack"
+    G
+
+    File.open(bundled_app("bin/rackup"), "wb") do |file|
+      file.print "OMG"
+    end
+
+    bundle! "binstubs rack"
 
     expect(bundled_app("bin/rackup").read).to_not eq("OMG")
   end

--- a/spec/runtime/executable_spec.rb
+++ b/spec/runtime/executable_spec.rb
@@ -152,9 +152,7 @@ RSpec.describe "Running bin/* commands" do
       gem "rack"
     G
 
-    File.open(bundled_app("bin/rackup"), "wb") do |file|
-      file.print "OMG"
-    end
+    create_file("bin/rackup", "OMG")
 
     bundle! "binstubs rack"
 

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -495,13 +495,13 @@ RSpec.describe "Bundler.setup" do
     end
 
     it "works even when the cache directory has been deleted" do
-      bundle "install --path vendor/bundle"
+      bundle! :install, forgotten_command_line_options(:path => "vendor/bundle")
       FileUtils.rm_rf vendored_gems("cache")
       expect(the_bundle).to include_gems "rack 1.0.0"
     end
 
     it "does not randomly change the path when specifying --path and the bundle directory becomes read only" do
-      bundle "install --path vendor/bundle"
+      bundle! :install, forgotten_command_line_options(:path => "vendor/bundle")
 
       with_read_only("**/*") do
         expect(the_bundle).to include_gems "rack 1.0.0"
@@ -603,7 +603,7 @@ RSpec.describe "Bundler.setup" do
 
   describe "when excluding groups" do
     it "doesn't change the resolve if --without is used" do
-      install_gemfile <<-G, :without => :rails
+      install_gemfile <<-G, forgotten_command_line_options(:without => :rails)
         source "file://#{gem_repo1}"
         gem "activesupport"
 
@@ -618,7 +618,7 @@ RSpec.describe "Bundler.setup" do
     end
 
     it "remembers --without and does not bail on bare Bundler.setup" do
-      install_gemfile <<-G, :without => :rails
+      install_gemfile <<-G, forgotten_command_line_options(:without => :rails)
         source "file://#{gem_repo1}"
         gem "activesupport"
 
@@ -633,7 +633,7 @@ RSpec.describe "Bundler.setup" do
     end
 
     it "remembers --without and does not include groups passed to Bundler.setup" do
-      install_gemfile <<-G, :without => :rails
+      install_gemfile <<-G, forgotten_command_line_options(:without => :rails)
         source "file://#{gem_repo1}"
         gem "activesupport"
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that on Bundler 1.0, command line options passed to the different commands would be remembered _across command invocations_. This was hella confusing for users, and made Bundler a difficult command line tool to work with -- you'd pass an option once, it'd be set without you realizing it, and Bundler would behave differently.

See https://trello.com/c/yGsPNDpg/48-stop-auto-remembering-any-command-flags for the original discussion, but I've excerpted bits below:

> Silently remembering flags that were passed to a command sometime in the past completely breaks all expectations for how command-line utilities work. It’s convenient for some users some of the time, but at the cost of many, many bugs filed that turn out to be unexpectedly remembered options.

### Was was your diagnosis of the problem?

My diagnosis was that, behind a feature flag, we'd change commands behavior to only set settings temporarily (for the life of the current process), and after that disable options that become useless when not remembered.

See https://github.com/bundler/bundler/pull/3955.

### What is your fix for the problem, implemented in this PR?

My fix is to remove most CLI options in Bundler 2. Those that remain are set only for the duration of the process, rather than persisted to disk.