### PR TITLE
[2.0] Print only version number from `bundler --version`

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -423,7 +423,12 @@ module Bundler
       if ARGV.include?("version")
         build_info = " (#{BuildMetadata.built_at} commit #{BuildMetadata.git_commit_sha})"
       end
-      Bundler.ui.info "Bundler version #{Bundler::VERSION}#{build_info}"
+
+      if Bundler.feature_flag.print_only_version_number?
+        Bundler.ui.info "#{Bundler::VERSION}#{build_info}"
+      else
+        Bundler.ui.info "Bundler version #{Bundler::VERSION}#{build_info}"
+      end
     end
     map %w[-v --version] => :version
 

--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -41,6 +41,7 @@ module Bundler
     settings_flag(:only_update_to_newer_versions) { bundler_2_mode? }
     settings_flag(:plugins) { @bundler_version >= Gem::Version.new("1.14") }
     settings_flag(:prefer_gems_rb) { bundler_2_mode? }
+    settings_flag(:print_only_version_number) { bundler_2_mode? }
     settings_flag(:setup_makes_kernel_gem_public) { !bundler_2_mode? }
     settings_flag(:skip_default_git_sources) { bundler_2_mode? }
     settings_flag(:specific_platform) { bundler_2_mode? }

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -42,6 +42,7 @@ module Bundler
       path.system
       plugins
       prefer_gems_rb
+      print_only_version_number
       setup_makes_kernel_gem_public
       silence_root_warning
       skip_default_git_sources

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -214,6 +214,8 @@ learn more about their operation in [bundle install(1)][bundle-install].
    Enable Bundler's experimental plugin system.
 * `prefer_gems_rb` (`BUNDLE_PREFER_GEMS_RB`)
    Prefer `gems.rb` to `Gemfile` when Bundler is searching for a Gemfile.
+* `print_only_version_number` (`BUNDLE_PRINT_ONLY_VERSION_NUMBER`)
+   Print only version number from `bundler --version`.
 * `redirect` (`BUNDLE_REDIRECT`):
    The number of redirects allowed for network requests. Defaults to `5`.
 * `retry` (`BUNDLE_RETRY`):

--- a/spec/bundler/cli_spec.rb
+++ b/spec/bundler/cli_spec.rb
@@ -146,8 +146,13 @@ To update, run `gem install bundler --pre`
 end
 
 RSpec.describe "bundler executable" do
-  it "shows the bundler version just as the `bundle` executable does" do
+  it "shows the bundler version just as the `bundle` executable does", :bundler => "< 2" do
     bundler "--version"
     expect(out).to eq("Bundler version #{Bundler::VERSION}")
+  end
+
+  it "shows the bundler version just as the `bundle` executable does", :bundler => "2" do
+    bundler "--version"
+    expect(out).to eq(Bundler::VERSION)
   end
 end

--- a/spec/commands/version_spec.rb
+++ b/spec/commands/version_spec.rb
@@ -2,23 +2,38 @@
 
 RSpec.describe "bundle version" do
   context "with -v" do
-    it "outputs the version" do
+    it "outputs the version", :bundler => "< 2" do
       bundle! "-v"
       expect(out).to eq("Bundler version #{Bundler::VERSION}")
+    end
+
+    it "outputs the version", :bundler => "2" do
+      bundle! "-v"
+      expect(out).to eq(Bundler::VERSION)
     end
   end
 
   context "with --version" do
-    it "outputs the version" do
+    it "outputs the version", :bundler => "< 2" do
       bundle! "--version"
       expect(out).to eq("Bundler version #{Bundler::VERSION}")
+    end
+
+    it "outputs the version", :bundler => "2" do
+      bundle! "--version"
+      expect(out).to eq(Bundler::VERSION)
     end
   end
 
   context "with version" do
-    it "outputs the version with build metadata" do
+    it "outputs the version with build metadata", :bundler => "< 2" do
       bundle! "version"
       expect(out).to match(/\ABundler version #{Regexp.escape(Bundler::VERSION)} \(\d{4}-\d{2}-\d{2} commit [a-fA-F0-9]{7,}\)\z/)
+    end
+
+    it "outputs the version with build metadata", :bundler => "2" do
+      bundle! "version"
+      expect(out).to match(/\A#{Regexp.escape(Bundler::VERSION)} \(\d{4}-\d{2}-\d{2} commit [a-fA-F0-9]{7,}\)\z/)
     end
   end
 end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

(Fix #4706)

The behavior was different from [Bundler 2 RFC](https://github.com/bundler/rfcs/pull/6/files#diff-0579edc0374571613cd01f0a42c19bdaR38).

### What was your diagnosis of the problem?

When it is `bundler_2_mode`, it behaves as written in RFC.

### What is your fix for the problem, implemented in this PR?

This PR will switch `Bundler.feature_flag` using `bundler_2_mode`.

### Why did you choose this fix out of the possible options?

Since #4708 does not use `Bundler.feature_flag`, then compatibility with Bundler 1 will be lost.
In addition, this PR adds specs for Bundler 2.