### PR TITLE
[ParallelInstaller] Show require tree when a gem fails to install due to corrupted lockfile

### DIFF
--- a/lib/bundler/installer/parallel_installer.rb
+++ b/lib/bundler/installer/parallel_installer.rb
@@ -112,7 +112,12 @@ module Bundler
         gem_installer = Bundler::GemInstaller.new(
           spec_install.spec, @installer, @standalone, worker_num, @force
         )
-        success, message = gem_installer.install_from_spec
+        success, message = begin
+          gem_installer.install_from_spec
+        rescue => e
+          raise e, "#{e}\n\n#{require_tree_for_spec(spec_install.spec)}"
+        end
+
         if success && !message.nil?
           spec_install.post_install_message = message
         elsif !success


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that when installation failed due to a corrupted lockfile or checksum mis-match, we wouldn't show the reason that gem was being installed in the first place, as we would when other errors happened.

See https://github.com/bundler/bundler/issues/5846

### What was your diagnosis of the problem?

My diagnosis was we needed to show that requirement tree whenever installation fails, regardless of the reason for the failure.

### What is your fix for the problem, implemented in this PR?

My fix rescues hard installation errors and re-raises with the tree appended.