### PR TITLE
exit if bundle bin path contains a path separator

### DIFF
--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -205,13 +205,13 @@ module Bundler
 
     def validate_bundle_path
       return unless Bundler.bundle_path.to_s.match(File::PATH_SEPARATOR)
-      message = "WARNING: Your bundle path contains a '#{File::PATH_SEPARATOR}', " \
+      message = "Your bundle path contains a '#{File::PATH_SEPARATOR}', " \
                 "which is the path separator for your system. Bundler cannot " \
                 "function correctly when the Bundle path contains the " \
                 "system's PATH separator. Please change your " \
                 "bundle path to not include '#{File::PATH_SEPARATOR}'." \
                 "\nYour current bundle path is '#{Bundler.bundle_path}'."
-      raise Bundler::BundlerError, message
+      raise Bundler::PathError, message
     end
 
     def find_gemfile(order_matters = false)

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -204,7 +204,7 @@ module Bundler
   private
 
     def validate_bundle_path
-      return unless Bundler.bundle_path.to_s.match(File::PATH_SEPARATOR)
+      return unless Bundler.bundle_path.to_s.include?(File::PATH_SEPARATOR)
       message = "Your bundle path contains a '#{File::PATH_SEPARATOR}', " \
                 "which is the path separator for your system. Bundler cannot " \
                 "function correctly when the Bundle path contains the " \

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -204,11 +204,11 @@ module Bundler
   private
 
     def validate_bundle_path
-      if Bundler.bundle_path.to_s.match(File::PATH_SEPARATOR)
-        puts 'WARNING: Your bundle path contains a ":", which can cause problems.'
-        puts 'Please change your bundle path path to not include ":".'
-        exit(1)
-      end
+      return unless Bundler.bundle_path.to_s.match(File::PATH_SEPARATOR)
+      puts "WARNING: Your bundle path contains a '#{File::PATH_SEPARATOR}', " \
+        "which is the path separator for your system."
+      puts "Please change your bundle path path to not include '#{File::PATH_SEPARATOR}'."
+      exit(1)
     end
 
     def find_gemfile(order_matters = false)

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -203,6 +203,14 @@ module Bundler
 
   private
 
+    def validate_bundle_path
+      if Bundler.bundle_path.to_s.match(File::PATH_SEPARATOR)
+        puts 'WARNING: Your bundle path contains a ":", which can cause problems.'
+        puts 'Please change your bundle path path to not include ":".'
+        exit(1)
+      end
+    end
+
     def find_gemfile(order_matters = false)
       given = ENV["BUNDLE_GEMFILE"]
       return given if given && !given.empty?
@@ -270,6 +278,7 @@ module Bundler
     end
 
     def set_path
+      validate_bundle_path
       paths = (ENV["PATH"] || "").split(File::PATH_SEPARATOR)
       paths.unshift "#{Bundler.bundle_path}/bin"
       Bundler::SharedHelpers.set_env "PATH", paths.uniq.join(File::PATH_SEPARATOR)

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -205,10 +205,13 @@ module Bundler
 
     def validate_bundle_path
       return unless Bundler.bundle_path.to_s.match(File::PATH_SEPARATOR)
-      puts "WARNING: Your bundle path contains a '#{File::PATH_SEPARATOR}', " \
-        "which is the path separator for your system."
-      puts "Please change your bundle path path to not include '#{File::PATH_SEPARATOR}'."
-      exit(1)
+      message = "WARNING: Your bundle path contains a '#{File::PATH_SEPARATOR}', " \
+                "which is the path separator for your system. Bundler cannot " \
+                "function correctly when the Bundle path contains the " \
+                "system's PATH separator. Please change your " \
+                "bundle path to not include '#{File::PATH_SEPARATOR}'." \
+                "\nYour current bundle path is '#{Bundler.bundle_path}'."
+      raise Bundler::BundlerError, message
     end
 
     def find_gemfile(order_matters = false)

--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -261,6 +261,16 @@ RSpec.describe Bundler::SharedHelpers do
       subject.set_bundle_environment
     end
 
+    it "exits if bundle path contains the path seperator" do
+      File::PATH_SEPARATOR = ':'
+      allow(Bundler).to receive(:bundle_path) { "so:me/dir/bin" }
+      expect(subject.send(:validate_bundle_path)).to raise_error(SystemExit)
+
+      File::PATH_SEPARATOR = '^'
+      allow(Bundler).to receive(:bundle_path) { "so^me/dir/bin" }
+      expect(subject.send(:validate_bundle_path)).to raise_error(SystemExit)
+    end
+
     context "ENV['PATH'] does not exist" do
       before { ENV.delete("PATH") }
 

--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -263,7 +263,7 @@ RSpec.describe Bundler::SharedHelpers do
 
     it "exits if bundle path contains the path seperator" do
       stub_const("File::PATH_SEPARATOR", ":".freeze)
