### PR TITLE
Avoid bundle exec rescue of SignalException

### DIFF
--- a/lib/bundler/cli/exec.rb
+++ b/lib/bundler/cli/exec.rb
@@ -73,7 +73,7 @@ module Bundler
       signals = Signal.list.keys - RESERVED_SIGNALS
       signals.each {|s| trap(s, "DEFAULT") }
       Kernel.load(file)
-    rescue SystemExit
+    rescue SystemExit, SignalException
       raise
     rescue Exception => e # rubocop:disable Lint/RescueException
       Bundler.ui = ui

--- a/lib/bundler/friendly_errors.rb
+++ b/lib/bundler/friendly_errors.rb
@@ -120,6 +120,8 @@ module Bundler
 
   def self.with_friendly_errors
     yield
+  rescue SignalException
+    raise
   rescue Exception => e
     FriendlyErrors.log_error(e)
     exit FriendlyErrors.exit_status(e)

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -538,6 +538,26 @@ RSpec.describe "bundle exec" do
       end
     end
 
+    context "the executable exits by SignalException" do
+      let(:executable) do
+        ex = super()
+        ex << "\n"
+        if LessThanProc.with(RUBY_VERSION).call("1.9")
+          # Ruby < 1.9 needs a flush for a exit by signal, later
+          # rubies do not
+          ex << "STDOUT.flush\n"
+        end
+        ex << "raise SignalException, 'SIGTERM'\n"
+        ex
+      end
+      let(:exit_code) do
+        # signal mask 128 + plus signal 15 -> TERM
+        # this is specified by C99
+        128 + 15
+      end
+      it_behaves_like "it runs"
+    end
+
     context "the executable is empty", :bundler => "< 2" do
       let(:executable) { "" }
 


### PR DESCRIPTION
Avoid rescue of SignalException in kernel_load and with_friendly_errors This allows SignalException to be handled gracefully by the ruby interpreter.

This supersedes #6091.

### What was the end-user problem that led to this PR?

Fixes #6090

### What was your diagnosis of the problem?

CLI::Exec#kernel_load should not rescue the SignalException. Neither should with_friendly_errors, so it unwinds all the way to the ruby interpreter. 

### What is your fix for the problem, implemented in this PR?

Two rescue and re-raises specific to SignalException.

### Why did you choose this fix out of the possible options?

My first naive attempt was #6091, where I had missed the outer rescue in with_friendly_errors, all of the other special friendly error behavior, and the spec dependencies. While I still suspect that kernel_load and friendly_errors might be rescuing/handling more than they should (for comparison: binstub doesn't do this) this is a much more minimal, safer, and easier fix to #6090.