### PR TITLE
[2.0] Enable specific_platform by default on 2.0

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -861,7 +861,7 @@ module Bundler
             "To add those platforms to the bundle, " \
             "run `bundle lock --add-platform #{mapped_platforms.join " "}`."
         end
-        platforms.each do |p|
+        Resolver.sort_platforms(platforms).each do |p|
           deps << DepProxy.new(dep, p) if remote || p == generic_local_platform
         end
       end

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -847,11 +847,12 @@ module Bundler
     end
 
     def expand_dependencies(dependencies, remote = false)
+      sorted_platforms = Resolver.sort_platforms(@platforms)
       deps = []
       dependencies.each do |dep|
         dep = Dependency.new(dep, ">= 0") unless dep.respond_to?(:name)
         next if !remote && !dep.current_platform?
-        platforms = dep.gem_platforms(@platforms)
+        platforms = dep.gem_platforms(sorted_platforms)
         if platforms.empty?
           mapped_platforms = dep.platforms.map {|p| Dependency::PLATFORM_MAP[p] }
           Bundler.ui.warn \
@@ -861,7 +862,7 @@ module Bundler
             "To add those platforms to the bundle, " \
             "run `bundle lock --add-platform #{mapped_platforms.join " "}`."
         end
-        Resolver.sort_platforms(platforms).each do |p|
+        platforms.each do |p|
           deps << DepProxy.new(dep, p) if remote || p == generic_local_platform
         end
       end

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -492,7 +492,7 @@ module Bundler
 
     def add_current_platform
       current_platform = Bundler.local_platform
-      add_platform(current_platform) if Bundler.settings[:specific_platform]
+      add_platform(current_platform) if Bundler.feature_flag.specific_platform?
       add_platform(generic(current_platform))
     end
 

--- a/lib/bundler/dependency.rb
+++ b/lib/bundler/dependency.rb
@@ -90,16 +90,14 @@ module Bundler
       @autorequire = Array(options["require"] || []) if options.key?("require")
     end
 
+    # Returns the platforms this dependency is valid for, in the same order as
+    # passed in the `valid_platforms` parameter
     def gem_platforms(valid_platforms)
       return valid_platforms if @platforms.empty?
 
-      platforms = []
-      @platforms.each do |p|
-        platform = PLATFORM_MAP[p]
-        next unless valid_platforms.include?(platform)
-        platforms |= [platform]
-      end
-      platforms
+      @gem_platforms ||= @platforms.map {|pl| PLATFORM_MAP[pl] }.compact.uniq
+
+      valid_platforms & @gem_platforms
     end
 
     def should_include?

--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -39,6 +39,7 @@ module Bundler
     settings_flag(:plugins) { @bundler_version >= Gem::Version.new("1.14") }
     settings_flag(:prefer_gems_rb) { bundler_2_mode? }
     settings_flag(:skip_default_git_sources) { bundler_2_mode? }
+    settings_flag(:specific_platform) { bundler_2_mode? }
     settings_flag(:suppress_install_using_messages) { bundler_2_mode? }
     settings_flag(:unlock_source_unlocks_spec) { !bundler_2_mode? }
     settings_flag(:update_requires_all_flag) { bundler_2_mode? }

--- a/lib/bundler/lazy_specification.rb
+++ b/lib/bundler/lazy_specification.rb
@@ -68,7 +68,7 @@ module Bundler
     end
 
     def __materialize__
-      search_object = Bundler.settings[:specific_platform] || Bundler.settings[:force_ruby_platform] ? self : Dependency.new(name, version)
+      search_object = Bundler.feature_flag.specific_platform? || Bundler.settings[:force_ruby_platform] ? self : Dependency.new(name, version)
       @specification = if source.is_a?(Source::Gemspec) && source.gemspec.name == name
         source.gemspec.tap {|s| s.source = source }
       else

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -37,6 +37,7 @@ module Bundler
       prefer_gems_rb
       silence_root_warning
       skip_default_git_sources
+      specific_platform
       suppress_install_using_messages
       unlock_source_unlocks_spec
       update_requires_all_flag

--- a/spec/bundler/definition_spec.rb
+++ b/spec/bundler/definition_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Bundler::Definition do
               rack (= 1.0)
 
         PLATFORMS
-          ruby
+          #{lockfile_platforms}
 
         DEPENDENCIES
           foo!
