### PR TITLE
Return an empty array if no extensions are found

### DIFF
--- a/lib/bundler/endpoint_specification.rb
+++ b/lib/bundler/endpoint_specification.rb
@@ -81,6 +81,8 @@ module Bundler
         @remote_specification.extensions
       elsif _local_specification
         _local_specification.extensions
+      else
+        []
       end
     end
 

--- a/lib/bundler/endpoint_specification.rb
+++ b/lib/bundler/endpoint_specification.rb
@@ -72,6 +72,8 @@ module Bundler
         @remote_specification.post_install_message
       elsif _local_specification
         _local_specification.post_install_message
+      else
+        super
       end
     end
 
@@ -82,7 +84,7 @@ module Bundler
       elsif _local_specification
         _local_specification.extensions
       else
-        []
+        super
       end
     end
 

--- a/spec/bundler/endpoint_specification_spec.rb
+++ b/spec/bundler/endpoint_specification_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Bundler::EndpointSpecification do
   let(:dependencies) { [] }
   let(:metadata)     { nil }
 
-  subject { described_class.new(name, version, platform, dependencies, metadata) }
+  subject(:spec) { described_class.new(name, version, platform, dependencies, metadata) }
 
   describe "#build_dependency" do
     let(:name)           { "foo" }
@@ -61,5 +61,11 @@ RSpec.describe Bundler::EndpointSpecification do
         )
       end
     end
+  end
+
+  it "supports equality comparison" do
+    other_spec = described_class.new("bar", version, platform, dependencies, metadata)
+    expect(spec).to eql(spec)
+    expect(spec).to_not eql(other_spec)
   end
 end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Attempting to compare endpoint specifications that didn't have any extensions was causing a `NoMethodError: undefined method `empty?' for nil:NilClass` error.

### What was your diagnosis of the problem?

The `extensions` method on `EndpointSpecification` was incorrectly returning `nil` when there were no extensions.

### What is your fix for the problem, implemented in this PR?

~~Return an empty array in that case, instead~~ Fall back to the base class implementation in that case, instead.

### Why did you choose this fix out of the possible options?

~~Alternative would be to call `super`. I presumed there was a reason that wasn't being done already, but it would also work.~~ Alternative would be to explicitly return an empty array, but all other methods call `super`, which feels more robust.
