### PR TITLE
[Update] Avoid a normal update when running with only --bundler

### DIFF
--- a/lib/bundler/cli/update.rb
+++ b/lib/bundler/cli/update.rb
@@ -45,7 +45,8 @@ module Bundler
         end
 
         Bundler.definition(:gems => gems, :sources => sources, :ruby => options[:ruby],
-                           :lock_shared_dependencies => options[:conservative])
+                           :lock_shared_dependencies => options[:conservative],
+                           :bundler => options[:bundler])
       end
 
       Bundler::CLI::Common.configure_gem_version_promoter(Bundler.definition, options)

--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -266,7 +266,7 @@ module Bundler
 
     # returns whether or not a re-resolve was needed
     def resolve_if_needed(options)
-      if !options["update"] && !options["force"] && !Bundler.settings[:inline] && Bundler.default_lockfile.file?
+      if !@definition.unlocking? && !options["force"] && !Bundler.settings[:inline] && Bundler.default_lockfile.file?
         return false if @definition.nothing_changed? && !@definition.missing_specs?
       end
 

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -629,6 +629,27 @@ RSpec.describe "bundle update --ruby" do
   end
 end
 
+RSpec.describe "bundle update --bundler" do
+  it "updates the bundler version in the lockfile without re-resolving" do
+    build_repo4 do
+      build_gem "rack", "1.0"
+    end
+
+    install_gemfile! <<-G
+      source "file:#{gem_repo4}"
+      gem "rack"
+    G
+    lockfile lockfile.sub(Bundler::VERSION, "1.0.0")
+
+    FileUtils.rm_r gem_repo4
+
+    bundle! :update, :bundler => true, :verbose => true
+    expect(the_bundle).to include_gem "rack 1.0"
+
+    expect(the_bundle.locked_gems.bundler_version).to eq v(Bundler::VERSION)
+  end
+end
+
 # these specs are slow and focus on integration and therefore are not exhaustive. unit specs elsewhere handle that.
 RSpec.describe "bundle update conservative" do
   context "patch and minor options" do


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was `bundle update --bundler` went through the full update/resolution path when really we just want to pin to a different bundler version.

### What was your diagnosis of the problem?

My diagnosis was we should just update the lockfile, without threading the rest of the process like an update.

This implements what @indirect requested in https://github.com/rubygems/rubygems/pull/1977#issuecomment-322852799.