### PR TITLE
[2.0] Use deployment instead of frozen as a setting on Bundler 2

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -130,6 +130,12 @@ module Bundler
       end
     end
 
+    def frozen?
+      frozen = settings[:deployment]
+      frozen ||= settings[:frozen] unless feature_flag.deployment_means_frozen?
+      frozen
+    end
+
     def locked_gems
       @locked_gems ||=
         if defined?(@definition) && @definition

--- a/lib/bundler/cli/check.rb
+++ b/lib/bundler/cli/check.rb
@@ -28,7 +28,7 @@ module Bundler
         not_installed.each {|s| Bundler.ui.error " * #{s.name} (#{s.version})" }
         Bundler.ui.warn "Install missing gems with `bundle install`"
         exit 1
-      elsif !Bundler.default_lockfile.file? && Bundler.settings[:frozen]
+      elsif !Bundler.default_lockfile.file? && Bundler.frozen?
         Bundler.ui.error "This bundle has been frozen, but there is no #{Bundler.default_lockfile.relative_path_from(SharedHelpers.pwd)} present"
         exit 1
       else

--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -44,7 +44,11 @@ module Bundler
 
         options[:local] = true if Bundler.app_cache.exist?
 
-        Bundler.settings[:frozen] = true unless Bundler.feature_flag.deployment_means_frozen?
+        if Bundler.feature_flag.deployment_means_frozen?
+          Bundler.settings.temporary(:deployment => true)
+        else
+          Bundler.settings[:frozen] ||= true
+        end
       end
 
       # When install is called with --no-deployment, disable deployment mode
@@ -177,7 +181,7 @@ module Bundler
 
     def normalize_settings
       Bundler.settings[:path]                = nil if options[:system]
-      Bundler.settings[:path]                = "vendor/bundle" if options[:deployment] && !Bundler.feature_flag.deployment_means_frozen?
+      Bundler.settings[:path]                = "vendor/bundle" if options[:deployment]
       Bundler.settings[:path]                = options["path"] if options["path"]
       Bundler.settings[:path]              ||= "bundle" if options["standalone"]
 

--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -214,13 +214,19 @@ module Bundler
     end
 
     def check_for_deployment_mode
-      if Bundler.frozen?
-        raise ProductionError, "You are trying to check outdated gems in " \
-          "deployment mode. Run `bundle outdated` elsewhere.\n" \
-          "\nIf this is a development machine, remove the " \
-          "#{Bundler.default_gemfile} freeze" \
-          "\nby running `bundle install --no-deployment`."
+      return unless Bundler.frozen?
+      suggested_command = if Bundler.settings.locations("frozen")[:global]
+        "bundle config --delete frozen"
+      elsif Bundler.settings.locations("deployment").keys.&([:global, :local]).any?
+        "bundle config --delete deployment"
+      else
+        "bundle install --no-deployment"
       end
+      raise ProductionError, "You are trying to check outdated gems in " \
+        "deployment mode. Run `bundle outdated` elsewhere.\n" \
+        "\nIf this is a development machine, remove the " \
+        "#{Bundler.default_gemfile} freeze" \
+        "\nby running `#{suggested_command}`."
     end
 
     def update_present_via_semver_portions(current_spec, active_spec, options)

--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -214,7 +214,7 @@ module Bundler
     end
 
     def check_for_deployment_mode
-      if Bundler.settings[:frozen]
+      if Bundler.frozen?
         raise ProductionError, "You are trying to check outdated gems in " \
           "deployment mode. Run `bundle outdated` elsewhere.\n" \
           "\nIf this is a development machine, remove the " \

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -102,7 +102,7 @@ module Bundler
       end
       @unlocking ||= @unlock[:ruby] ||= (!@locked_ruby_version ^ !@ruby_version)
 
-      add_current_platform unless Bundler.settings[:frozen]
+      add_current_platform unless Bundler.frozen?
 
       converge_path_sources_to_gemspec_sources
       @path_changes = converge_paths
@@ -234,7 +234,10 @@ module Bundler
     def resolve
       @resolve ||= begin
         last_resolve = converge_locked_specs
