### PR TITLE
Respect RUBYGEMS_HOST env var in release messaging

### DIFF
--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -118,7 +118,11 @@ module Bundler
     end
 
     def gem_push_host
-      allowed_push_host || "rubygems.org"
+      env_rubygems_host = ENV["RUBYGEMS_HOST"]
+      env_rubygems_host = nil if
+        env_rubygems_host && env_rubygems_host.empty?
+
+      allowed_push_host || env_rubygems_host || "rubygems.org"
     end
 
     def perform_git_push(options = "")

--- a/spec/bundler/gem_helper_spec.rb
+++ b/spec/bundler/gem_helper_spec.rb
@@ -256,5 +256,95 @@ RSpec.describe Bundler::GemHelper do
         end
       end
     end
+
+    describe "release:rubygem_push" do
+      let!(:rake_application) { Rake.application }
+
+      before(:each) do
+        Rake.application = Rake::Application.new
+        subject.install
+        allow(subject).to receive(:sh)
+      end
+
+      after(:each) do
+        Rake.application = rake_application
+      end
+
+      before do
+        Dir.chdir(app_path) do
+          `git init`
+          `git config user.email "you@example.com"`
+          `git config user.name "name"`
+          `git config push.default simple`
+        end
+
+        # silence messages
+        allow(Bundler.ui).to receive(:confirm)
+        allow(Bundler.ui).to receive(:error)
+
+        credentials = double("credentials", "file?" => true)
+        allow(Bundler.user_home).to receive(:join).
+          with(".gem/credentials").and_return(credentials)
+      end
+
+      describe "success messaging" do
+        context "No allowed_push_host set" do
+          before do
+            allow(subject).to receive(:allowed_push_host).and_return(nil)
+          end
+
+          around do |example|
+            orig_host = ENV["RUBYGEMS_HOST"]
+            ENV["RUBYGEMS_HOST"] = rubygems_host_env
+
+            example.run
+
+            ENV["RUBYGEMS_HOST"] = orig_host
+          end
+
+          context "RUBYGEMS_HOST env var is set" do
+            let(:rubygems_host_env) { "https://custom.env.gemhost.com" }
+
+            it "should report successful push to the host from the environment" do
+              mock_confirm_message "Pushed #{app_name} #{app_version} to #{rubygems_host_env}"
+
+              Rake.application["release:rubygem_push"].invoke
+            end
+          end
+
+          context "RUBYGEMS_HOST env var is not set" do
+            let(:rubygems_host_env) { nil }
+
+            it "should report successful push to rubygems.org" do
+              mock_confirm_message "Pushed #{app_name} #{app_version} to rubygems.org"
+
+              Rake.application["release:rubygem_push"].invoke
+            end
+          end
+
+          context "RUBYGEMS_HOST env var is an empty string" do
+            let(:rubygems_host_env) { "" }
+
+            it "should report successful push to rubygems.org" do
+              mock_confirm_message "Pushed #{app_name} #{app_version} to rubygems.org"
+
+              Rake.application["release:rubygem_push"].invoke
+            end
+          end
+        end
+
+        context "allowed_push_host set in gemspec" do
+          before do
+            allow(subject).to receive(:allowed_push_host).and_return("https://my.gemhost.com")
+          end
+
+          it "should report successful push to the allowed gem host" do
+            mock_confirm_message "Pushed #{app_name} #{app_version} to https://my.gemhost.com"
+
+            Rake.application["release:rubygem_push"].invoke
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

When running the `release` task, bundler didn't know anything
about the RUBYGEMS_HOST environment variable that rubygems respects when
doing a gem push.  This resulted in incorrect messaging, as environments
where this was set without an `allowed_push_host` configured would
message that the gem had been pushed to rubygems.org, when in fact it
was pushed elsewhere.

### What was your diagnosis of the problem?

Bundler was hardcoding `rubygems.org` in the event that an `allowed_push_host` setting was not specified, and didn't know anything about the `RUBYGEMS_HOST` env var.

### What is your fix for the problem, implemented in this PR?

Added a check for that variable and used it before the hardcoded `rubygems.org` if it exists.

### Why did you choose this fix out of the possible options?

I chose this fix because it seemed the most straightforward way to solve the problem.