### PR TITLE
Fix the tempalte of gems.rb

### DIFF
--- a/lib/bundler/templates/gems.rb
+++ b/lib/bundler/templates/gems.rb
@@ -5,4 +5,4 @@ source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
-# gems "rails"
+# gem "rails"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Building from source using `rake bundler_2:install`. (#5901)

```console
% bundle version
2.0.0.dev (2017-08-02 commit f184adfc1)% cd /tmp
% bundle init
Writing new gems.rb to /private/tmp/gems.rb
% cat gems.rb
# frozen_string_literal: true

# A sample gems.rb
source "https://rubygems.org"

git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }

# gems "rails"
```

Editing the comment out of `# gems "rails"` and executing it resulted in an error.

```console
% bundle install

[!] There was an error parsing `gems.rb`: Undefined local variable or method `gems' for Gemfile. Bundler cannot continue.

 #  from /private/tmp/gems.rb:8
 #  -------------------------------------------
 #
 >  gems "rails"
 #  -------------------------------------------
```

### What was your diagnosis of the problem?

[Like the Gemfile](https://github.com/bundler/bundler/blob/c4ae85f01edca72d48c617be07440c2cd600ab4f/lib/bundler/templates/Gemfile#L7), use `gem` method.

### What is your fix for the problem, implemented in this PR?
Use `gem` method instead of `gems` method.
