### PR TITLE
[WIP] Start implementation of permissions command

### DIFF
--- a/bundler.gemspec
+++ b/bundler.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rdiscount",  "~> 2.2"
   s.add_development_dependency "ronn",       "~> 0.7.3"
   s.add_development_dependency "rspec",      "~> 3.6"
+  s.add_development_dependency "pry"
 
   s.files = `git ls-files -z`.split("\x0").reject {|f| f.match(%r{^(test|spec|features)/}) }
   # we don't check in man pages, but we need to ship them because

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -567,6 +567,12 @@ module Bundler
       Issue.new.run
     end
 
+    desc "permissions", "CHECKS PERMISSIONS"
+    def permissions
+      require "bundler/cli/permissions"
+      Permissions.new.run
+    end
+
     desc "pristine [GEMS...]", "Restores installed gems to pristine condition from files located in the gem cache. Gem installed from a git repository will be issued `git checkout --force`."
     def pristine(*gems)
       require "bundler/cli/pristine"

--- a/lib/bundler/cli/permissions.rb
+++ b/lib/bundler/cli/permissions.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Bundler
+  class CLI::Permissions
+    attr_reader :bundle_path
+
+    def initialize
+      @bundle_path = Bundler.bundle_path
+    end
+
+    def run
+      return permission_error   if not_permissible?
+      return permission_warning if permissible_and_not_owner?
+
+      Bundler.ui.info "The Gemfile's permissions are satisfied"
+    end
+
+    private
+
+    def permission_warning
+      Bundler.ui.warn "WARN"
+    end
+
+    def permission_error
+      Bundler.ui.error "ERROR"
+    end
+
+    def not_permissible?
+      !permissible?
+    end
+
+    def permissible?
+      (bundle_path.writable? && bundle_path.readable?)
+    end
+
+    def permissible_and_not_owner?
+      permissible? && not_owner?
+    end
+
+    def owner?
+      bundle_path.owned?
+    end
+
+    def not_owner?
+      !owner?
+    end
+  end
+end

--- a/spec/commands/permissions_spec.rb
+++ b/spec/commands/permissions_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+require 'pry'
+
+RSpec.describe "bundle permissions" do
+  before do
+    gemfile <<-G
+      source "file://#{gem_repo1}"
+      gem "rails"
+    G
+  end
+
+  context "/.bundle directory" do
+    context "when it's owned by the user executing `bundle install`" do
+      it "returns a permissions satisfied message" do
+        bundle :permissions
+
+        expect(out).to eq("The Gemfile's permissions are satisfied")
+      end
+    end
+
+    context "when it's possible to read/write to by the user executing `bundle install`" do
+      it "raises a permissions warning message" do
+        FileUtils.chmod(0000, default_bundle_path.to_s)
+
+        bundle :permissions
+
+        expect(out).to include("WARN")
+      end
+    end
+
+    context "when it's not possible to read/write to by the user executing `bundle install`" do
+      it "raises a permissions error message" do
+        FileUtils.chmod(0000, default_bundle_path.to_s)
+
+        bundle :permissions
+
+        expect(out).to include("ERROR")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hello - This is a WIP in response to https://github.com/bundler/bundler/issues/5786. 

I'm envisioning a `bundle permissions` command that will display either a:

1. Permissions satisfied message
2. Permissions warning in the case `bundle install` can proceed, but the `bundle_path` and/or any child directories are not owned by the executing user.
3. Permissions error in the case bundle install cannot proceed

`bundle permissions` will be ran as a part of `bundle doctor`.

Let me know if I'm headed down the right path. Also, any ideas on how to simulate changing the user of a directory in tests? Can't seem to get specification 2 to work.

Lastly, taking recommendations on the specific message verbiage!

Note: Will fill out PR questionnaire upon completion.