### PR TITLE
use rubocop --parallel option

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -105,7 +105,8 @@ begin
     # can't go in the gemspec because of the ruby version requirement
     gem "rubocop", "= 0.50.0"
     require "rubocop/rake_task"
-    RuboCop::RakeTask.new
+    rubocop = RuboCop::RakeTask.new
+    rubocop.options = ["--parallel"]
   end
 
   namespace :spec do


### PR DESCRIPTION
### What was the end-user problem that led to this PR?
No

### What is your fix for the problem, implemented in this PR?

My fix enable rubocop's parallel option.
This may improve rubocop's test time.