@@ -171,7 +171,7 @@ RSpec.describe Bundler::Definition do
               rack (= 1.0)
 
         PLATFORMS
-          ruby
+          #{lockfile_platforms}
 
         DEPENDENCIES
           foo!
@@ -197,7 +197,7 @@ RSpec.describe Bundler::Definition do
             foo (1.0)
 
         PLATFORMS
-          ruby
+          #{lockfile_platforms}
 
         DEPENDENCIES
           foo

--- a/spec/commands/check_spec.rb
+++ b/spec/commands/check_spec.rb
@@ -297,7 +297,7 @@ RSpec.describe "bundle check" do
             rack (1.0.0)
 
         PLATFORMS
-          #{generic_local_platform}
+          #{lockfile_platforms}
 
         DEPENDENCIES
           rack

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -401,7 +401,7 @@ RSpec.describe "bundle install with gem sources" do
            specs:
 
          PLATFORMS
-           ruby
+           #{lockfile_platforms}
 
          DEPENDENCIES
 
@@ -425,7 +425,7 @@ RSpec.describe "bundle install with gem sources" do
            specs:
 
          PLATFORMS
-           ruby
+           #{lockfile_platforms}
 
          DEPENDENCIES
 

--- a/spec/commands/lock_spec.rb
+++ b/spec/commands/lock_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "bundle lock" do
           with_license (1.0)
 
       PLATFORMS
-        #{local}
+        #{lockfile_platforms}
 
       DEPENDENCIES
         foo
@@ -58,7 +58,7 @@ RSpec.describe "bundle lock" do
   it "prints a lockfile when there is no existing lockfile with --print" do
     bundle "lock --print"
 
-    expect(out).to include(@lockfile)
+    expect(out).to eq(@lockfile)
   end
 
   it "prints a lockfile when there is an existing lockfile with --print" do
@@ -166,13 +166,13 @@ RSpec.describe "bundle lock" do
     bundle! "lock --add-platform java x86-mingw32"
 
     lockfile = Bundler::LockfileParser.new(read_lockfile)
-    expect(lockfile.platforms).to eq([java, local, mingw])
+    expect(lockfile.platforms).to match_array(local_platforms.unshift(java, mingw).uniq)
   end
 
   it "supports adding the `ruby` platform" do
     bundle! "lock --add-platform ruby"
     lockfile = Bundler::LockfileParser.new(read_lockfile)
-    expect(lockfile.platforms).to eq([local, "ruby"].uniq)
+    expect(lockfile.platforms).to match_array(local_platforms.unshift("ruby").uniq)
   end
 
   it "warns when adding an unknown platform" do
@@ -184,17 +184,17 @@ RSpec.describe "bundle lock" do
     bundle! "lock --add-platform java x86-mingw32"
 
     lockfile = Bundler::LockfileParser.new(read_lockfile)
-    expect(lockfile.platforms).to eq([java, local, mingw])
+    expect(lockfile.platforms).to match_array(local_platforms.unshift(java, mingw).uniq)
 
     bundle! "lock --remove-platform java"
 
     lockfile = Bundler::LockfileParser.new(read_lockfile)
-    expect(lockfile.platforms).to eq([local, mingw])
+    expect(lockfile.platforms).to match_array(local_platforms.unshift(mingw).uniq)
   end
 
   it "errors when removing all platforms" do
-    bundle "lock --remove-platform #{local}"
-    expect(out).to include("Removing all platforms from the bundle is not allowed")
+    bundle "lock --remove-platform #{local_platforms.join(" ")}"
+    expect(last_command.bundler_err).to include("Removing all platforms from the bundle is not allowed")
   end
 
   # from https://github.com/bundler/bundler/issues/4896

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -520,7 +520,7 @@ RSpec.describe "bundle update --ruby" do
          specs:
 
        PLATFORMS
-         ruby
+         #{lockfile_platforms}
 
        DEPENDENCIES
 
@@ -546,7 +546,7 @@ RSpec.describe "bundle update --ruby" do
          specs:
 
        PLATFORMS
-         ruby
+         #{lockfile_platforms}
 
        DEPENDENCIES
 
@@ -590,7 +590,7 @@ RSpec.describe "bundle update --ruby" do
          specs:
 
        PLATFORMS
-         ruby
+         #{lockfile_platforms}
 
        DEPENDENCIES
 

