### PR TITLE
Capitalize the description lines in Bundler 2

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -194,7 +194,7 @@ module Bundler
       end
     end
 
-    desc "update [OPTIONS]", "update the current environment"
+    desc "update [OPTIONS]", "Update the current environment"
     long_desc <<-D
       Update will install the newest versions of the gems listed in the Gemfile. Use
       update when you have changed the Gemfile, or if you want to get the newest
@@ -291,7 +291,7 @@ module Bundler
       Add.new(options.dup, gem_name).run
     end
 
-    desc "outdated GEM [OPTIONS]", "list installed gems with newer versions available"
+    desc "outdated GEM [OPTIONS]", "List installed gems with newer versions available"
     long_desc <<-D
       Outdated lists the names and versions of gems that have a newer version available
       in the given source. Calling outdated with [GEM [GEM]] will only check for newer
@@ -375,7 +375,7 @@ module Bundler
       Exec.new(options, args).run
     end
 
-    desc "config NAME [VALUE]", "retrieve or set a configuration value"
+    desc "config NAME [VALUE]", "Retrieve or set a configuration value"
     long_desc <<-D
       Retrieves or sets a configuration value. If only one parameter is provided, retrieve the value. If two parameters are provided, replace the
       existing value with the newly provided one.
@@ -580,7 +580,7 @@ module Bundler
 
     if Bundler.feature_flag.plugins?
       require "bundler/cli/plugin"
-      desc "plugin SUBCOMMAND ...ARGS", "manage the bundler plugins"
+      desc "plugin SUBCOMMAND ...ARGS", "Manage the bundler plugins"
       subcommand "plugin", Plugin
     end
 


### PR DESCRIPTION
This PR is a small patch.

### What was the end-user problem that led to this PR?

I made the following changes locally to the code of the master branch and tried Bundler 2.0.

```diff
% git diff
diff --git a/lib/bundler/version.rb b/lib/bundler/version.rb
index dad4a88a2..386782023 100644
--- a/lib/bundler/version.rb
+++ b/lib/bundler/version.rb
@@ -7,7 +7,7 @@ module Bundler
   # We're doing this because we might write tests that deal
   # with other versions of bundler and we are unsure how to
   # handle this better.
-  VERSION = "1.15.1" unless defined?(::Bundler::VERSION)
+  VERSION = "2.0.0.dev" unless defined?(::Bundler::VERSION)

   def self.overwrite_loaded_gem_version
     begin
```

Here is the result of running the `bundle` command.

```console
% bundle
Bundler version 2.0.0.dev

Commands:
  bundle add GEM VERSION            # Add gem to Gemfile and run bundle install
  bundle binstubs GEM [OPTIONS]     # Install the binstubs of the listed gem
  bundle cache [OPTIONS]            # Locks and then caches all of the gems into vendor/cache
  bundle check [OPTIONS]            # Checks if the dependencies listed in Gemfile are satisfied by currently installed gems
  bundle clean [OPTIONS]            # Cleans up unused gems in your bundler directory
  bundle config NAME [VALUE]        # retrieve or set a configuration value
  bundle doctor [OPTIONS]           # Checks the bundle for common problems
  bundle env                        # Print information about the environment Bundler is running under
  bundle exec [OPTIONS]             # Run the command in context of the bundle
  bundle gem GEM [OPTIONS]          # Creates a skeleton for creating a rubygem
  bundle help [COMMAND]             # Describe available commands or one specific command
  bundle help [COMMAND]             # Describe subcommands or one specific subcommand
  bundle info GEM [OPTIONS]         # Show information for the given gem
  bundle init [OPTIONS]             # Generates a Gemfile into the current working directory
  bundle inject GEM VERSION         # Add the named gem, with version requirements, to the resolved Gemfile
  bundle install PLUGINS            # Install the plugin from the source
  bundle install [OPTIONS]          # Install the current environment to the system
  bundle issue                      # Learn how to report an issue in Bundler
  bundle licenses                   # Prints the license of all gems in the bundle
  bundle lock                       # Creates a lockfile without installing
  bundle open GEM                   # Opens the source directory of the given bundled gem
  bundle outdated GEM [OPTIONS]     # list installed gems with newer versions available
  bundle platform [OPTIONS]         # Displays platform compatibility information
  bundle plugin SUBCOMMAND ...ARGS  # manage the bundler plugins
  bundle pristine [GEMS...]         # Restores installed gems to pristine condition from files located in the gem cache. Gem installed from a git reposito...
  bundle show GEM [OPTIONS]         # Shows all gems that are part of the bundle, or the path to a given gem
  bundle update [OPTIONS]           # update the current environment
  bundle version                    # Prints the bundler's version information
  bundle viz [OPTIONS]              # Generates a visual dependency graph

Options:
      [--no-color]                 # Disable colorization in output
  -r, [--retry=NUM]                # Specify the number of times you wish to attempt network commands
  -V, [--verbose], [--no-verbose]  # Enable verbose output mode
```
The beginning of the description lines are not unified with capitalized.

### What was your diagnosis of the problem?

It is the same as above.

### What is your fix for the problem, implemented in this PR?

Unify the beginning of the description lines with capitalized.
```console
% bundle
Bundler version 2.0.0.dev

Commands:
  bundle add GEM VERSION            # Add gem to Gemfile and run bundle install
  bundle binstubs GEM [OPTIONS]     # Install the binstubs of the listed gem
  bundle cache [OPTIONS]            # Locks and then caches all of the gems into vendor/cache
  bundle check [OPTIONS]            # Checks if the dependencies listed in Gemfile are satisfied by currently installed gems
  bundle clean [OPTIONS]            # Cleans up unused gems in your bundler directory
  bundle config NAME [VALUE]        # Retrieve or set a configuration value
  bundle doctor [OPTIONS]           # Checks the bundle for common problems
  bundle env                        # Print information about the environment Bundler is running under
  bundle exec [OPTIONS]             # Run the command in context of the bundle
  bundle gem GEM [OPTIONS]          # Creates a skeleton for creating a rubygem
  bundle help [COMMAND]             # Describe available commands or one specific command
  bundle help [COMMAND]             # Describe subcommands or one specific subcommand
  bundle info GEM [OPTIONS]         # Show information for the given gem
  bundle init [OPTIONS]             # Generates a Gemfile into the current working directory
  bundle inject GEM VERSION         # Add the named gem, with version requirements, to the resolved Gemfile
  bundle install PLUGINS            # Install the plugin from the source
  bundle install [OPTIONS]          # Install the current environment to the system
  bundle issue                      # Learn how to report an issue in Bundler
  bundle licenses                   # Prints the license of all gems in the bundle
  bundle lock                       # Creates a lockfile without installing
  bundle open GEM                   # Opens the source directory of the given bundled gem
  bundle outdated GEM [OPTIONS]     # List installed gems with newer versions available
  bundle platform [OPTIONS]         # Displays platform compatibility information
  bundle plugin SUBCOMMAND ...ARGS  # Manage the bundler plugins
  bundle pristine [GEMS...]         # Restores installed gems to pristine condition from files located in the gem cache. Gem installed from a git reposito...
  bundle show GEM [OPTIONS]         # Shows all gems that are part of the bundle, or the path to a given gem
  bundle update [OPTIONS]           # Update the current environment
  bundle version                    # Prints the bundler's version information
  bundle viz [OPTIONS]              # Generates a visual dependency graph

Options:
      [--no-color]                 # Disable colorization in output
  -r, [--retry=NUM]                # Specify the number of times you wish to attempt network commands
  -V, [--verbose], [--no-verbose]  # Enable verbose output mode
```

Thanks.
