### PR TITLE
Support bundle_path used by war files generated with jruby's warbler

### DIFF
--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -208,6 +208,10 @@ module Bundler
       Gem.bin_path(gem, bin, ver)
     end
 
+    def path_separator
+      File::PATH_SEPARATOR
+    end
+
     def preserve_paths
       # this is a no-op outside of RubyGems 1.8
       yield
@@ -787,6 +791,10 @@ module Bundler
 
       def install_with_build_args(args)
         yield
+      end
+
+      def path_separator
+        Gem.path_separator
       end
     end
 

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -221,7 +221,7 @@ module Bundler
   private
 
     def validate_bundle_path
-      path_separator = Gem.respond_to?(:path_separator) ? Gem.path_separator : File::PATH_SEPARATOR
+      path_separator = Bundler.rubygems.path_separator
       return unless Bundler.bundle_path.to_s.split(path_separator).size > 1
       message = "Your bundle path contains text matching #{path_separator.inspect}, " \
                 "which is the path separator for your system. Bundler cannot " \

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -221,12 +221,12 @@ module Bundler
   private
 
     def validate_bundle_path
-      return unless Bundler.bundle_path.to_s.include?(File::PATH_SEPARATOR)
-      message = "Your bundle path contains a '#{File::PATH_SEPARATOR}', " \
+      return unless Bundler.bundle_path.to_s.split(Gem.path_separator).size > 1
+      message = "Your bundle path contains text matching #{Gem.path_separator.inspect}, " \
                 "which is the path separator for your system. Bundler cannot " \
                 "function correctly when the Bundle path contains the " \
                 "system's PATH separator. Please change your " \
-                "bundle path to not include '#{File::PATH_SEPARATOR}'." \
+                "bundle path to not match #{Gem.path_separator.inspect}." \
                 "\nYour current bundle path is '#{Bundler.bundle_path}'."
       raise Bundler::PathError, message
     end

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -221,7 +221,8 @@ module Bundler
   private
 
     def validate_bundle_path
-      return unless Bundler.bundle_path.to_s.split(Gem.path_separator).size > 1
+      path_separator = Gem.respond_to?(:path_separator) ? Gem.path_separator : File::PATH_SEPARATOR
+      return unless Bundler.bundle_path.to_s.split(path_separator).size > 1
       message = "Your bundle path contains text matching #{Gem.path_separator.inspect}, " \
                 "which is the path separator for your system. Bundler cannot " \
                 "function correctly when the Bundle path contains the " \

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -223,11 +223,11 @@ module Bundler
     def validate_bundle_path
       path_separator = Gem.respond_to?(:path_separator) ? Gem.path_separator : File::PATH_SEPARATOR
       return unless Bundler.bundle_path.to_s.split(path_separator).size > 1
-      message = "Your bundle path contains text matching #{Gem.path_separator.inspect}, " \
+      message = "Your bundle path contains text matching #{path_separator.inspect}, " \
                 "which is the path separator for your system. Bundler cannot " \
                 "function correctly when the Bundle path contains the " \
                 "system's PATH separator. Please change your " \
-                "bundle path to not match #{Gem.path_separator.inspect}." \
+                "bundle path to not match #{path_separator.inspect}." \
                 "\nYour current bundle path is '#{Bundler.bundle_path}'."
       raise Bundler::PathError, message
     end

--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -262,7 +262,11 @@ RSpec.describe Bundler::SharedHelpers do
     end
 
     it "exits if bundle path contains the unix-like path separator" do
-      allow(Gem).to receive(:path_separator).and_return(":")
+      if Gem.respond_to?(:path_separator)
+        allow(Gem).to receive(:path_separator).and_return(":")
+      else
+        stub_const("File::PATH_SEPARATOR", ":".freeze)
+      end
       allow(Bundler).to receive(:bundle_path) { Pathname.new("so:me/dir/bin") }
       expect { subject.send(:validate_bundle_path) }.to raise_error(
         Bundler::PathError,
@@ -275,7 +279,7 @@ RSpec.describe Bundler::SharedHelpers do
       )
     end
 
-    it "does not exit if bundle path is the jruby/warbler standard uri path" do
+    it "does not exit if bundle path is the jruby/warbler standard uri path", :ruby => "> 1.8.7" do
       allow(Gem).to receive(:path_separator).and_return(
         /(?<!jar:file|jar|file|classpath|uri:classloader|uri|http|https):/
       )
