### PR TITLE
update rubygems to v2.6.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,9 @@ matrix:
     # 1.x mode (we want to keep stuff passing in 1.x mode for now)
     - rvm: 2.4.2
       env: RGV=v2.6.14 BUNDLER_SPEC_SUB_VERSION=1.98
+    # RGV 2.6.13 is the final version that run with ruby1.8.x
     - rvm: 1.8.7
-      env: RGV=v2.6.14 BUNDLER_SPEC_SUB_VERSION=1.98
+      env: RGV=v2.6.13 BUNDLER_SPEC_SUB_VERSION=1.98
 
   allow_failures:
     - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ env:
   # We need to know if changes to rubygems will break bundler on release
   - RGV=master
   # Test the latest rubygems release with all of our supported rubies
-  - RGV=v2.6.13
+  - RGV=v2.6.14
 
 matrix:
   include:
@@ -48,9 +48,9 @@ matrix:
       env: RGV=master
     # 1.x mode (we want to keep stuff passing in 1.x mode for now)
     - rvm: 2.4.2
-      env: RGV=v2.6.13 BUNDLER_SPEC_SUB_VERSION=1.98
+      env: RGV=v2.6.14 BUNDLER_SPEC_SUB_VERSION=1.98
     - rvm: 1.8.7
-      env: RGV=v2.6.13 BUNDLER_SPEC_SUB_VERSION=1.98
+      env: RGV=v2.6.14 BUNDLER_SPEC_SUB_VERSION=1.98
 
   allow_failures:
     - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,9 +49,8 @@ matrix:
     # 1.x mode (we want to keep stuff passing in 1.x mode for now)
     - rvm: 2.4.2
       env: RGV=v2.6.14 BUNDLER_SPEC_SUB_VERSION=1.98
-    # RGV 2.6.13 is the final version that run with ruby1.8.x
     - rvm: 1.8.7
-      env: RGV=v2.6.13 BUNDLER_SPEC_SUB_VERSION=1.98
+      env: RGV=v2.6.14 BUNDLER_SPEC_SUB_VERSION=1.98
 
   allow_failures:
     - rvm: ruby-head

--- a/Rakefile
+++ b/Rakefile
@@ -80,7 +80,7 @@ namespace :spec do
       sh "sudo apt-get install graphviz -y 2>&1 | tail -n 2"
 
       # Install the gems with a consistent version of RubyGems
-      sh "gem update --system 2.6.13"
+      sh "gem update --system 2.6.14"
 
       $LOAD_PATH.unshift("./spec")
       require "support/rubygems_ext"
@@ -147,7 +147,7 @@ begin
       rubyopt = ENV["RUBYOPT"]
       # When editing this list, also edit .travis.yml!
       branches = %w[master]
-      releases = %w[v1.3.6 v1.3.7 v1.4.2 v1.5.3 v1.6.2 v1.7.2 v1.8.29 v2.0.14 v2.1.11 v2.2.5 v2.4.8 v2.5.2 v2.6.8 v2.6.13]
+      releases = %w[v1.3.6 v1.3.7 v1.4.2 v1.5.3 v1.6.2 v1.7.2 v1.8.29 v2.0.14 v2.1.11 v2.2.5 v2.4.8 v2.5.2 v2.6.8 v2.6.14]
       (branches + releases).each do |rg|
         desc "Run specs with RubyGems #{rg}"
         RSpec::Core::RakeTask.new(rg) do |t|

--- a/Rakefile
+++ b/Rakefile
@@ -147,7 +147,7 @@ begin
       rubyopt = ENV["RUBYOPT"]
       # When editing this list, also edit .travis.yml!
       branches = %w[master]
-      releases = %w[v1.3.6 v1.3.7 v1.4.2 v1.5.3 v1.6.2 v1.7.2 v1.8.29 v2.0.14 v2.1.11 v2.2.5 v2.4.8 v2.5.2 v2.6.8 v2.6.13 v2.6.14]
+      releases = %w[v1.3.6 v1.3.7 v1.4.2 v1.5.3 v1.6.2 v1.7.2 v1.8.29 v2.0.14 v2.1.11 v2.2.5 v2.4.8 v2.5.2 v2.6.8 v2.6.14]
       (branches + releases).each do |rg|
         desc "Run specs with RubyGems #{rg}"
         RSpec::Core::RakeTask.new(rg) do |t|

--- a/Rakefile
+++ b/Rakefile
@@ -147,7 +147,7 @@ begin
       rubyopt = ENV["RUBYOPT"]
       # When editing this list, also edit .travis.yml!
       branches = %w[master]
-      releases = %w[v1.3.6 v1.3.7 v1.4.2 v1.5.3 v1.6.2 v1.7.2 v1.8.29 v2.0.14 v2.1.11 v2.2.5 v2.4.8 v2.5.2 v2.6.8 v2.6.14]
+      releases = %w[v1.3.6 v1.3.7 v1.4.2 v1.5.3 v1.6.2 v1.7.2 v1.8.29 v2.0.14 v2.1.11 v2.2.5 v2.4.8 v2.5.2 v2.6.8 v2.6.13 v2.6.14]
       (branches + releases).each do |rg|
         desc "Run specs with RubyGems #{rg}"
         RSpec::Core::RakeTask.new(rg) do |t|


### PR DESCRIPTION
## What was the end-user problem that led to this PR?

rubygems v2.6.13 has important security issues.
So, It's better to update v2.6.14 to rubygems.

http://blog.rubygems.org/2017/10/09/2.6.14-released.html
