### PR TITLE
Pass gemspec directory path to Git

### DIFF
--- a/bundler.gemspec
+++ b/bundler.gemspec
@@ -4,6 +4,7 @@
 lib = File.expand_path("../lib/", __FILE__)
 $:.unshift lib unless $:.include?(lib)
 require "bundler/version"
+require "shellwords"
 
 Gem::Specification.new do |s|
   s.name        = "bundler"
@@ -43,7 +44,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency "ronn",       "~> 0.7.3"
   s.add_development_dependency "rspec",      "~> 3.6"
 
-  s.files = `git ls-files -z`.split("\x0").select {|f| f.match(%r{^(lib|exe)/}) }
+  s.files = `git -C #{Shellwords.escape File.dirname(__FILE__)} ls-files -z`.split("\x0").select {|f| f.match(%r{^(lib|exe)/}) }
+
   # we don't check in man pages, but we need to ship them because
   # we use them to generate the long-form help for each command.
   s.files += Dir.glob("man/**/*")


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was...
- This WIP PR tries to solve Issue #6029 
- When running commands like `dbundle -v` as described in [SETUP.md](https://github.com/bundler/bundler/blob/master/doc/development/SETUP.md#development-setup), commands give us a git error.
### What was your diagnosis of the problem?
- Like stated in Issue #6029, the git option `-C` should be used to pass the directory containing the gemspec file to the git command.

My diagnosis was...
- to give git the correct directory path where the gemspec file is

### What is your fix for the problem, implemented in this PR?
My fix...
- I'm wondering if I'm on the right track with this? 
- So, I ran `bin/rspec /spec/install/gemfile/gemspec_spec` and the specs passed. I then run the entire test suite and the `gemspec_spec` and a few other specs fail throughout the test suite. 
Then, I re-ran the failing specs files individually-- both as a whole, as well as on the failing lines, and yet they're green. I'm assuming I'll similarly get failing specs on Travis. I'm not really familiar with how to troubleshoot test suites with test pollution. 
- Could folks point me in the right direction? Any help would be much appreciated!

### Why did you choose this fix out of the possible options?

I chose this fix because...
- I chose to `require "pathname"`because I found it more intuitive to manipulate file paths with that library.