@@ -283,7 +287,7 @@ RSpec.describe Bundler::SharedHelpers do
       expect { subject.send(:validate_bundle_path) }.not_to raise_error(Bundler::PathError)
     end
 
-    it "exits if bundle path contains another directory with the jruby uri path separator" do
+    it "exits if bundle path contains another directory with the jruby uri path separator", :ruby => "> 1.8.7" do
       allow(Gem).to receive(:path_separator).and_return(
         /(?<!jar:file|jar|file|classpath|uri:classloader|uri|http|https):/
       )

--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -281,11 +281,7 @@ RSpec.describe Bundler::SharedHelpers do
 
     context "with a jruby path_separator regex", :ruby => "1.9" do
       # In versions of jruby that supported ruby 1.8, the path separator was the standard File::PATH_SEPARATOR
-      let(:regex) do
-        # If this is stated as a literal regex we get a syntax error when simply loading this file,
-        # even if the expression is never evaluated
-        eval("/(?<!jar:file|jar|file|classpath|uri:classloader|uri|http|https):/")
-      end
+      let(:regex) { Regexp.new('(?<!jar:file|jar|file|classpath|uri:classloader|uri|http|https):') }
       it "does not exit if bundle path is the standard uri path" do
         allow(Gem).to receive(:path_separator).and_return(regex)
         allow(Bundler).to receive(:bundle_path) { Pathname.new("uri:classloader:/WEB-INF/gems") }

--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -283,13 +283,13 @@ RSpec.describe Bundler::SharedHelpers do
       # In versions of jruby that supported ruby 1.8, the path separator was the standard File::PATH_SEPARATOR
       let(:regex) { Regexp.new("(?<!jar:file|jar|file|classpath|uri:classloader|uri|http|https):") }
       it "does not exit if bundle path is the standard uri path" do
-        allow(Gem).to receive(:path_separator).and_return(regex)
+        allow(Bundler.rubygems).to receive(:path_separator).and_return(regex)
         allow(Bundler).to receive(:bundle_path) { Pathname.new("uri:classloader:/WEB-INF/gems") }
         expect { subject.send(:validate_bundle_path) }.not_to raise_error
       end
 
       it "exits if bundle path contains another directory" do
-        allow(Gem).to receive(:path_separator).and_return(regex)
+        allow(Bundler.rubygems).to receive(:path_separator).and_return(regex)
         allow(Bundler).to receive(:bundle_path) {
           Pathname.new("uri:classloader:/WEB-INF/gems:other/dir")
         }

--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -281,11 +281,11 @@ RSpec.describe Bundler::SharedHelpers do
 
     context "with a jruby path_separator regex", :ruby => "1.9" do
       # In versions of jruby that supported ruby 1.8, the path separator was the standard File::PATH_SEPARATOR
-      let(:regex) {
+      let(:regex) do
         # If this is stated as a literal regex we get a syntax error when simply loading this file,
         # even if the expression is never evaluated
         eval("/(?<!jar:file|jar|file|classpath|uri:classloader|uri|http|https):/")
-      }
+      end
       it "does not exit if bundle path is the standard uri path" do
         allow(Gem).to receive(:path_separator).and_return(regex)
         allow(Bundler).to receive(:bundle_path) { Pathname.new("uri:classloader:/WEB-INF/gems") }

--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -279,33 +279,31 @@ RSpec.describe Bundler::SharedHelpers do
       )
     end
 
-    if RUBY_VERSION.to_f > 1.8 # In versions of jruby that supported ruby 1.8, the path separator was the standard File::PATH_SEPARATOR
-      context "with a jruby path_separator regex" do
-        let(:regex) { /(?<!jar:file|jar|file|classpath|uri:classloader|uri|http|https):/ }
-        it "does not exit if bundle path is the standard uri path" do
-          allow(Gem).to receive(:path_separator).and_return(regex)
-          allow(Bundler).to receive(:bundle_path) { Pathname.new("uri:classloader:/WEB-INF/gems") }
-          expect { subject.send(:validate_bundle_path) }.not_to raise_error
-        end
+    context "with a jruby path_separator regex", :ruby => "1.9" do # In versions of jruby that supported ruby 1.8, the path separator was the standard File::PATH_SEPARATOR
+      let(:regex) { /(?<!jar:file|jar|file|classpath|uri:classloader|uri|http|https):/ }
+      it "does not exit if bundle path is the standard uri path" do
+        allow(Gem).to receive(:path_separator).and_return(regex)
+        allow(Bundler).to receive(:bundle_path) { Pathname.new("uri:classloader:/WEB-INF/gems") }
+        expect { subject.send(:validate_bundle_path) }.not_to raise_error
+      end
 
