### PR TITLE
Include `bin/rspec` in directions to test doc changes

### DIFF
--- a/doc/documentation/WRITING.md
+++ b/doc/documentation/WRITING.md
@@ -49,6 +49,6 @@ If you make more changes to `bundle-cookies.ronn`, you'll need to run the `rake 
 We have tests for our documentation! The most important test file to run before you make your pull request is the one for the `help` command and another for documentation quality.
 
 ```
-$ rspec ./spec/commands/help_spec.rb
-$ rspec ./spec/quality_spec.rb
+$ bin/rspec ./spec/commands/help_spec.rb
+$ bin/rspec ./spec/quality_spec.rb
 ```


### PR DESCRIPTION
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was...
- I was updating documentation in a `.ronn` file. I struggled a bit when I tried testing my doc changes. When I tried running `rspec ./spec/commands/help_spec.rb` and `rspec ./spec/quality_spec.rb`, I kept getting this error: 

```
 uninitialized constant Bundler::EnvironmentPreserver::BUNDLER_PREFIX (NameError)
Did you mean?  Bundler::BundlerError
```

### What was your diagnosis of the problem?

My diagnosis was...
- @colby-swandale told me that I should run`bin/rspec` instead of `rspec`. It worked 🎈

### What is your fix for the problem, implemented in this PR?

My fix...
- To add in `bin/rspec` to the ["Writing docs for man pages" documentation](https://github.com/bundler/bundler/blob/master/doc/documentation/WRITING.md)

### Why did you choose this fix out of the possible options?

I chose this fix because...
- Hopefully this could help someone else save some time on their hands and prevent them from getting the same error I did.[[selfie-0 uploading...]]
[[selfie-1 uploading...]]
[[selfie-2 uploading...]]
