### PR TITLE
Allow user to override ~/.bundle with environment variables

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -193,19 +193,19 @@ module Bundler
       raise e.exception("#{warning}\nBundler also failed to create a temporary home directory at `#{path}':\n#{e}")
     end
 
-    def user_bundle_path(dir="home")
+    def user_bundle_path(dir = "home")
       env_var, fallback = case dir
-                when "home"
-                  ["BUNDLE_USER_HOME", Pathname.new(user_home).join(".bundle")]
-                when "cache"
-                  ["BUNDLE_USER_CACHE", user_bundle_path.join("cache")]
-                when "config"
-                  ["BUNDLE_USER_CONFIG", user_bundle_path.join("config")]
-                when "plugin"
-                  ["BUNDLE_USER_PLUGIN", user_bundle_path.join("plugin")]
-                else
-                  raise BundlerError, "Unknown user path requested: #{dir}"
-                end
+                          when "home"
+                            ["BUNDLE_USER_HOME", Pathname.new(user_home).join(".bundle")]
+                          when "cache"
+                            ["BUNDLE_USER_CACHE", user_bundle_path.join("cache")]
+                          when "config"
+                            ["BUNDLE_USER_CONFIG", user_bundle_path.join("config")]
+                          when "plugin"
+                            ["BUNDLE_USER_PLUGIN", user_bundle_path.join("plugin")]
+                          else
+                            raise BundlerError, "Unknown user path requested: #{dir}"
+                          end
       # `fallback` will already be a Pathname, but Pathname.new() is
       # idempotent so it's OK
       Pathname.new(ENV.fetch(env_var, fallback))

--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -193,8 +193,25 @@ module Bundler
       raise e.exception("#{warning}\nBundler also failed to create a temporary home directory at `#{path}':\n#{e}")
     end
 
-    def user_bundle_path
+    def user_bundle_path_default
       Pathname.new(user_home).join(".bundle")
+    end
+
+    def user_bundle_path(dir="home")
+      # if "home", user_bundle_path_default
+      env_var, fallback = case dir
+                when "home"
+                  ["BUNDLE_USER_HOME", user_bundle_path_default]
+                when "cache"
+                  ["BUNDLE_USER_CACHE", user_bundle_path.join("cache")]
+                when "config"
+                  ["BUNDLE_USER_CONFIG", user_bundle_path.join("config")]
+                when "plugin"
+                  ["BUNDLE_USER_PLUGIN", user_bundle_path.join("plugin")]
+                else
+                  nil
+                end
+      ENV.fetch(env_var, fallback)
     end
 
     def home
@@ -210,7 +227,7 @@ module Bundler
     end
 
     def user_cache
-      user_bundle_path.join("cache")
+      user_bundle_path("cache")
     end
 
     def root

--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -205,7 +205,7 @@ module Bundler
                             ["BUNDLE_USER_PLUGIN", user_bundle_path.join("plugin")]
                           else
                             raise BundlerError, "Unknown user path requested: #{dir}"
-                          end
+      end
       # `fallback` will already be a Pathname, but Pathname.new() is
       # idempotent so it's OK
       Pathname.new(ENV.fetch(env_var, fallback))

--- a/lib/bundler/plugin.rb
+++ b/lib/bundler/plugin.rb
@@ -80,8 +80,8 @@ module Bundler
 
     # The directory root for all plugin related data
     #
-    # Points to root in app_config_path if ran in an app else points to the one
-    # in user_bundle_path
+    # If run in an app, points to local root, in app_config_path
+    # Otherwise, points to global root, in Bundler.user_bundle_path("plugin")
     def root
       @root ||= if SharedHelpers.in_bundle?
         local_root
@@ -96,7 +96,7 @@ module Bundler
 
     # The global directory root for all plugin related data
     def global_root
-      Bundler.user_bundle_path.join("plugin")
+      Bundler.user_bundle_path("plugin")
     end
 
     # The cache directory for plugin stuffs

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -392,7 +392,7 @@ module Bundler
         Pathname.new(ENV["BUNDLE_CONFIG"])
       else
         begin
-          Bundler.user_bundle_path.join("config")
+          Bundler.user_bundle_path("config")
         rescue PermissionError, GenericSystemCallError
           nil
         end

--- a/spec/bundler/bundler_spec.rb
+++ b/spec/bundler/bundler_spec.rb
@@ -283,7 +283,6 @@ EOF
         expect(Bundler.user_bundle_path("config")).to eq(bundle_user_config_custom)
         expect(Bundler.user_bundle_path("plugin")).to eq(bundle_user_plugin_custom)
       end
-
     end
   end
 end

