### PR TITLE
Tweak gemspec template when using Ruby 2.x

### DIFF
--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -1,4 +1,6 @@
+<%- if RUBY_VERSION < "2.0.0" -%>
 # coding: utf-8
+<%- end -%>
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "<%= config[:namespaced_path] %>/version"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

There are unnecessary magic comment for currently maintained Ruby 2.2, 2.3, and 2.4.

### What was your diagnosis of the problem?

The default script encoding from Ruby 2.0 is UTF-8.

https://bugs.ruby-lang.org/issues/6679

Ruby 1.9 is EOL, so I think that there is not much Gem to start developed using it. 

### What is your fix for the problem, implemented in this PR?

This PR removes magic comment when starting Gem development (i.e. `bundle gem`) with Ruby 2.0 or higher version.