-        if Bundler.settings[:frozen] || (!unlocking? && nothing_changed?)
+        if Bundler.frozen?
+          Bundler.ui.debug "Frozen, using resolution from the lockfile"
+          last_resolve
+        elsif !unlocking? && nothing_changed?
           Bundler.ui.debug("Found no changes, using resolution from the lockfile")
           last_resolve
         else
@@ -319,10 +322,10 @@ module Bundler
         end
       end
 
-      preserve_unknown_sections ||= !updating_major && (Bundler.settings[:frozen] || !unlocking?)
+      preserve_unknown_sections ||= !updating_major && (Bundler.frozen? || !unlocking?)
       return if lockfiles_equal?(@lockfile_contents, contents, preserve_unknown_sections)
 
-      if Bundler.settings[:frozen]
+      if Bundler.frozen?
         Bundler.ui.error "Cannot write a changed lockfile while frozen."
         return
       end
@@ -660,7 +663,7 @@ module Bundler
     end
 
     def converge_dependencies
-      frozen = Bundler.settings[:frozen]
+      frozen = Bundler.frozen?
       (@dependencies + @locked_deps.values).each do |dep|
         locked_source = @locked_deps[dep.name]
         # This is to make sure that if bundler is installing in deployment mode and

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -376,8 +376,13 @@ module Bundler
              "updated #{Bundler.default_lockfile.relative_path_from(SharedHelpers.pwd)} to version control."
 
       unless explicit_flag
-
-        suggested_command = Bundler.settings.locations("frozen")[:global] == "1" ? "bundle config --delete frozen" : "bundle install --no-deployment"
+        suggested_command = if Bundler.settings.locations("frozen")[:global]
+          "bundle config --delete frozen"
+        elsif Bundler.settings.locations("deployment").keys.&([:global, :local]).any?
+          "bundle config --delete deployment"
+        else
+          "bundle install --no-deployment"
+        end
         msg << "\n\nIf this is a development machine, remove the #{Bundler.default_gemfile} " \
                "freeze \nby running `#{suggested_command}`."
       end

--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -30,6 +30,7 @@ module Bundler
     settings_flag(:allow_offline_install) { bundler_2_mode? }
     settings_flag(:cache_command_is_package) { bundler_2_mode? }
     settings_flag(:console_command) { !bundler_2_mode? }
+    settings_flag(:deployment_means_frozen) { bundler_2_mode? }
     settings_flag(:disable_multisource) { bundler_2_mode? }
     settings_flag(:error_on_stderr) { bundler_2_mode? }
     settings_flag(:global_gem_cache) { bundler_2_mode? }

--- a/lib/bundler/injector.rb
+++ b/lib/bundler/injector.rb
@@ -12,38 +12,40 @@ module Bundler
     end
 
     def inject(gemfile_path, lockfile_path)
-      if Bundler.settings[:frozen]
+      if Bundler.frozen?
         # ensure the lock and Gemfile are synced
         Bundler.definition.ensure_equivalent_gemfile_and_lockfile(true)
-        # temporarily remove frozen while we inject
-        frozen = Bundler.settings.delete(:frozen)
       end
 
-      # evaluate the Gemfile we have now
-      builder = Dsl.new
-      builder.eval_gemfile(gemfile_path)
+      # temporarily unfreeze
+      Bundler.settings.temporary(:deployment => false, :frozen => false) do
+        # evaluate the Gemfile we have now
+        builder = Dsl.new
+        builder.eval_gemfile(gemfile_path)
 
-      # don't inject any gems that are already in the Gemfile
-      @new_deps -= builder.dependencies
+        # don't inject any gems that are already in the Gemfile
+        @new_deps -= builder.dependencies
 
-      # add new deps to the end of the in-memory Gemfile
-      # Set conservative versioining to false because we want to let the resolver resolve the version first
-      builder.eval_gemfile("injected gems", build_gem_lines(false)) if @new_deps.any?
+        # add new deps to the end of the in-memory Gemfile
+        # Set conservative versioning to false because we want to let the resolver resolve the version first
+        builder.eval_gemfile("injected gems", build_gem_lines(false)) if @new_deps.any?
 
