### PR TITLE
Add graph re: bundle exec modifying lockfile

### DIFF
--- a/man/bundle-exec.ronn
+++ b/man/bundle-exec.ronn
@@ -63,6 +63,13 @@ It also modifies Rubygems:
   making system executables work
 * Add all gems in the bundle into Gem.loaded_specs
 
+Finally, `bundle exec` also implicitly modifies `Gemfile.lock` if the lockfile 
+and the Gemfile do not match. Bundler needs the Gemfile to determine things 
+such as a gem's groups, `autorequire`, and platforms, etc., and that 
+information isn't stored in the lockfile. The Gemfile and lockfile must be 
+synced in order to `bundle exec` successfully, so `bundle exec` 
+updates the lockfile beforehand.
+
 ### Loading
 
 By default, when attempting to `bundle exec` to a file with a ruby shebang,

--- a/man/bundle-exec.ronn
+++ b/man/bundle-exec.ronn
@@ -63,11 +63,11 @@ It also modifies Rubygems:
   making system executables work
 * Add all gems in the bundle into Gem.loaded_specs
 
-Finally, `bundle exec` also implicitly modifies `Gemfile.lock` if the lockfile 
-and the Gemfile do not match. Bundler needs the Gemfile to determine things 
-such as a gem's groups, `autorequire`, and platforms, etc., and that 
-information isn't stored in the lockfile. The Gemfile and lockfile must be 
-synced in order to `bundle exec` successfully, so `bundle exec` 
+Finally, `bundle exec` also implicitly modifies `Gemfile.lock` if the lockfile
+and the Gemfile do not match. Bundler needs the Gemfile to determine things
+such as a gem's groups, `autorequire`, and platforms, etc., and that
+information isn't stored in the lockfile. The Gemfile and lockfile must be
+synced in order to `bundle exec` successfully, so `bundle exec`
 updates the lockfile beforehand.
 
 ### Loading


### PR DESCRIPTION
Hey team,

I've added a graph to the documentation that explains why bundle exec makes changes to Gemfile.lock. It was originally referenced in this issue: https://github.com/bundler/bundler/issues/5245

Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was lack of clarity around why the `bundle exec` command modified the lock file. A user brought it up here: https://github.com/bundler/bundler/issues/5245 and the determination was to add it to the man page.

### What was your diagnosis of the problem?

My diagnosis was to add a graph in the "Environmental Modifications" section to explain the issue.

### What is your fix for the problem, implemented in this PR?

My fix was to update the docs! \o/

### Why did you choose this fix out of the possible options?

I chose this fix because enough users referenced it as a problem that needed to be addressed.