### PR TITLE
[Outdated] Support --group with the second group for a dependency

### DIFF
--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -118,7 +118,7 @@ module Bundler
           [nil, ordered_groups].flatten.each do |groups|
             gems = outdated_gems_by_groups[groups]
             contains_group = if groups
-              groups.split(",").include?(options[:group])
+              groups.split(", ").include?(options[:group])
             else
               options[:group] == "group"
             end

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -135,6 +135,17 @@ RSpec.describe "bundle outdated" do
       expect(out).to include("activesupport")
       expect(out).to include("duradura")
     end
+
+    it "returns a sorted list of outdated gems from one group => 'test'" do
+      test_group_option("test", 2)
+
+      expect(out).not_to include("===== Group default =====")
+      expect(out).not_to include("terranova (")
+
+      expect(out).to include("===== Group development, test =====")
+      expect(out).to include("activesupport")
+      expect(out).to include("duradura")
+    end
   end
 
   describe "with --groups option" do


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was `bundle outdated --group NAME` wouldn't work if it was the second group for the dependency.

Closes #6115.

### What was your diagnosis of the problem?

My diagnosis was we were joining with `, ` and splitting on `,`, so subsequent groups had an additional space.