### PR TITLE
Add clear error message when using a gem in the Gemfile with an empty name

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -268,6 +268,11 @@ Style/IfInsideElse:
     - 'lib/bundler/cli/install.rb'
 
 # Offense count: 1
+Style/IfUnlessModifier:
+  Exclude:
+    - 'lib/bundler/dsl.rb'
+
+# Offense count: 1
 Style/IfUnlessModifierOfIfUnless:
   Exclude:
     - 'spec/support/helpers.rb'

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -345,6 +345,9 @@ repo_name ||= user_name
       if name =~ /\s/
         raise GemfileError, %('#{name}' is not a valid gem name because it contains whitespace)
       end
+      if name.empty?
+        raise GemfileError, %(an empty gem name is not valid)
+      end
 
       normalize_hash(opts)
 

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -110,6 +110,11 @@ RSpec.describe Bundler::Dsl do
         to raise_error(Bundler::GemfileError, /is not a valid platform/)
     end
 
+    it "rejects empty gem name" do
+      expect { subject.gem("") }.
+        to raise_error(Bundler::GemfileError, /an empty gem name is not valid/)
+    end
+
     it "rejects with a leading space in the name" do
       expect { subject.gem(" foo") }.
         to raise_error(Bundler::GemfileError, /' foo' is not a valid gem name because it contains whitespace/)


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Users are allowed to add a gem to the Gemfile with an empty string as the name but Bundler won't find a gem with an empty and does not make this clear as possible to the end user. Using a Gemfile like:

```
source 'https://rubygems.org'
gem '', git: 'https://github.com/rack/rack'
```

Bundler will print the following:

```
› dbundler install
Fetching https://github.com/rack/rack
Fetching gem metadata from https://rubygems.org/.
Fetching gem metadata from https://rubygems.org/...........
Fetching gem metadata from https://rubygems.org/...
Could not find gem '' in https://github.com/rack/rack (at master@8693330).
The source does not contain any versions of ''

```

### What is your fix for the problem, implemented in this PR?

Check the name of the gem in the DSL. If the name is empty print a clear message to the user that using an empty name is not allowed

```
[!] There was an error parsing `Gemfile`: an empty gem name is not valid. Bundler cannot continue.

 #  from /Users/c/Desktop/Projects/testapp/Gemfile:2
 #  -------------------------------------------
 #  source 'https://rubygems.org'
 >  gem '', git: 'https://github.com/rack/rack'
 #  -------------------------------------------
```
