### PR TITLE
Added fileutils to exemptions gems. 

### DIFF
--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -1231,7 +1231,7 @@ end
         if Gem::Version.new(Gem::VERSION) >= Gem::Version.new("2.7") || ENV["RGV"] == "master"
           []
         else
-          %w[io-console openssl]
+          %w[io-console openssl fileutils]
         end << "bundler"
       end
 


### PR DESCRIPTION
It fixes broken tests caused by default gems with Ruby 2.5(also known as ruby-head on travis).

It is confirmed that fileutils will promote default gems on Ruby 2.5.0.