### PR TITLE
Update newgem README.md template for Bundler 2

### DIFF
--- a/lib/bundler/templates/newgem/README.md.tt
+++ b/lib/bundler/templates/newgem/README.md.tt
@@ -14,7 +14,7 @@ gem '<%= config[:name] %>'
 
 And then execute:
 
-    $ bundle
+    $ bundle install
 
 Or install it yourself as:
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

`bundle` command has been changed to display list of commands with Bundle 2.

```console
% bundle
Bundler version 2.0.0.dev (2017-09-29 commit 5e9c40aa1)

Bundler commands:

  Primary commands:
    bundle install [OPTIONS]    # Install the current environment to the system
    bundle update [OPTIONS]     # Update the current environment
    bundle cache [OPTIONS]      # Locks and then caches all of the gems into vendor/cache
    bundle exec [OPTIONS]       # Run the command in context of the bundle
    bundle config NAME [VALUE]  # Retrieve or set a configuration value
    bundle help [COMMAND]       # Describe available commands or one specific command
(snip)
```

Therefore, it can not be installed with `bundle` command written in README.md created by `bundle gem`.

### What was your diagnosis of the problem?

It is the same as above.

### What is your fix for the problem, implemented in this PR?

I think that it is better to write `bundle install` in the README template of `bundle gem`.