### PR TITLE
Update broken link in bundle-gem man page

### DIFF
--- a/man/bundle-gem.ronn
+++ b/man/bundle-gem.ronn
@@ -75,4 +75,4 @@ configuration file using the following names:
 
 ## SEE ALSO
 
-* bundle-config(1)
+* [bundle-config](http://bundler.io/v1.14/bundle_config.html)


### PR DESCRIPTION
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was...
- This resolves [Issue#296](https://github.com/bundler/bundler-site/issues/296) on bundler/bundler-site. 
### What was your diagnosis of the problem?

My diagnosis was...
- @olleolleolle came across a broken link in the `bundle gem` docs. Specifically, the `bundle-config` link in the "See Also" section was broken.

### What is your fix for the problem, implemented in this PR?

My fix...
- I fixed the broken link 🍒
### Why did you choose this fix out of the possible options?

I chose this fix because...
- To make navigating around the bundler docs a pleasant experience. 