--- a/spec/install/gemfile/platform_spec.rb
+++ b/spec/install/gemfile/platform_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe "bundle install across platforms" do
     expect(the_bundle).to include_gems "nokogiri 1.4.2 JAVA", "weakling 0.0.3"
   end
 
-  it "works with gems that have extra platform-specific runtime dependencies" do
+  it "works with gems that have extra platform-specific runtime dependencies", :bundler => "< 2" do
     simulate_platform x64_mac
 
     update_repo2 do

--- a/spec/install/gems/flex_spec.rb
+++ b/spec/install/gems/flex_spec.rb
@@ -299,7 +299,7 @@ RSpec.describe "bundle flex_install" do
         specs:
 
       PLATFORMS
-        ruby
+        #{lockfile_platforms}
 
       DEPENDENCIES
         rack

--- a/spec/lock/lockfile_bundler_1_spec.rb
+++ b/spec/lock/lockfile_bundler_1_spec.rb
@@ -189,6 +189,7 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
 
       PLATFORMS
         #{generic_local_platform}
+        #{specific_local_platform}
 
       DEPENDENCIES
         rack
@@ -299,6 +300,7 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
 
       PLATFORMS
         #{generic_local_platform}
+        #{specific_local_platform}
 
       DEPENDENCIES
         rack

--- a/spec/lock/lockfile_spec.rb
+++ b/spec/lock/lockfile_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
           rack (1.0.0)
 
       PLATFORMS
-        #{generic_local_platform}
+        #{lockfile_platforms}
 
       DEPENDENCIES
         rack
@@ -40,7 +40,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
           rack (1.0.0)
 
       PLATFORMS
-        #{generic_local_platform}
+        #{lockfile_platforms}
 
       DEPENDENCIES
         omg!
@@ -63,7 +63,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
           rack (1.0.0)
 
       PLATFORMS
-        #{generic_local_platform}
+        #{lockfile_platforms}
 
       DEPENDENCIES
         rack
@@ -83,7 +83,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
           rack (1.0.0)
 
       PLATFORMS
-        #{generic_local_platform}
+        #{lockfile_platforms}
 
       DEPENDENCIES
         rack
@@ -105,7 +105,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
           rack (1.0.0)
 
       PLATFORMS
-        #{generic_local_platform}
+        #{lockfile_platforms}
 
       DEPENDENCIES
         rack
@@ -123,7 +123,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
           rack (1.0.0)
 
       PLATFORMS
-        #{generic_local_platform}
+        #{lockfile_platforms}
 
       DEPENDENCIES
         rack
@@ -142,7 +142,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
           rack (1.0.0)
 
       PLATFORMS
-        #{generic_local_platform}
+        #{lockfile_platforms}
 
       DEPENDENCIES
         rack (> 0)
@@ -179,7 +179,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
 
     warning_message = "the running version of Bundler (9999999.0.0) is older " \
                       "than the version that created the lockfile (9999999.1.0)"
-    expect(out.scan(warning_message).size).to eq(1)
+    expect(last_command.bundler_err).to include warning_message
 
     lockfile_should_be <<-G
       GEM
@@ -188,7 +188,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
           rack (1.0.0)
 
       PLATFORMS
-        #{generic_local_platform}
+        #{lockfile_platforms}
 
       DEPENDENCIES
         rack
@@ -206,7 +206,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
           rack (1.0.0)
 
       PLATFORMS
-        #{generic_local_platform}
+        #{lockfile_platforms}
 
       DEPENDENCIES
         rack
@@ -221,8 +221,8 @@ RSpec.describe "the lockfile format", :bundler => "2" do
       gem "rack"
     G
 
-    expect(exitstatus > 0) if exitstatus
-    expect(out).to include("You must use Bundler 9999999 or greater with this lockfile.")
+    expect(last_command).to be_failure
+    expect(last_command.bundler_err).to include("You must use Bundler 9999999 or greater with this lockfile.")
   end
 
   it "shows a friendly error when running with a new bundler 2 lockfile" do
@@ -259,7 +259,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
       end
     G
 
-    expect(exitstatus > 0) if exitstatus
+    expect(last_command).to be_failure
     expect(out).to include("You must use Bundler 9999999 or greater with this lockfile.")
   end
 
@@ -298,7 +298,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
           rack (1.0.0)
 
       PLATFORMS
-        #{generic_local_platform}
+        #{lockfile_platforms}
 
       DEPENDENCIES
         rack
