### PR TITLE
Use https for the opensource.org link in README template, which you'r…

### DIFF
--- a/lib/bundler/templates/newgem/README.md.tt
+++ b/lib/bundler/templates/newgem/README.md.tt
@@ -37,7 +37,7 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/<%= co
 
 ## License
 
-The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
+The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
 <% end -%>
 <% if config[:coc] -%>
 


### PR DESCRIPTION
…e redirected to anyway

I'm skipping the questions because this is a one character documentation fix.