### PR TITLE
Compare sources using source's root

### DIFF
--- a/lib/bundler/source/path.rb
+++ b/lib/bundler/source/path.rb
@@ -65,7 +65,7 @@ module Bundler
 
       def eql?(other)
         return unless other.class == self.class
-        expand(@original_path) == expand(other.original_path) &&
+        expanded_original_path == other.expanded_original_path &&
           version == other.version
       end
 
@@ -117,6 +117,10 @@ module Bundler
 
       def is_a_path?
         instance_of?(Path)
+      end
+
+      def expanded_original_path
+        @expanded_original_path ||= expand(original_path)
       end
 
     private

--- a/spec/bundler/source/path_spec.rb
+++ b/spec/bundler/source/path_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+RSpec.describe Bundler::Source::Path do
+  before do
+    allow(Bundler).to receive(:root) { Pathname.new("root") }
+  end
+
+  describe "#eql?" do
+    subject { described_class.new("path" => "gems/a") }
+
+    context "with two equivalent relative paths from different roots" do
+      let(:a_gem_opts) { { "path" => "../gems/a", "root_path" => Bundler.root.join("nested") } }
+      let(:a_gem)      { described_class.new a_gem_opts }
+
+      it "returns true" do
+        expect(subject).to eq a_gem
+      end
+    end
+
+    context "with the same (but not equivalent) relative path from different roots" do
+      subject { described_class.new("path" => "gems/a") }
+
+      let(:a_gem_opts) { { "path" => "gems/a", "root_path" => Bundler.root.join("nested") } }
+      let(:a_gem)      { described_class.new a_gem_opts }
+
+      it "returns false" do
+        expect(subject).to_not eq a_gem
+      end
+    end
+  end
+end

--- a/spec/install/gemfile/eval_gemfile_spec.rb
+++ b/spec/install/gemfile/eval_gemfile_spec.rb
@@ -41,6 +41,13 @@ RSpec.describe "bundle install with gemfile that uses eval_gemfile" do
       bundle! :install
       expect(the_bundle).to include_gem("a 1.0")
     end
+
+    # Make sure that we are properly comparing path based gems between the
+    # parsed lockfile and the evaluated gemfile.
+    it "bundles with --deployment" do
+      bundle! :install
+      bundle! "install --deployment"
+    end
   end
 
   context "Gemfile uses gemspec paths after eval-ing a Gemfile" do


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Given a setup where:

1. A project's Gemfile makes use of another project's Gemfile and the `eval_gemfile` method to share the dependencies.  Something like:
  
  ```ruby
  # project_plugin's Gemfile
  
  eval_gemfile(File.expand_path("../../main_project/Gemfile", __FILE__))
  ```
  
2. The main project includes a path gem in it that is nested in the main project:
  
  ```ruby
  # main_project's Gemfile
  gem "foo_gem", :path => "vendor/foo_gem"
  ```
  
3. A `bundle install` is followed by a `bundle install --deployment`, the second of which triggers a comparison of the `lockfile.sources` and the `Bundler.definition`

A error will occur when comparing the specs, saying the the "foo_gem" source has been deleted:

```console
$ bundle install
...
$ bundle install --deployment
You are trying to install in deployment mode after changing
your Gemfile. Run `bundle install` elsewhere and add the
updated Gemfile.lock to version control.

the gemspecs for path gems changed


You have deleted from the Gemfile:
* source: source at `../main_project/vendor/foo_gem`
```

### What was your diagnosis of the problem?

(extracted from the commit message)

When doing the following:

    expand(other.original_path)

inside a `Bundler::Source::Path` instance, the `@root_path` from the instance that is having `eq?` called on it, the the `other` instance's `root_path`.  This, in obscure cases, can cause a bug when you are doing an nested eval_gemfile or other calls when comparing the lockfile's locked path sources to the `Bundler.definition`'s path sources.

### What is your fix for the problem, implemented in this PR?

Use a new public method, `Bundler::Source::Path#expanded_original_path`, in the `eq?` method instead of using's the instance's `#expand` method.

### Why did you choose this fix out of the possible options?

(extracted from the commit message)

Creating the `expanded_original_path` method allows a public interface to be made available (and doesn't mess with any exiting functionality) that allows comparing the source path of one `Source::Path`'s `expand_path` to another, where each uses their own `root_path` to resolve their full path, instead of sharing the base one and causing edge case bugs

