### PR TITLE
Delete redundant aliases from bundle outdated command 💫

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -312,8 +312,8 @@ module Bundler
       For more information on patch level options (--major, --minor, --patch,
       --update-strict) see documentation on the same options on the update command.
     D
-    method_option "group", :aliases => "--group", :type => :string, :banner => "List gems from a specific group"
-    method_option "groups", :aliases => "--groups", :type => :boolean, :banner => "List gems organized by groups"
+    method_option "group", :type => :string, :banner => "List gems from a specific group"
+    method_option "groups", :type => :boolean, :banner => "List gems organized by groups"
     method_option "local", :type => :boolean, :banner =>
       "Do not attempt to fetch gems remotely and use the gem cache instead"
     method_option "pre", :type => :boolean, :banner => "Check for newer pre-release gems"


### PR DESCRIPTION
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was...
- I was looking at the `bundle outdated` command in `cli.rb`, and noticed some flag aliases were the same as the original flags.
### What was your diagnosis of the problem?
My diagnosis was...
- I thought these aliases weren't necessary
### What is your fix for the problem, implemented in this PR?

My fix...
- I deleted two aliases from `bundle outdated`.
- I ran `rake spec:deps && bin/rspec spec/commands/outdated_spec.rb` locally and all tests passed.
### Why did you choose this fix out of the possible options?

I chose this fix because...
- to DRY up `cli.rb` 👌🏼