-      # resolve to see if the new deps broke anything
-      @definition = builder.to_definition(lockfile_path, {})
-      @definition.resolve_remotely!
+        # resolve to see if the new deps broke anything
+        @definition = builder.to_definition(lockfile_path, {})
+        @definition.resolve_remotely!
 
-      # since nothing broke, we can add those gems to the gemfile
-      append_to(gemfile_path, build_gem_lines(@options[:conservative_versioning])) if @new_deps.any?
+        # since nothing broke, we can add those gems to the gemfile
+        append_to(gemfile_path, build_gem_lines(@options[:conservative_versioning])) if @new_deps.any?
 
-      # since we resolved successfully, write out the lockfile
-      @definition.lock(Bundler.default_lockfile)
+        # since we resolved successfully, write out the lockfile
+        @definition.lock(Bundler.default_lockfile)
 
-      # return an array of the deps that we added
-      return @new_deps
-    ensure
-      Bundler.settings[:frozen] = "1" if frozen
+        # invalidate the cached Bundler.definition
+        Bundler.reset_paths!
+
+        # return an array of the deps that we added
+        @new_deps
+      end
     end
 
   private

--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -68,7 +68,7 @@ module Bundler
     def run(options)
       create_bundle_path
 
-      if Bundler.settings[:frozen]
+      if Bundler.frozen?
         @definition.ensure_equivalent_gemfile_and_lockfile(options[:deployment])
       end
 
@@ -83,7 +83,7 @@ module Bundler
       warn_on_incompatible_bundler_deps
       install(options)
 
-      lock unless Bundler.settings[:frozen]
+      lock unless Bundler.frozen?
       Standalone.new(options[:standalone], @definition).generate if options[:standalone]
     end
 

--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -11,7 +11,7 @@ module Bundler
     end
 
     def setup(*groups)
-      @definition.ensure_equivalent_gemfile_and_lockfile if Bundler.settings[:frozen]
+      @definition.ensure_equivalent_gemfile_and_lockfile if Bundler.frozen?
 
       groups.map!(&:to_sym)
 

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -14,6 +14,8 @@ module Bundler
       cache_all_platforms
       cache_command_is_package
       console_command
+      deployment
+      deployment_means_frozen
       disable_checksum_validation
       disable_exec_load
       disable_local_branch_check

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -139,7 +139,8 @@ learn more about their operation in [bundle install(1)][bundle-install].
 * `console` (`BUNDLE_CONSOLE`):
    The console that `bundle console` starts. Defaults to `irb`.
 * `deployment` (`BUNDLE_DEPLOYMENT`):
-   Disallow changes to the `Gemfile`.
+   Disallow changes to the `Gemfile`. When the `Gemfile` is changed and the
+   lockfile has not been updated, running Bundler commands will be blocked.
 * `disable_checksum_validation` (`BUNDLE_DISABLE_CHECKSUM_VALIDATION`):
    Allow installing gems even if they do not match the checksum provided by
    RubyGems.
@@ -164,8 +165,9 @@ learn more about their operation in [bundle install(1)][bundle-install].
    Ignore the current machine's platform and install only `ruby` platform gems.
    As a result, gems with native extensions will be compiled from source.
 * `frozen` (`BUNDLE_FROZEN`):
-   Disallow changes to the `Gemfile`. Defaults to `true` when `--deployment`
-   is used.
+   Disallow changes to the `Gemfile`. When the `Gemfile` is changed and the
+   lockfile has not been updated, running Bundler commands will be blocked.
+   Defaults to `true` when `--deployment` is used.
 * `gem.push_key` (`BUNDLE_GEM__PUSH_KEY`):
    Sets the `--key` parameter for `gem push` when using the `rake release`
    command with a private gemstash server.

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -138,6 +138,8 @@ learn more about their operation in [bundle install(1)][bundle-install].
    `bundle install`.
 * `console` (`BUNDLE_CONSOLE`):
    The console that `bundle console` starts. Defaults to `irb`.