@@ -324,7 +324,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
             rack
 
       PLATFORMS
-        #{generic_local_platform}
+        #{lockfile_platforms}
 
       DEPENDENCIES
         rack-obama
@@ -350,7 +350,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
             rack
 
       PLATFORMS
-        #{generic_local_platform}
+        #{lockfile_platforms}
 
       DEPENDENCIES
         rack-obama (>= 1.0)
@@ -389,7 +389,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
             rack
 
       PLATFORMS
-        #{generic_local_platform}
+        #{lockfile_platforms}
 
       DEPENDENCIES
         rack-obama (>= 1.0)!
@@ -414,7 +414,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
           net-ssh (1.0)
 
       PLATFORMS
-        ruby
+        #{lockfile_platforms}
 
       DEPENDENCIES
         net-sftp
@@ -444,7 +444,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
         specs:
 
       PLATFORMS
-        #{generic_local_platform}
+        #{lockfile_platforms}
 
       DEPENDENCIES
         foo!
@@ -472,7 +472,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
           foo (1.0)
 
       PLATFORMS
-        #{generic_local_platform}
+        #{lockfile_platforms}
 
       DEPENDENCIES
         foo!
@@ -517,7 +517,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
          #{Bundler::VERSION}
     L
 
-    bundle "install"
+    bundle! "install"
     expect(the_bundle).to include_gems "rack 1.0.0"
   end
 
@@ -541,7 +541,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
           foo (1.0)
 
       PLATFORMS
-        #{generic_local_platform}
+        #{lockfile_platforms}
 
       DEPENDENCIES
         foo!
@@ -571,7 +571,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
           foo (1.0)
 
       PLATFORMS
-        #{generic_local_platform}
+        #{lockfile_platforms}
 
       DEPENDENCIES
         foo!
@@ -601,7 +601,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
           foo (1.0)
 
       PLATFORMS
-        #{generic_local_platform}
+        #{lockfile_platforms}
 
       DEPENDENCIES
         foo!
@@ -628,7 +628,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
           foo (1.0)
 
       PLATFORMS
-        #{generic_local_platform}
+        #{lockfile_platforms}
 
       DEPENDENCIES
         foo!
@@ -658,7 +658,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
           foo (1.0)
 
       PLATFORMS
-        #{generic_local_platform}
+        #{lockfile_platforms}
 
       DEPENDENCIES
         foo!
@@ -698,7 +698,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
           foo (1.0)
 
       PLATFORMS
-        #{generic_local_platform}
+        #{lockfile_platforms}
 
       DEPENDENCIES
         bar!
@@ -733,7 +733,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
             rack
 
       PLATFORMS
-        #{generic_local_platform}
+        #{lockfile_platforms}
 
       DEPENDENCIES
         actionpack
@@ -774,7 +774,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
           rake (10.0.2)
 
       PLATFORMS
-        #{generic_local_platform}
+        #{lockfile_platforms}
 
       DEPENDENCIES
         rails
@@ -800,7 +800,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
           net-ssh (1.0)
 
       PLATFORMS
-        #{generic_local_platform}
+        #{lockfile_platforms}
 
       DEPENDENCIES
         double_deps
@@ -826,7 +826,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
             rack
 
       PLATFORMS
-        #{generic_local_platform}
+        #{lockfile_platforms}
 
       DEPENDENCIES
         rack-obama (>= 1.0)
@@ -852,7 +852,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
             rack
 
       PLATFORMS
-        #{generic_local_platform}
+        #{lockfile_platforms}
 
       DEPENDENCIES
         rack-obama (>= 1.0)
@@ -881,7 +881,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
           foo (1.0)
 
       PLATFORMS
-        #{generic_local_platform}
+        #{lockfile_platforms}
 
       DEPENDENCIES
         foo!
@@ -910,7 +910,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
           foo (1.0)
 
       PLATFORMS
-        #{generic_local_platform}
+        #{lockfile_platforms}
 
       DEPENDENCIES
         foo!
@@ -939,7 +939,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
           foo (1.0)
 
       PLATFORMS
-        #{generic_local_platform}
+        #{lockfile_platforms}
 
       DEPENDENCIES
         foo!
@@ -966,7 +966,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
           foo (1.0)
 
       PLATFORMS
-        #{generic_local_platform}
+        #{lockfile_platforms}
 
       DEPENDENCIES
         foo!
