### PR TITLE
Add a bin/bundle binstub

### DIFF
--- a/bin/bundle
+++ b/bin/bundle
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "rubygems"
+bundler_gemspec = Gem::Specification.load(File.expand_path("../../bundler.gemspec", __FILE__))
+bundler_gemspec.instance_variable_set(:@full_gem_path, File.expand_path("../..", __FILE__))
+bundler_gemspec.activate if bundler_gemspec.respond_to?(:activate)
+load File.expand_path("../../exe/bundle", __FILE__)

--- a/doc/development/SETUP.md
+++ b/doc/development/SETUP.md
@@ -20,7 +20,7 @@ Bundler doesn't use a Gemfile to list development dependencies, because when we 
 
 4. Set up a shell alias to run Bundler from your clone, e.g. a Bash alias:
 
-      `$ alias dbundle='ruby -I /path/to/bundler/lib /path/to/bundler/exe/bundle'`
+      `$ alias dbundle='/path/to/bundler/repo/bin/bundle'`
 
 ## Debugging with `pry`
 

--- a/lib/bundler/version.rb
+++ b/lib/bundler/version.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+# frozen_string_literal: false
 
 # Ruby 1.9.3 and old RubyGems don't play nice with frozen version strings
 # rubocop:disable MutableConstant


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that developing bundler can be difficult, and letting users use the in-development bundler locally should be as easy as possible.

### What was your diagnosis of the problem?

My diagnosis was we could use a binstub that handles setting up the load path for bundler, ensures the gem spec is activated, and loads the local bundler code.

### What is your fix for the problem, implemented in this PR?

My fix adds such a binstub.