### PR TITLE
Make Bundler.setup not make Kernel#gem public in Bundler 2

### DIFF
--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -38,6 +38,7 @@ module Bundler
     settings_flag(:only_update_to_newer_versions) { bundler_2_mode? }
     settings_flag(:plugins) { @bundler_version >= Gem::Version.new("1.14") }
     settings_flag(:prefer_gems_rb) { bundler_2_mode? }
+    settings_flag(:setup_makes_kernel_gem_public) { !bundler_2_mode? }
     settings_flag(:skip_default_git_sources) { bundler_2_mode? }
     settings_flag(:specific_platform) { bundler_2_mode? }
     settings_flag(:suppress_install_using_messages) { bundler_2_mode? }

--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -393,9 +393,8 @@ module Bundler
           raise e
         end
 
-        # TODO: delete this in 2.0, it's a backwards compatibility shim
-        # see https://github.com/bundler/bundler/issues/5102
-        kernel_class.send(:public, :gem)
+        # backwards compatibility shim, see https://github.com/bundler/bundler/issues/5102
+        kernel_class.send(:public, :gem) if Bundler.feature_flag.setup_makes_kernel_gem_public?
       end
     end
 

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -35,6 +35,7 @@ module Bundler
       only_update_to_newer_versions
       plugins
       prefer_gems_rb
+      setup_makes_kernel_gem_public
       silence_root_warning
       skip_default_git_sources
       specific_platform


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was Bundler 1 accidentally made `Kernel#gem` public, even though RubyGems declares it as private. Oops. We tried to make it private in 1.13, it broke stuff, so we added in a hack to keep it public.

### What was your diagnosis of the problem?

My diagnosis was we could delete that hack in 2.0.

### What is your fix for the problem, implemented in this PR?

My fix implements a feature flag that skips making `Kernel#gem` public, and adds regression tests for `gem` or `require` accidentally being made public.