### PR TITLE
 Avoid activating stdlib digest under Ruby 2.5

### DIFF
--- a/bundler.gemspec
+++ b/bundler.gemspec
@@ -1,9 +1,7 @@
 # coding: utf-8
 # frozen_string_literal: true
 
-lib = File.expand_path("../lib/", __FILE__)
-$:.unshift lib unless $:.include?(lib)
-require "bundler/version"
+require File.expand_path("../lib/bundler/version", __FILE__)
 require "shellwords"
 
 Gem::Specification.new do |s|

--- a/lib/bundler/compact_index_client/cache.rb
+++ b/lib/bundler/compact_index_client/cache.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "digest"
-
 module Bundler
   class CompactIndexClient
     class Cache
@@ -69,7 +67,7 @@ module Bundler
       def info_path(name)
         name = name.to_s
         if name =~ /[^a-z0-9_-]/
-          name += "-#{Digest(:MD5).hexdigest(name).downcase}"
+          name += "-#{SharedHelpers.digest(:MD5).hexdigest(name).downcase}"
           info_roots.last.join(name)
         else
           info_roots.first.join(name)

--- a/lib/bundler/compact_index_client/updater.rb
+++ b/lib/bundler/compact_index_client/updater.rb
@@ -104,7 +104,7 @@ module Bundler
         # because we need to preserve \n line endings on windows when calculating
         # the checksum
         SharedHelpers.filesystem_access(path, :read) do
-          Digest(:MD5).hexdigest(IO.read(path))
+          SharedHelpers.digest(:MD5).hexdigest(IO.read(path))
         end
       end
     end

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "bundler/lockfile_parser"
-require "digest"
 require "set"
 
 module Bundler

--- a/lib/bundler/plugin/api/source.rb
+++ b/lib/bundler/plugin/api/source.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "uri"
-require "digest"
 
 module Bundler
   module Plugin
@@ -272,7 +271,7 @@ module Bundler
         end
 
         def uri_hash
-          Digest(:SHA1).hexdigest(uri)
+          SharedHelpers.digest(:SHA1).hexdigest(uri)
         end
 
         # Note: Do not override if you don't know what you are doing.

--- a/lib/bundler/rubygems_gem_installer.rb
+++ b/lib/bundler/rubygems_gem_installer.rb
@@ -48,7 +48,7 @@ module Bundler
       return true unless source = @package.instance_variable_get(:@gem)
       return true unless source.respond_to?(:with_read_io)
       digest = source.with_read_io do |io|
-        digest = Digest(:SHA256).new
+        digest = SharedHelpers.digest(:SHA256).new
         digest << io.read(16_384) until io.eof?
         io.rewind
         send(checksum_type(checksum), digest)

--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "digest"
-
 module Bundler
   class Runtime
     include SharedHelpers

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -218,6 +218,11 @@ module Bundler
       end
     end
 
+    def digest(name)
+      require "digest"
+      Digest(name)
+    end
+
   private
 
     def validate_bundle_path

--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -2,7 +2,6 @@
 
 require "bundler/vendored_fileutils"
 require "uri"
-require "digest"
 
 module Bundler
   class Source
@@ -284,7 +283,7 @@ module Bundler
           # If there is no URI scheme, assume it is an ssh/git URI
           input = uri
         end
-        Digest(:SHA1).hexdigest(input)
+        SharedHelpers.digest(:SHA1).hexdigest(input)
       end
 
       def cached_revision

--- a/lib/bundler/source/rubygems/remote.rb
+++ b/lib/bundler/source/rubygems/remote.rb
@@ -26,7 +26,7 @@ module Bundler
             cache_uri = original_uri || uri
 
             uri_parts = [cache_uri.host, cache_uri.user, cache_uri.port, cache_uri.path]
-            uri_digest = Digest(:MD5).hexdigest(uri_parts.compact.join("."))
+            uri_digest = SharedHelpers.digest(:MD5).hexdigest(uri_parts.compact.join("."))
 
             uri_parts[-1] = uri_digest
             uri_parts.compact.join(".")


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was, under ruby 2.5, Bundler would activate digest, which is now a stdlib gem, preventing users from choosing a different version.

With this change, the travis build against trunk should go green, hopefully.

### What was your diagnosis of the problem?

My diagnosis was we needed to lazy-load digest.

### What is your fix for the problem, implemented in this PR?

My fix removes all `require "digest"` top-level statements from the Bundler codebase, and replaces the top-level `Digest` method with one that will `require "digest"`.

### Why did you choose this fix out of the possible options?

I chose this fix because it would keep the use of digest classes thread-safe.

\c @hsbt 