### PR TITLE
Avoid namespace pollution

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -494,7 +494,7 @@ EOF
     end
 
     def eval_gemspec(path, contents)
-      eval(contents, TOPLEVEL_BINDING, path.expand_path.to_s)
+      eval(contents, TOPLEVEL_BINDING.dup, path.expand_path.to_s)
     rescue ScriptError, StandardError => e
       msg = "There was an error while loading `#{path.basename}`: #{e.message}"
 

--- a/spec/bundler/bundler_spec.rb
+++ b/spec/bundler/bundler_spec.rb
@@ -102,6 +102,24 @@ RSpec.describe Bundler do
         subject
       end
     end
+
+    context "with gemspec containing local variables" do
+      before do
+        File.open(app_gemspec_path, "wb") do |f|
+          f.write strip_whitespace(<<-GEMSPEC)
+            must_not_leak = true
+            Gem::Specification.new do |gem|
+              gem.name = "leak check"
+            end
+          GEMSPEC
+        end
+      end
+
+      it "should not pollute the TOPLEVEL_BINDING" do
+        subject
+        expect(TOPLEVEL_BINDING.local_variables).to_not include(:must_not_leak)
+      end
+    end
   end
 
   describe "#which" do

--- a/spec/bundler/bundler_spec.rb
+++ b/spec/bundler/bundler_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe Bundler do
 
       it "should not pollute the TOPLEVEL_BINDING" do
         subject
-        expect(TOPLEVEL_BINDING.local_variables).to_not include(:must_not_leak)
+        expect(TOPLEVEL_BINDING.eval("local_variables")).to_not include(:must_not_leak)
       end
     end
   end


### PR DESCRIPTION
fixes #5958.

### What was the end-user problem that led to this PR?

The problem was that local variables are magically introduced into the global toplevel, when there is a local gemspec that has such local variables.

### What was your diagnosis of the problem?

My diagnosis was that `TOPLEVEL_BINDING` is used with `eval`

### What is your fix for the problem, implemented in this PR?

My fix is to duplicate that binding.

### Why did you choose this fix out of the possible options?

I chose this fix because it is clean and concise.  Other possible options are like reinventions of wheel.