### PR TITLE
ensure $HOME and Dir.tmpdir are writable

### DIFF
--- a/lib/bundler/compact_index_client/updater.rb
+++ b/lib/bundler/compact_index_client/updater.rb
@@ -26,60 +26,57 @@ module Bundler
       end
 
       def update(local_path, remote_path, retrying = nil)
+        local_temp_dir = create_tmpdir
+
         headers = {}
+        local_temp_path = Pathname.new(local_temp_dir).join(local_path.basename)
 
-        Bundler::SharedHelpers.filesystem_access(Dir.tmpdir, :write) do
-          Dir.mktmpdir("bundler-compact-index-") do |local_temp_dir|
-            local_temp_path = Pathname.new(local_temp_dir).join(local_path.basename)
-
-            # first try to fetch any new bytes on the existing file
-            if retrying.nil? && local_path.file?
-              FileUtils.cp local_path, local_temp_path
-              headers["If-None-Match"] = etag_for(local_temp_path)
-              headers["Range"] =
-                if local_temp_path.size.nonzero?
-                  # Subtract a byte to ensure the range won't be empty.
-                  # Avoids 416 (Range Not Satisfiable) responses.
-                  "bytes=#{local_temp_path.size - 1}-"
-                else
-                  "bytes=#{local_temp_path.size}-"
-                end
+        # first try to fetch any new bytes on the existing file
+        if retrying.nil? && local_path.file?
+          FileUtils.cp local_path, local_temp_path
+          headers["If-None-Match"] = etag_for(local_temp_path)
+          headers["Range"] =
+            if local_temp_path.size.nonzero?
+              # Subtract a byte to ensure the range won't be empty.
+              # Avoids 416 (Range Not Satisfiable) responses.
+              "bytes=#{local_temp_path.size - 1}-"
             else
-              # Fastly ignores Range when Accept-Encoding: gzip is set
-              headers["Accept-Encoding"] = "gzip"
+              "bytes=#{local_temp_path.size}-"
             end
+        else
+          # Fastly ignores Range when Accept-Encoding: gzip is set
+          headers["Accept-Encoding"] = "gzip"
+        end
 
-            response = @fetcher.call(remote_path, headers)
-            return nil if response.is_a?(Net::HTTPNotModified)
+        response = @fetcher.call(remote_path, headers)
+        return nil if response.is_a?(Net::HTTPNotModified)
 
-            content = response.body
-            if response["Content-Encoding"] == "gzip"
-              content = Zlib::GzipReader.new(StringIO.new(content)).read
-            end
+        content = response.body
+        if response["Content-Encoding"] == "gzip"
+          content = Zlib::GzipReader.new(StringIO.new(content)).read
+        end
 
-            SharedHelpers.filesystem_access(local_temp_path) do
-              if response.is_a?(Net::HTTPPartialContent) && local_temp_path.size.nonzero?
-                local_temp_path.open("a") {|f| f << slice_body(content, 1..-1) }
-              else
-                local_temp_path.open("w") {|f| f << content }
-              end
-            end
-
-            response_etag = (response["ETag"] || "").gsub(%r{\AW/}, "")
-            if etag_for(local_temp_path) == response_etag
-              SharedHelpers.filesystem_access(local_path) do
-                FileUtils.mv(local_temp_path, local_path)
-              end
-              return nil
-            end
-
-            if retrying
-              raise MisMatchedChecksumError.new(remote_path, response_etag, etag_for(local_temp_path))
-            end
-
-            update(local_path, remote_path, :retrying)
+        SharedHelpers.filesystem_access(local_temp_path) do
+          if response.is_a?(Net::HTTPPartialContent) && local_temp_path.size.nonzero?
+            local_temp_path.open("a") {|f| f << slice_body(content, 1..-1) }
+          else
+            local_temp_path.open("w") {|f| f << content }
           end
         end
+
+        response_etag = (response["ETag"] || "").gsub(%r{\AW/}, "")
+        if etag_for(local_temp_path) == response_etag
+          SharedHelpers.filesystem_access(local_path) do
+            FileUtils.mv(local_temp_path, local_path)
+          end
+          return nil
+        end
+
+        if retrying
+          raise MisMatchedChecksumError.new(remote_path, response_etag, etag_for(local_temp_path))
+        end
+
+        update(local_path, remote_path, :retrying)
       end
 
       def etag_for(path)
@@ -103,6 +100,17 @@ module Bundler
         SharedHelpers.filesystem_access(path, :read) do
           Digest::MD5.hexdigest(IO.read(path))
         end
+      end
+
+    private
+
+      def create_tmpdir
+        Dir.mktmpdir("bundler-compact-index-")
+      rescue Errno::EACCES
+        raise Bundler::PermissionError,
+          "Bundler does not have write access to create a temp directory " \
+          "within #{Dir.tmpdir}. Bundler must have write access to your " \
+          "systems temp directory to function properly. " \
       end
     end
   end

