### PR TITLE
Allow BUNDLE_GEMFILE to not be an absolute path

### DIFF
--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -28,7 +28,7 @@ module Bundler
     def default_gemfile
       gemfile = find_gemfile(:order_matters)
       raise GemfileNotFound, "Could not locate Gemfile" unless gemfile
-      Pathname.new(gemfile).untaint
+      Pathname.new(gemfile).untaint.expand_path
     end
 
     def default_lockfile
@@ -191,7 +191,7 @@ module Bundler
 
     def find_gemfile(order_matters = false)
       given = ENV["BUNDLE_GEMFILE"]
-      return File.expand_path(given) if given && !given.empty?
+      return given if given && !given.empty?
       names = gemfile_names
       names.reverse! if order_matters && Bundler.feature_flag.prefer_gems_rb?
       find_file(*names)

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -191,7 +191,7 @@ module Bundler
 
     def find_gemfile(order_matters = false)
       given = ENV["BUNDLE_GEMFILE"]
-      return given if given && !given.empty?
+      return File.expand_path(given) if given && !given.empty?
       names = gemfile_names
       names.reverse! if order_matters && Bundler.feature_flag.prefer_gems_rb?
       find_file(*names)

--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Bundler::SharedHelpers do
       context "currently in directory with a Gemfile" do
         before { File.new("Gemfile", "w") }
 
-        it "returns path of the bundle gemfile" do
+        it "returns path of the bundle Gemfile" do
           expect(subject.in_bundle?).to eq("#{bundled_app}/Gemfile")
         end
       end
@@ -118,6 +118,14 @@ RSpec.describe Bundler::SharedHelpers do
 
       it "returns ENV['BUNDLE_GEMFILE']" do
         expect(subject.in_bundle?).to eq("/path/Gemfile")
+      end
+    end
+
+    context "ENV['BUNDLE_GEMFILE'] is set without an absolute path" do
+      before { ENV["BUNDLE_GEMFILE"] = "Gemfile" }
+
+      it "returns path of the bundle Gemfile" do
+        expect(subject.in_bundle?).to eq("#{bundled_app}/Gemfile")
       end
     end
 

--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -30,6 +30,16 @@ RSpec.describe Bundler::SharedHelpers do
         )
       end
     end
+
+    context "Gemfile is not an absolute path" do
+      before { ENV["BUNDLE_GEMFILE"] = "Gemfile" }
+
+      let(:expected_gemfile_path) { Pathname.new("Gemfile").expand_path }
+
+      it "returns the Gemfile path" do
+        expect(subject.default_gemfile).to eq(expected_gemfile_path)
+      end
+    end
   end
 
   describe "#default_lockfile" do
@@ -118,14 +128,6 @@ RSpec.describe Bundler::SharedHelpers do
 
       it "returns ENV['BUNDLE_GEMFILE']" do
         expect(subject.in_bundle?).to eq("/path/Gemfile")
-      end
-    end
-
-    context "ENV['BUNDLE_GEMFILE'] is set without an absolute path" do
-      before { ENV["BUNDLE_GEMFILE"] = "Gemfile" }
-
-      it "returns path of the bundle Gemfile" do
-        expect(subject.in_bundle?).to eq("#{bundled_app}/Gemfile")
       end
     end
 


### PR DESCRIPTION
Hello - I was stalking the open issues and had time to implement this quick PR for your review. This is a direct fix to https://github.com/bundler/bundler/issues/5712.

I implemented the fix that @segiddins suggested in the comments, just added a test scenario. Please let me know if anything else is needed!

---

### What was the end-user problem that led to this PR?

The problem was that starting with Bundler 1.15.0, `Bundler.setup` fails with an `ArgumentError` raised from `Pathname#relative_path_from` when the following conditions are met:

- Bundler is in deployment mode; and
- A Gemfile is explicitly specified via the `BUNDLE_GEMFILE` environment variable; and
- That Gemfile is not an absolute path (e.g. `BUNDLE_GEMFILE=Gemfile`)

### Was was your diagnosis of the problem?

My diagnosis was that in `Bundler::SharedHelpers#default_gemfile`, the `Pathname` object being instantiated was not being expanded. So, in the case that `ENV["BUNDLE_GEMFILE"]` was not an absolute path, `Bundle.setup` would error out `Bundler.default_lockfile.relative_path_from(SharedHelpers.pwd)` since `Bundler.default_lockfile` derived itself from `Bundler.default_gemfile`.

### What is your fix for the problem, implemented in this PR?

My fix was to add `expand_path` to the `Pathname` object being returned in `Bundler::SharedHelpers#default_gemfile`

### Why did you choose this fix out of the possible options?

I chose this fix because Bundler was already deriving `Bundler::Sharedhelpers#root` with an `#expand_path`, so I wanted to follow that pattern. 