### PR TITLE
Fix uninitialised constant Gem::ConfigFile::SYSTEM_CONFIG_PATH

### DIFF
--- a/lib/bundler/env.rb
+++ b/lib/bundler/env.rb
@@ -104,7 +104,7 @@ module Bundler
       out << ["  Platforms", Gem.platforms.join(", ")]
       out << ["Ruby", ruby_version]
       out << ["  Full Path", Gem.ruby]
-      out << ["  Config Dir", Gem::ConfigFile::SYSTEM_CONFIG_PATH]
+      out << ["  Config Dir", Pathname.new(Gem::ConfigFile::SYSTEM_WIDE_CONFIG_FILE).dirname]
       out << ["RubyGems", Gem::VERSION]
       out << ["  Gem Home", ENV.fetch("GEM_HOME") { Gem.dir }]
       out << ["  Gem Path", ENV.fetch("GEM_PATH") { Gem.path.join(File::PATH_SEPARATOR) }]


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

`bundle env` uses the constant `Gem::ConfigFile::SYSTEM_CONFIG_PATH` which is not defined in early versions of RubyGems.

See: https://travis-ci.org/bundler/bundler/builds/276981165

### What is your fix for the problem, implemented in this PR?

While `SYSTEM_CONFIG_PATH` is not defined for earlier versions of RubyGems, a constant called `Gem::ConfigFile::SYSTEM_WIDE_CONFIG_FILE` does appear to be both in current and early versions of RubyGems which contains the path (plus the ruby config file) we want.

### Why did you choose this fix out of the possible options?

This fix is compatible with all the tested versions of RubyGems in CI and is not overly complex.
