### PR TITLE
Fix spec on 2.0 broken with the v1.15.2 merge

### DIFF
--- a/spec/bundler/cli_spec.rb
+++ b/spec/bundler/cli_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "bundle executable" do
 
     it "doesn't print defaults" do
       install_gemfile! "", :verbose => true
-      expect(out).to start_with("Running `bundle install --no-color --retry 0 --verbose` with bundler #{Bundler::VERSION}")
+      expect(last_command.stdout).to start_with("Running `bundle install --no-color --retry 0 --verbose` with bundler #{Bundler::VERSION}")
     end
   end
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was I merged in a change necessary to keep the 1.15.x specs passing accidentally, even though it broke the 2.0 spec. Oops.