### PR TITLE
[RemoteSpecification] Fail gracefully when deps is an array of array of string

### DIFF
--- a/lib/bundler/remote_specification.rb
+++ b/lib/bundler/remote_specification.rb
@@ -73,7 +73,15 @@ module Bundler
     end
 
     def dependencies
-      @dependencies || method_missing(:dependencies)
+      @dependencies ||= begin
+        deps = method_missing(:dependencies)
+
+        # allow us to handle when the specs dependencies are an array of array of string
+        # see https://github.com/bundler/bundler/issues/5797
+        deps = deps.map {|d| d.is_a?(Gem::Dependency) ? d : Gem::Dependency.new(*d) }
+
+        deps
+      end
     end
 
     def git_version


### PR DESCRIPTION
Instead of containing Gem::Dependency objects

### What was the end-user problem that led to this PR?

The problem was some gems have invalid gemspecs served by RubyGems.org. See https://github.com/bundler/bundler/issues/5797.

### Was was your diagnosis of the problem?

My diagnosis was (very old) some gemspecs can have `s.dependencies = [["name", "req"]]` instead of `s.dependencies = [Gem::Dependency.new("name", "req")]`.

### What is your fix for the problem, implemented in this PR?

My fix coerces the invalid dependencies to an array of dependency objects so we can fail more gracefully during installation, without spitting out the error template.

Closes #5797.

### Why did you choose this fix out of the possible options?

I chose this fix because it allows resolution to finish, and falls back upon existing error messages.