### PR TITLE
implement new list command

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -261,7 +261,18 @@ module Bundler
       Show.new(options, gem_name).run
     end
     # TODO: 2.0 remove `bundle show`
-    map %w[list] => "show"
+
+    if Bundler.feature_flag.list_command?
+      desc "list", "list all gems in the bundle"
+      def list
+        require "bundler/cli/list"
+        List.new.run
+      end
+
+      map %w[ls] => "list"
+    else
+      map %w[list] => "show"
+    end
 
     desc "info GEM [OPTIONS]", "Show information for the given gem"
     method_option "path", :type => :boolean, :banner => "Print full path to gem"

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -263,10 +263,11 @@ module Bundler
     # TODO: 2.0 remove `bundle show`
 
     if Bundler.feature_flag.list_command?
-      desc "list", "list all gems in the bundle"
+      desc "list", "List all gems in the bundle"
+      method_option "name-only", :type => :boolean, :banner => "print only the gem names"
       def list
         require "bundler/cli/list"
-        List.new.run
+        List.new(options).run
       end
 
       map %w[ls] => "list"

--- a/lib/bundler/cli/list.rb
+++ b/lib/bundler/cli/list.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Bundler
+  class CLI::List
+    def run
+      specs = Bundler.load.specs.reject {|s| s.name == "bundler" }
+
+      return Bundler.ui.info "No gems in the Gemfile" if specs.empty?
+      Bundler.ui.info "Gems included by the bundle:"
+      specs.sort_by(&:name).each do |s|
+        Bundler.ui.info "  * #{s.name} (#{s.version}#{s.git_version})"
+      end
+
+      Bundler.ui.info "Use `bundle info` to print more detailed information about a gem"
+    end
+  end
+end

--- a/lib/bundler/cli/list.rb
+++ b/lib/bundler/cli/list.rb
@@ -2,12 +2,17 @@
 
 module Bundler
   class CLI::List
+    def initialize(options)
+      @options = options
+    end
+
     def run
-      specs = Bundler.load.specs.reject {|s| s.name == "bundler" }
+      specs = Bundler.load.specs.reject {|s| s.name == "bundler" }.sort_by(&:name)
+      return specs.each {|s| Bundler.ui.info s.name } if @options["name-only"]
 
       return Bundler.ui.info "No gems in the Gemfile" if specs.empty?
       Bundler.ui.info "Gems included by the bundle:"
-      specs.sort_by(&:name).each do |s|
+      specs.each do |s|
         Bundler.ui.info "  * #{s.name} (#{s.version}#{s.git_version})"
       end
 

--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -48,6 +48,7 @@ module Bundler
     settings_flag(:unlock_source_unlocks_spec) { !bundler_2_mode? }
     settings_flag(:update_requires_all_flag) { bundler_2_mode? }
     settings_flag(:default_install_uses_path) { bundler_2_mode? }
+    settings_flag(:list_command) { bundler_2_mode? }
 
     settings_option(:default_cli_command) { bundler_2_mode? ? :cli_help : :install }
 

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -34,6 +34,7 @@ module Bundler
       global_gem_cache
       ignore_messages
       init_gems_rb
+      list_command
       lockfile_uses_separate_rubygems_sources
       major_deprecations
       no_install

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -193,6 +193,8 @@ learn more about their operation in [bundle install(1)][bundle-install].
    Generate a `gems.rb` instead of a `Gemfile` when running `bundle init`.
 * `jobs` (`BUNDLE_JOBS`):
    The number of gems Bundler can install in parallel. Defaults to 1.
+* `list_command` (`BUNDLE_LIST_COMMAND`)
+   Enable new list command feature
 * `major_deprecations` (`BUNDLE_MAJOR_DEPRECATIONS`):
    Whether Bundler should print deprecation warnings for behavior that will
    be changed in the next major version.

--- a/man/bundle-list.ronn
+++ b/man/bundle-list.ronn
@@ -1,0 +1,10 @@
+bundle-list(1) -- List all the gems in the bundle
+=========================================================================
+
+## SYNOPSIS
+
+`bundle list`
+
+## DESCRIPTION
+
+Prints a list of all the gems in the bundle including their version

--- a/man/bundle-list.ronn
+++ b/man/bundle-list.ronn
@@ -3,8 +3,13 @@ bundle-list(1) -- List all the gems in the bundle
 
 ## SYNOPSIS
 
-`bundle list`
+`bundle list` [--name-only]
 
 ## DESCRIPTION
 
-Prints a list of all the gems in the bundle including their version
+Prints a list of all the gems in the bundle including their version.
+
+## OPTIONS
+
+* `--name-only`:
+  Print only the name of each gem.

--- a/spec/commands/list_spec.rb
+++ b/spec/commands/list_spec.rb
@@ -8,6 +8,13 @@ RSpec.describe "bundle list", :bundler => "2" do
     G
   end
 
+  context "with name-only option" do
+    it "prints only the name of the gems in the bundle" do
+      bundle "list --name-only"
+      expect(out).to eq "rack"
+    end
+  end
+
   context "when no gems are in the gemfile" do
     before do
       install_gemfile <<-G

--- a/spec/commands/list_spec.rb
+++ b/spec/commands/list_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+RSpec.describe "bundle list", :bundler => "2" do
+  before do
+    install_gemfile <<-G
+      source "file://#{gem_repo1}"
+      gem "rack"
+    G
+  end
+
+  context "when no gems are in the gemfile" do
+    before do
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+      G
+    end
+
+    it "prints message saying no gems are in the bundle" do
+      bundle "list"
+      expect(out).to include("No gems in the Gemfile")
+    end
+  end
+
+  it "lists gems installed in the bundle" do
+    bundle "list"
+    expect(out).to include("  * rack (1.0.0)")
+  end
+
+  it "aliases the ls command to list" do
+    bundle "ls"
+    expect(out).to include("Gems included by the bundle")
+  end
+end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

We're removing the `bundle show` command (which has been replaced with `bundle info`) but we should probably still have a command to list the gems in the bundle.

### What was your diagnosis of the problem?

`bundle show` has been marked as deprecated but a replacement for listing gems does not yet exist

### What is your fix for the problem, implemented in this PR?

Add a new `bundle list` (including `ls` alias) that prints the gems in the bundle, this was taken from #4754
