### PR TITLE
Add spec for prerelease dependency resolution

### DIFF
--- a/spec/resolver/basic_spec.rb
+++ b/spec/resolver/basic_spec.rb
@@ -44,6 +44,12 @@ RSpec.describe "Resolving" do
     should_resolve_as %w[activesupport-3.0.5 i18n-0.4.2 builder-2.1.2 activerecord-3.0.5 activemodel-3.0.5]
   end
 
+  it "resolves a gem specified with a pre-release version" do
+    dep "activesupport", "~> 3.0.0.beta"
+    dep "activemerchant"
+    should_resolve_as %w[activemerchant-2.3.5 activesupport-3.0.0.beta1]
+  end
+
   it "raises an exception if a child dependency is not resolved" do
     @index = a_unresovable_child_index
     dep "chef_app_error"

--- a/spec/support/indexes.rb
+++ b/spec/support/indexes.rb
@@ -75,6 +75,9 @@ module Spec
         gem "rack", %w[0.8 0.9 0.9.1 0.9.2 1.0 1.1]
         gem "rack-mount", %w[0.4 0.5 0.5.1 0.5.2 0.6]
 
+        # --- Pre-release support
+        gem "rubygems\0", ["1.3.2"]
+
         # --- Rails
         versions "1.2.3 2.2.3 2.3.5 3.0.0.beta 3.0.0.beta1" do |version|
           gem "activesupport", version


### PR DESCRIPTION
Bundler-specific version of https://github.com/CocoaPods/Resolver-Integration-Specs/pull/12. We didn't have any specs for resolving pre-release versions before, and I'm nervous about https://github.com/CocoaPods/Molinillo/pull/69 breaking this when introduced.