### PR TITLE
Add spec that pre-release versions aren't selected when not in the Gemfile

### DIFF
--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -103,7 +103,7 @@ module Bundler
         results = index.search(dependency, @base[dependency.name])
 
         inital_requirement = @initial_requirements.find {|req| req.name == dependency.name }
-        if inital_requirement && !inital_requirement.requirement.prerelease?
+        if !inital_requirement || !inital_requirement.requirement.prerelease?
           # Move prereleases to the beginning of the list, so they're considered
           # last during resolution.
           pre, results = results.partition {|spec| spec.version.prerelease? }

--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -42,7 +42,9 @@ module Bundler
     end
 
     def start(requirements)
-      @initial_requirements = requirements
+      @prerelease_specified = {}
+      requirements.each {|dep| @prerelease_specified[dep.name] ||= dep.prerelease? }
+
       verify_gemfile_dependencies_are_found!(requirements)
       dg = @resolver.resolve(requirements, @base_dg)
       dg.map(&:payload).
@@ -102,8 +104,7 @@ module Bundler
         index = index_for(dependency)
         results = index.search(dependency, @base[dependency.name])
 
-        inital_requirement = @initial_requirements.find {|req| req.name == dependency.name }
-        if !inital_requirement || !inital_requirement.requirement.prerelease?
+        unless @prerelease_specified[dependency.name]
           # Move prereleases to the beginning of the list, so they're considered
           # last during resolution.
           pre, results = results.partition {|spec| spec.version.prerelease? }

--- a/spec/resolver/basic_spec.rb
+++ b/spec/resolver/basic_spec.rb
@@ -56,6 +56,11 @@ RSpec.describe "Resolving" do
     should_resolve_as %w[reform-1.0.0 activesupport-2.3.5]
   end
 
+  it "doesn't select a pre-release for sub-dependencies" do
+    dep "reform"
+    should_resolve_as %w[reform-1.0.0 activesupport-2.3.5]
+  end
+
   it "raises an exception if a child dependency is not resolved" do
     @index = a_unresovable_child_index
     dep "chef_app_error"

--- a/spec/resolver/basic_spec.rb
+++ b/spec/resolver/basic_spec.rb
@@ -50,6 +50,12 @@ RSpec.describe "Resolving" do
     should_resolve_as %w[activemerchant-2.3.5 activesupport-3.0.0.beta1]
   end
 
+  it "doesn't select a pre-release if not specified in the Gemfile" do
+    dep "activesupport"
+    dep "reform"
+    should_resolve_as %w[reform-1.0.0 activesupport-2.3.5]
+  end
+
   it "raises an exception if a child dependency is not resolved" do
     @index = a_unresovable_child_index
     dep "chef_app_error"

--- a/spec/resolver/basic_spec.rb
+++ b/spec/resolver/basic_spec.rb
@@ -61,6 +61,11 @@ RSpec.describe "Resolving" do
     should_resolve_as %w[reform-1.0.0 activesupport-2.3.5]
   end
 
+  it "selects a pre-release for sub-dependencies if it's the only option" do
+    dep "need-pre"
+    should_resolve_as %w[need-pre-1.0.0 activesupport-3.0.0.beta1]
+  end
+
   it "raises an exception if a child dependency is not resolved" do
     @index = a_unresovable_child_index
     dep "chef_app_error"

--- a/spec/support/indexes.rb
+++ b/spec/support/indexes.rb
@@ -141,6 +141,10 @@ module Spec
         gem "reform", ["1.0.0"] do
           dep "activesupport", ">= 1.0.0.beta1"
         end
+
+        gem "need-pre", ["1.0.0"] do
+          dep "activesupport", "~> 3.0.0.beta1"
+        end
       end
     end
 

--- a/spec/support/indexes.rb
+++ b/spec/support/indexes.rb
@@ -137,6 +137,10 @@ module Spec
             dep "activesupport", ">= #{version}"
           end
         end
+
+        gem "reform", ["1.0.0"] do
+          dep "activesupport", ">= 1.0.0.beta1"
+        end
       end
     end
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that a pre-release version was being installed when the user hadn't asked for one, and a non-prerelease install was possible.

### What was your diagnosis of the problem?

My diagnosis was that this was caused by the change to the way pre-releases get selected for resolution when we moved to Molinillo 0.6.0. See the change to `lib/bundler/index.rb` in https://github.com/bundler/bundler/pull/5902.

### What is your fix for the problem, implemented in this PR?

My fix... isn't present yet. Basically we want to replicate the `wants_prerelease || only_prerelease` behaviour in `Bundler::Resolver#requirement_satisfied_by?`, but it's late and I haven't thought about how to do that yet. Instead, here's a failing spec.

### Why did you choose this fix out of the possible options?

I chose this fix because it's late and I haven't thought about how to fix this yet, but I at least wanted it flagged.
