### PR TITLE
Add missing flag aliases to docs 🌟

### DIFF
--- a/man/bundle-gem.ronn
+++ b/man/bundle-gem.ronn
@@ -67,6 +67,7 @@ configuration file using the following names:
   on this option. If this option is unspecified, an interactive prompt will be
   displayed and the answer will be saved in Bundler's global config for future
   `bundle gem` use.
+  If no option is specified, the default testing framework is RSpec.
 
 * `-e`, `--edit[=EDITOR]`:
   Open the resulting GEM_NAME.gemspec in EDITOR, or the default editor if not

--- a/man/bundle-install.ronn
+++ b/man/bundle-install.ronn
@@ -84,7 +84,7 @@ time `bundle install` is run, use `bundle config` (see bundle-config(1)).
   root and will try to find `Gemfile.lock` and `vendor/cache` relative
   to this location.
 
-* `--jobs=[<number>]`:
+* `--jobs=[<number>]`, `-j[<number>]`:
   The maximum number of parallel download and install jobs. The default
   is `1`.
 

--- a/man/bundle-outdated.ronn
+++ b/man/bundle-outdated.ronn
@@ -37,7 +37,7 @@ are up to date, Bundler will exit with a status of 0. Otherwise, it will exit 1.
 * `--strict`:
   Only list newer versions allowed by your Gemfile requirements.
 
-* `--parseable`:
+* `--parseable`, `--porcelain`:
    Use minimal formatting for more parseable output.
 
 * `--group`:

--- a/man/bundle-update.ronn
+++ b/man/bundle-update.ronn
@@ -28,7 +28,7 @@ gem.
 
 ## OPTIONS
 
-* `--group=<name>`:
+* `--group=<name>`, `-g=[<name>]`:
   Only update the gems in the specified group. For instance, you can update all gems
   in the development group with `bundle update --group development`. You can also
   call `bundle update rails --group test` to update the rails gem and all gems in
@@ -51,7 +51,7 @@ gem.
 * `--full-index`:
   Fall back to using the single-file index of all gems.
 
-* `--jobs=[<number>]`:
+* `--jobs=[<number>]`, `-j[<number>]`:
   Specify the number of jobs to run in parallel. The default is `1`.
 
 * `--retry=[<number>]`:

--- a/man/bundle-viz.ronn
+++ b/man/bundle-viz.ronn
@@ -18,13 +18,13 @@ The associated gems must also be installed via `bundle install(1)`.
 
 ## OPTIONS
 
-* `--file`:
+* `--file`, `-f`:
   The name to use for the generated file. See `--format` option
-* `--format`:
+* `--format`, `-F`:
   This is output format option. Supported format is png, jpg, svg, dot ...
-* `--requirements`:
+* `--requirements`, `-R`:
   Set to show the version of each required dependency.
-* `--version`:
+* `--version`, `-v`:
   Set to show each gem version.
-* `--without`:
+* `--without`, `-W`:
   Exclude gems that are part of the specified named group.

--- a/man/bundle.ronn
+++ b/man/bundle.ronn
@@ -18,7 +18,10 @@ started, and Gemfile(5) for more information on the `Gemfile` format.
 * `--no-color`:
   Print all output without color
 
-* `--verbose`:
+* `--retry`, `-r`:
+  Specify the number of times you wish to attempt network commands
+
+* `--verbose`, `-V`:
   Print out additional logging information
 
 ## BUNDLE COMMANDS


### PR DESCRIPTION
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was...
- I noticed in the documentation that a lot of aliases for flags were missing.

### What was your diagnosis of the problem?

My diagnosis was...
- I added missing aliases for flags into the documentation. 

### What is your fix for the problem, implemented in this PR?

My fix...
- I added the missing flag aliases into the docs, so that users can more easily access this information. 💖
- I also added in a line describing how RSpec is the default testing framework 
### Why did you choose this fix out of the possible options?

I chose this fix because...
- more bundler knowledge for bundler users is helpful 🍒
