### PR TITLE
[CLI] Dont print an outdated version warning when running a parseable command

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -6,6 +6,9 @@ require "bundler/vendored_thor"
 module Bundler
   class CLI < Thor
     AUTO_INSTALL_CMDS = %w[show binstubs outdated exec open console licenses clean].freeze
+    PARSEABLE_COMMANDS = %w[
+      check config help exec platform show version
+    ].freeze
 
     def self.start(*)
       super
@@ -13,12 +16,14 @@ module Bundler
       Bundler.ui = UI::Shell.new
       raise e
     ensure
-      warn_on_outdated_bundler
       Bundler::SharedHelpers.print_major_deprecations!
     end
 
     def self.dispatch(*)
-      super {|i| i.send(:print_command) }
+      super do |i|
+        i.send(:print_command)
+        i.send(:warn_on_outdated_bundler)
+      end
     end
 
     def initialize(*args)
@@ -641,7 +646,7 @@ module Bundler
       _, _, config = @_initializer
       current_command = config[:current_command]
       command_name = current_command.name
-      return if %w[exec version check platform show help].include?(command_name)
+      return if PARSEABLE_COMMANDS.include?(command_name)
       command = ["bundle", command_name] + args
       options_to_print = options.dup
       options_to_print.delete_if do |k, v|
@@ -653,8 +658,13 @@ module Bundler
       Bundler.ui.info "Running `#{command * " "}` with bundler #{Bundler::VERSION}"
     end
 
-    def self.warn_on_outdated_bundler
+    def warn_on_outdated_bundler
       return if Bundler.settings[:disable_version_check]
+
+      _, _, config = @_initializer
+      current_command = config[:current_command]
+      command_name = current_command.name
+      return if PARSEABLE_COMMANDS.include?(command_name)
 
       latest = Fetcher::CompactIndex.
                new(nil, Source::Rubygems::Remote.new(URI("https://rubygems.org")), nil).
@@ -672,6 +682,5 @@ module Bundler
     rescue
       nil
     end
-    private_class_method :warn_on_outdated_bundler
   end
 end

--- a/spec/bundler/cli_spec.rb
+++ b/spec/bundler/cli_spec.rb
@@ -57,8 +57,9 @@ RSpec.describe "bundle executable" do
 
   context "with --verbose" do
     it "prints the running command" do
-      bundle! "config", :verbose => true
-      expect(last_command.stdout).to start_with("Running `bundle config --verbose` with bundler #{Bundler::VERSION}")
+      gemfile ""
+      bundle! "info bundler", :verbose => true
+      expect(last_command.stdout).to start_with("Running `bundle info bundler --no-color --verbose` with bundler #{Bundler::VERSION}")
     end
 
     it "doesn't print defaults" do
@@ -118,6 +119,16 @@ To update, run `gem install bundler`
       context "and disable_version_check is set" do
         before { bundle! "config disable_version_check true" }
         include_examples "no warning"
+      end
+
+      context "running a parseable command" do
+        it "prints no warning" do
+          bundle! "config --parseable foo"
+          expect(last_command.stdboth).to eq ""
+
+          bundle "platform --ruby"
+          expect(last_command.stdboth).to eq "Could not locate Gemfile"
+        end
       end
 
       context "and is a pre-release" do


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was the outdated bundler version warning could be printed when running a command whose output should be parseable.

@schneems pointed this out on twitter

### What was your diagnosis of the problem?

My diagnosis was parsable commands needed to have such extraneous output suppressed.

### What is your fix for the problem, implemented in this PR?

My fix was to use the blacklist from printing the running command to bail out on the outdated bundler version warning as well.

### Why did you choose this fix out of the possible options?

I chose this fix because it means we can have a single list of parseable command.