+* `deployment` (`BUNDLE_DEPLOYMENT`):
+   Disallow changes to the `Gemfile`.
 * `disable_checksum_validation` (`BUNDLE_DISABLE_CHECKSUM_VALIDATION`):
    Allow installing gems even if they do not match the checksum provided by
    RubyGems.

--- a/spec/bundler/settings_spec.rb
+++ b/spec/bundler/settings_spec.rb
@@ -137,6 +137,22 @@ that would suck --ehhh=oh geez it looks like i might have broken bundler somehow
 
       expect(Bundler.settings[:no_install]).to eq true
     end
+
+    it "returns the return value of the block" do
+      ret = Bundler.settings.temporary({}) { :ret }
+      expect(ret).to eq :ret
+    end
+
+    context "when called without a block" do
+      it "leaves the setting changed" do
+        Bundler.settings.temporary(:foo => :random)
+        expect(Bundler.settings[:foo]).to eq :random
+      end
+
+      it "returns nil" do
+        expect(Bundler.settings.temporary(:foo => :bar)).to be_nil
+      end
+    end
   end
 
   describe "#set_global" do

--- a/spec/commands/add_spec.rb
+++ b/spec/commands/add_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe "bundle add" do
 
   it "using combination of short form options works like long form" do
     bundle "add 'foo' -s='file://#{gem_repo2}' -g='development' -v='~>1.0'"
-    expect(bundled_app("Gemfile").read).to match(%r{gem "foo", "~> 1.0", :group => \[:development\], :source => "file:\/\/#{gem_repo2}"})
+    expect(bundled_app("Gemfile").read).to include %(gem "foo", "~> 1.0", :group => [:development], :source => "file://#{gem_repo2}")
     expect(the_bundle).to include_gems "foo 1.1"
   end
 

--- a/spec/commands/check_spec.rb
+++ b/spec/commands/check_spec.rb
@@ -214,17 +214,17 @@ RSpec.describe "bundle check" do
   end
 
   it "fails when there's no lock file and frozen is set" do
-    gemfile <<-G
+    install_gemfile! <<-G
       source "file://#{gem_repo1}"
       gem "foo"
     G
 
-    bundle "install"
-    bundle "install --deployment"
+    bundle! "config deployment true"
+    bundle! :install
     FileUtils.rm(bundled_app("Gemfile.lock"))
 
     bundle :check
-    expect(exitstatus).not_to eq(0) if exitstatus
+    expect(last_command).to be_failure
   end
 
   context "--path" do

--- a/spec/commands/inject_spec.rb
+++ b/spec/commands/inject_spec.rb
@@ -79,7 +79,11 @@ Usage: "bundle inject GEM VERSION"
   context "when frozen" do
     before do
       bundle "install"
-      bundle "config --local frozen 1"
+      if Bundler.feature_flag.bundler_2_mode?
+        bundle! "config --local deployment true"
+      else
+        bundle! "config --local frozen true"
+      end
     end
 
     it "injects anyway" do
@@ -96,7 +100,7 @@ Usage: "bundle inject GEM VERSION"
     it "restores frozen afterwards" do
       bundle "inject 'rack-obama' '> 0'"
       config = YAML.load(bundled_app(".bundle/config").read)
-      expect(config["BUNDLE_FROZEN"]).to eq("1")
+      expect(config["BUNDLE_DEPLOYMENT"] || config["BUNDLE_FROZEN"]).to eq("true")
     end
 
     it "doesn't allow Gemfile changes" do

--- a/spec/commands/package_spec.rb
+++ b/spec/commands/package_spec.rb
@@ -205,6 +205,7 @@ RSpec.describe "bundle package" do
     subject { bundle "package --frozen" }
 
     it "tries to install with frozen" do
+      bundle! "config deployment true"
       gemfile <<-G
         source "file://#{gem_repo1}"
         gem "rack"
@@ -216,7 +217,7 @@ RSpec.describe "bundle package" do
       expect(out).to include("You have added to the Gemfile")
       expect(out).to include("* rack-obama")
       bundle "env"
-      expect(out).to include("frozen")
+      expect(out).to include("frozen").or include("deployment")
     end
   end
 end

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe "bundle update" do
   end
 
   describe "in a frozen bundle" do
