### PR TITLE
Add new line after newgem gemspec template

### DIFF
--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -1,6 +1,7 @@
 <%- if RUBY_VERSION < "2.0.0" -%>
 # coding: utf-8
 <%- end -%>
+
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "<%= config[:namespaced_path] %>/version"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

When using `bundle gem` to create a new gem, the created gemspec file starts with 

```
# coding: utf-8
lib = File.expand_path('../lib', __FILE__)
```

Rubocop recommends having a blank line after magic comments (like `# coding: utf-8`).

### What was your diagnosis of the problem?

The rubocop style guide recommends having a blank line after "magic comments" ([see link](https://github.com/bbatsov/ruby-style-guide#separate-magic-comments-from-code)).   The main bundler.gemspec follows this recommendation, but the .gemspec, that is created for new gems, does not.

### What is your fix for the problem, implemented in this PR?

Update the template file to have a blank line after the magic comment.

### Why did you choose this fix out of the possible options?

It's what rubocop wants.
