### PR TITLE
[CLI] Suggest bundle update --bundler when a newer version is installed

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -677,8 +677,17 @@ module Bundler
 
       current = Gem::Version.new(VERSION)
       return if current >= latest
+      latest_installed = Bundler.rubygems.find_name("bundler").map(&:version).max
 
-      Bundler.ui.warn "The latest bundler is #{latest}, but you are currently running #{current}.\nTo update, run `gem install bundler#{" --pre" if latest.prerelease?}`"
+      installation = "To install the latest version, run `gem install bundler#{" --pre" if latest.prerelease?}`"
+      if latest_installed && latest_installed > current
+        suggestion = "To update to the most recent installed version, run `bundle update --bundler`"
+        suggestion = "#{installation}\n#{suggestion}" if latest_installed > latest
+      else
+        suggestion = installation
+      end
+
+      Bundler.ui.warn "The latest bundler is #{latest}, but you are currently running #{current}.\n#{suggestion}"
     rescue
       nil
     end

--- a/spec/bundler/cli_spec.rb
+++ b/spec/bundler/cli_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe "bundle executable" do
         bundle "fail"
         expect(last_command.stdout).to start_with(<<-EOS.strip)
 The latest bundler is #{latest_version}, but you are currently running #{bundler_version}.
-To update, run `gem install bundler`
+To install the latest version, run `gem install bundler`
         EOS
       end
 
@@ -137,7 +137,7 @@ To update, run `gem install bundler`
           bundle "fail"
           expect(last_command.stdout).to start_with(<<-EOS.strip)
 The latest bundler is #{latest_version}, but you are currently running #{bundler_version}.
-To update, run `gem install bundler --pre`
+To install the latest version, run `gem install bundler --pre`
           EOS
         end
       end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem is once users start using our new `bin/bundle` binstub or the RubyGems that helps lock to the bundler version in the lockfile, the outdated bundler version warning was outdated.

### What was your diagnosis of the problem?

My diagnosis was we needed to tell people to `bundle update --bundler`, and restrict the `gem install` suggestion to when the latest version indeed wasn't installed.

### What is your fix for the problem, implemented in this PR?

My fix takes into account the actual installed bundler versions.

@indirect I think this addresses your concern on the RG PR?