### PR TITLE
Fix bundle binstubs stanadlone flag

### DIFF
--- a/lib/bundler/cli/binstubs.rb
+++ b/lib/bundler/cli/binstubs.rb
@@ -33,7 +33,9 @@ module Bundler
 
         if options[:standalone]
           next Bundler.ui.warn("Sorry, Bundler can only be run via RubyGems.") if gem_name == "bundler"
-          installer.generate_standalone_bundler_executable_stubs(spec)
+          Bundler.settings.temporary(:path => (Bundler.settings[:path] || Bundler.root)) do
+            installer.generate_standalone_bundler_executable_stubs(spec)
+          end
         else
           installer.generate_bundler_executable_stubs(spec, :force => options[:force], :binstubs_cmd => true)
         end

--- a/man/bundle-binstubs.ronn
+++ b/man/bundle-binstubs.ronn
@@ -34,6 +34,9 @@ Calling binstubs with [GEM [GEM]] will create binstubs for all given gems.
   Makes binstubs that can work without depending on Rubygems or Bundler at
   runtime.
 
+* `--sheband`:
+  Specify a different shebang executable name than the default (default 'ruby')
+
 ## BUNDLE INSTALL --BINSTUBS
 
 To create binstubs for all the gems in the bundle you can use the `--binstubs`

--- a/spec/commands/binstubs_spec.rb
+++ b/spec/commands/binstubs_spec.rb
@@ -263,20 +263,29 @@ RSpec.describe "bundle binstubs <gem>" do
     end
   end
 
-  context "after installing with --standalone" do
+  context "with --standalone option" do
     before do
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "file://#{gem_repo1}"
         gem "rack"
       G
-      forgotten_command_line_options(:path => "bundle")
-      bundle! "install", :standalone => true
     end
 
-    it "includes the standalone path" do
-      bundle! "binstubs rack", :standalone => true
-      standalone_line = File.read(bundled_app("bin/rackup")).each_line.find {|line| line.include? "$:.unshift" }.strip
-      expect(standalone_line).to eq %($:.unshift File.expand_path "../../bundle", path.realpath)
+    it "generates a standalone binstub" do
+      bundle! "binstubs rack --standalone"
+      expect(bundled_app("bin/rackup")).to exist
+    end
+
+    it "generates a binstub that does not depend on rubygems or bundler" do
+      bundle! "binstubs rack --standalone"
+      expect(File.read(bundled_app("bin/rackup"))).to_not include("Gem.bin_path")
+    end
+
+    context "when specified --path option" do
+      it "generates a standalone binstub at the given path" do
+        bundle! "binstubs rack --standalone --path foo"
+        expect(bundled_app("foo/rackup")).to exist
+      end
     end
   end
 

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -502,6 +502,23 @@ RSpec.describe "bundle install with gem sources" do
     end
   end
 
+  context "after installing with --standalone" do
+    before do
+      install_gemfile! <<-G
+        source "file://#{gem_repo1}"
+        gem "rack"
+      G
+      forgotten_command_line_options(:path => "bundle")
+      bundle! "install", :standalone => true
+    end
+
+    it "includes the standalone path" do
+      bundle! "binstubs rack", :standalone => true
+      standalone_line = File.read(bundled_app("bin/rackup")).each_line.find {|line| line.include? "$:.unshift" }.strip
+      expect(standalone_line).to eq %($:.unshift File.expand_path "../../bundle", path.realpath)
+    end
+  end
+
   describe "when bundle install is executed with unencoded authentication" do
     before do
       gemfile <<-G


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Currently, specifying the `--standalone` flag breaks `bundler binstubs` unless you have the `path` setting set in your bundle config. This is breaking in different ways but mostly for the same reason.

Bundler Master:
```
RuntimeError: Can't standalone without an explicit path set
  /Users/c/Desktop/Projects/bundler/lib/bundler/installer.rb:158:in `generate_standalone_bundler_executable_stubs'
  /Users/c/Desktop/Projects/bundler/lib/bundler/cli/binstubs.rb:36:in `block in run'
  /Users/c/Desktop/Projects/bundler/lib/bundler/cli/binstubs.rb:26:in `each'
```

Bundler 1.15.4:
```
TypeError: no implicit conversion of nil into String
  /Users/c/.rubies/ruby-2.4.1/lib/ruby/2.4.0/pathname.rb:409:in `initialize'
  /Users/c/.rubies/ruby-2.4.1/lib/ruby/2.4.0/pathname.rb:409:in `new'
  /Users/c/.rubies/ruby-2.4.1/lib/ruby/2.4.0/pathname.rb:409:in `join'
  /Users/c/.gem/ruby/2.4.1/gems/bundler-1.15.4/lib/bundler/installer.rb:142:in `generate_standalone_bundler_executable_stubs'
```

This was not caught in our tests because the `--standalone` flag was infact not being tested.

Another issue is that we have command options for the `bundle binstubs` command which are missing documentation in the man pages.

### What was your diagnosis of the problem?

This error occurs when the `path` setting is not set which `generate_standalone_bundler_executable_stubs` expects to be set

### What is your fix for the problem, implemented in this PR?

Set a temporary path setting in the binstubs command of either any currently set `path` setting or use `Bundler.root` instead.

### Why did you choose this fix out of the possible options?

This was the most simplest solution that i can think of without having to change the standalone binstub generator.