### PR TITLE
[2.0] Don't create gem home before setting it

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -524,13 +524,6 @@ EOF
     end
 
     def configure_gem_home
-      # TODO: This mkdir_p is only needed for JRuby <= 1.5 and should go away (GH #602)
-      begin
-        FileUtils.mkdir_p bundle_path.to_s
-      rescue
-        nil
-      end
-
       Bundler::SharedHelpers.set_env "GEM_HOME", File.expand_path(bundle_path, root)
       Bundler.rubygems.clear_paths
     end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

(Follow up of #2884)

It seems that [the PR](#2884) written in [Bundler 2 RFC](https://github.com/bundler/rfcs/pull/6/files#diff-0579edc0374571613cd01f0a42c19bdaR30) is not included in master.

### What was your diagnosis of the problem?

It applies to master branch based on the PR implementation written in RFC.

### What is your fix for the problem, implemented in this PR?

This PR will switch `Bundler.feature_flag` using `bundler_2_mode`.

### Why did you choose this fix out of the possible options?

Since #2884 does not use `Bundler.feature_flag`, then compatibility with Bundler 1 will be lost.