### PR TITLE
Use helper methods for relative path references in the specs

### DIFF
--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -61,8 +61,6 @@ RSpec.describe "bundle exec" do
   it "handles --keep-file-descriptors" do
     require "tempfile"
 
-    bundle_bin = File.expand_path(bindir.join("bundle"), __FILE__)
-
     command = Tempfile.new("io-test")
     command.sync = true
     command.write <<-G
@@ -71,7 +69,7 @@ RSpec.describe "bundle exec" do
       else
         require 'tempfile'
         io = Tempfile.new("io-test-fd")
-        args = %W[#{Gem.ruby} -I#{lib} #{bundle_bin} exec --keep-file-descriptors #{Gem.ruby} #{command.path} \#{io.to_i}]
+        args = %W[#{Gem.ruby} -I#{lib} #{bindir.join("bundle")} exec --keep-file-descriptors #{Gem.ruby} #{command.path} \#{io.to_i}]
         args << { io.to_i => io } if RUBY_VERSION >= "2.0"
         exec(*args)
       end

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "bundle exec" do
   it "handles --keep-file-descriptors" do
     require "tempfile"
 
-    bundle_bin = File.expand_path("#{Spec::Path.bindir}/bundle", __FILE__)
+    bundle_bin = File.expand_path(Spec::Path.bindir.join("bundle"), __FILE__)
 
     command = Tempfile.new("io-test")
     command.sync = true
@@ -474,7 +474,7 @@ RSpec.describe "bundle exec" do
       Bundler.rubygems.extend(Monkey)
       G
       bundle "install --deployment"
-      bundle "exec ruby -e '`#{Spec::Path.bindir}/bundler -v`; puts $?.success?'"
+      bundle "exec ruby -e '`#{Spec::Path.bindir.join("bundler")} -v`; puts $?.success?'"
       expect(out).to match("true")
     end
   end

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "bundle exec" do
   it "handles --keep-file-descriptors" do
     require "tempfile"
 
-    bundle_bin = File.expand_path("../../../exe/bundle", __FILE__)
+    bundle_bin = File.expand_path("#{Spec::Path.bin}/bundle", __FILE__)
 
     command = Tempfile.new("io-test")
     command.sync = true
@@ -474,7 +474,7 @@ RSpec.describe "bundle exec" do
       Bundler.rubygems.extend(Monkey)
       G
       bundle "install --deployment"
-      bundle "exec ruby -e '`../../exe/bundler -v`; puts $?.success?'"
+      bundle "exec ruby -e '`#{Spec::Path.bin}/bundler -v`; puts $?.success?'"
       expect(out).to match("true")
     end
   end

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "bundle exec" do
   it "handles --keep-file-descriptors" do
     require "tempfile"
 
-    bundle_bin = File.expand_path("#{Spec::Path.bin}/bundle", __FILE__)
+    bundle_bin = File.expand_path("#{Spec::Path.bindir}/bundle", __FILE__)
 
     command = Tempfile.new("io-test")
     command.sync = true
@@ -474,7 +474,7 @@ RSpec.describe "bundle exec" do
       Bundler.rubygems.extend(Monkey)
       G
       bundle "install --deployment"
-      bundle "exec ruby -e '`#{Spec::Path.bin}/bundler -v`; puts $?.success?'"
+      bundle "exec ruby -e '`#{Spec::Path.bindir}/bundler -v`; puts $?.success?'"
       expect(out).to match("true")
     end
   end

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "bundle exec" do
   it "handles --keep-file-descriptors" do
     require "tempfile"
 
-    bundle_bin = File.expand_path(Spec::Path.bindir.join("bundle"), __FILE__)
+    bundle_bin = File.expand_path(bindir.join("bundle"), __FILE__)
 
     command = Tempfile.new("io-test")
     command.sync = true
@@ -474,7 +474,7 @@ RSpec.describe "bundle exec" do
       Bundler.rubygems.extend(Monkey)
       G
       bundle "install --deployment"
-      bundle "exec ruby -e '`#{Spec::Path.bindir.join("bundler")} -v`; puts $?.success?'"
+      bundle "exec ruby -e '`#{bindir.join("bundler")} -v`; puts $?.success?'"
       expect(out).to match("true")
     end
   end

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -170,11 +170,10 @@ RSpec.describe "bundle gem" do
 
     # This spec cannot have `git` available in the test env
     before do
-      bundle_bin = File.expand_path(bindir.join("bundle"), __FILE__)
       load_paths = [lib, spec]
       load_path_str = "-I#{load_paths.join(File::PATH_SEPARATOR)}"
 
-      sys_exec "PATH=\"\" #{Gem.ruby} #{load_path_str} #{bundle_bin} gem #{gem_name}"
+      sys_exec "PATH=\"\" #{Gem.ruby} #{load_path_str} #{bindir.join("bundle")} gem #{gem_name}"
     end
 
     it "creates the gem without the need for git" do

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "bundle gem" do
       user = bundleuser
     EOF
     @git_config_location = ENV["GIT_CONFIG"]
-    path = "#{File.expand_path("../../tmp", File.dirname(__FILE__))}/test_git_config.txt"
+    path = "#{File.expand_path(Spec::Path.tmp, File.dirname(__FILE__))}/test_git_config.txt"
     File.open(path, "w") {|f| f.write(git_config_content) }
     ENV["GIT_CONFIG"] = path
   end
@@ -170,7 +170,7 @@ RSpec.describe "bundle gem" do
 
     # This spec cannot have `git` available in the test env
     before do
-      bundle_bin = File.expand_path("../../../exe/bundle", __FILE__)
+      bundle_bin = File.expand_path("#{Spec::Path.bin}/bundle", __FILE__)
       load_paths = [lib, spec]
       load_path_str = "-I#{load_paths.join(File::PATH_SEPARATOR)}"
 

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe "bundle gem" do
 
     # This spec cannot have `git` available in the test env
     before do
-      bundle_bin = File.expand_path("#{Spec::Path.bindir}/bundle", __FILE__)
+      bundle_bin = File.expand_path(Spec::Path.bindir.join("bundle"), __FILE__)
       load_paths = [lib, spec]
       load_path_str = "-I#{load_paths.join(File::PATH_SEPARATOR)}"
 

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe "bundle gem" do
 
     # This spec cannot have `git` available in the test env
     before do
-      bundle_bin = File.expand_path("#{Spec::Path.bin}/bundle", __FILE__)
+      bundle_bin = File.expand_path("#{Spec::Path.bindir}/bundle", __FILE__)
       load_paths = [lib, spec]
       load_path_str = "-I#{load_paths.join(File::PATH_SEPARATOR)}"
 

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "bundle gem" do
       user = bundleuser
     EOF
     @git_config_location = ENV["GIT_CONFIG"]
-    path = "#{File.expand_path(Spec::Path.tmp, File.dirname(__FILE__))}/test_git_config.txt"
+    path = "#{File.expand_path(tmp, File.dirname(__FILE__))}/test_git_config.txt"
     File.open(path, "w") {|f| f.write(git_config_content) }
     ENV["GIT_CONFIG"] = path
   end
@@ -170,7 +170,7 @@ RSpec.describe "bundle gem" do
 
     # This spec cannot have `git` available in the test env
     before do
-      bundle_bin = File.expand_path(Spec::Path.bindir.join("bundle"), __FILE__)
+      bundle_bin = File.expand_path(bindir.join("bundle"), __FILE__)
       load_paths = [lib, spec]
       load_path_str = "-I#{load_paths.join(File::PATH_SEPARATOR)}"
 

--- a/spec/commands/show_spec.rb
+++ b/spec/commands/show_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "bundle show", :bundler => "< 2" do
 
     it "prints the path to the running bundler" do
       bundle "show bundler"
-      expect(out).to eq(File.expand_path("../../../", __FILE__))
+      expect(out).to eq(File.expand_path(Spec::Path.root.to_s, __FILE__))
     end
 
     it "complains if gem not in bundle" do

--- a/spec/commands/show_spec.rb
+++ b/spec/commands/show_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "bundle show", :bundler => "< 2" do
 
     it "prints the path to the running bundler" do
       bundle "show bundler"
-      expect(out).to eq(File.expand_path(Spec::Path.root.to_s, __FILE__))
+      expect(out).to eq(File.expand_path(root.to_s, __FILE__))
     end
 
     it "complains if gem not in bundle" do

--- a/spec/commands/show_spec.rb
+++ b/spec/commands/show_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "bundle show", :bundler => "< 2" do
 
     it "prints the path to the running bundler" do
       bundle "show bundler"
-      expect(out).to eq(File.expand_path(root.to_s, __FILE__))
+      expect(out).to eq(root.to_s)
     end
 
     it "complains if gem not in bundle" do

--- a/spec/runtime/with_clean_env_spec.rb
+++ b/spec/runtime/with_clean_env_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "Bundler.with_env helpers" do
 
     it "should clean up RUBYLIB" do
       code = "print Bundler.clean_env['RUBYLIB']"
-      ENV["RUBYLIB"] = File.expand_path(Spec::Path.root.join("lib"), __FILE__) + File::PATH_SEPARATOR + "/foo"
+      ENV["RUBYLIB"] = File.expand_path(root.join("lib"), __FILE__) + File::PATH_SEPARATOR + "/foo"
       result = bundle("exec '#{Gem.ruby}' -e #{code.inspect}")
       expect(result).to eq("/foo")
     end

--- a/spec/runtime/with_clean_env_spec.rb
+++ b/spec/runtime/with_clean_env_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "Bundler.with_env helpers" do
 
     it "should clean up RUBYLIB" do
       code = "print Bundler.clean_env['RUBYLIB']"
-      ENV["RUBYLIB"] = File.expand_path("../../../lib", __FILE__) + File::PATH_SEPARATOR + "/foo"
+      ENV["RUBYLIB"] = File.expand_path("#{Spec::Path.root}/lib", __FILE__) + File::PATH_SEPARATOR + "/foo"
       result = bundle("exec '#{Gem.ruby}' -e #{code.inspect}")
       expect(result).to eq("/foo")
     end

--- a/spec/runtime/with_clean_env_spec.rb
+++ b/spec/runtime/with_clean_env_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "Bundler.with_env helpers" do
 
     it "should clean up RUBYLIB" do
       code = "print Bundler.clean_env['RUBYLIB']"
-      ENV["RUBYLIB"] = File.expand_path("#{Spec::Path.root}/lib", __FILE__) + File::PATH_SEPARATOR + "/foo"
+      ENV["RUBYLIB"] = File.expand_path(Spec::Path.root.join("lib"), __FILE__) + File::PATH_SEPARATOR + "/foo"
       result = bundle("exec '#{Gem.ruby}' -e #{code.inspect}")
       expect(result).to eq("/foo")
     end

--- a/spec/runtime/with_clean_env_spec.rb
+++ b/spec/runtime/with_clean_env_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "Bundler.with_env helpers" do
 
     it "should clean up RUBYLIB" do
       code = "print Bundler.clean_env['RUBYLIB']"
-      ENV["RUBYLIB"] = File.expand_path(root.join("lib"), __FILE__) + File::PATH_SEPARATOR + "/foo"
+      ENV["RUBYLIB"] = root.join("lib").to_s + File::PATH_SEPARATOR + "/foo"
       result = bundle("exec '#{Gem.ruby}' -e #{code.inspect}")
       expect(result).to eq("/foo")
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,10 +7,11 @@ require "bundler/psyched_yaml"
 require "bundler/vendored_fileutils"
 require "uri"
 require "digest/sha1"
+require File.expand_path("../support/path.rb", __FILE__)
 
 begin
   require "rubygems"
-  spec = Gem::Specification.load("bundler.gemspec")
+  spec = Gem::Specification.load(Spec::Path.gemspec.to_s)
   rspec = spec.dependencies.find {|d| d.name == "rspec" }
   gem "rspec", rspec.requirement.to_s
   require "rspec"
@@ -46,7 +47,7 @@ $debug = false
 Spec::Manpages.setup
 Spec::Rubygems.setup
 FileUtils.rm_rf(Spec::Path.gem_repo1)
-ENV["RUBYOPT"] = "#{ENV["RUBYOPT"]} -r#{Spec::Path.root}/spec/support/hax.rb"
+ENV["RUBYOPT"] = "#{ENV["RUBYOPT"]} -r#{Spec::Path.spec}/support/hax.rb"
 ENV["BUNDLE_SPEC_RUN"] = "true"
 
 # Don't wrap output in tests

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,7 +47,7 @@ $debug = false
 Spec::Manpages.setup
 Spec::Rubygems.setup
 FileUtils.rm_rf(Spec::Path.gem_repo1)
-ENV["RUBYOPT"] = "#{ENV["RUBYOPT"]} -r#{Spec::Path.spec}/support/hax.rb"
+ENV["RUBYOPT"] = "#{ENV["RUBYOPT"]} -r#{Spec::Path.spec_dir}/support/hax.rb"
 ENV["BUNDLE_SPEC_RUN"] = "true"
 
 # Don't wrap output in tests

--- a/spec/support/artifice/endpoint.rb
+++ b/spec/support/artifice/endpoint.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require File.expand_path("../../path.rb", __FILE__)
-require File.expand_path("#{Spec::Path.root}/lib/bundler/deprecate", __FILE__)
+require File.expand_path(Spec::Path.root.join("lib/bundler/deprecate"), __FILE__)
 include Spec::Path
 
 $LOAD_PATH.unshift(*Dir[Spec::Path.base_system_gems.join("gems/{artifice,rack,tilt,sinatra}-*/lib")].map(&:to_s))

--- a/spec/support/artifice/endpoint.rb
+++ b/spec/support/artifice/endpoint.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require File.expand_path("../../path.rb", __FILE__)
-require File.expand_path("../../../../lib/bundler/deprecate", __FILE__)
+require File.expand_path("#{Spec::Path.root}/lib/bundler/deprecate", __FILE__)
 include Spec::Path
 
 $LOAD_PATH.unshift(*Dir[Spec::Path.base_system_gems.join("gems/{artifice,rack,tilt,sinatra}-*/lib")].map(&:to_s))

--- a/spec/support/artifice/endpoint.rb
+++ b/spec/support/artifice/endpoint.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require File.expand_path("../../path.rb", __FILE__)
-require File.expand_path(Spec::Path.root.join("lib/bundler/deprecate"), __FILE__)
+require Spec::Path.root.join("lib/bundler/deprecate")
 include Spec::Path
 
 $LOAD_PATH.unshift(*Dir[Spec::Path.base_system_gems.join("gems/{artifice,rack,tilt,sinatra}-*/lib")].map(&:to_s))

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require File.expand_path("../path.rb", __FILE__)
 
 module Spec
   module Helpers
@@ -88,11 +89,11 @@ module Spec
     end
 
     def lib
-      File.expand_path("../../../lib", __FILE__)
+      File.expand_path("#{Spec::Path.root}/lib", __FILE__)
     end
 
     def spec
-      File.expand_path("../../../spec", __FILE__)
+      File.expand_path(Spec::Path.spec.to_s, __FILE__)
     end
 
     def bundle(cmd, options = {})
@@ -102,7 +103,7 @@ module Spec
       no_color = options.delete("no-color") { cmd.to_s !~ /\A(e|ex|exe|exec|conf|confi|config)(\s|\z)/ }
       options["no-color"] = true if no_color
 
-      bundle_bin = options.delete("bundle_bin") || File.expand_path("../../../exe/bundle", __FILE__)
+      bundle_bin = options.delete("bundle_bin") || File.expand_path("#{Spec::Path.bin}/bundle", __FILE__)
 
       if system_bundler = options.delete(:system_bundler)
         bundle_bin = "-S bundle"
@@ -171,12 +172,12 @@ module Spec
     end
 
     def bundler(cmd, options = {})
-      options["bundle_bin"] = File.expand_path("../../../exe/bundler", __FILE__)
+      options["bundle_bin"] = File.expand_path("#{Spec::Path.bin}/bundler", __FILE__)
       bundle(cmd, options)
     end
 
     def bundle_ruby(options = {})
-      options["bundle_bin"] = File.expand_path("../../../exe/bundle_ruby", __FILE__)
+      options["bundle_bin"] = File.expand_path("#{Spec::Path.bin}/bundle_ruby", __FILE__)
       bundle("", options)
     end
 
@@ -300,7 +301,7 @@ module Spec
       gem_repo = options.fetch(:gem_repo) { gem_repo1 }
       gems.each do |g|
         path = if g == :bundler
-          Dir.chdir(root) { gem_command! :build, "#{root}/bundler.gemspec" }
+          Dir.chdir(root) { gem_command! :build, Spec::Path.gemspec.to_s }
           bundler_path = root + "bundler-#{Bundler::VERSION}.gem"
         elsif g.to_s =~ %r{\A/.*\.gem\z}
           g

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -88,11 +88,11 @@ module Spec
     end
 
     def lib
-      File.expand_path(Spec::Path.root.join("lib"), __FILE__)
+      File.expand_path(root.join("lib"), __FILE__)
     end
 
     def spec
-      File.expand_path(Spec::Path.spec_dir.to_s, __FILE__)
+      File.expand_path(spec_dir.to_s, __FILE__)
     end
 
     def bundle(cmd, options = {})
@@ -102,7 +102,7 @@ module Spec
       no_color = options.delete("no-color") { cmd.to_s !~ /\A(e|ex|exe|exec|conf|confi|config)(\s|\z)/ }
       options["no-color"] = true if no_color
 
-      bundle_bin = options.delete("bundle_bin") || File.expand_path(Spec::Path.bindir.join("bundle"), __FILE__)
+      bundle_bin = options.delete("bundle_bin") || File.expand_path(bindir.join("bundle"), __FILE__)
 
       if system_bundler = options.delete(:system_bundler)
         bundle_bin = "-S bundle"
@@ -171,12 +171,12 @@ module Spec
     end
 
     def bundler(cmd, options = {})
-      options["bundle_bin"] = File.expand_path(Spec::Path.bindir.join("bundler"), __FILE__)
+      options["bundle_bin"] = File.expand_path(bindir.join("bundler"), __FILE__)
       bundle(cmd, options)
     end
 
     def bundle_ruby(options = {})
-      options["bundle_bin"] = File.expand_path(Spec::Path.bindir.join("bundle_ruby"), __FILE__)
+      options["bundle_bin"] = File.expand_path(bindir.join("bundle_ruby"), __FILE__)
       bundle("", options)
     end
 
@@ -300,7 +300,7 @@ module Spec
       gem_repo = options.fetch(:gem_repo) { gem_repo1 }
       gems.each do |g|
         path = if g == :bundler
-          Dir.chdir(root) { gem_command! :build, Spec::Path.gemspec.to_s }
+          Dir.chdir(root) { gem_command! :build, gemspec.to_s }
           bundler_path = root + "bundler-#{Bundler::VERSION}.gem"
         elsif g.to_s =~ %r{\A/.*\.gem\z}
           g

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require File.expand_path("../path.rb", __FILE__)
 
 module Spec

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -94,7 +94,7 @@ module Spec
     end
 
     def spec
-      File.expand_path(Spec::Path.spec.to_s, __FILE__)
+      File.expand_path(Spec::Path.spec_dir.to_s, __FILE__)
     end
 
     def bundle(cmd, options = {})
@@ -104,7 +104,7 @@ module Spec
       no_color = options.delete("no-color") { cmd.to_s !~ /\A(e|ex|exe|exec|conf|confi|config)(\s|\z)/ }
       options["no-color"] = true if no_color
 
-      bundle_bin = options.delete("bundle_bin") || File.expand_path("#{Spec::Path.bin}/bundle", __FILE__)
+      bundle_bin = options.delete("bundle_bin") || File.expand_path("#{Spec::Path.bindir}/bundle", __FILE__)
 
       if system_bundler = options.delete(:system_bundler)
         bundle_bin = "-S bundle"
@@ -173,12 +173,12 @@ module Spec
     end
 
     def bundler(cmd, options = {})
-      options["bundle_bin"] = File.expand_path("#{Spec::Path.bin}/bundler", __FILE__)
+      options["bundle_bin"] = File.expand_path("#{Spec::Path.bindir}/bundler", __FILE__)
       bundle(cmd, options)
     end
 
     def bundle_ruby(options = {})
-      options["bundle_bin"] = File.expand_path("#{Spec::Path.bin}/bundle_ruby", __FILE__)
+      options["bundle_bin"] = File.expand_path("#{Spec::Path.bindir}/bundle_ruby", __FILE__)
       bundle("", options)
     end
 

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require File.expand_path("../path.rb", __FILE__)
-
 module Spec
   module Helpers
     def reset!

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -88,7 +88,7 @@ module Spec
     end
 
     def lib
-      File.expand_path("#{Spec::Path.root}/lib", __FILE__)
+      File.expand_path(Spec::Path.root.join("lib"), __FILE__)
     end
 
     def spec
@@ -102,7 +102,7 @@ module Spec
       no_color = options.delete("no-color") { cmd.to_s !~ /\A(e|ex|exe|exec|conf|confi|config)(\s|\z)/ }
       options["no-color"] = true if no_color
 
-      bundle_bin = options.delete("bundle_bin") || File.expand_path("#{Spec::Path.bindir}/bundle", __FILE__)
+      bundle_bin = options.delete("bundle_bin") || File.expand_path(Spec::Path.bindir.join("bundle"), __FILE__)
 
       if system_bundler = options.delete(:system_bundler)
         bundle_bin = "-S bundle"
@@ -171,12 +171,12 @@ module Spec
     end
 
     def bundler(cmd, options = {})
-      options["bundle_bin"] = File.expand_path("#{Spec::Path.bindir}/bundler", __FILE__)
+      options["bundle_bin"] = File.expand_path(Spec::Path.bindir.join("bundler"), __FILE__)
       bundle(cmd, options)
     end
 
     def bundle_ruby(options = {})
-      options["bundle_bin"] = File.expand_path("#{Spec::Path.bindir}/bundle_ruby", __FILE__)
+      options["bundle_bin"] = File.expand_path(Spec::Path.bindir.join("bundle_ruby"), __FILE__)
       bundle("", options)
     end
 

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -88,11 +88,11 @@ module Spec
     end
 
     def lib
-      File.expand_path(root.join("lib"), __FILE__)
+      root.join("lib")
     end
 
     def spec
-      File.expand_path(spec_dir.to_s, __FILE__)
+      spec_dir.to_s
     end
 
     def bundle(cmd, options = {})
@@ -102,7 +102,7 @@ module Spec
       no_color = options.delete("no-color") { cmd.to_s !~ /\A(e|ex|exe|exec|conf|confi|config)(\s|\z)/ }
       options["no-color"] = true if no_color
 
-      bundle_bin = options.delete("bundle_bin") || File.expand_path(bindir.join("bundle"), __FILE__)
+      bundle_bin = options.delete("bundle_bin") || bindir.join("bundle")
 
       if system_bundler = options.delete(:system_bundler)
         bundle_bin = "-S bundle"
@@ -171,12 +171,12 @@ module Spec
     end
 
     def bundler(cmd, options = {})
-      options["bundle_bin"] = File.expand_path(bindir.join("bundler"), __FILE__)
+      options["bundle_bin"] = bindir.join("bundler")
       bundle(cmd, options)
     end
 
     def bundle_ruby(options = {})
-      options["bundle_bin"] = File.expand_path(bindir.join("bundle_ruby"), __FILE__)
+      options["bundle_bin"] = bindir.join("bundle_ruby")
       bundle("", options)
     end
 

--- a/spec/support/path.rb
+++ b/spec/support/path.rb
@@ -9,15 +9,15 @@ module Spec
     end
 
     def gemspec
-      @gemspec ||= Pathname.new(File.expand_path("#{root}/bundler.gemspec", __FILE__))
+      @gemspec ||= Pathname.new(File.expand_path(root.join("bundler.gemspec"), __FILE__))
     end
 
     def bin
-      @bin ||= Pathname.new(File.expand_path("#{root}/exe", __FILE__))
+      @bin ||= Pathname.new(File.expand_path(root.join("exe"), __FILE__))
     end
 
     def spec
-      @spec ||= Pathname.new(File.expand_path("#{root}/spec", __FILE__))
+      @spec ||= Pathname.new(File.expand_path(root.join("spec"), __FILE__))
     end
 
     def tmp(*path)
@@ -95,7 +95,7 @@ module Spec
     end
 
     def bundler_path
-      Pathname.new(File.expand_path("#{root}/lib", __FILE__))
+      Pathname.new(File.expand_path(root.join("lib"), __FILE__))
     end
 
     def global_plugin_gem(*args)

--- a/spec/support/path.rb
+++ b/spec/support/path.rb
@@ -8,6 +8,18 @@ module Spec
       @root ||= Pathname.new(File.expand_path("../../..", __FILE__))
     end
 
+    def gemspec
+      @gemspec ||= Pathname.new(File.expand_path("#{root}/bundler.gemspec", __FILE__))
+    end
+
+    def bin
+      @bin ||= Pathname.new(File.expand_path("#{root}/exe", __FILE__))
+    end
+
+    def spec
+      @spec ||= Pathname.new(File.expand_path("#{root}/spec", __FILE__))
+    end
+
     def tmp(*path)
       root.join("tmp", *path)
     end
@@ -83,7 +95,7 @@ module Spec
     end
 
     def bundler_path
-      Pathname.new(File.expand_path("../../../lib", __FILE__))
+      Pathname.new(File.expand_path("#{root}/lib", __FILE__))
     end
 
     def global_plugin_gem(*args)

--- a/spec/support/path.rb
+++ b/spec/support/path.rb
@@ -12,12 +12,12 @@ module Spec
       @gemspec ||= Pathname.new(File.expand_path(root.join("bundler.gemspec"), __FILE__))
     end
 
-    def bin
-      @bin ||= Pathname.new(File.expand_path(root.join("exe"), __FILE__))
+    def bindir
+      @bindir ||= Pathname.new(File.expand_path(root.join("exe"), __FILE__))
     end
 
-    def spec
-      @spec ||= Pathname.new(File.expand_path(root.join("spec"), __FILE__))
+    def spec_dir
+      @spec_dir ||= Pathname.new(File.expand_path(root.join("spec"), __FILE__))
     end
 
     def tmp(*path)


### PR DESCRIPTION
Ruby core needs to change `Spec::Path.root` and gemspec, bin, spec directories structure.

1. I changed spec directory from `spec` to `spec/bundler` because ruby core has rubyspec files under the `spec/rubyspec`.
2. I changed gemspec location to `bundler.gemspec` to `lib/bundler.gemspec`.

ref. https://bugs.ruby-lang.org/issues/12733#note-15

This pull request make we can modify root, gemspec path to flexible locations. After merging this pull request, I will add directory structure of ruby core repository to only `spec/support/path.rb`
