### PR TITLE
Add documentation for packaging with --no-install

### DIFF
--- a/man/bundle-package.ronn
+++ b/man/bundle-package.ronn
@@ -65,3 +65,8 @@ machine and check in the gems. For instance, you can run
 `bundle package` on an identical staging box during your
 staging process, and check in the `vendor/cache` before
 deploying to production.
+
+By default, [bundle package(1)][bundle-package] fetches and also
+installs the gems to the default location. To package the
+dependencies to `vendor/cache` without installing them to the
+local install location, you can run `bundle package --no-install`.


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

I need to package gems for deployment but don't want to install them on the local system. 

### What was your diagnosis of the problem?

The behaviour is a part of bundler but it is not documented anywhere in man pages or the bundler site. To find the answer, one has to look at issues that were closed a few years ago.

### What is your fix for the problem, implemented in this PR?

I've updated the man page for the `bundle package` command. Hopefully, this will trickle down to bundler site pages for package command whenever CI publishes it. 

Followed the doc [here](https://github.com/bundler/bundler/blob/master/doc/documentation/WRITING.md) to run tests.

### Why did you choose this fix out of the possible options?

It felt appropriate to document a flag available on a CLI in its help pages.