### PR TITLE
Explain how to write docs for bundler.io

### DIFF
--- a/doc/documentation/README.md
+++ b/doc/documentation/README.md
@@ -27,3 +27,5 @@ Just like Bundler, we have a grand plan (really, a wish list of sorts) for Bundl
 ## Translations
 
 We don't currently have any translations, but please reach out to us if you would like to help get this going.
+
+Please feel free to reach out to [@arbonap](https://github.com/arbonap) if you'd like to help localize Bundler in Spanish.

--- a/doc/documentation/WRITING.md
+++ b/doc/documentation/WRITING.md
@@ -52,3 +52,16 @@ We have tests for our documentation! The most important test file to run before 
 $ bin/rspec ./spec/commands/help_spec.rb
 $ bin/rspec ./spec/quality_spec.rb
 ```
+
+# Writing docs for [the Bundler documentation site](bundler.io)
+
+If you'd like to submit a pull request for any of the primary commands or utilities on [the Bundler documentation site](bundler.io), please follow the instructions above for writing documentation for man pages from the `bundler/bundler` repository. They are the same in each case.
+
+Note: Editing `.ronn` files from the `bundler/bundler` repository for the primary commands and utilities documentation is all you need 🎉. There is no need to manually change anything in the `bundler/bundler-site` repository, because the man pages and the docs for primary commands and utilities on [the Bundler documentation site](bundler.io) are one in the same. They are generated automatically from the `bundler/bundler` repository's `.ronn` files from the `rake man/build` command. In other words, after updating `.ronn` file and running `rake man/build` in `bundler`, `.ronn` files map to the auto-generated files in the `source/man` directory of `bundler-site`.
+
+Additionally, if you'd like to add a guide or tutorial: in the `bundler/bundler-site` repository, go to `/bundler-site/source/current_version_of_bundler/guides` and add [a new Markdown file](https://guides.github.com/features/mastering-markdown/) (with an extension ending in `.md`). Be sure to correctly format the title of your new guide, like so:
+```
+---
+title: RubyGems.org SSL/TLS Troubleshooting Guide
+---
+```


### PR DESCRIPTION
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was...
- When trying to add documentation for [bundler.io](bundler.io), I was confused as to what files I should exactly add my changes.

### What was your diagnosis of the problem?

My diagnosis was...
- I asked around in Bundler's slack what file I should edit to make doc changes for bundler.io. 
### What is your fix for the problem, implemented in this PR?

My fix...
-  I added documentation that explains how editing `.ronn` files from `bundler/bundler` is all you need to update documentation about primary commands and utilities on the [bundler.io](bundler.io) site. I explained how it's not necessary to touch files from `bundler/bundler-site`. 

### Why did you choose this fix out of the possible options?

I chose this fix because...
- Hopefully this will alleviate some confusion surrounding how to contribute to bundler's documentation, and how exactly . 
- Addresses one of the bullet-points from Issue #5026, specifically the "mention how the different doc files map to bundler.io and bundle help"
- Refer to Issue #4987 for more in-depth context