### PR TITLE
Space between { and | missing

### DIFF
--- a/lib/bundler/templates/Gemfile
+++ b/lib/bundler/templates/Gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # gem "rails"


### PR DESCRIPTION
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

This does not follow ruby style best practice.

### What was your diagnosis of the problem?

There should be space between { and |.

### What is your fix for the problem, implemented in this PR?

Add a space between { and |.

### Why did you choose this fix out of the possible options?

I chose this fix because most of us follow the ruby guide style.
