### PR TITLE
Adding process lock for bundle install operations

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -40,6 +40,7 @@ module Bundler
   autoload :LazySpecification,      "bundler/lazy_specification"
   autoload :LockfileParser,         "bundler/lockfile_parser"
   autoload :MatchPlatform,          "bundler/match_platform"
+  autoload :ProcessLock,            "bundler/process_lock"
   autoload :RemoteSpecification,    "bundler/remote_specification"
   autoload :Resolver,               "bundler/resolver"
   autoload :Retry,                  "bundler/retry"

--- a/lib/bundler/process_lock.rb
+++ b/lib/bundler/process_lock.rb
@@ -4,18 +4,21 @@ module Bundler
   class ProcessLock
     def self.lock(bundle_path = Bundler.bundle_path)
       lock_file_path = File.join(bundle_path, "bundler.lock")
+      has_lock = false
 
       File.open(lock_file_path, "w") do |f|
         f.flock(File::LOCK_EX)
-
+        has_lock = true
         yield
+        f.flock(File::LOCK_UN)
       end
-    rescue Errno::ENOLCK # NFS
-      raise if Thread.main != Thread.current
-
+    rescue Errno::EACCES, Errno::ENOLCK
+      # In the case the user does not have access to
+      # create the lock file or is using NFS where
+      # locks are not available we skip locking.
       yield
     ensure
-      File.delete(lock_file_path) if File.exist?(lock_file_path)
+      FileUtils.rm_f(lock_file_path) if has_lock
     end
   end
 end

--- a/lib/bundler/process_lock.rb
+++ b/lib/bundler/process_lock.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Bundler
+  class ProcessLock
+    def self.lock(bundle_path = Bundler.bundle_path)
+      lock_file_path = File.join(bundle_path, "bundler.lock")
+
+      File.open(lock_file_path, "w") do |f|
+        f.flock(File::LOCK_EX)
+
+        yield
+      end
+    rescue Errno::ENOLCK # NFS
+      raise if Thread.main != Thread.current
+
+      yield
+    ensure
+      File.delete(lock_file_path) if File.exist?(lock_file_path)
+    end
+  end
+end

--- a/spec/install/process_lock_spec.rb
+++ b/spec/install/process_lock_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+RSpec.describe "process lock spec" do
+  describe "when an install operation is already holding a process lock" do
+    it "will not run a second concurrent bundle install until the lock is released" do
+      thread = Thread.new do
+        Bundler::ProcessLock.lock(default_bundle_path) do
+          sleep 1 # ignore quality_spec
+          expect(the_bundle).not_to include_gems "rack 1.0"
+        end
+      end
+
+      install_gemfile! <<-G
+        source "file://#{gem_repo1}"
+        gem "rack"
+      G
+
+      thread.join
+      expect(the_bundle).to include_gems "rack 1.0"
+    end
+  end
+end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

As per #5851 multiple concurrent bundle installs would cause failures when compiling

### What was your diagnosis of the problem?

As described in #5851 a sample project was created demonstrating the issue when running a docker-compose solution of 2 containers using a gem cache volume

### What is your fix for the problem, implemented in this PR?

The fix is to implement an installation process lock so that only one process can execute an install at one time

### Why did you choose this fix out of the possible options?

I chose this fix because it was discussed in #5851 as a possible solution