### PR TITLE
Stop gitignoring Gemfile.lock in default template

### DIFF
--- a/lib/bundler/templates/newgem/gitignore.tt
+++ b/lib/bundler/templates/newgem/gitignore.tt
@@ -1,6 +1,5 @@
 /.bundle/
 /.yardoc
-/Gemfile.lock
 /_yardoc/
 /coverage/
 /doc/


### PR DESCRIPTION
This will be followed up with a documentation PR on some best practices to keep gems tested against up to date dependencies. 

### What was the end-user problem that led to this PR?

The problem was that sometimes open source contributors get discouraged because they can't setup the project they want to contribute to easily. 

### Was was your diagnosis of the problem?

My diagnosis was that a lot of projects gitignore `Gemfile.lock` just because it's gitignored by default in the new gem template. This causes `bundle install` to no longer be guaranteed to work. And `bundle install` is usually the first step towards a contribution.

### What is your fix for the problem, implemented in this PR?

My fix was to remove the `Gemfile.lock` entry from the gitignore template.

### Why did you choose this fix out of the possible options?

I chose this fix because to prevent a file from being gitignored, removing it from the `.gitignore` file usually does the trick :) 
