### PR TITLE
Digest fixes for 1-16-stable

### DIFF
--- a/lib/bundler/compact_index_client/cache.rb
+++ b/lib/bundler/compact_index_client/cache.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "digest/md5"
+require "digest"
 
 module Bundler
   class CompactIndexClient
@@ -69,7 +69,7 @@ module Bundler
       def info_path(name)
         name = name.to_s
         if name =~ /[^a-z0-9_-]/
-          name += "-#{Digest::MD5.hexdigest(name).downcase}"
+          name += "-#{Digest(:MD5).hexdigest(name).downcase}"
           info_roots.last.join(name)
         else
           info_roots.first.join(name)

--- a/lib/bundler/compact_index_client/updater.rb
+++ b/lib/bundler/compact_index_client/updater.rb
@@ -99,7 +99,7 @@ module Bundler
         # because we need to preserve \n line endings on windows when calculating
         # the checksum
         SharedHelpers.filesystem_access(path, :read) do
-          Digest::MD5.hexdigest(IO.read(path))
+          Digest(:MD5).hexdigest(IO.read(path))
         end
       end
     end

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "bundler/lockfile_parser"
-require "digest/sha1"
+require "digest"
 require "set"
 
 module Bundler

--- a/lib/bundler/plugin/api/source.rb
+++ b/lib/bundler/plugin/api/source.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "uri"
-require "digest/sha1"
+require "digest"
 
 module Bundler
   module Plugin
@@ -272,7 +272,7 @@ module Bundler
         end
 
         def uri_hash
-          Digest::SHA1.hexdigest(uri)
+          Digest(:SHA1).hexdigest(uri)
         end
 
         # Note: Do not override if you don't know what you are doing.

--- a/lib/bundler/rubygems_gem_installer.rb
+++ b/lib/bundler/rubygems_gem_installer.rb
@@ -48,7 +48,7 @@ module Bundler
       return true unless source = @package.instance_variable_get(:@gem)
       return true unless source.respond_to?(:with_read_io)
       digest = source.with_read_io do |io|
-        digest = Digest::SHA256.new
+        digest = Digest(:SHA256).new
         digest << io.read(16_384) until io.eof?
         io.rewind
         send(checksum_type(checksum), digest)

--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "digest/sha1"
+require "digest"
 
 module Bundler
   class Runtime

--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -2,7 +2,7 @@
 
 require "bundler/vendored_fileutils"
 require "uri"
-require "digest/sha1"
+require "digest"
 
 module Bundler
   class Source
@@ -284,7 +284,7 @@ module Bundler
           # If there is no URI scheme, assume it is an ssh/git URI
           input = uri
         end
-        Digest::SHA1.hexdigest(input)
+        Digest(:SHA1).hexdigest(input)
       end
 
       def cached_revision

--- a/lib/bundler/source/rubygems/remote.rb
+++ b/lib/bundler/source/rubygems/remote.rb
@@ -26,7 +26,7 @@ module Bundler
             cache_uri = original_uri || uri
 
             uri_parts = [cache_uri.host, cache_uri.user, cache_uri.port, cache_uri.path]
-            uri_digest = Digest::MD5.hexdigest(uri_parts.compact.join("."))
+            uri_digest = Digest(:MD5).hexdigest(uri_parts.compact.join("."))
 
             uri_parts[-1] = uri_digest
             uri_parts.compact.join(".")

--- a/lib/bundler/vendor/thor/lib/thor/runner.rb
+++ b/lib/bundler/vendor/thor/lib/thor/runner.rb
@@ -3,7 +3,7 @@ require "bundler/vendor/thor/lib/thor/group"
 require "bundler/vendor/thor/lib/thor/core_ext/io_binary_read"
 
 require "yaml"
-require "digest/md5"
+require "digest"
 require "pathname"
 
 class Bundler::Thor::Runner < Bundler::Thor #:nodoc: # rubocop:disable ClassLength
@@ -90,7 +90,7 @@ class Bundler::Thor::Runner < Bundler::Thor #:nodoc: # rubocop:disable ClassLeng
     end
 
     thor_yaml[as] = {
-      :filename   => Digest::MD5.hexdigest(name + as),
+      :filename   => Digest(:MD5).hexdigest(name + as),
       :location   => location,
       :namespaces => Bundler::Thor::Util.namespaces_in_content(contents, base)
     }

--- a/spec/bundler/plugin/api/source_spec.rb
+++ b/spec/bundler/plugin/api/source_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Bundler::Plugin::API::Source do
 
   context "install_path" do
     let(:uri) { "uri://to/a/repository-name" }
