### PR TITLE
Adding graphs explaining binstubs

### DIFF
--- a/man/bundle-binstubs.ronn
+++ b/man/bundle-binstubs.ronn
@@ -7,15 +7,15 @@ bundle-binstubs(1) -- Install the binstubs of the listed gems
 
 ## DESCRIPTION
 
-Binstubs are scripts that wrap aroung executables. Bundler creates a 
-small Ruby file (a binstub) that loads Bundler, runs the command, 
+Binstubs are scripts that wrap aroung executables. Bundler creates a
+small Ruby file (a binstub) that loads Bundler, runs the command,
 and puts it into `bin/`. Binstubs are a shortcut—or alternative—
-to always using `bundle exec`, with the additional benefit of linking 
-the binstub inside of an application to the exact version of the gem the
-application needs.
+to always using `bundle exec`. This gives you a file that can by run
+directly, and one that will always run the correct gem version
+used by the application.
 
-For example, if you run `bundle binstubs rspec-core`, Bundler will create 
-the file `bin/rspec`. That file will contain just enough code to load Bundler, 
+For example, if you run `bundle binstubs rspec-core`, Bundler will create
+the file `bin/rspec`. That file will contain enough code to load Bundler,
 tell it to load the bundled gems, and then run rspec.
 
 This command generates binstubs for executables in `GEM_NAME`.

--- a/man/bundle-binstubs.ronn
+++ b/man/bundle-binstubs.ronn
@@ -7,6 +7,17 @@ bundle-binstubs(1) -- Install the binstubs of the listed gems
 
 ## DESCRIPTION
 
+Binstubs are scripts that wrap aroung executables. Bundler creates a 
+small Ruby file (a binstub) that loads Bundler, runs the command, 
+and puts it into `bin/`. Binstubs are a shortcut—or alternative—
+to always using `bundle exec`, with the additional benefit of linking 
+the binstub inside of an application to the exact version of the gem the
+application needs.
+
+For example, if you run `bundle binstubs rspec-core`, Bundler will create 
+the file `bin/rspec`. That file will contain just enough code to load Bundler, 
+tell it to load the bundled gems, and then run rspec.
+
 This command generates binstubs for executables in `GEM_NAME`.
 Binstubs are put into `bin`, or the `--path` directory if one has been set.
 Calling binstubs with [GEM [GEM]] will create binstubs for all given gems.


### PR DESCRIPTION
Added a paragraph that explains what binstubs is and how it works, per feedback from @arbonap.

Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was...without an explanation of what binstubs is and what it does, it's difficult for 
users to understand where to apply the binstubs command. Shout out to @arbonap for calling this out!

### What was your diagnosis of the problem?

My diagnosis was...to take a wonderful explanation given by @indirect about what binstubs are and turn it into a paragraph! 😄 

### What is your fix for the problem, implemented in this PR?

My fix...is two intro paragraphs in the "DESCRIPTION" section, before going into what the command does.

### Why did you choose this fix out of the possible options?

I chose this fix because...explanations help users 👍 