### PR TITLE
Change deprecation from `bundle list` to `bundle show`

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -245,11 +245,11 @@ module Bundler
     method_option "outdated", :type => :boolean,
                               :banner => "Show verbose output including whether gems are outdated."
     def show(gem_name = nil)
-      Bundler::SharedHelpers.major_deprecation("use `bundle show` instead of `bundle list`") if ARGV[0] == "list"
+      Bundler::SharedHelpers.major_deprecation("use `bundle list` instead of `bundle show`") if ARGV[0] == "show"
       require "bundler/cli/show"
       Show.new(options, gem_name).run
     end
-    # TODO: 2.0 remove `bundle list`
+    # TODO: 2.0 remove `bundle show`
     map %w[list] => "show"
 
     desc "info GEM [OPTIONS]", "Show information for the given gem"

--- a/man/bundle.ronn
+++ b/man/bundle.ronn
@@ -102,4 +102,4 @@ and execute it, passing down any extra arguments to it.
 These commands are obsolete and should no longer be used
 
 * `bundle cache(1)`
-* `bundle list(1)`
+* `bundle show(1)`

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -253,18 +253,18 @@ The :bitbucket git source is deprecated, and will be removed in Bundler 2.0. Add
     end
   end
 
-  context "bundle list" do
+  context "bundle show" do
     it "prints a deprecation warning" do
       install_gemfile! <<-G
         source "file://#{gem_repo1}"
         gem "rack"
       G
 
-      bundle! :list
+      bundle! :show
 
       warnings.gsub!(/gems included.*?\[DEPRECATED/im, "[DEPRECATED")
 
-      expect(warnings).to have_major_deprecation("use `bundle show` instead of `bundle list`")
+      expect(warnings).to have_major_deprecation("use `bundle list` instead of `bundle show`")
     end
   end
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

I understand that `bundle show` will be removed in Bundler 2.0, not `bundle list`. 

https://github.com/bundler/rfcs/pull/6/files#r125875779

In the current message, there is a possibility of misleading the command which will be removed in Bundler 2.0.

### What was your diagnosis of the problem?

I think that it is better to display `bundle show` instead of `bundle list` in the deprecated warning.

### What is your fix for the problem, implemented in this PR?

Change the deprecated warning from `bundle list` to `bundle show`.

### Why did you choose this fix out of the possible options?

I thought that changing the console message was a simple and effective change to the end user.
