### PR TITLE
Explain RUBYOPT in Debugging section of Setup docs

### DIFF
--- a/doc/development/SETUP.md
+++ b/doc/development/SETUP.md
@@ -27,3 +27,14 @@ Bundler doesn't use a Gemfile to list development dependencies, because when we 
 ## Debugging with `pry`
 
 To dive into the code with Pry: `RUBYOPT=-rpry dbundle` to require pry and then run commands.
+
+For background context: you can manipulate environment variables in Ruby to control the Ruby interpreter's behavior. Ruby uses the `RUBYOPT` environment variable to specify options to launch Ruby with.
+
+The arguments of `RUBYOPT` are applied as if you had typed them as flags after `ruby`. The `-r` flag means 'require'. So saying `-rpry` means `require 'pry'`. To illustrate, `ruby -rpry /path/to/bundle` is the same as `RUBYOPT=-rpry ruby /path/to/bundle`.
+
+So, `RUBYOPT=-rpry dbundle` is saying "require pry and require this path to Bundler", which means that you will start your development environment with `pry` and your local bundler.
+
+_Why is this necessary?_ Why isn't `require 'pry'; binding.pry` enough?
+
+The reason for combining `RUBYOPT` with `dbundle` is because Bundler takes over what gems are available. If you have `pry` installed on your machine but not included in the Gemfile, Bundler itself will remove `pry` from the list of gems you can require. Setting `RUBYOPT=-rpry` is a way to require `pry` before Bundler takes over and removes it from the list of gems that can be required. That way, later, you can take advantage of `binding.pry` and have it work.
+Unfortunately, if you waited until the point of `binding.pry` to `require 'pry'`, it would fail anytime `pry` is not in the Gemfile.


### PR DESCRIPTION
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was...
- I was looking through `SETUP.md` and I didn't understand why I had to set the `RUBYOPT` env variable to `-rpry dbundle`. I was wondering why I couldn't just normally use `require 'pry'; binding.pry` to debug Bundler's codebase.

### What was your diagnosis of the problem?

My diagnosis was...
- To add more explanations to the Setup documentation.

### What is your fix for the problem, implemented in this PR?

My fix...
- I asked @indirect and @jules2689 all about `RUBYOPT`, and why we have to set `RUBYOPT` to require pry and require this path to Bundler. I used their wonderful explanations and tried synthesizing their knowledge in a way that made sense to those who aren't familiar with `RUBYOPT`. I also included background context as to why Bundler chooses to do this.

### Why did you choose this fix out of the possible options?

I chose this fix because...
- Having background context of how and why Bundler combines `RUBYOPT` with `dbundle` in the Setup docs will help new contributors ramp-up.
- I also think having this knowledge will (hopefully) help new contributors not put in `require 'pry'; binding.pry` like they may be used to in other Ruby projects. ✨

Let me know what y'all think of this first draft 👌🏼. I'm happy to incorporate changes.