### PR TITLE
Add more explanations to `bundle pristine`

### DIFF
--- a/man/bundle-pristine.ronn
+++ b/man/bundle-pristine.ronn
@@ -7,7 +7,28 @@ bundle-pristine(1) -- Restores installed gems to their pristine condition
 
 ## DESCRIPTION
 
-`pristine` restores the installed gems in the bundle to their pristine condition using the local gem
-cache from RubyGems. For git gems - a forced checkout will be performed.
+`pristine` restores the installed gems in the bundle to their pristine condition
+using the local gem cache from RubyGems. For git gems, a forced checkout will be performed.
 
-Note the Bundler gem cannot be restored to its original state with `pristine`.
+For further explanation, `bundle pristine` ignores unpacked files on disk. In other
+words, this command utilizes the local `.gem` cache or the gem's git repository
+as if one were installing from scratch.
+
+Note: the Bundler gem cannot be restored to its original state with `pristine`.
+One also cannot use `bundle pristine` on gems with a 'path' option in the Gemfile,
+because bundler has no original copy it can restore from.
+
+When is it practical to use `bundle pristine`?
+
+It comes in handy when a developer is debugging a gem. `bundle pristine` is a
+great way to get rid of experimental changes to a gem that one may not want.
+
+Why use `bundle pristine` over `gem pristine --all`?
+
+Both commands are very similar.
+For context: `bundle pristine`, without arguments, cleans all gems from the lockfile.
+Meanwhile, `gem pristine --all` cleans all installed gems for that Ruby version.
+
+If a developer forgets which gems in their project they might
+have been debugging, the Rubygems `gem pristine [GEMNAME]` command may be inconvenient.
+One can avoid waiting for `gem pristine --all`, and instead run `bundle pristine`.


### PR DESCRIPTION
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was...
- I didn't know in what situations it was practical to use `bundle pristine`.

### What was your diagnosis of the problem?

My diagnosis was...
- To write more docs for [bundler.io](bundler.io) and the man pages

### What is your fix for the problem, implemented in this PR?

My fix...
- To add more documentation regarding what practical situations a developer can use `bundle pristine`. 
- Also, I added some explanation between the differences between `bundle pristine` and `gem pristine --all`
- Added a note that `pristine` doesn't work for local gems

### Why did you choose this fix out of the possible options?

I chose this fix because...
- Hopefully with a practical example of when to use `bundle pristine`, bundler's users can use this command more ✨