### PR TITLE
Add line re: CGI escape

### DIFF
--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -288,6 +288,7 @@ revision in the `Gemfile.lock` to the local git repo revision. This
 requires the same attention as git submodules. Before pushing to
 the remote, you need to ensure the local override was pushed, otherwise
 you may point to a commit that only exists in your local machine.
+You'll also need to CGI escape your usernames and passwords as well.
 
 Bundler does many checks to ensure a developer won't work with
 invalid references. Particularly, we force a developer to specify


### PR DESCRIPTION
Added a sentence in line 291 re: CGI escaping passwords and usernames. Resolves issue: https://github.com/bundler/bundler/issues/5643

Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was needing to make it clear that users had to CGI escape usernames and passwords before pushing to remote. Referenced here: https://github.com/bundler/bundler/issues/5643

### What was your diagnosis of the problem?

My diagnosis was to add a sentence to the man page as a reminder.

### What is your fix for the problem, implemented in this PR?

My fix was to add a sentence to the man page :)

### Why did you choose this fix out of the possible options?

I chose this fix because it would make things clearer for users.