### PR TITLE
Remove uneeded files packaged into bunder's gem build on rubygems

### DIFF
--- a/bundler.gemspec
+++ b/bundler.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "ronn",       "~> 0.7.3"
   s.add_development_dependency "rspec",      "~> 3.6"
 
-  s.files = `git ls-files -z`.split("\x0").reject {|f| f.match(%r{^(test|spec|features)/}) }
+  s.files = `git ls-files -z`.split("\x0").select {|f| f.match(%r{^(lib|exe)/}) }
   # we don't check in man pages, but we need to ship them because
   # we use them to generate the long-form help for each command.
   s.files += Dir.glob("man/**/*")

--- a/bundler.gemspec
+++ b/bundler.gemspec
@@ -41,6 +41,8 @@ Gem::Specification.new do |s|
   # we don't check in man pages, but we need to ship them because
   # we use them to generate the long-form help for each command.
   s.files += Dir.glob("man/**/*")
+  # Include the CHANGELOG.md, LICENSE.md, README.md manually
+  s.files += %w[CHANGELOG.md LICENSE.md README.md]
 
   s.bindir        = "exe"
   s.executables   = %w[bundle bundler]


### PR DESCRIPTION
What was the end-user problem that led to this PR?
--------------------------------------------------

I noticed while doing a `bundle open bundler` (inception!) that we have included the `bin/` directory in the packaged gem.  While this is not hurting anything, it provides a bunch of scripts that won't function properly in any capacity when installed through ruby gems.

While doing that, I noticed that the dotfiles for CI were also packaged up in the gem, so I made sure to only include specific files from there that seemed to provide value when being shipped as a gem.


What is your fix for the problem, implemented in this PR?
---------------------------------------------------------

Change the reduction of the results from `git ls-files` to be a whitelist instead of a blacklist.  This was to reduce the complexity of the regexp that would have resulted from change what directories to include, not ship CI files in the top level dir, while also still wanting to ship the `CHANGELOG.md`, `LICENSE.md`, and `README.md` files along with the build, since I think they do provide value being included with the packaged gem.


Why did you choose this fix out of the possible options?
--------------------------------------------------------

Some of the choices here were a bit subjective, especially what I decided on as "necessary" regarding the `.md` files that I included.  Projects like rails went with these three, so I decided to use that as a base, but some might think that the `CHANGELOG.md` being included is a bit excessive and is a large file that most won't even read in this form, and I don't have a hard opinion one way or the other.

That said, I do think that developer files should not be packaged in the gem, and this precedent has already been set with the original blacklist, it just wasn't very complete.  How I did it could probably be changed based on developer preference, but I tried to stay as true to what was already there before all else.