### PR TITLE
When the locked bundler is under 2.0, allow any version < 2

### DIFF
--- a/lib/bundler/templates/Executable.bundler
+++ b/lib/bundler/templates/Executable.bundler
@@ -70,7 +70,8 @@ m = Module.new do
   def load_bundler!
     ENV["BUNDLE_GEMFILE"] ||= gemfile
 
-    activate_bundler(bundler_version)
+    # must dup string for RG < 1.8 compatibility
+    activate_bundler(bundler_version.dup)
   end
 
   def activate_bundler(bundler_version)

--- a/lib/bundler/templates/Executable.bundler
+++ b/lib/bundler/templates/Executable.bundler
@@ -66,6 +66,9 @@ m = Module.new do
   end
 
   def activate_bundler(bundler_version)
+    if Gem::Version.correct?(bundler_version) && Gem::Version.new(bundler_version).release < Gem::Version.new("2.0")
+      bundler_version = "< 2"
+    end
     gem_error = activation_error_handling do
       gem "bundler", bundler_version
     end

--- a/lib/bundler/templates/Executable.bundler
+++ b/lib/bundler/templates/Executable.bundler
@@ -24,9 +24,17 @@ m = Module.new do
   def cli_arg_version
     return unless invoked_as_script? # don't want to hijack other binstubs
     return unless "update".start_with?(ARGV.first || " ") # must be running `bundle update`
-    return unless update = ARGV.find {|a| a.start_with?("--bundler") } # must have a --bundler arg
-    return unless update =~ /--bundler(?:=(.+))?/
-    $1 || ">= 0.a"
+    bundler_version = nil
+    update_index = nil
+    ARGV.each_with_index do |a, i|
+      if update_index && update_index.succ == i && a =~ Gem::Version::ANCHORED_VERSION_PATTERN
+        bundler_version = a
+      end
+      next unless a =~ /\A--bundler(?:[= ](#{Gem::Version::VERSION_PATTERN}))?\z/
+      bundler_version = $1 || ">= 0.a"
+      update_index = i
+    end
+    bundler_version
   end
 
   def gemfile

--- a/spec/commands/binstubs_spec.rb
+++ b/spec/commands/binstubs_spec.rb
@@ -107,19 +107,21 @@ RSpec.describe "bundle binstubs <gem>" do
         end
 
         it "runs the correct version of bundler when the version is older" do
-          lockfile lockfile.gsub(system_bundler_version, "1.0")
+          simulate_bundler_version "55"
+          lockfile lockfile.gsub(system_bundler_version, "44.0")
           sys_exec "#{bundled_app("bin/bundle")} install"
           expect(exitstatus).to eq(42) if exitstatus
-          expect(last_command.stderr).to include("Activating bundler (1.0) failed:").
-            and include("To install the version of bundler this project requires, run `gem install bundler -v '1.0'`")
+          expect(last_command.stderr).to include("Activating bundler (44.0) failed:").
+            and include("To install the version of bundler this project requires, run `gem install bundler -v '44.0'`")
         end
 
         it "runs the correct version of bundler when the version is a pre-release" do
-          lockfile lockfile.gsub(system_bundler_version, "1.12.0.a")
+          simulate_bundler_version "55"
+          lockfile lockfile.gsub(system_bundler_version, "2.12.0.a")
           sys_exec "#{bundled_app("bin/bundle")} install"
           expect(exitstatus).to eq(42) if exitstatus
-          expect(last_command.stderr).to include("Activating bundler (1.12.0.a) failed:").
-            and include("To install the version of bundler this project requires, run `gem install bundler -v '1.12.0.a'`")
+          expect(last_command.stderr).to include("Activating bundler (2.12.0.a) failed:").
+            and include("To install the version of bundler this project requires, run `gem install bundler -v '2.12.0.a'`")
         end
       end
 

--- a/spec/support/rubygems_ext.rb
+++ b/spec/support/rubygems_ext.rb
@@ -22,7 +22,6 @@ module Spec
         "rake" => "10.0.2",
         # 3.0.0 breaks 1.9.2 specs
         "builder" => "2.1.2",
-        "bundler" => "1.12.0",
       }
       # ruby-graphviz is used by the viz tests
       deps["ruby-graphviz"] = nil if RUBY_VERSION >= "1.9.3"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was the bin stub would lock to a specific version even for a 1.x version, which was an incompatible change.

See @indirect's comment in https://github.com/rubygems/rubygems/pull/1977#issuecomment-322852799

### What was your diagnosis of the problem?

My diagnosis was we needed to only pin to a specific version for 2.0+.

### What is your fix for the problem, implemented in this PR?

My fix transforms any 1.x bundler version to a "< 2" constraint.