### PR TITLE
[Package] Always resolve remotely for --all-platforms

### DIFF
--- a/lib/bundler/cli/package.rb
+++ b/lib/bundler/cli/package.rb
@@ -27,10 +27,7 @@ module Bundler
     def install
       require_relative "install"
       options = self.options.dup
-      if Bundler.settings[:cache_all_platforms]
-        options["local"] = false
-        options["update"] = true
-      end
+      options["local"] = false if Bundler.settings[:cache_all_platforms]
       Bundler::CLI::Install.new(options).run
     end
 

--- a/lib/bundler/cli/package.rb
+++ b/lib/bundler/cli/package.rb
@@ -11,7 +11,6 @@ module Bundler
     def run
       Bundler.ui.level = "error" if options[:quiet]
       Bundler.settings.set_command_option_if_given :path, options[:path]
-      Bundler.settings.set_command_option_if_given :cache_all_platforms, options["all-platforms"]
       Bundler.settings.set_command_option_if_given :cache_path, options["cache-path"]
 
       setup_cache_all
@@ -19,7 +18,10 @@ module Bundler
 
       # TODO: move cache contents here now that all bundles are locked
       custom_path = Bundler.settings[:path] if options[:path]
-      Bundler.load.cache(custom_path)
+
+      Bundler.settings.temporary(:cache_all_platforms => options["all-platforms"]) do
+        Bundler.load.cache(custom_path)
+      end
     end
 
   private

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -167,7 +167,7 @@ module Bundler
     def specs
       @specs ||= begin
         begin
-          specs = resolve.materialize(Bundler.settings[:cache_all_platforms] ? dependencies : requested_dependencies)
+          specs = resolve.materialize(requested_dependencies)
         rescue GemNotFound => e # Handle yanked gem
           gem_name, gem_version = extract_gem_info(e)
           locked_gem = @locked_specs[gem_name].last

--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -296,7 +296,7 @@ module Bundler
 
     # returns whether or not a re-resolve was needed
     def resolve_if_needed(options)
-      if !@definition.unlocking? && !options["force"] && !Bundler.settings[:inline] && Bundler.default_lockfile.file?
+      if !@definition.unlocking? && !options["force"] && !options["all-platforms"] && !Bundler.settings[:inline] && Bundler.default_lockfile.file?
         return false if @definition.nothing_changed? && !@definition.missing_specs?
       end
 

--- a/spec/commands/package_spec.rb
+++ b/spec/commands/package_spec.rb
@@ -203,6 +203,25 @@ RSpec.describe "bundle package" do
       bundle "package --all-platforms"
       expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
     end
+
+    it "does not attempt to install gems in without groups" do
+      install_gemfile! <<-G, forgotten_command_line_options(:without => "wo")
+        source "file:#{gem_repo1}"
+        gem "rack"
+        group :wo do
+          gem "weakling"
+        end
+      G
+
+      bundle! :package, "all-platforms" => true
+      expect(bundled_app("vendor/cache/weakling-0.0.3.gem")).to exist
+      expect(the_bundle).to include_gem "rack 1.0"
+      expect(the_bundle).not_to include_gem "weakling"
+
+      bundle! :install, forgotten_command_line_options(:without => "wo")
+      expect(the_bundle).to include_gem "rack 1.0"
+      expect(the_bundle).not_to include_gem "weakling"
+    end
   end
 
   context "with --frozen" do


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was `bundle package --all-platforms` causes `bundle install` to ignore `--with` and `--without`.

Closes https://github.com/bundler/bundler/issues/6074.

### What was your diagnosis of the problem?

My diagnosis was `Installer#resolve_if_needed` had to always resolve remotely for `--all-platforms`, because we would be trying to package things that weren't available locally.

### Why did you choose this fix out of the possible options?

I chose this fix because it avoids refactoring any of the other packaging code.