### PR TITLE
Convert pristine command desc to long_desc

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -603,7 +603,12 @@ module Bundler
       Issue.new.run
     end
 
-    desc "pristine [GEMS...]", "Restores installed gems to pristine condition from files located in the gem cache. Gem installed from a git repository will be issued `git checkout --force`."
+    desc "pristine [GEMS...]", "Restores installed gems to pristine condition"
+    long_desc <<-D
+      Restores installed gems to pristine condition from files located in the
+      gem cache. Gems installed from a git repository will be issued `git
+      checkout --force`.
+    D
     def pristine(*gems)
       require "bundler/cli/pristine"
       Pristine.new(gems).run


### PR DESCRIPTION
What was the end-user problem that led to this PR?
--------------------------------------------------

When taking a look at the output that was shown when doing `bundle cli_help`, half of the output for describing the `bundle pristine` command is truncated.


What was your diagnosis of the problem?
---------------------------------------

My diagnosis was that we had to long of a "basic description" (`desc`) for the `bundle pristine` command.


What is your fix for the problem, implemented in this PR?
---------------------------------------------------------

Convert the existing `desc` to a `long_desc`, and provide a shorter one for `desc`.


Why did you choose this fix out of the possible options?
--------------------------------------------------------

I chose this fix because it retained the same info that was there previously, but provided a much more terse description in summary like situations like `bundle cli_help`.