### PR TITLE
enable rspec --profiling option

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -2,3 +2,4 @@
 --color
 --warnings
 --require spec_helper
+--profile


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Test is too slow to run at local. It's pain.

### What is your fix for the problem, implemented in this PR?

My fix is for profiling test at local by default.
if it enable this, 

```
Top 10 slowest examples (34.13 seconds, 3.2% of total time):
  bundle install with git sources git sources that include credentials that are username and password does not display the password
    4.09 seconds ./spec/install/gemfile/git_spec.rb:1322
  compact index api does not fetch every spec if the index of gems is large when doing back deps & everything is the compact index
    3.86 seconds ./spec/install/gems/compact_index_spec.rb:426
  bundle install with git sources git sources that include credentials that is an oauth token displays the oauth scheme but not the oauth token
    3.74 seconds ./spec/install/gemfile/git_spec.rb:1338
  compact index api does not fetch every spec if the index of gems is large when doing back deps
    3.54 seconds ./spec/install/gems/compact_index_spec.rb:401
  gemcutter's dependency API does not fetch every spec if the index of gems is large when doing back deps using blocks
    3.48 seconds ./spec/install/gems/dependency_api_spec.rb:399
  global gem caching using the cross-application user cache when installing gems from a different directory uses the global cache as a source
    3.32 seconds ./spec/install/global_cache_spec.rb:136
  bundle exec nested bundle exec with a system gem that shadows a default gem only leaves the default gem in the stdlib available
    3.32 seconds ./spec/commands/exec_spec.rb:736
  .bundle/config subcommands unset
    2.96 seconds ./spec/commands/config_spec.rb:411
  global gem caching using the cross-application user cache when the same gem from different sources is installed should use the appropriate one from the global cache
    2.92 seconds ./spec/install/global_cache_spec.rb:41
  global gem caching using the cross-application user cache when the same gem from different sources is installed should not install if the wrong source is provided
    2.89 seconds ./spec/install/global_cache_spec.rb:84
Top 10 slowest example groups:
  global gem caching
    2.06 seconds average (12.35 seconds / 6 examples) ./spec/install/global_cache_spec.rb:3
  bundle pristine
    1.45 seconds average (14.46 seconds / 10 examples) ./spec/commands/pristine_spec.rb:5
  bundle outdated
    1.34 seconds average (77.68 seconds / 58 examples) ./spec/commands/outdated_spec.rb:3
  process lock spec
    1.31 seconds average (1.31 seconds / 1 example) ./spec/install/process_lock_spec.rb:3
  bundle install with :allow_offline_install
    1.26 seconds average (5.03 seconds / 4 examples) ./spec/install/allow_offline_install_spec.rb:3
  bundle package with git
    1.24 seconds average (11.15 seconds / 9 examples) ./spec/cache/git_spec.rb:16
  bundle update conservative
    1.18 seconds average (11.84 seconds / 10 examples) ./spec/commands/update_spec.rb:655
  bundle cache with git
    1.18 seconds average (10.6 seconds / 9 examples) ./spec/cache/git_spec.rb:16
  bundle cache
    1.18 seconds average (34.12 seconds / 29 examples) ./spec/cache/gems_spec.rb:3
  bundle update in more complicated situations
    1.16 seconds average (3.49 seconds / 3 examples) ./spec/commands/update_spec.rb:353
Finished in 18 minutes 3 seconds (files took 1.12 seconds to load)
```

is added on test result.