--- a/lib/bundler/compact_index_client/updater.rb
+++ b/lib/bundler/compact_index_client/updater.rb
@@ -29,8 +29,6 @@ module Bundler
         headers = {}
 
         Bundler::SharedHelpers.filesystem_access(Dir.tmpdir, :write) do
-          validate_permissions_on_home
-
           Dir.mktmpdir("bundler-compact-index-") do |local_temp_dir|
             local_temp_path = Pathname.new(local_temp_dir).join(local_path.basename)
 
@@ -105,16 +103,6 @@ module Bundler
         SharedHelpers.filesystem_access(path, :read) do
           Digest::MD5.hexdigest(IO.read(path))
         end
-      end
-
-    private
-
-      def validate_permissions_on_home
-        return if File.stat(ENV["HOME"]).writable?
-        raise Bundler::PermissionError,
-          "Bundler does not have write access to $HOME. Bundler must " \
-          "have write access to $HOME to function properly. " \
-          "$HOME is currently #{ENV["HOME"]}"
       end
     end
   end

--- a/lib/bundler/compact_index_client/updater.rb
+++ b/lib/bundler/compact_index_client/updater.rb
@@ -26,57 +26,63 @@ module Bundler
       end
 
       def update(local_path, remote_path, retrying = nil)
-        local_temp_dir = create_tmpdir
-
         headers = {}
-        local_temp_path = Pathname.new(local_temp_dir).join(local_path.basename)
 
-        # first try to fetch any new bytes on the existing file
-        if retrying.nil? && local_path.file?
-          FileUtils.cp local_path, local_temp_path
-          headers["If-None-Match"] = etag_for(local_temp_path)
-          headers["Range"] =
-            if local_temp_path.size.nonzero?
-              # Subtract a byte to ensure the range won't be empty.
-              # Avoids 416 (Range Not Satisfiable) responses.
-              "bytes=#{local_temp_path.size - 1}-"
-            else
-              "bytes=#{local_temp_path.size}-"
-            end
-        else
-          # Fastly ignores Range when Accept-Encoding: gzip is set
-          headers["Accept-Encoding"] = "gzip"
-        end
+        Dir.mktmpdir("bundler-compact-index-") do |local_temp_dir|
+          local_temp_path = Pathname.new(local_temp_dir).join(local_path.basename)
 
-        response = @fetcher.call(remote_path, headers)
-        return nil if response.is_a?(Net::HTTPNotModified)
-
-        content = response.body
-        if response["Content-Encoding"] == "gzip"
-          content = Zlib::GzipReader.new(StringIO.new(content)).read
-        end
-
-        SharedHelpers.filesystem_access(local_temp_path) do
-          if response.is_a?(Net::HTTPPartialContent) && local_temp_path.size.nonzero?
-            local_temp_path.open("a") {|f| f << slice_body(content, 1..-1) }
+          # first try to fetch any new bytes on the existing file
+          if retrying.nil? && local_path.file?
+            FileUtils.cp local_path, local_temp_path
+            headers["If-None-Match"] = etag_for(local_temp_path)
+            headers["Range"] =
+              if local_temp_path.size.nonzero?
+                # Subtract a byte to ensure the range won't be empty.
+                # Avoids 416 (Range Not Satisfiable) responses.
+                "bytes=#{local_temp_path.size - 1}-"
+              else
+                "bytes=#{local_temp_path.size}-"
+              end
           else
-            local_temp_path.open("w") {|f| f << content }
+            # Fastly ignores Range when Accept-Encoding: gzip is set
+            headers["Accept-Encoding"] = "gzip"
           end
-        end
 
-        response_etag = (response["ETag"] || "").gsub(%r{\AW/}, "")
-        if etag_for(local_temp_path) == response_etag
-          SharedHelpers.filesystem_access(local_path) do
-            FileUtils.mv(local_temp_path, local_path)
+          response = @fetcher.call(remote_path, headers)
+          return nil if response.is_a?(Net::HTTPNotModified)
+
+          content = response.body
+          if response["Content-Encoding"] == "gzip"
+            content = Zlib::GzipReader.new(StringIO.new(content)).read
           end
-          return nil
-        end
 
-        if retrying
-          raise MisMatchedChecksumError.new(remote_path, response_etag, etag_for(local_temp_path))
-        end
+          SharedHelpers.filesystem_access(local_temp_path) do
+            if response.is_a?(Net::HTTPPartialContent) && local_temp_path.size.nonzero?
+              local_temp_path.open("a") {|f| f << slice_body(content, 1..-1) }
+            else
+              local_temp_path.open("w") {|f| f << content }
+            end
+          end
 
-        update(local_path, remote_path, :retrying)
+          response_etag = (response["ETag"] || "").gsub(%r{\AW/}, "")
+          if etag_for(local_temp_path) == response_etag
+            SharedHelpers.filesystem_access(local_path) do
+              FileUtils.mv(local_temp_path, local_path)
+            end
+            return nil
+          end
+
+          if retrying
+            raise MisMatchedChecksumError.new(remote_path, response_etag, etag_for(local_temp_path))
+          end
+
+          update(local_path, remote_path, :retrying)
+        end
+      rescue Errno::EACCES
+        raise Bundler::PermissionError,
+          "Bundler does not have write access to create a temp directory " \
+          "within #{Dir.tmpdir}. Bundler must have write access to your " \
+          "systems temp directory to function properly. "
       end
 
       def etag_for(path)