-      allow(Bundler).to receive(:bundle_path) { "so:me/dir/bin" }
+      allow(Bundler).to receive(:bundle_path) { Pathname.new("so:me/dir/bin") }
       expect { subject.send(:validate_bundle_path) }.to raise_error(
         Bundler::PathError,
         "Your bundle path contains a ':', which is the " \

--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -265,8 +265,8 @@ RSpec.describe Bundler::SharedHelpers do
       stub_const("File::PATH_SEPARATOR", ":".freeze)
       allow(Bundler).to receive(:bundle_path) { "so:me/dir/bin" }
       expect { subject.send(:validate_bundle_path) }.to raise_error(
-        Bundler::BundlerError,
-        "WARNING: Your bundle path contains a ':', which is the " \
+        Bundler::PathError,
+        "Your bundle path contains a ':', which is the " \
         "path separator for your system. Bundler cannot " \
         "function correctly when the Bundle path contains the " \
         "system's PATH separator. Please change your " \

--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -264,25 +264,15 @@ RSpec.describe Bundler::SharedHelpers do
     it "exits if bundle path contains the path seperator" do
       stub_const("File::PATH_SEPARATOR", ":".freeze)
       allow(Bundler).to receive(:bundle_path) { "so:me/dir/bin" }
-      begin
-        expect(subject.send(:validate_bundle_path)).to raise_exception(SystemExit).
-          and output("WARNING: Your bundle path contains a ':', which is the" \
-                     " path separator for your system. Please change your" \
-                     " bundle path path to not include ':'.")
-      rescue SystemExit => e
-        expect(e.status).to eq(1)
-      end
-
-      stub_const("File::PATH_SEPARATOR", "^".freeze)
-      allow(Bundler).to receive(:bundle_path) { "so^me/dir/bin" }
-      begin
-        expect(subject.send(:validate_bundle_path)).to raise_exception(SystemExit).
-          and output("WARNING: Your bundle path contains a '^', which is the" \
-                     " path separator for your system. Please change your" \
-                     " bundle path path to not include '^'.")
-      rescue SystemExit => e
-        expect(e.status).to eq(1)
-      end
+      expect { subject.send(:validate_bundle_path) }.to raise_error(
+        Bundler::BundlerError,
+        "WARNING: Your bundle path contains a ':', which is the " \
+        "path separator for your system. Bundler cannot " \
+        "function correctly when the Bundle path contains the " \
+        "system's PATH separator. Please change your " \
+        "bundle path to not include ':'.\nYour current bundle " \
+        "path is '#{Bundler.bundle_path}'."
+      )
     end
 
     context "ENV['PATH'] does not exist" do

--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -262,13 +262,27 @@ RSpec.describe Bundler::SharedHelpers do
     end
 
     it "exits if bundle path contains the path seperator" do
-      File::PATH_SEPARATOR = ':'
+      stub_const("File::PATH_SEPARATOR", ":".freeze)
       allow(Bundler).to receive(:bundle_path) { "so:me/dir/bin" }
-      expect(subject.send(:validate_bundle_path)).to raise_error(SystemExit)
+      begin
+        expect(subject.send(:validate_bundle_path)).to raise_exception(SystemExit).
+          and output("WARNING: Your bundle path contains a ':', which is the" \
+                     " path separator for your system. Please change your" \
+                     " bundle path path to not include ':'.")
+      rescue SystemExit => e
+        expect(e.status).to eq(1)
+      end
 
-      File::PATH_SEPARATOR = '^'
+      stub_const("File::PATH_SEPARATOR", "^".freeze)
       allow(Bundler).to receive(:bundle_path) { "so^me/dir/bin" }
-      expect(subject.send(:validate_bundle_path)).to raise_error(SystemExit)
+      begin
+        expect(subject.send(:validate_bundle_path)).to raise_exception(SystemExit).
+          and output("WARNING: Your bundle path contains a '^', which is the" \
+                     " path separator for your system. Please change your" \
+                     " bundle path path to not include '^'.")
+      rescue SystemExit => e
+        expect(e.status).to eq(1)
+      end
     end
 
     context "ENV['PATH'] does not exist" do


### PR DESCRIPTION
fixes #5485

### What was the end-user problem that led to this PR?

Bundler does not work with paths that contain the path separator.

### What was your diagnosis of the problem?

The ```bundle_bin``` path can't contain a path separator.

### What is your fix for the problem, implemented in this PR?

We can validate the ```bundle_path``` to make sure that it does not contain the
current ```File::PATH_SEPARATOR```. If we find the path separator, we exit with a non-zero
code and give the user an error message. 

### Why did you choose this fix out of the possible options?

I chose this fix because it was recommended by @colby-swandale.
