### PR TITLE
[CLI] For now, disable the new version warning by default

### DIFF
--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -73,6 +73,7 @@ module Bundler
     ].freeze
 
     DEFAULT_CONFIG = {
+      :disable_version_check => true,
       :redirect => 5,
       :retry => 3,
       :timeout => 10,

--- a/spec/bundler/cli_spec.rb
+++ b/spec/bundler/cli_spec.rb
@@ -96,6 +96,8 @@ RSpec.describe "bundle executable" do
     let(:bundler_version) { "1.1" }
     let(:latest_version) { nil }
     before do
+      bundle! "config --global disable_version_check false"
+
       simulate_bundler_version(bundler_version)
       if latest_version
         info_path = home(".bundle/cache/compact_index/rubygems.org.443.29b0360b937aa4d161703e6160654e47/info/bundler")


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was people were getting confused by the terseness and bluntness of the current outdated bundler version warning.

### What was your diagnosis of the problem?

My diagnosis was we need to spend time fine-tuning the message, including when it is displayed. But given the lack of time to do so immediately, I thought it best to disable the warning for now, until someone can make a PR that addresses the comments and concerns raised in #6004.