### PR TITLE
[2.0] Globally cache built extensions for RG & Git sources

### DIFF
--- a/lib/bundler/rubygems_gem_installer.rb
+++ b/lib/bundler/rubygems_gem_installer.rb
@@ -20,9 +20,9 @@ module Bundler
 
     def build_extensions
       extension_cache_path = options[:bundler_extension_cache_path]
-      return super unless extension_cache_path
+      return super unless extension_cache_path && extension_dir = Bundler.rubygems.spec_extension_dir(spec)
 
-      extension_dir = Pathname.new(spec.extension_dir)
+      extension_dir = Pathname.new(extension_dir)
       build_complete = SharedHelpers.filesystem_access(extension_cache_path.join("gem.build_complete"), :read, &:file?)
       if build_complete && !options[:force]
         SharedHelpers.filesystem_access(extension_dir.parent, &:mkpath)

--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -93,6 +93,11 @@ module Bundler
       end.flatten(1)
     end
 
+    def spec_extension_dir(spec)
+      return unless spec.respond_to?(:extension_dir)
+      spec.extension_dir
+    end
+
     def stub_set_spec(stub, spec)
       stub.instance_variable_set(:@spec, spec)
     end

--- a/lib/bundler/source.rb
+++ b/lib/bundler/source.rb
@@ -73,5 +73,18 @@ module Bundler
         Bundler.ui.info message
       end
     end
+
+    def extension_cache_path(spec)
+      return unless Bundler.feature_flag.global_gem_cache?
+      return unless source_slug = extension_cache_slug(spec)
+      Bundler.user_cache.join(
+        "extensions", Gem::Platform.local.to_s, Bundler.ruby_scope,
+        source_slug, spec.full_name
+      )
+    end
+
+    def extension_cache_slug(_)
+      nil
+    end
   end
 end

--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -209,19 +209,12 @@ module Bundler
       # When using local git repos, this is set to the local repo.
       def cache_path
         @cache_path ||= begin
-          git_scope = "#{base_name}-#{uri_hash}"
-
           if Bundler.requires_sudo? || Bundler.feature_flag.global_gem_cache?
             Bundler.user_cache
           else
             Bundler.bundle_path.join("cache", "bundler")
           end.join("git", git_scope)
         end
-      end
-
-      def extension_cache_path(spec)
-        return unless Bundler.feature_flag.global_gem_cache?
-        cache_path.join("extensions", Bundler.ruby_scope, extension_dir_name)
       end
 
       def app_cache_dirname
@@ -322,6 +315,14 @@ module Bundler
           stub.full_gem_path = Pathname.new(file).dirname.expand_path(root).to_s.untaint
           StubSpecification.from_stub(stub)
         end
+      end
+
+      def git_scope
+        "#{base_name}-#{uri_hash}"
+      end
+
+      def extension_cache_slug(_)
+        extension_dir_name
       end
     end
   end

--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -219,6 +219,11 @@ module Bundler
         end
       end
 
+      def extension_cache_path(spec)
+        return unless Bundler.feature_flag.global_gem_cache?
+        cache_path.join("extensions", Bundler.ruby_scope, spec.full_name)
+      end
+
       def app_cache_dirname
         "#{base_name}-#{shortref_for_path(cached_revision || revision)}"
       end

--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -221,7 +221,7 @@ module Bundler
 
       def extension_cache_path(spec)
         return unless Bundler.feature_flag.global_gem_cache?
-        cache_path.join("extensions", Bundler.ruby_scope, spec.full_name)
+        cache_path.join("extensions", Bundler.ruby_scope, extension_dir_name)
       end
 
       def app_cache_dirname

--- a/lib/bundler/source/path.rb
+++ b/lib/bundler/source/path.rb
@@ -227,7 +227,8 @@ module Bundler
           spec,
           :env_shebang => false,
           :disable_extensions => options[:disable_extensions],
-          :build_args => options[:build_args]
+          :build_args => options[:build_args],
+          :bundler_extension_cache_path => extension_cache_path(spec)
         )
         installer.post_install
       rescue Gem::InvalidSpecificationException => e
@@ -242,6 +243,10 @@ module Bundler
         end
 
         Bundler.ui.warn "The validation message from RubyGems was:\n  #{e.message}"
+      end
+
+      def extension_cache_path(spec)
+        nil
       end
     end
   end

--- a/lib/bundler/source/path.rb
+++ b/lib/bundler/source/path.rb
@@ -244,10 +244,6 @@ module Bundler
 
         Bundler.ui.warn "The validation message from RubyGems was:\n  #{e.message}"
       end
-
-      def extension_cache_path(spec)
-        nil
-      end
     end
   end
 end

--- a/lib/bundler/source/path/installer.rb
+++ b/lib/bundler/source/path/installer.rb
@@ -7,6 +7,7 @@ module Bundler
         attr_reader :spec
 
         def initialize(spec, options = {})
+          @options            = options
           @spec               = spec
           @gem_dir            = Bundler.rubygems.path(spec.full_gem_path)
           @wrappers           = true

--- a/lib/bundler/source/rubygems.rb
+++ b/lib/bundler/source/rubygems.rb
@@ -148,7 +148,8 @@ module Bundler
               :wrappers            => true,
               :env_shebang         => true,
               :build_args          => opts[:build_args],
-              :bundler_expected_checksum => spec.respond_to?(:checksum) && spec.checksum
+              :bundler_expected_checksum => spec.respond_to?(:checksum) && spec.checksum,
+              :bundler_extension_cache_path => extension_cache_path(spec)
             ).install
           end
           spec.full_gem_path = installed_spec.full_gem_path