-    let(:hash) { Digest::SHA1.hexdigest(uri) }
+    let(:hash) { Digest(:SHA1).hexdigest(uri) }
     let(:install_path) { Pathname.new "/bundler/install/path" }
 
     before do

--- a/spec/bundler/source/rubygems/remote_spec.rb
+++ b/spec/bundler/source/rubygems/remote_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Bundler::Source::Rubygems::Remote do
   end
 
   before do
-    allow(Digest::MD5).to receive(:hexdigest).with(duck_type(:to_s)) {|string| "MD5HEX(#{string})" }
+    allow(Digest(:MD5)).to receive(:hexdigest).with(duck_type(:to_s)) {|string| "MD5HEX(#{string})" }
   end
 
   let(:uri_no_auth) { URI("https://gems.example.com") }

--- a/spec/commands/clean_spec.rb
+++ b/spec/commands/clean_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe "bundle clean" do
 
     bundle :clean
 
-    digest = Digest::SHA1.hexdigest(git_path.to_s)
+    digest = Digest(:SHA1).hexdigest(git_path.to_s)
     cache_path = Bundler::VERSION.start_with?("1.") ? vendored_gems("cache/bundler/git/foo-1.0-#{digest}") : home(".bundle/cache/git/foo-1.0-#{digest}")
     expect(cache_path).to exist
   end
@@ -175,7 +175,7 @@ RSpec.describe "bundle clean" do
 
     expect(vendored_gems("gems/rack-1.0.0")).to exist
     expect(vendored_gems("bundler/gems/foo-#{revision[0..11]}")).not_to exist
-    digest = Digest::SHA1.hexdigest(git_path.to_s)
+    digest = Digest(:SHA1).hexdigest(git_path.to_s)
     expect(vendored_gems("cache/bundler/git/foo-#{digest}")).not_to exist
 
     expect(vendored_gems("specifications/rack-1.0.0.gemspec")).to exist
@@ -254,7 +254,7 @@ RSpec.describe "bundle clean" do
 
     expect(out).to include("")
     expect(vendored_gems("bundler/gems/foo-#{revision[0..11]}")).to exist
-    digest = Digest::SHA1.hexdigest(git_path.to_s)
+    digest = Digest(:SHA1).hexdigest(git_path.to_s)
     expect(vendored_gems("cache/bundler/git/foo-#{digest}")).to_not exist
   end
 

--- a/spec/plugins/source/example_spec.rb
+++ b/spec/plugins/source/example_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe "real source plugins" do
     end
 
     describe "bundle cache/package" do
-      let(:uri_hash) { Digest::SHA1.hexdigest(lib_path("a-path-gem-1.0").to_s) }
+      let(:uri_hash) { Digest(:SHA1).hexdigest(lib_path("a-path-gem-1.0").to_s) }
       it "copies repository to vendor cache and uses it" do
         bundle "install"
         bundle :cache, forgotten_command_line_options([:all, :cache_all] => true)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,8 @@ $:.unshift File.expand_path("../../lib", __FILE__)
 require "bundler/psyched_yaml"
 require "bundler/vendored_fileutils"
 require "uri"
-require "digest/sha1"
+require "digest"
+require File.expand_path("../support/path.rb", __FILE__)
 
 begin
   require "rubygems"

--- a/spec/support/artifice/compact_index.rb
+++ b/spec/support/artifice/compact_index.rb
@@ -82,7 +82,7 @@ class CompactIndexAPI < Endpoint
               CompactIndex::Dependency.new(d.name, reqs)
             end
             checksum = begin
-                         Digest::SHA256.file("#{GEM_REPO}/gems/#{spec.original_name}.gem").base64digest
+                         Digest(:SHA256).file("#{GEM_REPO}/gems/#{spec.original_name}.gem").base64digest
                        rescue
                          nil
                        end

--- a/spec/support/artifice/compact_index.rb
+++ b/spec/support/artifice/compact_index.rb
@@ -15,7 +15,7 @@ class CompactIndexAPI < Endpoint
 
     def etag_response
       response_body = yield
-      checksum = Digest::MD5.hexdigest(response_body)
+      checksum = Digest(:MD5).hexdigest(response_body)
       return if not_modified?(checksum)
       headers "ETag" => quote(checksum)
       headers "Surrogate-Control" => "max-age=2592000, stale-while-revalidate=60"


### PR DESCRIPTION
This PR is patching the `1-16-stable` branch with the digest fixes so that commits/pull requests to the branch be intermittently failing during CI.

See #6117 