### PR TITLE
Handle missing socket when warning about OpenSSL version

### DIFF
--- a/lib/bundler/vendored_persistent.rb
+++ b/lib/bundler/vendored_persistent.rb
@@ -30,6 +30,7 @@ module Bundler
       return unless (uri.host || "").end_with?("rubygems.org")
 
       socket = connection.instance_variable_get(:@socket)
+      return unless socket
       socket_io = socket.io
       return unless socket_io.respond_to?(:ssl_version)
       ssl_version = socket_io.ssl_version

--- a/spec/bundler/vendored_persistent_spec.rb
+++ b/spec/bundler/vendored_persistent_spec.rb
@@ -45,6 +45,12 @@ RSpec.describe Bundler::PersistentHTTP do
       include_examples "does not warn"
     end
 
+    context "without a socket" do
+      let(:socket) { nil }
+
+      include_examples "does not warn"
+    end
+
     context "with a different TLD" do
       let(:uri) { "https://foo.bar" }
       include_examples "does not warn"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Stubbing Rubygems requests with WebMock was causing `undefined method 'io' for nil:NilClass` errors when using Bundler 1.16.0.pre.1

### What was your diagnosis of the problem?

My diagnosis was that the new warning text about old OpenSSL versions didn't consider the case that a connection might not have an `@socket` variable set.

### What is your fix for the problem, implemented in this PR?

Guard against this by returning early in that case.

### Why did you choose this fix out of the possible options?

I chose this fix because it works, and because `Net::HTTP` itself has some guards in it around `nil` values for `@socket` ([example](https://github.com/ruby/ruby/blob/trunk/lib/net/http.rb#L858-L860)). This isn't my area, though, so it could be that a fix is needed in WebMock, not here...
