### PR TITLE
[YAMLSerializer] Handle empty strings properly

### DIFF
--- a/lib/bundler/yaml_serializer.rb
+++ b/lib/bundler/yaml_serializer.rb
@@ -37,7 +37,7 @@ module Bundler
     HASH_REGEX = /
       ^
       ([ ]*) # indentations
-      (.*) # key
+      (.+) # key
       (?::(?=(?:\s|$))) # :  (without the lookahead the #key includes this when : is present in value)
       [ ]?
       (?: !\s)? # optional exclamation mark found with ruby 1.9.3
@@ -54,10 +54,10 @@ module Bundler
       last_empty_key = nil
       str.split(/\r?\n/).each do |line|
         if match = HASH_REGEX.match(line)
-          indent, key, _, val = match.captures
+          indent, key, quote, val = match.captures
           key = convert_to_backward_compatible_key(key)
           depth = indent.scan(/  /).length
-          if val.empty?
+          if quote.empty? && val.empty?
             new_hash = {}
             stack[depth][key] = new_hash
             stack[depth + 1] = new_hash

--- a/spec/bundler/yaml_serializer_spec.rb
+++ b/spec/bundler/yaml_serializer_spec.rb
@@ -156,6 +156,7 @@ RSpec.describe Bundler::YAMLSerializer do
         "a_joke" => {
           "my-stand" => "I can totally keep secrets",
           "but" => "The people I tell them to can't :P",
+          "wouldn't it be funny if this string were empty?" => "",
         },
         "more" => {
           "first" => [
@@ -166,6 +167,7 @@ RSpec.describe Bundler::YAMLSerializer do
             "What did the sea say to the sand?",
             "Nothing, it simply waved.",
           ],
+          "array with empty string" => [""],
         },
         "sales" => {
           "item" => "A Parachute",


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that empty strings in YAML were being read in as empty hashes.

Closes https://github.com/bundler/bundler/issues/5881.

### What was your diagnosis of the problem?

My diagnosis was we needed to fix the YAML Serializer to understand `""` as an empty string.

### What is your fix for the problem, implemented in this PR?

My fix ensures that a hash isn't created when the parser encounters `""`.