### PR TITLE
[Env] Print all gemfiles that have been evaled

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -15,7 +15,9 @@ module Bundler
       :locked_gems,
       :platforms,
       :requires,
-      :ruby_version
+      :ruby_version,
+      :lockfile,
+      :gemfiles
     )
 
     # Given a gemfile and lockfile creates a Bundler definition
@@ -52,7 +54,7 @@ module Bundler
     #   to be updated or true if all gems should be updated
     # @param ruby_version [Bundler::RubyVersion, nil] Requested Ruby Version
     # @param optional_groups [Array(String)] A list of optional groups
-    def initialize(lockfile, dependencies, sources, unlock, ruby_version = nil, optional_groups = [])
+    def initialize(lockfile, dependencies, sources, unlock, ruby_version = nil, optional_groups = [], gemfiles = [])
       @unlocking = unlock == true || !unlock.empty?
 
       @dependencies    = dependencies
@@ -62,6 +64,7 @@ module Bundler
       @remote          = false
       @specs           = nil
       @ruby_version    = ruby_version
+      @gemfiles        = gemfiles
 
       @lockfile               = lockfile
       @lockfile_contents      = String.new

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -34,14 +34,16 @@ module Bundler
       @ruby_version         = nil
       @gemspecs             = []
       @gemfile              = nil
+      @gemfiles             = []
       add_git_sources
     end
 
     def eval_gemfile(gemfile, contents = nil)
-      expanded_gemfile_path = Pathname.new(gemfile).expand_path
+      expanded_gemfile_path = Pathname.new(gemfile).expand_path(@gemfile && @gemfile.parent)
       original_gemfile = @gemfile
       @gemfile = expanded_gemfile_path
-      contents ||= Bundler.read_file(gemfile.to_s)
+      @gemfiles << expanded_gemfile_path
+      contents ||= Bundler.read_file(@gemfile.to_s)
       instance_eval(contents.dup.untaint, gemfile.to_s, 1)
     rescue Exception => e
       message = "There was an error " \
@@ -213,7 +215,7 @@ module Bundler
     end
 
     def to_definition(lockfile, unlock)
-      Definition.new(lockfile, @dependencies, @sources, unlock, @ruby_version, @optional_groups)
+      Definition.new(lockfile, @dependencies, @sources, unlock, @ruby_version, @optional_groups, @gemfiles)
     end
 
     def group(*args, &blk)

--- a/lib/bundler/env.rb
+++ b/lib/bundler/env.rb
@@ -31,9 +31,18 @@ module Bundler
       return out unless SharedHelpers.in_bundle?
 
       if print_gemfile
+        gemfiles = [Bundler.default_gemfile]
+        begin
+          gemfiles = Bundler.definition.gemfiles
+        rescue GemfileNotFound
+          nil
+        end
+
         out << "\n## Gemfile\n"
-        out << "\n### #{Bundler.default_gemfile.relative_path_from(SharedHelpers.pwd)}\n\n"
-        out << "```ruby\n" << read_file(Bundler.default_gemfile).chomp << "\n```\n"
+        gemfiles.each do |gemfile|
+          out << "\n### #{Pathname.new(gemfile).relative_path_from(SharedHelpers.pwd)}\n\n"
+          out << "```ruby\n" << read_file(gemfile).chomp << "\n```\n"
+        end
 
         out << "\n### #{Bundler.default_lockfile.relative_path_from(SharedHelpers.pwd)}\n\n"
         out << "```\n" << read_file(Bundler.default_lockfile).chomp << "\n```\n"

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Bundler::Dsl do
 
   describe "#method_missing" do
     it "raises an error for unknown DSL methods" do
-      expect(Bundler).to receive(:read_file).with("Gemfile").
+      expect(Bundler).to receive(:read_file).with(bundled_app("Gemfile").to_s).
         and_return("unknown")
 
       error_msg = "There was an error parsing `Gemfile`: Undefined local variable or method `unknown' for Gemfile. Bundler cannot continue."
@@ -83,13 +83,13 @@ RSpec.describe Bundler::Dsl do
 
   describe "#eval_gemfile" do
     it "handles syntax errors with a useful message" do
-      expect(Bundler).to receive(:read_file).with("Gemfile").and_return("}")
+      expect(Bundler).to receive(:read_file).with(bundled_app("Gemfile").to_s).and_return("}")
       expect { subject.eval_gemfile("Gemfile") }.
         to raise_error(Bundler::GemfileError, /There was an error parsing `Gemfile`: (syntax error, unexpected tSTRING_DEND|(compile error - )?syntax error, unexpected '\}'). Bundler cannot continue./)
     end
 
     it "distinguishes syntax errors from evaluation errors" do
-      expect(Bundler).to receive(:read_file).with("Gemfile").and_return(
+      expect(Bundler).to receive(:read_file).with(bundled_app("Gemfile").to_s).and_return(
         "ruby '2.1.5', :engine => 'ruby', :engine_version => '1.2.4'"
       )
       expect { subject.eval_gemfile("Gemfile") }.

--- a/spec/install/gemfile/eval_gemfile_spec.rb
+++ b/spec/install/gemfile/eval_gemfile_spec.rb
@@ -65,4 +65,18 @@ RSpec.describe "bundle install with gemfile that uses eval_gemfile" do
       expect(the_bundle).to include_gem "gunks 0.0.1", :source => "path@#{bundled_app("gems", "gunks")}"
     end
   end
+
+  context "eval-ed Gemfile references other gemfiles" do
+    it "works with relative paths" do
+      create_file "other/Gemfile-other", "gem 'rack'"
+      create_file "other/Gemfile", "eval_gemfile 'Gemfile-other'"
+      create_file "Gemfile-alt", <<-G
+        source "file:#{gem_repo1}"
+        eval_gemfile "other/Gemfile"
+      G
+      install_gemfile! "eval_gemfile File.expand_path('Gemfile-alt')"
+
+      expect(the_bundle).to include_gem "rack 1.0.0"
+    end
+  end
 end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was we'd get error reports like https://github.com/bundler/bundler/issues/5381 where the env output was insufficient to reproduce the issue because `eval_gemfile` had been used.

### What was your diagnosis of the problem?

My diagnosis was we needed to print out all gem files that had gone through `eval_gemfile`

### What is your fix for the problem, implemented in this PR?

My fix keeps track of all eval'ed gem files and prints them all out in the env report.