-        it "exits if bundle path contains another directory" do
-          allow(Gem).to receive(:path_separator).and_return(regex)
-          allow(Bundler).to receive(:bundle_path) {
-            Pathname.new("uri:classloader:/WEB-INF/gems:other/dir")
-          }
+      it "exits if bundle path contains another directory" do
+        allow(Gem).to receive(:path_separator).and_return(regex)
+        allow(Bundler).to receive(:bundle_path) {
+          Pathname.new("uri:classloader:/WEB-INF/gems:other/dir")
+        }
 
-          expect { subject.send(:validate_bundle_path) }.to raise_error(
-            Bundler::PathError,
-            "Your bundle path contains text matching " \
-            "/(?<!jar:file|jar|file|classpath|uri:classloader|uri|http|https):/, which is the " \
-            "path separator for your system. Bundler cannot " \
-            "function correctly when the Bundle path contains the " \
-            "system's PATH separator. Please change your " \
-            "bundle path to not match " \
-            "/(?<!jar:file|jar|file|classpath|uri:classloader|uri|http|https):/." \
-            "\nYour current bundle path is '#{Bundler.bundle_path}'."
-          )
-        end
+        expect { subject.send(:validate_bundle_path) }.to raise_error(
+          Bundler::PathError,
+          "Your bundle path contains text matching " \
+          "/(?<!jar:file|jar|file|classpath|uri:classloader|uri|http|https):/, which is the " \
+          "path separator for your system. Bundler cannot " \
+          "function correctly when the Bundle path contains the " \
+          "system's PATH separator. Please change your " \
+          "bundle path to not match " \
+          "/(?<!jar:file|jar|file|classpath|uri:classloader|uri|http|https):/." \
+          "\nYour current bundle path is '#{Bundler.bundle_path}'."
+        )
       end
     end
 

--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -262,15 +262,15 @@ RSpec.describe Bundler::SharedHelpers do
     end
 
     it "exits if bundle path contains the path separator" do
-      stub_const("File::PATH_SEPARATOR", ":".freeze)
+      allow(Gem).to receive(:path_separator).and_return(":")
       allow(Bundler).to receive(:bundle_path) { Pathname.new("so:me/dir/bin") }
       expect { subject.send(:validate_bundle_path) }.to raise_error(
         Bundler::PathError,
-        "Your bundle path contains a ':', which is the " \
+        "Your bundle path contains text matching \":\", which is the " \
         "path separator for your system. Bundler cannot " \
         "function correctly when the Bundle path contains the " \
         "system's PATH separator. Please change your " \
-        "bundle path to not include ':'.\nYour current bundle " \
+        "bundle path to not match \":\".\nYour current bundle " \
         "path is '#{Bundler.bundle_path}'."
       )
     end

--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -281,7 +281,7 @@ RSpec.describe Bundler::SharedHelpers do
 
     context "with a jruby path_separator regex", :ruby => "1.9" do
       # In versions of jruby that supported ruby 1.8, the path separator was the standard File::PATH_SEPARATOR
-      let(:regex) { Regexp.new('(?<!jar:file|jar|file|classpath|uri:classloader|uri|http|https):') }
+      let(:regex) { Regexp.new("(?<!jar:file|jar|file|classpath|uri:classloader|uri|http|https):") }
       it "does not exit if bundle path is the standard uri path" do
         allow(Gem).to receive(:path_separator).and_return(regex)
         allow(Bundler).to receive(:bundle_path) { Pathname.new("uri:classloader:/WEB-INF/gems") }

--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -279,34 +279,36 @@ RSpec.describe Bundler::SharedHelpers do
       )
     end
 