-    it "should fail loudly" do
+    it "should fail loudly", :bundler => "< 2" do
       bundle! "install --deployment"
       bundle "update", :all => bundle_update_requires_all?
 
@@ -207,11 +207,18 @@ RSpec.describe "bundle update" do
       expect(exitstatus).not_to eq(0) if exitstatus
     end
 
-    it "should suggest different command when frozen is set globally" do
+    it "should suggest different command when frozen is set globally", :bundler => "< 2" do
       bundle! "config --global frozen 1"
       bundle "update", :all => bundle_update_requires_all?
-      expect(out).to match(/You are trying to install in deployment mode after changing.your Gemfile/m)
-      expect(out).to match(/freeze \nby running `bundle config --delete frozen`./m)
+      expect(out).to match(/You are trying to install in deployment mode after changing.your Gemfile/m).
+        and match(/freeze \nby running `bundle config --delete frozen`./m)
+    end
+
+    it "should suggest different command when frozen is set globally", :bundler => "2" do
+      bundle! "config --global deployment true"
+      bundle "update", :all => bundle_update_requires_all?
+      expect(out).to match(/You are trying to install in deployment mode after changing.your Gemfile/m).
+        and match(/freeze \nby running `bundle config --delete deployment`./m)
     end
   end
 

--- a/spec/install/deploy_spec.rb
+++ b/spec/install/deploy_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe "install with --deployment or --frozen" do
       expect(out).to include("The path `#{lib_path("path_gem-1.0")}` does not exist.")
     end
 
-    it "can have --frozen set via an environment variable" do
+    it "can have --frozen set via an environment variable", :bundler => "< 2" do
       gemfile <<-G
         source "file://#{gem_repo1}"
         gem "rack"
@@ -171,6 +171,22 @@ RSpec.describe "install with --deployment or --frozen" do
       G
 
       ENV["BUNDLE_FROZEN"] = "1"
+      bundle "install"
+      expect(out).to include("deployment mode")
+      expect(out).to include("You have added to the Gemfile")
+      expect(out).to include("* rack-obama")
+      expect(out).not_to include("You have deleted from the Gemfile")
+      expect(out).not_to include("You have changed in the Gemfile")
+    end
+
+    it "can have --deployment set via an environment variable" do
+      gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem "rack"
+        gem "rack-obama"
+      G
+
+      ENV["BUNDLE_DEPLOYMENT"] = "true"
       bundle "install"
       expect(out).to include("deployment mode")
       expect(out).to include("You have added to the Gemfile")
@@ -187,6 +203,7 @@ RSpec.describe "install with --deployment or --frozen" do
       G
 
       ENV["BUNDLE_FROZEN"] = "false"
+      ENV["BUNDLE_DEPLOYMENT"] = "false"
       bundle "install"
       expect(out).not_to include("deployment mode")
       expect(out).not_to include("You have added to the Gemfile")
@@ -277,7 +294,9 @@ RSpec.describe "install with --deployment or --frozen" do
     end
 
     it "remembers that the bundle is frozen at runtime" do
-      bundle "install --deployment"
+      bundle! :lock
+
+      bundle! "config deployment true"
 
       gemfile <<-G
         source "file://#{gem_repo1}"

--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -172,6 +172,7 @@ RSpec.describe "The library itself" do
       cache_command_is_package
       console_command
       default_cli_command
+      deployment_means_frozen
       gem.coc
       gem.mit
       inline


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was bundler had a `--deployment` flag, a `--frozen` flag and a `frozen` setting. All frozen meant was the lockfile couldn't change, whereas `--deployment` meant the full "deployment experience". This was confusing.

Closes https://github.com/bundler/bundler/issues/4619.

### What was your diagnosis of the problem?

My diagnosis was  we want to get rid of the `--frozen` setting and add a new `deployment` setting that will be used by default on Bundler 2.

### What is your fix for the problem, implemented in this PR?

My fix adds the deployment setting, and updates the myriad places we use `Bundler.settings[:frozen]` to take it into account, along with fixing the behavior when `bundle config deployment true` is used instead of the command line switches.