### PR TITLE
Avoid warning for stubbing `nil`

### DIFF
--- a/spec/bundler/vendored_persistent_spec.rb
+++ b/spec/bundler/vendored_persistent_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Bundler::PersistentHTTP do
 
     before do
       allow(connection).to receive(:use_ssl?).and_return(!tls_version.nil?)
-      allow(socket).to receive(:io).and_return(socket_io)
+      allow(socket).to receive(:io).and_return(socket_io) if socket
       connection.instance_variable_set(:@socket, socket)
 
       if tls_version


### PR DESCRIPTION
since we now test what happens if `socket` is `nil`, and `rspec-mocks` warns when we do that