### PR TITLE
bundle exec via kernel load doesn't need to rescue exceptions

### DIFF
--- a/lib/bundler/cli/exec.rb
+++ b/lib/bundler/cli/exec.rb
@@ -73,13 +73,6 @@ module Bundler
       signals = Signal.list.keys - RESERVED_SIGNALS
       signals.each {|s| trap(s, "DEFAULT") }
       Kernel.load(file)
-    rescue SystemExit
-      raise
-    rescue Exception => e # rubocop:disable Lint/RescueException
-      Bundler.ui = ui
-      Bundler.ui.error "bundler: failed to load command: #{cmd} (#{file})"
-      backtrace = e.backtrace.take_while {|bt| !bt.start_with?(__FILE__) }
-      abort "#{e.class}: #{e.message}\n  #{backtrace.join("\n  ")}"
     end
 
     def process_title(file, args)


### PR DESCRIPTION
Make `bundle exec` via Kernel.load handle exceptions just like a
bundler binstub: Kernel::load is called and any exceptions raised are
allowed to bubble up and be handled in the default way by the ruby
interpreter.

### What was the end-user problem that led to this PR?

Fixes #6090 

### What was your diagnosis of the problem?

CLI::Exec#kernel_load should not rescue the SignalException

### What is your fix for the problem, implemented in this PR?

Remove rescue blocks in this function

### Why did you choose this fix out of the possible options?

An alternative would be to include SignalException  along with SystemExit to bypass the `rescue Exeption` block below.  However `bundle exec` with kernel load should really IMO, behave identically to a `bundle binstub` generated wrapper. These wrappers just call Kernel::load without any rescues.