### PR TITLE
Limit specs to rack-test < 0.7.0 for Ruby 1.8.7 compatibility

### DIFF
--- a/spec/support/rubygems_ext.rb
+++ b/spec/support/rubygems_ext.rb
@@ -11,6 +11,9 @@ module Spec
         # TODO: revert to `< 2` once https://github.com/rack/rack/issues/1168 is
         # addressed
         "rack" => "1.6.6",
+        # rack-test 0.7.0 dropped 1.8.7 support
+        # https://github.com/rack-test/rack-test/issues/193#issuecomment-314230318
+        "rack-test" => "< 0.7.0",
         "artifice" => "~> 0.6.0",
         "compact_index" => "~> 0.11.0",
         "sinatra" => "~> 1.4.7",


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was the specs were broken by the release of `rack-test 0.7.0`.

### What was your diagnosis of the problem?

My diagnosis was `rack-test` has intentionally dropped 1.8.7 support, though we didn't catch that immediately because they didn't put a `required_ruby_version` in their gemspec.

### What is your fix for the problem, implemented in this PR?

My fix pins us to older versions of the gem.