### PR TITLE
Add RB_USER_INSTALL to preserved ENV keys

### DIFF
--- a/lib/bundler/environment_preserver.rb
+++ b/lib/bundler/environment_preserver.rb
@@ -14,6 +14,7 @@ module Bundler
       PATH
       RUBYLIB
       RUBYOPT
+      RB_USER_INSTALL
     ].map(&:freeze).freeze
     BUNDLER_PREFIX = "BUNDLER_ORIG_".freeze
 

--- a/lib/bundler/environment_preserver.rb
+++ b/lib/bundler/environment_preserver.rb
@@ -12,9 +12,9 @@ module Bundler
       GEM_PATH
       MANPATH
       PATH
+      RB_USER_INSTALL
       RUBYLIB
       RUBYOPT
-      RB_USER_INSTALL
     ].map(&:freeze).freeze
     BUNDLER_PREFIX = "BUNDLER_ORIG_".freeze
 


### PR DESCRIPTION
This PR adds the environment variable `RB_USER_INSTALL` to the list of preserved keys. That variable is used on FreeBSD.

  - see #6013 

Without this change, Bundler's usage of it with the shared helpers to set a preserved env would raise this:

> ArgumentError: new key RB_USER_INSTALL

(This seems to be the only env var which is used but not listed in the preserved keys list.)