### PR TITLE
Use universal rubygems method for installing gems

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -47,10 +47,17 @@ namespace :spec do
       deps.delete("rdiscount")
     end
 
-    gem_install_command = "install --no-ri --no-rdoc --conservative " + deps.sort_by {|name, _| name }.map do |name, version|
-      "'#{name}:#{version}'"
-    end.join(" ")
-    sh %(#{Gem.ruby} -S gem #{gem_install_command})
+    if Gem::VERSION < "2.0.0"
+      deps.sort_by {|name, _| name }.map do |name, version|
+        gem_install_command = "install --no-ri --no-rdoc --conservative #{name} -v '#{version}'"
+        sh %(#{Gem.ruby} -S gem #{gem_install_command})
+      end
+    else
+      gem_install_command = "install --no-ri --no-rdoc --conservative " + deps.sort_by {|name, _| name }.map do |name, version|
+        "'#{name}:#{version}'"
+      end.join(" ")
+      sh %(#{Gem.ruby} -S gem #{gem_install_command})
+    end
 
     # Download and install gems used inside tests
     $LOAD_PATH.unshift("./spec")


### PR DESCRIPTION
What was the end-user problem that led to this PR?
--------------------------------------------------

When following the [setup documentation](https://github.com/bundler/bundler/blob/master/doc/development/SETUP.md) for bundler, it suggests to run `bin/rake spec:deps` to install the development dependencies for bundler.

Doing this with ruby 1.9.3 (and not upgrading rubygems) will cause this to fail.

What was your diagnosis of the problem?
---------------------------------------

Ruby 1.9.3 ships with a version of rubygems that is less than 2.0, and doesn't include the mechanisms for installing multiple gems (with specific versions) using colon delimited strings (which is the mechanism used to do so in `spec:deps`).

What is your fix for the problem, implemented in this PR?
---------------------------------------------------------

By using `ruby -S gem install [GEM_NAME] -v [GEM_VERSION]` for each gem, it is a universal way of installing targeted versions of gems on various versions of ruby/rubygems that isn't rubygems dependent.

Why did you choose this fix out of the possible options?
--------------------------------------------------------

This was the easiest implementation to do that maintains the same documentaion and instructions necessary to setup bundler for development.

The cons with this approach is that is causes additional subshell invocations to be launched for each gem, instead of one, which will be slower.  Since this is a finite number of calls we are doing this for (5 currently), I expect that to be negligible compared to the total time necessary load up the rubygems `gem` command and fetch each gem from rubygems (we can compare the travis builds from master to see this to compare).

An alternative to this approach would be to call out to the `Gem::Installer` directly from within the rake task, and avoid calling out to the `gem` command all together.  This has the downside of requiring more code to do it, but should alleviate the any extra time caused by using `sh` call to install the gems (might try this in a separate commit so it will have another build on travis and we can compare that result to the initial implementation).