### PR TITLE
deprecate the bundle viz command

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -482,20 +482,23 @@ module Bundler
       end
     end
 
-    desc "viz [OPTIONS]", "Generates a visual dependency graph", :hide => true
-    long_desc <<-D
-      Viz generates a PNG file of the current Gemfile as a dependency graph.
-      Viz requires the ruby-graphviz gem (and its dependencies).
-      The associated gems must also be installed via 'bundle install'.
-    D
-    method_option :file, :type => :string, :default => "gem_graph", :aliases => "-f", :desc => "The name to use for the generated file. see format option"
-    method_option :format, :type => :string, :default => "png", :aliases => "-F", :desc => "This is output format option. Supported format is png, jpg, svg, dot ..."
-    method_option :requirements, :type => :boolean, :default => false, :aliases => "-R", :desc => "Set to show the version of each required dependency."
-    method_option :version, :type => :boolean, :default => false, :aliases => "-v", :desc => "Set to show each gem version."
-    method_option :without, :type => :array, :default => [], :aliases => "-W", :banner => "GROUP[ GROUP...]", :desc => "Exclude gems that are part of the specified named group."
-    def viz
-      require "bundler/cli/viz"
-      Viz.new(options.dup).run
+    if Bundler.feature_flag.viz_command?
+      desc "viz [OPTIONS]", "Generates a visual dependency graph", :hide => true
+      long_desc <<-D
+        Viz generates a PNG file of the current Gemfile as a dependency graph.
+        Viz requires the ruby-graphviz gem (and its dependencies).
+        The associated gems must also be installed via 'bundle install'.
+      D
+      method_option :file, :type => :string, :default => "gem_graph", :aliases => "-f", :desc => "The name to use for the generated file. see format option"
+      method_option :format, :type => :string, :default => "png", :aliases => "-F", :desc => "This is output format option. Supported format is png, jpg, svg, dot ..."
+      method_option :requirements, :type => :boolean, :default => false, :aliases => "-R", :desc => "Set to show the version of each required dependency."
+      method_option :version, :type => :boolean, :default => false, :aliases => "-v", :desc => "Set to show each gem version."
+      method_option :without, :type => :array, :default => [], :aliases => "-W", :banner => "GROUP[ GROUP...]", :desc => "Exclude gems that are part of the specified named group."
+      def viz
+        SharedHelpers.major_deprecation 2, "The `viz` command has been moved to the `bundle-viz` gem, see https://github.com/bundler/bundler-viz"
+        require "bundler/cli/viz"
+        Viz.new(options.dup).run
+      end
     end
 
     old_gem = instance_method(:gem)

--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -53,6 +53,7 @@ module Bundler
     settings_flag(:unlock_source_unlocks_spec) { !bundler_2_mode? }
     settings_flag(:update_requires_all_flag) { bundler_2_mode? }
     settings_flag(:use_gem_version_promoter_for_major_updates) { bundler_2_mode? }
+    settings_flag(:viz_command) { !bundler_2_mode? }
 
     settings_option(:default_cli_command) { bundler_2_mode? ? :cli_help : :install }
 

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -54,6 +54,7 @@ module Bundler
       unlock_source_unlocks_spec
       update_requires_all_flag
       use_gem_version_promoter_for_major_updates
+      viz_command
     ].freeze
 
     NUMBER_KEYS = %w[

--- a/spec/commands/viz_spec.rb
+++ b/spec/commands/viz_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "bundle viz", :ruby => "1.9.3", :if => Bundler.which("dot") do
+RSpec.describe "bundle viz", :ruby => "1.9.3", :bundler => "< 2", :if => Bundler.which("dot") do
   let(:ruby_graphviz) do
     graphviz_glob = base_system_gems.join("cache/ruby-graphviz*")
     Pathname.glob(graphviz_glob).first

--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -180,6 +180,7 @@ RSpec.describe "The library itself" do
       lockfile_uses_separate_rubygems_sources
       use_gem_version_promoter_for_major_updates
       warned_version
+      viz_command
     ]
 
     all_settings = Hash.new {|h, k| h[k] = [] }


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The `bundle viz` command is to been removed from bundler 2 and extracted into a plugin

Closes #5180 

### What is your fix for the problem, implemented in this PR?

Deprecate the `bundle viz` command with an error explaining that a new gem will replace it's functionality.
