### PR TITLE
Fix doubled message in verbose mode

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -205,19 +205,18 @@ module Bundler
     end
 
     def missing_specs?
-      missing = []
-      resolve.materialize(requested_dependencies, missing)
+      missing = missing_specs
       return false if missing.empty?
       Bundler.ui.debug "The definition is missing #{missing.map(&:full_name)}"
       true
     rescue BundlerError => e
-      Bundler.ui.debug "The definition is missing dependencies, failed to resolve & materialize locally (#{e})"
-      true
-    ensure
       @index = nil
       @resolve = nil
       @specs = nil
       @gem_version_promoter = nil
+
+      Bundler.ui.debug "The definition is missing dependencies, failed to resolve & materialize locally (#{e})"
+      true
     end
 
     def requested_specs

--- a/spec/install/gemfile/gemspec_spec.rb
+++ b/spec/install/gemfile/gemspec_spec.rb
@@ -145,7 +145,9 @@ RSpec.describe "bundle install from an existing gemspec" do
     G
 
     bundle! "install", :verbose => true
-    expect(out).to include("Found no changes, using resolution from the lockfile")
+
+    message = "Found no changes, using resolution from the lockfile"
+    expect(out.scan(message).size).to eq(1)
   end
 
   it "should match a lockfile without needing to re-resolve with development dependencies" do
@@ -162,7 +164,9 @@ RSpec.describe "bundle install from an existing gemspec" do
     G
 
     bundle! "install", :verbose => true
-    expect(out).to include("Found no changes, using resolution from the lockfile")
+
+    message = "Found no changes, using resolution from the lockfile"
+    expect(out.scan(message).size).to eq(1)
   end
 
   it "should match a lockfile on non-ruby platforms with a transitive platform dependency" do


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was doubled informative message in verbose mode (#6028)

### What was your diagnosis of the problem?

`Bundler::Definition#missing_specs?` clears the `@resolve` ivar due to
the fact that `ensure` clause evaluates regardless whether exception
occurred. That results in repeated resolution, and, therefore, in
repeated debug messages.

### What is your fix for the problem, implemented in this PR?

This change moves ivars clearing into the `rescue` clause, so
`@resolve` will be cleared only in case when `BundlerError` occurs

### Why did you choose this fix out of the possible options?

I chose this fix because running deps resolution twice is a bad idea anyway and it needs to be prevented.

