### PR TITLE
[Inline] Work when BUNDLE_BIN is set

### DIFF
--- a/lib/bundler/inline.rb
+++ b/lib/bundler/inline.rb
@@ -60,9 +60,11 @@ def gemfile(install = false, options = {}, &gemfile)
 
   Bundler.ui = ui if install
   if install || missing_specs.call
-    installer = Bundler::Installer.install(Bundler.root, definition, :system => true, :inline => true)
-    installer.post_install_messages.each do |name, message|
-      Bundler.ui.info "Post-install message from #{name}:\n#{message}"
+    Bundler.settings.temporary(:inline => true) do
+      installer = Bundler::Installer.install(Bundler.root, definition, :system => true)
+      installer.post_install_messages.each do |name, message|
+        Bundler.ui.info "Post-install message from #{name}:\n#{message}"
+      end
     end
   end
 

--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -247,7 +247,7 @@ module Bundler
     end
 
     def resolve_if_needed(options)
-      if !options["update"] && !options[:inline] && !options["force"] && Bundler.default_lockfile.file?
+      if !options["update"] && !options["force"] && !Bundler.settings[:inline] && Bundler.default_lockfile.file?
         return if @definition.nothing_changed? && !@definition.missing_specs?
       end
 

--- a/lib/bundler/installer/gem_installer.rb
+++ b/lib/bundler/installer/gem_installer.rb
@@ -65,6 +65,7 @@ module Bundler
     end
 
     def generate_executable_stubs
+      return if Bundler.settings[:inline]
       if Bundler.settings[:bin] && standalone
         installer.generate_standalone_bundler_executable_stubs(spec)
       elsif Bundler.settings[:bin]

--- a/spec/bundler/installer/gem_installer_spec.rb
+++ b/spec/bundler/installer/gem_installer_spec.rb
@@ -18,8 +18,9 @@ RSpec.describe Bundler::GemInstaller do
   context "spec_settings is build option" do
     it "invokes install method with build_args", :rubygems => ">= 2" do
       allow(Bundler.settings).to receive(:[]).with(:bin)
+      allow(Bundler.settings).to receive(:[]).with(:inline)
       allow(Bundler.settings).to receive(:[]).with("build.dummy").and_return("--with-dummy-config=dummy")
-      allow(spec_source).to receive(:install).with(spec, :force => false, :ensure_builtin_gems_cached => false, :build_args => ["--with-dummy-config=dummy"])
+      expect(spec_source).to receive(:install).with(spec, :force => false, :ensure_builtin_gems_cached => false, :build_args => ["--with-dummy-config=dummy"])
       subject.install_from_spec
     end
   end

--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -174,6 +174,7 @@ RSpec.describe "The library itself" do
       default_cli_command
       gem.coc
       gem.mit
+      inline
       lockfile_uses_separate_rubygems_sources
       warned_version
     ]

--- a/spec/runtime/inline_spec.rb
+++ b/spec/runtime/inline_spec.rb
@@ -252,4 +252,19 @@ RSpec.describe "bundler/inline#gemfile" do
     expect(err).to be_empty
     expect(exitstatus).to be_zero if exitstatus
   end
+
+  it "installs inline gems when BUNDLE_BIN is set" do
+    ENV["BUNDLE_BIN"] = "/usr/local/bundle/bin"
+
+    script <<-RUBY
+      gemfile do
+        source "file://#{gem_repo1}"
+        gem "rack" # has the rackup executable
+      end
+
+      puts RACK
+    RUBY
+    expect(last_command).to be_success
+    expect(last_command.stdout).to eq "1.0.0"
+  end
 end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that `bundler/inline` would fail when `$BUNDLE_BIN` was set.

Closes #5847.

### What was your diagnosis of the problem?

My diagnosis was we needed to skip installing binstubs when doing an inline install.

### What is your fix for the problem, implemented in this PR?

My fix sets a temporary setting for `:inline` and skips installing binstubs when that's true.

### Why did you choose this fix out of the possible options?

I chose this fix because it was minimally intrusive.