### PR TITLE
Don't suggest upgrading to prerelease versions

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -724,6 +724,7 @@ module Bundler
                instance_variable_get(:@cache).
                dependencies("bundler").
                map {|d| Gem::Version.new(d.first) }.
+               reject(&:prerelease?).
                max
       return unless latest
 

--- a/spec/bundler/cli_spec.rb
+++ b/spec/bundler/cli_spec.rb
@@ -147,13 +147,8 @@ To install the latest version, run `gem install bundler`
 
       context "and is a pre-release" do
         let(:latest_version) { "222.0.0.pre.4" }
-        it "prints the version warning" do
-          bundle "fail"
-          expect(last_command.stdout).to start_with(<<-EOS.strip)
-The latest bundler is #{latest_version}, but you are currently running #{bundler_version}.
-To install the latest version, run `gem install bundler --pre`
-          EOS
-        end
+
+        include_examples "no warning"
       end
     end
   end


### PR DESCRIPTION
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was that people on my team are reluctant to upgrade to a pre-release version of bundler due to fears about bugs, breaking changes, etc.

Teams may be reluctant to upgrade to pre-release versions and printing a warning message about a prerelease version each time `bundle install` is run is a little misleading if the team is on the latest stable version of Bundler.

### What was your diagnosis of the problem?

My diagnosis was that Bundler is including pre-release versions in its check for the current maximum version of Bundler.

### What is your fix for the problem, implemented in this PR?

My fix is to not include pre-release versions in the version check.

### Why did you choose this fix out of the possible options?

I chose this fix (versus `bundle config disable_version_check true`)  because I believe that this problem probably affects other teams as well.
