### PR TITLE
[2.0] Automatically bundle clean without a path set

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -5,6 +5,8 @@ require "bundler/vendored_thor"
 
 module Bundler
   class CLI < Thor
+    require "bundler/cli/common"
+
     AUTO_INSTALL_CMDS = %w[show binstubs outdated exec open console licenses clean].freeze
     PARSEABLE_COMMANDS = %w[
       check config help exec platform show version

--- a/lib/bundler/cli/add.rb
+++ b/lib/bundler/cli/add.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "bundler/cli/common"
-
 module Bundler
   class CLI::Add
     def initialize(options, gem_name)

--- a/lib/bundler/cli/binstubs.rb
+++ b/lib/bundler/cli/binstubs.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "bundler/cli/common"
-
 module Bundler
   class CLI::Binstubs
     attr_reader :options, :gems

--- a/lib/bundler/cli/common.rb
+++ b/lib/bundler/cli/common.rb
@@ -90,5 +90,13 @@ module Bundler
     def self.patch_level_options(options)
       [:major, :minor, :patch].select {|v| options.keys.include?(v.to_s) }
     end
+
+    def self.clean_after_install?
+      clean = Bundler.settings[:clean]
+      return clean unless clean.nil?
+      clean ||= Bundler.feature_flag.auto_clean_without_path? && Bundler.settings[:path].nil?
+      clean &&= !Bundler.use_system_gems?
+      clean
+    end
   end
 end

--- a/lib/bundler/cli/info.rb
+++ b/lib/bundler/cli/info.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "bundler/cli/common"
-
 module Bundler
   class CLI::Info
     attr_reader :gem_name, :options

--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "bundler/cli/common"
-
 module Bundler
   class CLI::Install
     attr_reader :options
@@ -82,7 +80,7 @@ module Bundler
 
       warn_ambiguous_gems
 
-      if Bundler.settings[:clean] && !Bundler.use_system_gems?
+      if CLI::Common.clean_after_install?
         require "bundler/cli/clean"
         Bundler::CLI::Clean.new(options).run
       end

--- a/lib/bundler/cli/lock.rb
+++ b/lib/bundler/cli/lock.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "bundler/cli/common"
-
 module Bundler
   class CLI::Lock
     attr_reader :options

--- a/lib/bundler/cli/open.rb
+++ b/lib/bundler/cli/open.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "bundler/cli/common"
 require "shellwords"
 
 module Bundler

--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "bundler/cli/common"
-
 module Bundler
   class CLI::Outdated
     attr_reader :options, :gems

--- a/lib/bundler/cli/pristine.rb
+++ b/lib/bundler/cli/pristine.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "bundler/cli/common"
-
 module Bundler
   class CLI::Pristine
     def initialize(gems)

--- a/lib/bundler/cli/show.rb
+++ b/lib/bundler/cli/show.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "bundler/cli/common"
-
 module Bundler
   class CLI::Show
     attr_reader :options, :gem_name, :latest_specs

--- a/lib/bundler/cli/update.rb
+++ b/lib/bundler/cli/update.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "bundler/cli/common"
-
 module Bundler
   class CLI::Update
     attr_reader :options, :gems
@@ -63,7 +61,7 @@ module Bundler
       installer = Installer.install Bundler.root, Bundler.definition, opts
       Bundler.load.cache if Bundler.app_cache.exist?
 
-      if Bundler.settings[:clean] && !Bundler.use_system_gems?
+      if CLI::Common.clean_after_install?
         require "bundler/cli/clean"
         Bundler::CLI::Clean.new(options).run
       end

--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -29,15 +29,18 @@ module Bundler
 
     settings_flag(:allow_bundler_dependency_conflicts) { bundler_2_mode? }
     settings_flag(:allow_offline_install) { bundler_2_mode? }
+    settings_flag(:auto_clean_without_path) { bundler_2_mode? }
     settings_flag(:cache_all) { bundler_2_mode? }
     settings_flag(:cache_command_is_package) { bundler_2_mode? }
     settings_flag(:console_command) { !bundler_2_mode? }
+    settings_flag(:default_install_uses_path) { bundler_2_mode? }
     settings_flag(:deployment_means_frozen) { bundler_2_mode? }
     settings_flag(:disable_multisource) { bundler_2_mode? }
     settings_flag(:error_on_stderr) { bundler_2_mode? }
     settings_flag(:forget_cli_options) { bundler_2_mode? }
     settings_flag(:global_gem_cache) { bundler_2_mode? }
     settings_flag(:init_gems_rb) { bundler_2_mode? }
+    settings_flag(:list_command) { bundler_2_mode? }
     settings_flag(:lockfile_uses_separate_rubygems_sources) { bundler_2_mode? }
     settings_flag(:only_update_to_newer_versions) { bundler_2_mode? }
     settings_flag(:plugins) { @bundler_version >= Gem::Version.new("1.14") }
@@ -49,8 +52,6 @@ module Bundler
     settings_flag(:suppress_install_using_messages) { bundler_2_mode? }
     settings_flag(:unlock_source_unlocks_spec) { !bundler_2_mode? }
     settings_flag(:update_requires_all_flag) { bundler_2_mode? }
-    settings_flag(:default_install_uses_path) { bundler_2_mode? }
-    settings_flag(:list_command) { bundler_2_mode? }
 
     settings_option(:default_cli_command) { bundler_2_mode? ? :cli_help : :install }
 

--- a/lib/bundler/index.rb
+++ b/lib/bundler/index.rb
@@ -112,6 +112,7 @@ module Bundler
         spec_sets.values.each(&blk)
       end
       sources.each {|s| s.each(&blk) }
+      self
     end
 
     # returns a list of the dependencies

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -12,6 +12,7 @@ module Bundler
       allow_bundler_dependency_conflicts
       allow_deployment_source_credential_changes
       allow_offline_install
+      auto_clean_without_path
       auto_install
       cache_all
       cache_all_platforms

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -126,6 +126,9 @@ learn more about their operation in [bundle install(1)][bundle-install].
    Ex: `https://some.host.com/gems/path/` -> `https://user_name:password@some.host.com/gems/path`
 * `allow_offline_install` (`BUNDLE_ALLOW_OFFLINE_INSTALL`):
    Allow Bundler to use cached data when installing without network access.
+* `auto_clean_without_path` (`BUNDLE_AUTO_CLEAN_WITHOUT_PATH`):
+   Automatically run `bundle clean` after installing when an explicit `path`
+   has not been set and Bundler is not installing into the system gems.
 * `auto_install` (`BUNDLE_AUTO_INSTALL`):
    Automatically run `bundle install` when gems are missing.
 * `bin` (`BUNDLE_BIN`):
@@ -168,7 +171,7 @@ learn more about their operation in [bundle install(1)][bundle-install].
 * `disable_version_check` (`BUNDLE_DISABLE_VERSION_CHECK`):
    Stop Bundler from checking if a newer Bundler version is available on
    rubygems.org.
-* `error_on_stderr` (`BUNDLE_ERROR_ON_STDERR`)
+* `error_on_stderr` (`BUNDLE_ERROR_ON_STDERR`):
    Print Bundler errors to stderr.
 * `force_ruby_platform` (`BUNDLE_FORCE_RUBY_PLATFORM`):
    Ignore the current machine's platform and install only `ruby` platform gems.

--- a/spec/commands/clean_spec.rb
+++ b/spec/commands/clean_spec.rb
@@ -383,6 +383,30 @@ RSpec.describe "bundle clean" do
     should_not_have_gems "foo-1.0"
   end
 
+  it "automatically cleans when path has not been set", :bundler => "2" do
+    build_repo2
+
+    install_gemfile! <<-G
+      source "file://#{gem_repo2}"
+
+      gem "foo"
+    G
+
+    update_repo2 do
+      build_gem "foo", "1.0.1"
+    end
+
+    bundle! "update", :all => true
+
+    files = Pathname.glob(bundled_app(".bundle", Bundler.ruby_scope, "*", "*"))
+    files.map! {|f| f.to_s.sub(bundled_app(".bundle", Bundler.ruby_scope).to_s, "") }
+    expect(files.sort).to eq %w[
+      /cache/foo-1.0.1.gem
+      /gems/foo-1.0.1
+      /specifications/foo-1.0.1.gemspec
+    ]
+  end
+
   it "does not clean automatically on --path" do
     gemfile <<-G
       source "file://#{gem_repo1}"

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -617,7 +617,7 @@ RSpec.describe "bundle exec" do
       let(:exit_code) { Bundler::GemNotFound.new.status_code }
       let(:expected) { <<-EOS.strip }
 \e[31mCould not find gem 'rack (= 2)' in locally installed gems.
-The source contains 'rack' at: 0.9.1, 1.0.0\e[0m
+The source contains 'rack' at: 1.0.0\e[0m
 \e[33mRun `bundle install` to install missing gems.\e[0m
       EOS
 

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -218,6 +218,7 @@ RSpec.describe "bundle exec" do
   end
 
   it "raises a helpful error when exec'ing to something outside of the bundle", :rubygems => ">= 2.5.2" do
+    bundle! "config clean false" # want to keep the rackup binstub
     install_gemfile! <<-G
       source "file://#{gem_repo1}"
       gem "with_license"

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -191,6 +191,8 @@ RSpec.describe "bundle outdated" do
         build_gem "activesupport", "2.3.4"
       end
 
+      bundle! "config clean false"
+
       install_gemfile <<-G
         source "file://#{gem_repo2}"
         gem "activesupport", "2.3.4"

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -498,6 +498,7 @@ RSpec.describe "bundle update" do
       end
 
       bundle! "update", :all => bundle_update_requires_all?
+      out.sub!("Removing foo (1.0)\n", "")
       out.gsub!(/RubyGems [\d\.]+ is not threadsafe.*\n?/, "")
       expect(out).to include strip_whitespace(<<-EOS).strip
         Resolving dependencies...

--- a/spec/install/allow_offline_install_spec.rb
+++ b/spec/install/allow_offline_install_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe "bundle install with :allow_offline_install" do
     it "will install from the compact index" do
       system_gems ["rack-1.0.0"], :path => :bundle_path
 
+      bundle! "config clean false"
       install_gemfile! <<-G, :artifice => "compact_index"
         source "http://testgemserver.local"
         gem "rack-obama"

--- a/spec/plugins/source/example_spec.rb
+++ b/spec/plugins/source/example_spec.rb
@@ -36,6 +36,10 @@ RSpec.describe "real source plugins" do
                 mkdir_p(install_path.parent)
                 FileUtils.cp_r(path, install_path)
 
+                spec_path = install_path.join("\#{spec.full_name}.gemspec")
+                spec_path.open("wb") {|f| f.write spec.to_ruby }
+                spec.loaded_from = spec_path.to_s
+
                 post_install(spec)
 
                 nil
@@ -251,6 +255,10 @@ RSpec.describe "real source plugins" do
                 Dir.chdir install_path do
                   `git reset --hard \#{revision}`
                 end
+
+                spec_path = install_path.join("\#{spec.full_name}.gemspec")
+                spec_path.open("wb") {|f| f.write spec.to_ruby }
+                spec.loaded_from = spec_path.to_s
 
                 post_install(spec)
 

--- a/spec/support/command_execution.rb
+++ b/spec/support/command_execution.rb
@@ -8,7 +8,18 @@ module Spec
     include RSpec::Matchers::Composable
 
     def to_s
-      "$ #{command.strip}"
+      c = Shellwords.shellsplit(command.strip).map {|s| s.include?("\n") ? " \\\n  <<EOS\n#{s.gsub(/^/, "  ").chomp}\nEOS" : Shellwords.shellescape(s) }
+      c = c.reduce("") do |acc, elem|
+        concat = acc + " " + elem
+
+        last_line = concat.match(/.*\z/)[0]
+        if last_line.size >= 100
+          acc + " \\\n  " + elem
+        else
+          concat
+        end
+      end
+      "$ #{c.strip}"
     end
     alias_method :inspect, :to_s
 

--- a/spec/update/git_spec.rb
+++ b/spec/update/git_spec.rb
@@ -117,8 +117,10 @@ RSpec.describe "bundle update" do
 
     describe "with submodules" do
       before :each do
-        build_gem "submodule", :to_bundle => true do |s|
-          s.write "lib/submodule.rb", "puts 'GEM'"
+        build_repo4 do
+          build_gem "submodule" do |s|
+            s.write "lib/submodule.rb", "puts 'GEM'"
+          end
         end
 
         build_git "submodule", "1.0" do |s|
@@ -137,6 +139,7 @@ RSpec.describe "bundle update" do
 
       it "it unlocks the source when submodules are added to a git source" do
         install_gemfile <<-G
+          source "file:#{gem_repo4}"
           git "#{lib_path("has_submodule-1.0")}" do
             gem "has_submodule"
           end
@@ -146,6 +149,7 @@ RSpec.describe "bundle update" do
         expect(out).to eq("GEM")
 
         install_gemfile <<-G
+          source "file:#{gem_repo4}"
           git "#{lib_path("has_submodule-1.0")}", :submodules => true do
             gem "has_submodule"
           end
@@ -156,22 +160,24 @@ RSpec.describe "bundle update" do
       end
 
       it "unlocks the source when submodules are removed from git source", :git => ">= 2.9.0" do
-        install_gemfile <<-G
+        install_gemfile! <<-G
+          source "file:#{gem_repo4}"
           git "#{lib_path("has_submodule-1.0")}", :submodules => true do
             gem "has_submodule"
           end
         G
 
-        run "require 'submodule'"
+        run! "require 'submodule'"
         expect(out).to eq("GIT")
 
-        install_gemfile <<-G
+        install_gemfile! <<-G
+          source "file:#{gem_repo4}"
           git "#{lib_path("has_submodule-1.0")}" do
             gem "has_submodule"
           end
         G
 
-        run "require 'submodule'"
+        run! "require 'submodule'"
         expect(out).to eq("GEM")
       end
     end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was with the switch to defaulting to a local install in 2.0, we're concerned about taking up too much disk space.

### What was your diagnosis of the problem?

My diagnosis was we'd like to run `bundle clean` when possible.

Closes https://github.com/bundler/bundler/issues/5875.

### What is your fix for the problem, implemented in this PR?

My fix runs `clean` automatically on 2.0 when a `path` has _not_ been set.

### Why did you choose this fix out of the possible options?

I chose this fix because it avoids the possibility of accidentally cleaning a shared location.