@@ -497,6 +498,11 @@ module Bundler
         return unless cache_slug = remote.cache_slug
 
         Bundler.user_cache.join("gems", cache_slug, spec.file_name)
+      end
+
+      def extension_cache_path(spec)
+        return unless download_path = download_cache_path(spec)
+        download_path.parent.join("extensions", Bundler.ruby_scope, spec.full_name)
       end
     end
   end

--- a/lib/bundler/source/rubygems.rb
+++ b/lib/bundler/source/rubygems.rb
@@ -500,9 +500,9 @@ module Bundler
         Bundler.user_cache.join("gems", cache_slug, spec.file_name)
       end
 
-      def extension_cache_path(spec)
-        return unless download_path = download_cache_path(spec)
-        download_path.parent.join("extensions", Bundler.ruby_scope, spec.full_name)
+      def extension_cache_slug(spec)
+        return unless remote = spec.remote
+        remote.cache_slug
       end
     end
   end

--- a/spec/install/global_cache_spec.rb
+++ b/spec/install/global_cache_spec.rb
@@ -186,4 +186,50 @@ RSpec.describe "global gem caching" do
       end
     end
   end
+
+  describe "extension caching", :rubygems => "2.2" do
+    it "works" do
+      build_git "very_simple_git_binary", &:add_c_extension
+      build_lib "very_simple_path_binary", &:add_c_extension
+      revision = revision_for(lib_path("very_simple_git_binary-1.0"))[0, 12]
+
+      install_gemfile! <<-G
+        source "file:#{gem_repo1}"
+
+        gem "very_simple_binary"
+        gem "very_simple_git_binary", :git => "#{lib_path("very_simple_git_binary-1.0")}"
+        gem "very_simple_path_binary", :path => "#{lib_path("very_simple_path_binary-1.0")}"
+      G
+
+      gem_binary_cache = home(".bundle", "cache", "extensions", specific_local_platform.to_s, Bundler.ruby_scope,
+        Digest(:MD5).hexdigest("#{gem_repo1}/"), "very_simple_binary-1.0")
+      git_binary_cache = home(".bundle", "cache", "extensions", specific_local_platform.to_s, Bundler.ruby_scope,
+        "very_simple_git_binary-1.0-#{revision}", "very_simple_git_binary-1.0")
+
+      cached_extensions = Pathname.glob(home(".bundle", "cache", "extensions", "*", "*", "*", "*", "*")).sort
+      expect(cached_extensions).to eq [gem_binary_cache, git_binary_cache].sort
+
+      run! <<-R
+        require 'very_simple_binary_c'; puts ::VERY_SIMPLE_BINARY_IN_C
+        require 'very_simple_git_binary_c'; puts ::VERY_SIMPLE_GIT_BINARY_IN_C
+      R
+      expect(out).to eq "VERY_SIMPLE_BINARY_IN_C\nVERY_SIMPLE_GIT_BINARY_IN_C"
+
+      FileUtils.rm Dir[home(".bundle", "cache", "extensions", "**", "*binary_c*")]
+
+      gem_binary_cache.join("very_simple_binary_c.rb").open("w") {|f| f << "puts File.basename(__FILE__)" }
+      git_binary_cache.join("very_simple_git_binary_c.rb").open("w") {|f| f << "puts File.basename(__FILE__)" }
+
+      bundle! "config --local path different_path"
+      bundle! :install
+
+      expect(Dir[home(".bundle", "cache", "extensions", "**", "*binary_c*")]).to all(end_with(".rb"))
+
+      run! <<-R
+        require 'very_simple_binary_c'
+        require 'very_simple_git_binary_c'
+      R
+      expect(out).to eq "very_simple_binary_c.rb\nvery_simple_git_binary_c.rb"
+    end
+  end
 end

--- a/spec/support/builders.rb
+++ b/spec/support/builders.rb
@@ -566,7 +566,7 @@ module Spec
 
           # exit 1 unless with_config("simple")
 
-          extension_name = "very_simple_binary_c"
+          extension_name = "#{name}_c"
           if extra_lib_dir = with_config("ext-lib")
             # add extra libpath if --with-ext-lib is
             # passed in as a build_arg
@@ -576,11 +576,11 @@ module Spec
           end
           create_makefile extension_name
         RUBY
-        write "ext/very_simple_binary.c", <<-C
+        write "ext/#{name}.c", <<-C
           #include "ruby.h"
 
-          void Init_very_simple_binary_c() {
-            rb_define_module("VerySimpleBinaryInC");
+          void Init_#{name}_c() {
+            rb_define_module("#{Builders.constantize(name)}_IN_C");
           }
         C
       end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was with the switch to defaulting the install path to `./.bundle`, you'd need to rebuild extensions for each app you use a gem in.

Closes #5905 

### What was your diagnosis of the problem?

My diagnosis was we could globally cache built extensions in a per-ruby, per-source directory, similar to how 2.0 global `.gem` caching and the git cache works.

### What is your fix for the problem, implemented in this PR?

My fix implements that cache.

### Remaining questions:

- [x] Tests
- [x] Right now, the directory structure is `cache/gems/remote_name/extensions/ruby_scope/gem_full_name`. I'm wondering whether we should make it `cache/extensions/ruby_scope/source_slug/gem_full_name` instead to make removing the cache for an old ruby version easier?
- [x] Should the cache path include something about the local OS? ie. do we want to force a re-compile when the user updates OS versions?