### PR TITLE
Add a spec for installing git deps after packaging without git

### DIFF
--- a/spec/cache/git_spec.rb
+++ b/spec/cache/git_spec.rb
@@ -220,5 +220,22 @@ end
       gemspec = bundled_app("vendor/cache/foo-1.0-#{ref}/foo.gemspec").read
       expect(gemspec).to_not match("`echo bob`")
     end
+
+    it "can install after #{cmd} with git not installed" do
+      build_git "foo"
+
+      gemfile <<-G
+        gem "foo", :git => '#{lib_path("foo-1.0")}'
+      G
+      bundle! "config set cache_all true"
+      bundle! cmd, "all-platforms" => true, :install => false, :path => "./vendor/cache"
+
+      simulate_new_machine
+      with_path_as "" do
+        bundle! "config set deployment true"
+        bundle! :install, :local => true
+        expect(the_bundle).to include_gem "foo 1.0"
+      end
+    end
   end
 end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was v1.15 seemed to break installing without git when the git deps had already been packaged (see https://github.com/bundler/bundler/issues/6066).

### What was your diagnosis of the problem?

My diagnosis was we actually seemed to have fixed this for 1.16.

### What is your fix for the problem, implemented in this PR?

My fix adds a test to ensure we won't regress.