-    it "does not exit if bundle path is the jruby/warbler standard uri path", :ruby => "> 1.8.7" do
-      allow(Gem).to receive(:path_separator).and_return(
-        /(?<!jar:file|jar|file|classpath|uri:classloader|uri|http|https):/
-      )
-      allow(Bundler).to receive(:bundle_path) { Pathname.new("uri:classloader:/WEB-INF/gems") }
-      expect { subject.send(:validate_bundle_path) }.not_to raise_error(Bundler::PathError)
+    if RUBY_VERSION.to_f > 1.8 # In versions of jruby that supported ruby 1.8, the path separator was the standard File::PATH_SEPARATOR
+      context "with a jruby path_separator regex" do
+        let(:regex) { /(?<!jar:file|jar|file|classpath|uri:classloader|uri|http|https):/ }
+        it "does not exit if bundle path is the standard uri path" do
+          allow(Gem).to receive(:path_separator).and_return(regex)
+          allow(Bundler).to receive(:bundle_path) { Pathname.new("uri:classloader:/WEB-INF/gems") }
+          expect { subject.send(:validate_bundle_path) }.not_to raise_error
+        end
+
+        it "exits if bundle path contains another directory" do
+          allow(Gem).to receive(:path_separator).and_return(regex)
+          allow(Bundler).to receive(:bundle_path) {
+            Pathname.new("uri:classloader:/WEB-INF/gems:other/dir")
+          }
+
+          expect { subject.send(:validate_bundle_path) }.to raise_error(
+            Bundler::PathError,
+            "Your bundle path contains text matching " \
+            "/(?<!jar:file|jar|file|classpath|uri:classloader|uri|http|https):/, which is the " \
+            "path separator for your system. Bundler cannot " \
+            "function correctly when the Bundle path contains the " \
+            "system's PATH separator. Please change your " \
+            "bundle path to not match " \
+            "/(?<!jar:file|jar|file|classpath|uri:classloader|uri|http|https):/." \
+            "\nYour current bundle path is '#{Bundler.bundle_path}'."
+          )
+        end
+      end
     end
 
-    it "exits if bundle path contains another directory with the jruby uri path separator", :ruby => "> 1.8.7" do
-      allow(Gem).to receive(:path_separator).and_return(
-        /(?<!jar:file|jar|file|classpath|uri:classloader|uri|http|https):/
-      )
-      allow(Bundler).to receive(:bundle_path) {
-        Pathname.new("uri:classloader:/WEB-INF/gems:other/dir")
-      }
-
-      expect { subject.send(:validate_bundle_path) }.to raise_error(
-        Bundler::PathError,
-        "Your bundle path contains text matching " \
-        "/(?<!jar:file|jar|file|classpath|uri:classloader|uri|http|https):/, which is the " \
-        "path separator for your system. Bundler cannot " \
-        "function correctly when the Bundle path contains the " \
-        "system's PATH separator. Please change your " \
-        "bundle path to not match " \
-        "/(?<!jar:file|jar|file|classpath|uri:classloader|uri|http|https):/." \
-        "\nYour current bundle path is '#{Bundler.bundle_path}'."
-      )
-    end
 
     context "ENV['PATH'] does not exist" do
       before { ENV.delete("PATH") }

--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -309,7 +309,6 @@ RSpec.describe Bundler::SharedHelpers do
       end
     end
 
-
     context "ENV['PATH'] does not exist" do
       before { ENV.delete("PATH") }
 

--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -279,8 +279,13 @@ RSpec.describe Bundler::SharedHelpers do
       )
     end
 
-    context "with a jruby path_separator regex", :ruby => "1.9" do # In versions of jruby that supported ruby 1.8, the path separator was the standard File::PATH_SEPARATOR
-      let(:regex) { /(?<!jar:file|jar|file|classpath|uri:classloader|uri|http|https):/ }
+    context "with a jruby path_separator regex", :ruby => "1.9" do
+      # In versions of jruby that supported ruby 1.8, the path separator was the standard File::PATH_SEPARATOR
+      let(:regex) {
+        # If this is stated as a literal regex we get a syntax error when simply loading this file,
+        # even if the expression is never evaluated
+        eval("/(?<!jar:file|jar|file|classpath|uri:classloader|uri|http|https):/")
+      }
       it "does not exit if bundle path is the standard uri path" do
         allow(Gem).to receive(:path_separator).and_return(regex)
         allow(Bundler).to receive(:bundle_path) { Pathname.new("uri:classloader:/WEB-INF/gems") }


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Closes #5975. The problem was that recent code to detect a bad bundle_path by looking for the PATH_SEPARATOR character broke when running from a war file generated by jruby's warbler.

### What was your diagnosis of the problem?

My diagnosis was that the path separator used was not appropriate in this circumstance.

### What is your fix for the problem, implemented in this PR?

My fix implements the suggestion from @segiddins to use the same path splitting logic used by RubyGems under jruby to determine if the bad path is present.

### Why did you choose this fix out of the possible options?

I chose this fix because it provides a way to detect the original problem that is consistent with the handling within RubyGems.