### PR TITLE
Bump to a Bundler 2 version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,6 @@ addons:
 rvm:
   - 2.4.1
   - 2.3.4
-  - 2.2.7
-  - 2.1.10
-  - 2.0.0
-  - 1.9.3
-  - 1.8.7
 
 # Rubygems versions MUST be available as rake tasks
 # see Rakefile:125 for the list of possible RGV values
@@ -40,86 +35,23 @@ env:
   # We need to know if changes to rubygems will break bundler on release
   - RGV=master
   # Test the latest rubygems release with all of our supported rubies
-  - RGV=v2.6.8
+  - RGV=v2.6.13
 
 matrix:
   include:
-    - rvm: 2.4.1
-      env: RGV=v2.6.8 BUNDLER_SPEC_SUB_VERSION=2.0.0
     # Ruby 2.4, Rubygems 2.6.8 and up
     # Ruby 2.3, Rubygems 2.5.1 and up
-    - rvm: 2.2.6
+    - rvm: 2.3.4
       env: RGV=v2.5.2
-    # Ruby 2.2, Rubygems 2.4.5 and up
-    - rvm: 2.2.6
-      env: RGV=v2.4.8
-    # Ruby 2.1, Rubygems 2.2.2 and up
-    - rvm: 2.1.10
-      env: RGV=v2.2.5
-    # Ruby 2.0.0, Rubygems 2.0.0 and up
-    - rvm: 2.0.0
-      env: RGV=v2.2.5
-    - rvm: 2.0.0
-      env: RGV=v2.1.11
-    - rvm: 2.0.0
-      env: RGV=v2.0.14
-    # Ruby 1.9.3, Rubygems 1.5.3 and up
-    - rvm: 1.9.3
-      env: RGV=v2.2.5
-    - rvm: 1.9.3
-      env: RGV=v2.1.11
-    - rvm: 1.9.3
-      env: RGV=v2.0.14
-    - rvm: 1.9.3
-      env: RGV=v1.8.29
-    - rvm: 1.9.3
-      env: RGV=v1.7.2
-    - rvm: 1.9.3
-      env: RGV=v1.6.2
-    - rvm: 1.9.3
-      env: RGV=v1.5.3
-
-    # Ruby 1.8.7, Rubygems 1.3.6 and up
-    - rvm: 1.8.7
-      env: RGV=v2.2.5
-    # ALLOWED FAILURES
-    # since the great Travis image outage, frequent random segfaults :'(
-    - rvm: 1.8.7
-      env: RGV=v2.0.14
-    - rvm: 1.8.7
-      env: RGV=v1.8.29
-    - rvm: 1.8.7
-      env: RGV=v1.7.2
-    - rvm: 1.8.7
-      env: RGV=v1.6.2
-    - rvm: 1.8.7
-      env: RGV=v1.5.3
-    - rvm: 1.8.7
-      env: RGV=v1.4.2
-    - rvm: 1.8.7
-      env: RGV=v1.3.7
-    - rvm: 1.8.7
-      env: RGV=v1.3.6
     # Ruby-head (we want to know how we're doing, but not fail the build)
     - rvm: ruby-head
       env: RGV=master
+    # 1.x mode (we want to keep stuff passing in 1.x mode for now)
+    - rvm: 2.4.1
+      env: RGV=v2.6.13 BUNDLER_SPEC_SUB_VERSION=1.98
+    - rvm: 1.8.7
+      env: RGV=v2.6.13 BUNDLER_SPEC_SUB_VERSION=1.98
 
   allow_failures:
-    - rvm: 1.8.7
-      env: RGV=v2.0.14
-    - rvm: 1.8.7
-      env: RGV=v1.8.29
-    - rvm: 1.8.7
-      env: RGV=v1.7.2
-    - rvm: 1.8.7
-      env: RGV=v1.6.2
-    - rvm: 1.8.7
-      env: RGV=v1.5.3
-    - rvm: 1.8.7
-      env: RGV=v1.4.2
-    - rvm: 1.8.7
-      env: RGV=v1.3.7
-    - rvm: 1.8.7
-      env: RGV=v1.3.6
     - rvm: ruby-head
       env: RGV=master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 script: rake spec:travis
 before_script:
+  - travis_retry rake -E 'module ::Bundler; VERSION = "0.0.0"; end' override_version
   - travis_retry rake spec:travis:deps
-  - travis_retry rake override_version
   - travis_retry rake man:build
   - travis_retry rake spec:rubygems:clone_rubygems_$RGV
 

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,9 @@ else
   File.expand_path("tmp/rubygems")
 end
 
-BUNDLER_SPEC = Gem::Specification.load("bundler.gemspec")
+def bundler_spec
+  @bundler_spec ||= Gem::Specification.load("bundler.gemspec")
+end
 
 def safe_task(&block)
   yield