@@ -999,8 +999,6 @@ RSpec.describe "the lockfile format", :bundler => "2" do
       gem "rack"
     G
 
-    platforms = ["java", generic_local_platform.to_s].sort
-
     lockfile_should_be <<-G
       GEM
         remote: file:#{gem_repo1}/
@@ -1008,8 +1006,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
           rack (1.0.0)
 
       PLATFORMS
-        #{platforms[0]}
-        #{platforms[1]}
+        #{lockfile_platforms "java", generic_local_platform, specific_local_platform}
 
       DEPENDENCIES
         rack
@@ -1020,25 +1017,29 @@ RSpec.describe "the lockfile format", :bundler => "2" do
   end
 
   it "persists the spec's platform to the lockfile" do
-    build_gem "platform_specific", "1.0.0", :to_system => true do |s|
-      s.platform = Gem::Platform.new("universal-java-16")
+    build_repo2 do
+      build_gem "platform_specific", "1.0" do |s|
+        s.platform = Gem::Platform.new("universal-java-16")
+      end
     end
 
     simulate_platform "universal-java-16"
 
-    install_gemfile <<-G
-      source "file://#{gem_repo1}"
+    install_gemfile! <<-G
+      source "file://#{gem_repo2}"
       gem "platform_specific"
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file:#{gem_repo1}/
+        remote: file:#{gem_repo2}/
         specs:
           platform_specific (1.0-java)
+          platform_specific (1.0-universal-java-16)
 
       PLATFORMS
         java
+        universal-java-16
 
       DEPENDENCIES
         platform_specific
@@ -1068,7 +1069,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
           rack (1.0.0)
 
       PLATFORMS
-        ruby
+        #{lockfile_platforms}
 
       DEPENDENCIES
         activesupport
@@ -1093,7 +1094,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
           rack (1.0.0)
 
       PLATFORMS
-        ruby
+        #{lockfile_platforms}
 
       DEPENDENCIES
         rack
@@ -1117,7 +1118,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
           rack (1.0.0)
 
       PLATFORMS
-        ruby
+        #{lockfile_platforms}
 
       DEPENDENCIES
         rack (= 1.0)
@@ -1141,7 +1142,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
           rack (1.0.0)
 
       PLATFORMS
-        ruby
+        #{lockfile_platforms}
 
       DEPENDENCIES
         rack (= 1.0)
@@ -1186,7 +1187,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
           rack (0.9.1)
 
       PLATFORMS
-        ruby
+        #{lockfile_platforms}
 
       DEPENDENCIES
         rack (> 0.9, < 1.0)
@@ -1210,7 +1211,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
           rack (0.9.1)
 
       PLATFORMS
-        ruby
+        #{lockfile_platforms}
 
       DEPENDENCIES
         rack (> 0.9, < 1.0)
@@ -1262,7 +1263,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
           omg (1.0)
 
       PLATFORMS
-        #{local}
+        #{lockfile_platforms}
 
       DEPENDENCIES
         omg!
@@ -1289,7 +1290,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
           omg (1.0)
 
       PLATFORMS
-        #{local}
+        #{lockfile_platforms}
 
       DEPENDENCIES
         omg!
@@ -1307,7 +1308,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
           rack_middleware (1.0)
 
       PLATFORMS
-        #{local}
+        #{lockfile_platforms}
 
       DEPENDENCIES
         rack_middleware
@@ -1402,7 +1403,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
       >>>>>>>
 
       PLATFORMS
-        ruby
+        #{lockfile_platforms}
 
       DEPENDENCIES
         rack

--- a/spec/other/platform_spec.rb
+++ b/spec/other/platform_spec.rb
@@ -2,6 +2,12 @@
 
 RSpec.describe "bundle platform" do
   context "without flags" do
+    let(:bundle_platform_platforms_string) do
+      platforms = [rb]
+      platforms.unshift(specific_local_platform) if Bundler.feature_flag.bundler_2_mode?
+      platforms.map {|pl| "* #{pl}" }.join("\n")
+    end
+
     it "returns all the output" do
       gemfile <<-G
         source "file://#{gem_repo1}"
@@ -16,7 +22,7 @@ RSpec.describe "bundle platform" do
 Your platform is: #{RUBY_PLATFORM}
 
 Your app has gems that work on these platforms:
