### PR TITLE
Add uninstallation instructions to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,29 +12,15 @@ It does this by managing the gems that the application depends on. Given a list 
 
 ### Installation and usage
 
-To install:
+To install (or update to the latest version):
 
 ```
 gem install bundler
 ```
 
-To update:
+To install a prerelease version (if one is available), run `gem install bundler --pre`. To uninstall Bundler, run `gem uninstall bundler`.
 
-- Run `gem install bundler` again
-
-To install prereleases:
-
-```
-gem install bundler --pre
-```
-
-To uninstall:
-
-```
-gem uninstall bundler
-```
-
-Bundler is most commonly used to manage your application's dependencies. To use it for this:
+Bundler is most commonly used to manage your application's dependencies. For example, these commands will allow you to use Bundler to manage the `rspec` gem for your application:
 
 ```
 bundle init

--- a/README.md
+++ b/README.md
@@ -18,6 +18,22 @@ To install:
 gem install bundler
 ```
 
+To update:
+
+- Run `gem install bundler` again
+
+To install prereleases:
+
+```
+gem install bundler --pre
+```
+
+To uninstall:
+
+```
+gem uninstall bundler
+```
+
 Bundler is most commonly used to manage your application's dependencies. To use it for this:
 
 ```


### PR DESCRIPTION
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was...
- I haven't seen anywhere in Bundler's documentation any instructions on how to uninstall bundler.

### What was your diagnosis of the problem?

My diagnosis was...
- I added instructions to `gem uninstall bundler` in the README 👌🏼

### What is your fix for the problem, implemented in this PR?

My fix...
- I know it's unlikely for someone to want to uninstall bundler, but I still think it's worthwhile to have instructions for this somewhere in the docs.

### Why did you choose this fix out of the possible options?

I chose this fix because...
- I made a new section in the README and put it underneath the _Installation and usage_ section, because I thought it made the most logical sense to place it there. I didn't place it anywhere in the [bundler.io](http://bundler.io/docs.html) site. Please let me know if I should make a new section for this somewhere there, or if anyone has any edits to the README changes -- I'd be happy to implement those. 
