### PR TITLE
update rubygems to v2.6.13

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -80,7 +80,7 @@ namespace :spec do
       sh "sudo apt-get install graphviz -y 2>&1 | tail -n 2"
 
       # Install the gems with a consistent version of RubyGems
-      sh "gem update --system 2.6.12"
+      sh "gem update --system 2.6.13"
 
       $LOAD_PATH.unshift("./spec")
       require "support/rubygems_ext"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

rubygems v2.6.12 has important security issues.
So, It's better to update v2.6.13 to rubygems.
http://blog.rubygems.org/2017/08/27/2.6.13-released.html