### PR TITLE
Fix bundler update instructions in TROUBLESHOOTING

### DIFF
--- a/doc/TROUBLESHOOTING.md
+++ b/doc/TROUBLESHOOTING.md
@@ -42,7 +42,7 @@ list](http://bundler.io/compatibility.html), and make sure that the version of B
 If these instructions don't work, or you can't find any appropriate instructions, you can try these troubleshooting steps:
 
     # Update to the latest version of bundler
-    `gem install bundler`
+    gem install bundler
 
     # Remove user-specific gems and git repos
     rm -rf ~/.bundle/ ~/.gem/bundler/ ~/.gems/cache/bundler/


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Doing the previous command from the TROUBLESHOOTING guide returns an error:

```sh
$ `gem update bundler`
zsh: command not found: Updating
```

### What is your fix for the problem, implemented in this PR?

Removing both ``` ` ``` in the documentation.