### PR TITLE
Fix default gem activation test when using Ruby 2.5

### DIFF
--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -1231,7 +1231,7 @@ end
         if Gem::Version.new(Gem::VERSION) >= Gem::Version.new("2.7") || ENV["RGV"] == "master"
           []
         else
-          %w[io-console openssl]
+          %w[io-console openssl etc fileutils]
         end << "bundler"
       end
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

ruby-head (Ruby 2.5.0dev) has failed at Travis CI.

https://travis-ci.org/bundler/bundler/jobs/259991764

### What was your diagnosis of the problem?

Standard libraries are cut out to Gem in Ruby 2.5. `etc` and `fileutils` are also among them.

- Gemify etc ... https://bugs.ruby-lang.org/issues/13256
- Gemify fileutils ... https://bugs.ruby-lang.org/issues/13197

### What is your fix for the problem, implemented in this PR?

This PR passes tests by including them in exemptions just like `openssl`.