### PR TITLE
[CLI] Switch around the --strict option for bundle outdated

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -350,9 +350,10 @@ module Bundler
       "Do not attempt to fetch gems remotely and use the gem cache instead"
     method_option "pre", :type => :boolean, :banner => "Check for newer pre-release gems"
     method_option "source", :type => :array, :banner => "Check against a specific source"
-    method_option "strict", :type => :boolean, :banner =>
+    strict_is_update = Bundler.feature_flag.forget_cli_options?
+    method_option "filter-strict", :type => :boolean, :aliases => strict_is_update ? [] : %w[--strict], :banner =>
       "Only list newer versions allowed by your Gemfile requirements"
-    method_option "update-strict", :type => :boolean, :banner =>
+    method_option "update-strict", :type => :boolean, :aliases => strict_is_update ? %w[--strict] : [], :banner =>
       "Strict conservative resolution, do not allow any gem to be updated past latest --patch | --minor | --major"
     method_option "minor", :type => :boolean, :banner => "Prefer updating only to next minor version"
     method_option "major", :type => :boolean, :banner => "Prefer updating to next major version (default)"

--- a/lib/bundler/cli/common.rb
+++ b/lib/bundler/cli/common.rb
@@ -83,7 +83,7 @@ module Bundler
       raise InvalidOption, "Provide only one of the following options: #{patch_level.join(", ")}" unless patch_level.length <= 1
       definition.gem_version_promoter.tap do |gvp|
         gvp.level = patch_level.first || :major
-        gvp.strict = options[:strict] || options["update-strict"]
+        gvp.strict = options[:strict] || options["update-strict"] || options["filter-strict"]
       end
     end
 

--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -41,7 +41,7 @@ module Bundler
 
       # the patch level options imply strict is also true. It wouldn't make
       # sense otherwise.
-      strict = options[:strict] ||
+      strict = options["filter-strict"] ||
         Bundler::CLI::Common.patch_level_options(options).any?
 
       filter_options_patch = options.keys &

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -302,14 +302,15 @@ RSpec.describe "bundle outdated" do
     end
   end
 
-  describe "with --strict option" do
+  filter_strict_option = Bundler.feature_flag.bundler_2_mode? ? :"filter-strict" : :strict
+  describe "with --#{filter_strict_option} option" do
     it "only reports gems that have a newer version that matches the specified dependency version requirements" do
       update_repo2 do
         build_gem "activesupport", "3.0"
         build_gem "weakling", "0.0.5"
       end
 
-      bundle "outdated --strict"
+      bundle :outdated, filter_strict_option => true
 
       expect(out).to_not include("activesupport (newest")
       expect(out).to include("(newest 0.0.5, installed 0.0.3, requested ~> 0.0.1)")
@@ -321,7 +322,7 @@ RSpec.describe "bundle outdated" do
         gem "rack_middleware", "1.0"
       G
 
-      bundle "outdated --strict"
+      bundle :outdated, filter_strict_option => true
 
       expect(out).to_not include("rack (1.2")
     end
@@ -339,7 +340,7 @@ RSpec.describe "bundle outdated" do
           build_gem "weakling", "0.0.5"
         end
 
-        bundle "outdated --strict --filter-patch"
+        bundle :outdated, filter_strict_option => true, "filter-patch" => true
 
         expect(out).to_not include("activesupport (newest")
         expect(out).to include("(newest 0.0.5, installed 0.0.3")
@@ -357,7 +358,7 @@ RSpec.describe "bundle outdated" do
           build_gem "weakling", "0.1.5"
         end
 
-        bundle "outdated --strict --filter-minor"
+        bundle :outdated, filter_strict_option => true, "filter-minor" => true
 
         expect(out).to_not include("activesupport (newest")
         expect(out).to include("(newest 0.1.5, installed 0.0.3")
@@ -375,7 +376,7 @@ RSpec.describe "bundle outdated" do
           build_gem "weakling", "1.1.5"
         end
 
-        bundle "outdated --strict --filter-major"
+        bundle :outdated, filter_strict_option => true, "filter-major" => true
 
         expect(out).to_not include("activesupport (newest")
         expect(out).to include("(newest 1.1.5, installed 0.0.3")


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was

> outdated would be more consistent to change --strict to --filter-strict and --update-strict to --strict

### What was your diagnosis of the problem?

My diagnosis was

> let's rename --strict to --filter-strict and rename the current --update-strict to --strict. In another ticket, later, we can expand the way outdated works to not need as many flags to show the relevant info

### What is your fix for the problem, implemented in this PR?

My fix switches around the options, by just making `--strict` an alias that means something different on 2.0 than on 1.0

### Why did you choose this fix out of the possible options?

I chose this fix because it allowed keeping temporary 1.x compatibility, versus wholesale renaming of the option.