-* ruby
+#{bundle_platform_platforms_string}
 
 Your Gemfile specifies a Ruby version requirement:
 * ruby #{RUBY_VERSION}
@@ -39,7 +45,7 @@ G
 Your platform is: #{RUBY_PLATFORM}
 
 Your app has gems that work on these platforms:
-* ruby
+#{bundle_platform_platforms_string}
 
 Your Gemfile specifies a Ruby version requirement:
 * ruby #{RUBY_VERSION}p#{RUBY_PATCHLEVEL}
@@ -60,7 +66,7 @@ G
 Your platform is: #{RUBY_PLATFORM}
 
 Your app has gems that work on these platforms:
-* ruby
+#{bundle_platform_platforms_string}
 
 Your Gemfile does not specify a Ruby version requirement.
 G
@@ -80,7 +86,7 @@ G
 Your platform is: #{RUBY_PLATFORM}
 
 Your app has gems that work on these platforms:
-* ruby
+#{bundle_platform_platforms_string}
 
 Your Gemfile specifies a Ruby version requirement:
 * ruby #{not_local_ruby_version}

--- a/spec/plugins/source/example_spec.rb
+++ b/spec/plugins/source/example_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe "real source plugins" do
             a-path-gem (1.0)
 
         PLATFORMS
-          #{generic_local_platform}
+          #{lockfile_platforms}
 
         DEPENDENCIES
           a-path-gem!
@@ -395,7 +395,7 @@ RSpec.describe "real source plugins" do
             ma-gitp-gem (1.0)
 
         PLATFORMS
-          #{generic_local_platform}
+          #{lockfile_platforms}
 
         DEPENDENCIES
           ma-gitp-gem!

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -1092,7 +1092,7 @@ end
             rack (1.0.0)
 
         PLATFORMS
-          #{generic_local_platform}
+          #{lockfile_platforms}
 
         DEPENDENCIES
           rack
@@ -1150,7 +1150,7 @@ end
             rack (1.0.0)
 
         PLATFORMS
-          #{generic_local_platform}
+          #{lockfile_platforms}
 
         DEPENDENCIES
           rack

--- a/spec/support/command_execution.rb
+++ b/spec/support/command_execution.rb
@@ -36,5 +36,10 @@ module Spec
       return true unless exitstatus
       exitstatus == 0
     end
+
+    def failure?
+      return true unless exitstatus
+      exitstatus > 0
+    end
   end
 end

--- a/spec/support/platforms.rb
+++ b/spec/support/platforms.rb
@@ -43,6 +43,10 @@ module Spec
       generic_local_platform
     end
 
+    def specific_local_platform
+      Bundler.local_platform
+    end
+
     def not_local
       all_platforms.find {|p| p != generic_local_platform }
     end

--- a/spec/support/platforms.rb
+++ b/spec/support/platforms.rb
@@ -98,5 +98,18 @@ module Spec
     def not_local_patchlevel
       9999
     end
+
+    def lockfile_platforms(*platforms)
+      platforms = local_platforms if platforms.empty?
+      platforms.map(&:to_s).sort.join("\n  ")
+    end
+
+    def local_platforms
+      if Bundler::VERSION.split(".").first.to_i > 1
+        [local, specific_local_platform]
+      else
+        [local]
+      end
+    end
   end
 end

--- a/spec/update/git_spec.rb
+++ b/spec/update/git_spec.rb
@@ -354,7 +354,7 @@ RSpec.describe "bundle update" do
             foo (2.0)
 
         PLATFORMS
-          ruby
+          #{lockfile_platforms}
 
         DEPENDENCIES
           foo!


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that Bundler has somewhat suspect handling of multi-platform gems. We'd assume that different platform versions of gems were generally interchangeable, so if Bundler resolved to the "ruby" platform gem we'd just blindly try to swap in the gem for the local platform, which could lead to issues (say if the sets of dependencies were different).

### Was was your diagnosis of the problem?

My diagnosis was that we needed to stop only working with the notion of "generic" platforms, which mapped everything to (basically) either java, pure ruby, and windows, and instead keep track of the actual platforms a bundle was being used on, and resolve for those specific platforms.

### What is your fix for the problem, implemented in this PR?

My fix enables the changes made in https://github.com/bundler/bundler/pull/4836 by default on Bundler 2.

### Why did you choose this fix out of the possible options?

I chose this fix because it means Bundler will default to more correct platforms semantics out of the box.