### PR TITLE
[2.0] [DSL] Remove default git sources on 2.0

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -204,6 +204,7 @@ module Bundler
 
     def github(repo, options = {})
       raise ArgumentError, "GitHub sources require a block" unless block_given?
+      raise DeprecatedError, "The #github method has been removed" if Bundler.feature_flag.skip_default_git_sources?
       github_uri  = @git_sources["github"].call(repo)
       git_options = normalize_hash(options).merge("uri" => github_uri)
       git_source  = @sources.add_git_source(git_options)
@@ -264,6 +265,8 @@ module Bundler
   private
 
     def add_git_sources
+      return if Bundler.feature_flag.skip_default_git_sources?
+
       git_source(:github) do |repo_name|
         warn_deprecated_git_source(:github, <<-'RUBY'.strip, 'Change any "reponame" :github sources to "username/reponame".')
 "https://github.com/#{repo_name}.git"

--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -36,6 +36,7 @@ module Bundler
     settings_flag(:only_update_to_newer_versions) { bundler_2_mode? }
     settings_flag(:plugins) { @bundler_version >= Gem::Version.new("1.14") }
     settings_flag(:prefer_gems_rb) { bundler_2_mode? }
+    settings_flag(:skip_default_git_sources) { bundler_2_mode? }
     settings_flag(:unlock_source_unlocks_spec) { !bundler_2_mode? }
     settings_flag(:update_requires_all_flag) { bundler_2_mode? }
 

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -34,6 +34,7 @@ module Bundler
       plugins
       prefer_gems_rb
       silence_root_warning
+      skip_default_git_sources
       unlock_source_unlocks_spec
       update_requires_all_flag
     ].freeze

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -240,6 +240,9 @@ learn more about their operation in [bundle install(1)][bundle-install].
 * `global_gem_cache` (`BUNDLE_GLOBAL_GEM_CACHE`):
    Whether Bundler should cache all gems globally, rather than locally to the
    installing Ruby installation.
+* `skip_default_git_sources` (`BUNDLE_SKIP_DEFAULT_GIT_SOURCES`):
+   Whether Bundler should skip adding default git source shortcuts to the
+   Gemfile DSL.
 
 In general, you should set these settings per-application by using the applicable
 flag to the [bundle install(1)][bundle-install] or [bundle package(1)][bundle-package] command.

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Bundler::Dsl do
       expect { subject.git_source(:example) }.to raise_error(Bundler::InvalidOption)
     end
 
-    context "default hosts (git, gist)" do
+    context "default hosts (git, gist)", :bundler => "< 2" do
       it "converts :github to :git" do
         subject.gem("sparks", :github => "indirect/sparks")
         github_uri = "git://github.com/indirect/sparks.git"
@@ -60,6 +60,12 @@ RSpec.describe Bundler::Dsl do
         subject.gem("not-really-a-gem", :bitbucket => "mcorp")
         bitbucket_uri = "https://mcorp@bitbucket.org/mcorp/mcorp.git"
         expect(subject.dependencies.first.source.uri).to eq(bitbucket_uri)
+      end
+    end
+
+    context "default git sources", :bundler => "2" do
+      it "has none" do
+        expect(subject.instance_variable_get(:@git_sources)).to eq({})
       end
     end
   end
@@ -218,7 +224,7 @@ RSpec.describe Bundler::Dsl do
     #   gem 'spree_api'
     #   gem 'spree_backend'
     # end
-    describe "#github" do
+    describe "#github", :bundler => "< 2" do
       it "from github" do
         spree_gems = %w[spree_core spree_api spree_backend]
         subject.github "spree" do
@@ -228,6 +234,17 @@ RSpec.describe Bundler::Dsl do
         subject.dependencies.each do |d|
           expect(d.source.uri).to eq("git://github.com/spree/spree.git")
         end
+      end
+    end
+
+    describe "#github", :bundler => "2" do
+      it "from github" do
+        expect do
+          spree_gems = %w[spree_core spree_api spree_backend]
+          subject.github "spree" do
+            spree_gems.each {|spree_gem| subject.send :gem, spree_gem }
+          end
+        end.to raise_error(Bundler::DeprecatedError, /github method has been removed/)
       end
     end
   end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was the default git source shortcuts have been deprecated, but still existed in 2.0.

### Was was your diagnosis of the problem?

My diagnosis was we needed to avoid adding them in 2.0.

### What is your fix for the problem, implemented in this PR?

My fix is to introduce a feature flag, which when enabled will stop adding the sources to the DSL, and additionally will disable the `github` DSL method.