### PR TITLE
[RubyGemsIntegration] Require bundler/gemdeps before using it

### DIFF
--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -814,6 +814,7 @@ module Bundler
 
       def use_gemdeps(gemfile)
         ENV["BUNDLE_GEMFILE"] ||= File.expand_path(gemfile)
+        require "bundler/gemdeps"
         runtime = Bundler.setup
         Bundler.ui = nil
         activated_spec_names = runtime.requested_specs.map(&:to_spec).sort_by(&:name)


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was `Bundler.rubygems.use_gemdeps` would raise a missing constant error.

### What was your diagnosis of the problem?

My diagnosis was we needed to require the gemdeps file

### What is your fix for the problem, implemented in this PR?

My fix requires the gemdeps file.

### Why did you choose this fix out of the possible options?

I chose this fix because watching autocorrect struggle to understand that `gemdeps` is not the same as `genders` is priceless.