### PR TITLE
Added a sentence to `binstubs`

### DIFF
--- a/man/bundle-install.ronn
+++ b/man/bundle-install.ronn
@@ -51,7 +51,7 @@ time `bundle install` is run, use `bundle config` (see bundle-config(1)).
   file (a binstub) that loads Bundler, runs the command, and puts it in `bin/`.
   This lets you link the binstub inside of an application to the exact gem
   version the application needs.
-  
+ 
   Creates a directory (defaults to `~/bin`) and places any executables from the
   gem there. These executables run in Bundler's context. If used, you might add
   this directory to your environment's `PATH` variable. For instance, if the

--- a/man/bundle-install.ronn
+++ b/man/bundle-install.ronn
@@ -48,7 +48,7 @@ time `bundle install` is run, use `bundle config` (see bundle-config(1)).
 
 * `--binstubs[=<directory>]`:
   Binstubs are scripts that wrap around executables. Bundler creates a small Ruby
-  file (a binstub) that loads Bundler, runs the command, and puts it in `bin/`. 
+  file (a binstub) that loads Bundler, runs the command, and puts it in `bin/`.
   This lets you link the binstub inside of an application to the exact gem
   version the application needs.
   

--- a/man/bundle-install.ronn
+++ b/man/bundle-install.ronn
@@ -47,7 +47,12 @@ To apply any of `--deployment`, `--path`, `--binstubs`, or `--without` every
 time `bundle install` is run, use `bundle config` (see bundle-config(1)).
 
 * `--binstubs[=<directory>]`:
-  Creates a directory (defaults to `~/bin`) and place any executables from the
+  Binstubs are scripts that wrap around executables. Bundler creates a small Ruby
+  file (a binstub) that loads Bundler, runs the command, and puts it in `bin/`. 
+  This lets you link the binstub inside of an application to the exact gem
+  version the application needs.
+  
+  Creates a directory (defaults to `~/bin`) and places any executables from the
   gem there. These executables run in Bundler's context. If used, you might add
   this directory to your environment's `PATH` variable. For instance, if the
   `rails` gem comes with a `rails` executable, this flag will create a

--- a/man/bundle-install.ronn
+++ b/man/bundle-install.ronn
@@ -51,7 +51,7 @@ time `bundle install` is run, use `bundle config` (see bundle-config(1)).
   file (a binstub) that loads Bundler, runs the command, and puts it in `bin/`.
   This lets you link the binstub inside of an application to the exact gem
   version the application needs.
- 
+
   Creates a directory (defaults to `~/bin`) and places any executables from the
   gem there. These executables run in Bundler's context. If used, you might add
   this directory to your environment's `PATH` variable. For instance, if the


### PR DESCRIPTION
Per feedback from @arbonap, we've added a sentence that briefly explains what binstubs is to the binstubs section.

Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was...no understanding of what binstubs is. Added a quick two sentences!

### What was your diagnosis of the problem?

My diagnosis was...we needed some language there. @arbonap and @indirect pointed this out and offered the explanations.

### What is your fix for the problem, implemented in this PR?

My fix...was to turn their explanations into simple language!

### Why did you choose this fix out of the possible options?

I chose this fix because...it'll help users understand binstubs better