--- a/spec/bundler/bundler_spec.rb
+++ b/spec/bundler/bundler_spec.rb
@@ -227,4 +227,58 @@ EOF
       expect(Bundler.tmp_home_path("USER", "")).to eq(Pathname("/TMP/bundler/home/USER"))
     end
   end
+
+  context "user cache dir" do
+    let(:home_path)         { ENV.fetch "HOME" }
+    let(:bundle_user_cache_default) { "#{home_path}/.cache" }
+    let(:bundle_user_cache_custom)  { "#{home_path}/User/cache" }
+    let(:fallback_dir)      { "#{bundle_user_cache_default}/bundler" }
+    let(:cache_dir)         { "#{bundle_user_cache_custom}/bundler" }
+    let(:legacy_cache_dir)  { "#{home_path}/.bundle/cache" }
+
+    describe "#bundle_user_path_config" do
+      before do
+        allow(Bundler.rubygems).to receive(:user_home).and_return(home_path)
+        allow(File).to receive(:writable?).with(home_path).and_return(true)
+        allow(File).to receive(:directory?).with(home_path).and_return(true)
+        allow(File).to receive(:directory?).with(fallback_dir).and_return(true)
+        allow(File).to receive(:directory?).with(cache_dir).and_return(true)
+      end
+
+      it "should use the value of BUNDLE_USER_CACHE_HOME" do
+        ENV["BUNDLE_USER_CACHE_HOME"] = bundle_user_cache_custom
+        expect(Bundler.bundle_user_home("CACHE", fallback_dir)).to eq(Pathname(cache_dir))
+      end
+
+      it "should fall back to the alternative directory" do
+        expect(Bundler.bundle_user_home("CACHE", bundle_user_cache_default)).to eq(Pathname(fallback_dir))
+      end
+    end
+
+    describe "#user_cache" do
+      before do
+        allow(Bundler.rubygems).to receive(:user_home).and_return(home_path)
+        allow(File).to receive(:writable?).with(home_path).and_return(true)
+        allow(File).to receive(:directory?).with(home_path).and_return(true)
+      end
+
+      it "should use ~/.bundle/cache if it exists" do
+        allow(FileTest).to receive(:exist?).with(legacy_cache_dir).and_return(true)
+        expect(Bundler.user_cache).to eq(Pathname(legacy_cache_dir))
+      end
+
+      it "should use BUNDLE_USER_CACHE_HOME if set" do
+        allow(FileTest).to receive(:exist?).with(legacy_cache_dir).and_return(false)
+        allow(FileTest).to receive(:exist?).with(cache_dir).and_return(true)
+        ENV["BUNDLE_USER_CACHE_HOME"] = bundle_user_cache_custom
+        expect(Bundler.user_cache).to eq(Pathname(cache_dir))
+      end
+
+      it "should use ~/.cache/bundler as default cache path" do
+        allow(FileTest).to receive(:exist?).with(legacy_cache_dir).and_return(false)
+        allow(FileTest).to receive(:exist?).with(fallback_dir).and_return(true)
+        expect(Bundler.user_cache).to eq(Pathname(fallback_dir))
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

As in #4333, users wanted a way to make Bundler respect the XDG specification.

### What was your diagnosis of the problem?

The directory `~/.bundle` was hard-coded and could not be configured.

### What is your fix for the problem, implemented in this PR?

Allow users to configure `~/.bundle` and its relevant sub-directories by setting environment variables. The environment variables and their fallbacks are as follows:

| variable | fallback if unset |
|---|---|
| `BUNDLE_USER_HOME` | `$HOME/.bundle` |
| `BUNDLE_USER_CACHE`  | `$BUNDLE_USER_HOME/cache` |
| `BUNDLE_USER_CONFIG` | `$BUNDLE_USER_HOME/config` |
| `BUNDLE_USER_PLUGIN` | `$BUNDLE_USER_HOME/plugin` |

### Why did you choose this fix out of the possible options?

Unlike https://github.com/bundler/bundler/pull/5787, This solution is not specific to the XDG specification. Users have all kinds of setups, and this is a very general system for allowing them to configure their development machines however they need. It tries to keep all files created by Bundler in the same place (as per https://github.com/bundler/bundler/pull/5787#issuecomment-310154273), but allows the user to override that convention _if they really want to and they know what they are doing_.

If they want to use XDG for everything, they can do it by explicitly setting the `BUNDLE_USER_*` variables to the equivalent `XDG_DATA_*`. If they just want to get `.bundle` out of their home directory, they can do it by setting `BUNDLE_USER_HOME` and don't have to mess with the more specific env variables if they don't want to.

To me, this solution strikes the right balance between "fine-grained control for power users" and "simple, sane defaults for everyone else".

Please let me know if my tests can be improved. My only Ruby experience so far has been writing Homebrew formulas and configuring Jekyll, so I'm sure I have a lot to learn.