### PR TITLE
Remove a blank line in generated gemspec for RUBY_VERSION >= "2.0.0"

### DIFF
--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -1,7 +1,7 @@
 <%- if RUBY_VERSION < "2.0.0" -%>
 # coding: utf-8
-<%- end -%>
 
+<%- end -%>
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "<%= config[:namespaced_path] %>/version"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Need to remove a leading blank line of generated gemspec.

### What was your diagnosis of the problem?

```erb
<%- if RUBY_VERSION < "2.0.0" -%>
# coding: utf-8
<%- end -%>

lib = File.expand_path("../lib", __FILE__)
...
```

When executing `bundle gem xxx` with ruby (< 2.0), the leading blank line is appeared.

### What is your fix for the problem, implemented in this PR?

Move a blank line into the `if` block.

### Why did you choose this fix out of the possible options?

😃 