### PR TITLE
[Source::Git] Cache repos globally

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -207,10 +207,6 @@ module Bundler
       bundle_path.join("specifications")
     end
 
-    def cache
-      bundle_path.join("cache/bundler")
-    end
-
     def user_cache
       user_bundle_path.join("cache")
     end

--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -211,11 +211,11 @@ module Bundler
         @cache_path ||= begin
           git_scope = "#{base_name}-#{uri_hash}"
 
-          if Bundler.requires_sudo?
-            Bundler.user_bundle_path.join("cache/git", git_scope)
+          if Bundler.requires_sudo? || Bundler.feature_flag.global_gem_cache?
+            Bundler.user_cache
           else
-            Bundler.cache.join("git", git_scope)
-          end
+            Bundler.bundle_path.join("cache", "bundler")
+          end.join("git", git_scope)
         end
       end
 

--- a/spec/commands/clean_spec.rb
+++ b/spec/commands/clean_spec.rb
@@ -142,7 +142,8 @@ RSpec.describe "bundle clean" do
     bundle :clean
 
     digest = Digest::SHA1.hexdigest(git_path.to_s)
-    expect(vendored_gems("cache/bundler/git/foo-1.0-#{digest}")).to exist
+    cache_path = Bundler::VERSION.start_with?("1.") ? vendored_gems("cache/bundler/git/foo-1.0-#{digest}") : home(".bundle/cache/git/foo-1.0-#{digest}")
+    expect(cache_path).to exist
   end
 
   it "removes unused git gems" do
@@ -671,7 +672,7 @@ RSpec.describe "bundle clean" do
       gem "foo"
     G
 
-    bundle "install", forgotten_command_line_options(:path => "vendor/bundle", :clean => false)
+    bundle! "install", forgotten_command_line_options(:path => "vendor/bundle", :clean => false)
 
     gemfile <<-G
       source "file://#{gem_repo1}"
@@ -680,8 +681,8 @@ RSpec.describe "bundle clean" do
       gem "weakling"
     G
 
-    bundle "config auto_install 1"
-    bundle :clean
+    bundle! "config auto_install 1"
+    bundle! :clean
     expect(out).to include("Installing weakling 0.0.3")
     should_have_gems "thin-1.0", "rack-1.0.0", "weakling-0.0.3"
     should_not_have_gems "foo-1.0"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Closes https://github.com/bundler/bundler/issues/5895.

The problem was:

> Now that we have a "global" user-wide cache of gems, it would be great to also have a user-wide place to keep git repos. In 1.x, the default system path provided that user-wide cache, and losing it because of the default 2.0 path will slow down installs with git repos by a lot.

### What was your diagnosis of the problem?

My diagnosis was we needed to change the git cache location to something global

### What is your fix for the problem, implemented in this PR?

My fix uses the global "~/.bundle/cache" directory to cache git gems

### Why did you choose this fix out of the possible options?

I chose this fix because it means the cache (which only contains _downloaded_ information, nothing evaluated at runtime) can be shared across every app and every ruby version