### PR TITLE
Rename `-rubygems` option.

### DIFF
--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -213,7 +213,7 @@ module Spec
         args = args.gsub(/(?=")/, "\\")
         args = %("#{args}")
       end
-      sys_exec("#{Gem.ruby} -rubygems -S gem --backtrace #{command} #{args}")
+      sys_exec("#{Gem.ruby} -rrubygems -S gem --backtrace #{command} #{args}")
     end
     bang :gem_command
 


### PR DESCRIPTION
 It only needs with Ruby 1.8 and Ruby 2.5 will remove it.

This commit picked r60125 from ruby/ruby: https://github.com/ruby/ruby/commit/9de6c712b66aad77df40661c1fc6d37e9a5c251a