### PR TITLE
Use ssl client cert and ca cert settings from gem configuration as fallbacks

### DIFF
--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -249,8 +249,11 @@ module Bundler
           con.cert_store = bundler_cert_store
         end
 
-        if Bundler.settings[:ssl_client_cert]
-          pem = File.read(Bundler.settings[:ssl_client_cert])
+        ssl_client_cert = Bundler.settings[:ssl_client_cert] ||
+          (Bundler.rubygems.configuration.ssl_client_cert if
+            Bundler.rubygems.configuration.respond_to?(:ssl_client_cert))
+        if ssl_client_cert
+          pem = File.read(ssl_client_cert)
           con.cert = OpenSSL::X509::Certificate.new(pem)
           con.key  = OpenSSL::PKey::RSA.new(pem)
         end
@@ -279,11 +282,14 @@ module Bundler
 
     def bundler_cert_store
       store = OpenSSL::X509::Store.new
-      if Bundler.settings[:ssl_ca_cert]
-        if File.directory? Bundler.settings[:ssl_ca_cert]
-          store.add_path Bundler.settings[:ssl_ca_cert]
+      ssl_ca_cert = Bundler.settings[:ssl_ca_cert] ||
+        (Bundler.rubygems.configuration.ssl_ca_cert if
+          Bundler.rubygems.configuration.respond_to?(:ssl_ca_cert))
+      if ssl_ca_cert
+        if File.directory? ssl_ca_cert
+          store.add_path ssl_ca_cert
         else
-          store.add_file Bundler.settings[:ssl_ca_cert]
+          store.add_file ssl_ca_cert
         end
       else
         store.set_default_paths


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was having to configure ssl client cert and ca cert in bundler and gem.

### What is your fix for the problem, implemented in this PR?

My fix makes bundler check the gem configuration for these settings.

### Why did you choose this fix out of the possible options?

I chose this fix because it makes sense for the user to only configure these once.

Couldn't find existing coverage for this in the tests so haven't added any...

Also assume a changelog entry is needed but can't see a unreleased changes section so not sure how this is handled.
