### PR TITLE
Avoid making unnecessary network requests fetching specs

### DIFF
--- a/bin/bundle1
+++ b/bin/bundle1
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+module Bundler
+  VERSION = "1.98".freeze
+end
+
+load File.expand_path("../bundle", __FILE__)

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -923,7 +923,7 @@ module Bundler
       pinned_names = []
       default = Bundler.feature_flag.lockfile_uses_separate_rubygems_sources? && sources.default_source
       @dependencies.each do |dep|
-        dep_source = dep.source || default
+        next unless dep_source = dep.source || default
         next if dep_source == skip
         pinned_names << dep.name
       end

--- a/lib/bundler/fetcher/dependency.rb
+++ b/lib/bundler/fetcher/dependency.rb
@@ -7,7 +7,7 @@ module Bundler
   class Fetcher
     class Dependency < Base
       def available?
-        fetch_uri.scheme != "file" && downloader.fetch(dependency_api_uri)
+        @available ||= fetch_uri.scheme != "file" && downloader.fetch(dependency_api_uri)
       rescue NetworkDownError => e
         raise HTTPError, e.message
       rescue AuthenticationRequiredError

--- a/lib/bundler/index.rb
+++ b/lib/bundler/index.rb
@@ -115,6 +115,12 @@ module Bundler
       self
     end
 
+    def spec_names
+      names = specs.keys + sources.map(&:spec_names)
+      names.uniq!
+      names
+    end
+
     # returns a list of the dependencies
     def unmet_dependency_names
       dependency_names.select do |name|

--- a/lib/bundler/index.rb
+++ b/lib/bundler/index.rb
@@ -139,19 +139,6 @@ module Bundler
       names.uniq
     end
 
-    def dependency_names_if_available
-      reduce([]) do |names, spec|
-        case spec
-        when EndpointSpecification, Gem::Specification, LazySpecification, StubSpecification
-          names.concat(spec.dependencies)
-        when RemoteSpecification # from the full index
-          return nil
-        else
-          raise "unhandled spec type in #dependency_names_if_available (#{spec.inspect})"
-        end
-      end.tap {|n| n && n.map!(&:name) }
-    end
-
     def use(other, override_dupes = false)
       return unless other
       other.each do |s|

--- a/lib/bundler/source.rb
+++ b/lib/bundler/source.rb
@@ -38,6 +38,10 @@ module Bundler
     # dependencies, looking for gems we don't have info on yet.
     def double_check_for(*); end
 
+    def dependency_names_to_double_check
+      specs.dependency_names
+    end
+
     def include?(other)
       other == self
     end

--- a/lib/bundler/source/rubygems.rb
+++ b/lib/bundler/source/rubygems.rb
@@ -260,7 +260,11 @@ module Bundler
 
         unmet_dependency_names = unmet_dependency_names.call
         unless unmet_dependency_names.nil?
-          unmet_dependency_names -= remote_specs.spec_names # avoid re-fetching things we've already gotten
+          if api_fetchers.size <= 1
+            # can't do this when there are multiple fetchers because then we might not fetch from _all_
+            # of them
+            unmet_dependency_names -= remote_specs.spec_names # avoid re-fetching things we've already gotten
+          end
           return if unmet_dependency_names.empty?
         end
 

--- a/lib/bundler/spec_set.rb
+++ b/lib/bundler/spec_set.rb
@@ -110,9 +110,10 @@ module Bundler
 
     def merge(set)
       arr = sorted.dup
-      set.each do |s|
-        next if arr.any? {|s2| s2.name == s.name && s2.version == s.version && s2.platform == s.platform }
-        arr << s
+      set.each do |set_spec|
+        full_name = set_spec.full_name
+        next if arr.any? {|spec| spec.full_name == full_name }
+        arr << set_spec
       end
       SpecSet.new(arr)
     end

--- a/spec/install/gems/dependency_api_spec.rb
+++ b/spec/install/gems/dependency_api_spec.rb
@@ -368,7 +368,7 @@ RSpec.describe "gemcutter's dependency API" do
 
     bundle :install, :artifice => "endpoint_extra"
 
-    expect(out).to include("Fetching gem metadata from http://localgemserver.test/..")
+    expect(out).to include("Fetching gem metadata from http://localgemserver.test/.")
     expect(out).to include("Fetching source index from http://localgemserver.test/extra")
   end
 

--- a/spec/install/gems/dependency_api_spec.rb
+++ b/spec/install/gems/dependency_api_spec.rb
@@ -320,7 +320,7 @@ RSpec.describe "gemcutter's dependency API" do
       gem 'somegem', '1.0.0'
     G
 
-    bundle :install, :artifice => "endpoint_extra_api"
+    bundle! :install, :artifice => "endpoint_extra_api"
 
     expect(the_bundle).to include_gems "somegem 1.0.0"
     expect(the_bundle).to include_gems "activesupport 1.2.3"

--- a/spec/support/artifice/endpoint.rb
+++ b/spec/support/artifice/endpoint.rb
@@ -8,10 +8,36 @@ $LOAD_PATH.unshift(*Dir[Spec::Path.base_system_gems.join("gems/{artifice,rack,ti
 require "artifice"
 require "sinatra/base"
 
+ALL_REQUESTS = [] # rubocop:disable Style/MutableConstant
+ALL_REQUESTS_MUTEX = Mutex.new
+
+at_exit do
+  if expected = ENV["BUNDLER_SPEC_ALL_REQUESTS"]
+    expected = expected.split("\n").sort
+    actual = ALL_REQUESTS.sort
+
+    unless expected == actual
+      raise "Unexpected requests!\nExpected:\n\t#{expected.join("\n\t")}\n\nActual:\n\t#{actual.join("\n\t")}"
+    end
+  end
+end
+
 class Endpoint < Sinatra::Base
+  def self.all_requests
+    @all_requests ||= []
+  end
+
   GEM_REPO = Pathname.new(ENV["BUNDLER_SPEC_GEM_REPO"] || Spec::Path.gem_repo1)
   set :raise_errors, true
   set :show_exceptions, false
+
+  def call!(*)
+    super.tap do
+      ALL_REQUESTS_MUTEX.synchronize do
+        ALL_REQUESTS << @request.url
+      end
+    end
+  end
 
   helpers do
     def dependencies_for(gem_names, gem_repo = GEM_REPO)


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was installing `source "https://rubygems.org"; gem "rack"` could cause bundler to make requests for _hundreds_ of specs, drastically slowing down installation. This was a regression in 1.16 caused by the new source pinning logic.

### What was your diagnosis of the problem?

My diagnosis was the "double checking" step of creating the definition's index was accidentally saying Bundler needed to download specs for _every gem installed_, along with their dependencies _for every version in existence_.

### What is your fix for the problem, implemented in this PR?

My fix narrows down the set of names that need to be double-checked for to (a) only those that could possibly be needed for resolution (b) and only those specs that could possibly come from many sources (i.e. are "unpinned")

### Why did you choose this fix out of the possible options?

I chose this fix because it takes that `rack` gemfile back down to __2__ requests: `/versions` and `/info/rack`, as it should be, while maintaining proper searching for back-deps.