### PR TITLE
[Update] Warn when an explicitly updated spec does not get a newer version

### DIFF
--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -373,6 +373,24 @@ RSpec.describe "bundle update in more complicated situations" do
     expect(the_bundle).to include_gems "thin 2.0", "rack 1.2", "rack-obama 1.0"
   end
 
+  it "will warn when some explicitly updated gems are not updated" do
+    install_gemfile! <<-G
+      source "file:#{gem_repo2}"
+
+      gem "thin"
+      gem "rack-obama"
+    G
+
+    update_repo2 do
+      build_gem("thin", "2.0") {|s| s.add_dependency "rack" }
+      build_gem "rack", "10.0"
+    end
+
+    bundle! "update thin rack-obama"
+    expect(last_command.stdboth).to include "Bundler attempted to update rack-obama but its version stayed the same"
+    expect(the_bundle).to include_gems "thin 2.0", "rack 10.0", "rack-obama 1.0"
+  end
+
   it "will update only from pinned source" do
     install_gemfile <<-G
       source "file://#{gem_repo2}"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was you could run `bundle update foo bar` and it would be possible that either `foo` or `bar` not move to a newer version.

### What was your diagnosis of the problem?

My diagnosis was we should tell users when this happens!

### What is your fix for the problem, implemented in this PR?

My fix warns when a locked bundle has `bundle update` called with an explicit list of gems and one of those gems could not actually be _updated_.

### Why did you choose this fix out of the possible options?

I chose this fix because it didn't require mucking around with the resolved.