### PR TITLE
Use Bundler::Installer for bundle pristine

### DIFF
--- a/spec/commands/pristine_spec.rb
+++ b/spec/commands/pristine_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "bundle pristine" do
     build_repo2 do
       build_gem "weakling"
       build_gem "baz-dev", "1.0.0"
+      build_gem "very_simple_binary", &:add_c_extension
       build_git "foo", :path => lib_path("foo")
       build_lib "bar", :path => lib_path("bar")
     end
@@ -18,6 +19,7 @@ RSpec.describe "bundle pristine" do
     install_gemfile! <<-G
       source "file://#{gem_repo2}"
       gem "weakling"
+      gem "very_simple_binary"
       gem "foo", :git => "#{lib_path("foo")}"
       gem "bar", :path => "#{lib_path("bar")}"
 
@@ -140,6 +142,23 @@ RSpec.describe "bundle pristine" do
     it "raises when one of them is not in the lockfile" do
       bundle "pristine abcabcabc"
       expect(out).to include("Could not find gem 'abcabcabc'.")
+    end
+  end
+
+  context "when a build config exists for one of the gems" do
+    let(:very_simple_binary) { Bundler.definition.specs["very_simple_binary"].first }
+    let(:c_ext_dir)          { Pathname.new(very_simple_binary.full_gem_path).join("ext") }
+    let(:build_opt)          { "--with-ext-lib=#{c_ext_dir}" }
+    before { bundle "config build.very_simple_binary -- #{build_opt}" }
+
+    # This just verifies that the generated Makefile from the c_ext gem makes
+    # use of the build_args from the bundle config
+    it "applies the config when installing the gem" do
+      bundle! "pristine"
+
+      makefile_contents = File.read(c_ext_dir.join("Makefile").to_s)
+      expect(makefile_contents).to match(/libpath =.*#{c_ext_dir}/)
+      expect(makefile_contents).to match(/LIBPATH =.*-L#{c_ext_dir}/)
     end
   end
 end

--- a/spec/support/builders.rb
+++ b/spec/support/builders.rb
@@ -562,10 +562,17 @@ module Spec
         write "ext/extconf.rb", <<-RUBY
           require "mkmf"
 
+
           # exit 1 unless with_config("simple")
 
           extension_name = "very_simple_binary_c"
-          dir_config extension_name
+          if extra_lib_dir = with_config("ext-lib")
+            # add extra libpath if --with-ext-lib is
+            # passed in as a build_arg
+            dir_config extension_name, nil, extra_lib_dir
+          else
+            dir_config extension_name
+          end
           create_makefile extension_name
         RUBY
         write "ext/very_simple_binary.c", <<-C


### PR DESCRIPTION
Fixes bundler pristine to respect the `bundle config` options for particular gems.  In my particular case, on OSX I have a keg version of `pg` and a bundle config with the following entry:

```console
$ bundle config
...

build.pg
Set for the current user (/Users/nicklamuro/.bundle/config): "--with-pg-config=/usr/local/Cellar/postgresql@9.5/9.5.6/bin/pg_config"

```

This would not be respected


What was the end-user problem that led to this PR?
--------------------------------------------------

See above, but steps to reproduce (requires `bundler` >= 1.15):

1. Install postgres on your machine if it is not already there (OS dependent)
  
2. Add the following bundler build arg for `pg`:
  
  ```console
  $ bundle config build.pg -- --with-pg-config=$(which pg_config)
  ```
  
2. Make sure `pg_config` is not in your `$PATH`:
  
  ```console
  $ export PATH=$(echo "$PATH" | sed "s|:$(dirname $(which pg_conf)))||")
  ```
  
* Create a simple project with `pg` as a single gem in your Gemfile:
  
  ```
  # Gemfile
  gem "pg"
  ```
  
* Bundle:
  
  ```console
  $ bundle install
  ```
  
* Attempt to `bundle pristine` (you should get an error):

  ```console
  $ bundle pristine
  ```


What was your diagnosis of the problem?
---------------------------------------

The newly added `bundle pristine` did no use the same code that was used by `bundle install` to execute the re-installation of the gem.


What is your fix for the problem, implemented in this PR?
---------------------------------------------------------

By making use of the `Bundler::Installer` and `Bundler::Installer::GemInstaller` code that is already used with `bundle install`, we can reuse the code that injects the `bundle config` options into each gem that is being installed.


Why did you choose this fix out of the possible options?
--------------------------------------------------------

Didn't want to repeat code that was already being used elsewhere.  Caused a few lines of code to be added that weren't there previously, but nothing obscene.