### PR TITLE
Add tasks to make running in 2.0 mode easier

### DIFF
--- a/bin/bundle2
+++ b/bin/bundle2
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+module Bundler
+  VERSION = "2.0.0.dev".freeze
+end
+
+load File.expand_path("../bundle", __FILE__)

--- a/task/bundler_2.rake
+++ b/task/bundler_2.rake
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+namespace :bundler_2 do
+  task :install do
+    ENV["BUNDLER_SPEC_SUB_VERSION"] = "2.0.0.dev"
+    Rake::Task["spec:travis:sub_version"].invoke
+    Rake::Task["install"].invoke
+    sh("git", "checkout", "--", "lib/bundler/version.rb")
+  end
+end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was it was too difficult to run Bundler in 2.0 mode.

### What was your diagnosis of the problem?

My diagnosis was we needed a way to install a dev version of 2.0, and also to run commands as bundler 2.

### What is your fix for the problem, implemented in this PR?

My fix adds a `bin/bundle2` bin stub that runs bundler as 2.0.0.dev, and a `bundle_2:install` rake task that will install `bundler-2.0.0.dev`