@@ -37,7 +39,7 @@ end
 namespace :spec do
   desc "Ensure spec dependencies are installed"
   task :deps do
-    deps = Hash[BUNDLER_SPEC.development_dependencies.map do |d|
+    deps = Hash[bundler_spec.development_dependencies.map do |d|
       [d.name, d.requirement.to_s]
     end]
     deps["rubocop"] ||= "= 0.49.1" if RUBY_VERSION >= "2.0.0" # can't go in the gemspec because of the ruby version requirement
@@ -91,7 +93,7 @@ namespace :spec do
 end
 
 begin
-  rspec = BUNDLER_SPEC.development_dependencies.find {|d| d.name == "rspec" }
+  rspec = bundler_spec.development_dependencies.find {|d| d.name == "rspec" }
   gem "rspec", rspec.requirement.to_s
   require "rspec/core/rake_task"
 

--- a/Rakefile
+++ b/Rakefile
@@ -144,7 +144,7 @@ begin
       rubyopt = ENV["RUBYOPT"]
       # When editing this list, also edit .travis.yml!
       branches = %w[master]
-      releases = %w[v1.3.6 v1.3.7 v1.4.2 v1.5.3 v1.6.2 v1.7.2 v1.8.29 v2.0.14 v2.1.11 v2.2.5 v2.4.8 v2.5.2 v2.6.8]
+      releases = %w[v1.3.6 v1.3.7 v1.4.2 v1.5.3 v1.6.2 v1.7.2 v1.8.29 v2.0.14 v2.1.11 v2.2.5 v2.4.8 v2.5.2 v2.6.8 v2.6.13]
       (branches + releases).each do |rg|
         desc "Run specs with RubyGems #{rg}"
         RSpec::Core::RakeTask.new(rg) do |t|

--- a/lib/bundler/version.rb
+++ b/lib/bundler/version.rb
@@ -7,7 +7,7 @@ module Bundler
   # We're doing this because we might write tests that deal
   # with other versions of bundler and we are unsure how to
   # handle this better.
-  VERSION = "1.16.0.pre.2" unless defined?(::Bundler::VERSION)
+  VERSION = "2.0.0.dev" unless defined?(::Bundler::VERSION)
 
   def self.overwrite_loaded_gem_version
     begin

--- a/task/build_metadata.rake
+++ b/task/build_metadata.rake
@@ -4,7 +4,7 @@ def write_build_metadata(build_metadata)
   build_metadata_file = "lib/bundler/build_metadata.rb"
 
   ivars = build_metadata.sort.map do |k, v|
-    "    @#{k} = #{BUNDLER_SPEC.send(:ruby_code, v)}"
+    "    @#{k} = #{bundler_spec.send(:ruby_code, v)}"
   end.join("\n")
 
   contents = File.read(build_metadata_file)
@@ -14,7 +14,7 @@ end
 
 task :build_metadata do
   build_metadata = {
-    :built_at => BUNDLER_SPEC.date.utc.strftime("%Y-%m-%d"),
+    :built_at => bundler_spec.date.utc.strftime("%Y-%m-%d"),
     :git_commit_sha => `git rev-parse --short HEAD`.strip,
     :release => Rake::Task["release"].instance_variable_get(:@already_invoked),
   }

--- a/task/release.rake
+++ b/task/release.rake
@@ -123,7 +123,7 @@ namespace :release do
     version = args.version
 
     version ||= begin
-      version = BUNDLER_SPEC.version
+      version = bundler_spec.version
       segments = version.segments
       if segments.last.is_a?(String)
         segments << "1"
@@ -133,7 +133,7 @@ namespace :release do
       segments.join(".")
     end
 
-    confirm "You are about to release #{version}, currently #{BUNDLER_SPEC.version}"
+    confirm "You are about to release #{version}, currently #{bundler_spec.version}"
 
     milestones = gh_api_request(:path => "repos/bundler/bundler/milestones?state=open")
     unless patch_milestone = milestones.find {|m| m["title"] == version }
@@ -147,7 +147,7 @@ namespace :release do
     end
     prs.compact!
 
-    BUNDLER_SPEC.version = version
+    bundler_spec.version = version
 
     branch = version.split(".", 3)[0, 2].push("stable").join("-")
     sh("git", "checkout", branch)


### PR DESCRIPTION
Now that we've branched `1-16-stable` and the [2.0 milestone](https://github.com/bundler/bundler/milestone/13) is nearly done, it's time that we target `master` to be Bundler 2.

Until Bundler 2 final is released, I'd like us to keep testing rudimentary 1.x support, to make backporting things to `1-16-stable` easier, but I've severely cut down the matrix. I'm willing to take it upon myself that 1.x stable maintains esoteric Ruby/RubyGems version compatibility now, rather than requiring it from all those who try to contribute to the project (in reality, this just means fixing up `1-16-stable` after back porting and before a release).

@bundler/core: 2.0 is finally happening!