### PR TITLE
fix documented init gems rb config env var

### DIFF
--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -189,7 +189,7 @@ learn more about their operation in [bundle install(1)][bundle-install].
 * `ignore_messages` (`BUNDLE_IGNORE_MESSAGES`): When set, no post install
    messages will be printed. To silence a single gem, use dot notation like
    `ignore_messages.httparty true`.
-* `init_gems_rb` (`BUNDLE_NEW_GEMFILE_NAME`)
+* `init_gems_rb` (`BUNDLE_INIT_GEMS_RB`)
    Generate a `gems.rb` instead of a `Gemfile` when running `bundle init`.
 * `jobs` (`BUNDLE_JOBS`):
    The number of gems Bundler can install in parallel. Defaults to 1.


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

I documented the env var for the init new gem file feature flag incorrectly

### What was your diagnosis of the problem?

    › BUNDLE_NEW_GEMFILE_NAME=1 dbundler init
    Writing new Gemfile to /Users/c/Desktop/Projects/testapp/Gemfile

does not generate the gems.rb as expected

### What is your fix for the problem, implemented in this PR?

Use the correct env name to generate gems.rb