@@ -100,17 +106,6 @@ module Bundler
         SharedHelpers.filesystem_access(path, :read) do
           Digest::MD5.hexdigest(IO.read(path))
         end
-      end
-
-    private
-
-      def create_tmpdir
-        Dir.mktmpdir("bundler-compact-index-")
-      rescue Errno::EACCES
-        raise Bundler::PermissionError,
-          "Bundler does not have write access to create a temp directory " \
-          "within #{Dir.tmpdir}. Bundler must have write access to your " \
-          "systems temp directory to function properly. " \
       end
     end
   end

--- a/spec/bundler/compact_index_client/updater_spec.rb
+++ b/spec/bundler/compact_index_client/updater_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe Bundler::CompactIndexClient::Updater do
     let(:remote_path) { double(:remote_path) }
 
     it "Errno::EACCES is raised" do
-      allow(Dir).to receive(:tmpdir) { "/tmp" }
       allow(Dir).to receive(:mktmpdir) { raise Errno::EACCES }
 
       expect do

--- a/spec/bundler/compact_index_client/updater_spec.rb
+++ b/spec/bundler/compact_index_client/updater_spec.rb
@@ -42,21 +42,4 @@ RSpec.describe Bundler::CompactIndexClient::Updater do
       end.to raise_error(Bundler::PermissionError)
     end
   end
-
-  context "when bundler doesn't have permissions on $HOME" do
-    let(:response) { double(:response, :body => "") }
-    let(:local_path) { Pathname("/tmp/localpath") }
-    let(:remote_path) { double(:remote_path) }
-    let(:home_file_stat) { File::Stat.new("/") }
-
-    it "Bundler::PermissionError is raised" do
-      allow(Dir).to receive(:tmpdir) { "/tmp" }
-      allow(File).to receive(:stat).with(anything) { home_file_stat }
-      allow(home_file_stat).to receive(:writable?) { false }
-
-      expect do
-        updater.update(local_path, remote_path)
-      end.to raise_error(Bundler::PermissionError)
-    end
-  end
 end

--- a/spec/bundler/compact_index_client/updater_spec.rb
+++ b/spec/bundler/compact_index_client/updater_spec.rb
@@ -27,4 +27,36 @@ RSpec.describe Bundler::CompactIndexClient::Updater do
       end.to raise_error(Bundler::CompactIndexClient::Updater::MisMatchedChecksumError)
     end
   end
+
+  context "when bundler doesn't have permissions on Dir.tmpdir" do
+    let(:response) { double(:response, :body => "") }
+    let(:local_path) { Pathname("/tmp/localpath") }
+    let(:remote_path) { double(:remote_path) }
+
+    it "Errno::EACCES is raised" do
+      allow(Dir).to receive(:tmpdir) { "/tmp" }
+      allow(Dir).to receive(:mktmpdir) { raise Errno::EACCES }
+
+      expect do
+        updater.update(local_path, remote_path)
+      end.to raise_error(Bundler::PermissionError)
+    end
+  end
+
+  context "when bundler doesn't have permissions on $HOME" do
+    let(:response) { double(:response, :body => "") }
+    let(:local_path) { Pathname("/tmp/localpath") }
+    let(:remote_path) { double(:remote_path) }
+    let(:home_file_stat) { File::Stat.new("/") }
+
+    it "Bundler::PermissionError is raised" do
+      allow(Dir).to receive(:tmpdir) { "/tmp" }
+      allow(File).to receive(:stat).with(anything) { home_file_stat }
+      allow(home_file_stat).to receive(:writable?) { false }
+
+      expect do
+        updater.update(local_path, remote_path)
+      end.to raise_error(Bundler::PermissionError)
+    end
+  end
 end


### PR DESCRIPTION
Fixes #5518

### What was the end-user problem that led to this PR?
A user had issues installing gems due to a permissions issue on the temp dir, because
Bundler was not checking for proper permissions on the temp directory or $HOME.

### What was your diagnosis of the problem?
After discussing the issue with @colby-swandale, the solution was to check permissions on $HOME and the ```tmpdir```.

### What is your fix for the problem, implemented in this PR?
The creation of the [temp dir](https://github.com/bundler/bundler/blob/master/lib/bundler/compact_index_client/updater.rb#L31) is now wrapped in the block passed to ```filesystem_access```, so ```filesystem_access``` will rescue the ```Errno::EACCES``` exception which is thrown if the effective user of the bundler process doesn't have sufficient permissions to create the temp dir.

### Why did you choose this fix out of the possible options?
I chose this fix because it's what was discussed in the original issue thread.
