### PR TITLE
Fix failing spec for `bundle plugin list`

### DIFF
--- a/spec/plugins/list_spec.rb
+++ b/spec/plugins/list_spec.rb
@@ -53,8 +53,18 @@ RSpec.describe "bundler plugin list" do
       plugin_should_be_installed("foo", "bar")
       bundle "plugin list"
 
-      expected_output = "foo\n-----\n  shout\n\nbar\n-----\n  scream"
-      expect(out).to include(expected_output)
+      if RUBY_VERSION < "1.9"
+        # Bundler::Plugin::Index#installed_plugins is keys of Hash,
+        # and Hash is not ordered in prior to Ruby 1.9.
+        # So, foo and bar plugins are not always listed in that order.
+        expected_output1 = "foo\n-----\n  shout"
+        expect(out).to include(expected_output1)
+        expected_output2 = "bar\n-----\n  scream"
+        expect(out).to include(expected_output2)
+      else
+        expected_output = "foo\n-----\n  shout\n\nbar\n-----\n  scream"
+        expect(out).to include(expected_output)
+      end
     end
   end
 end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was failure of Travis CI build. (refs: [build for #6123](https://travis-ci.org/bundler/bundler/builds/292436821?utm_source=github_status&utm_medium=notification))

### What was your diagnosis of the problem?

Bundler::Plugin::Index#installed_plugins is keys of Hash,
and Hash is not ordered in prior to Ruby 1.9.
`foo` and `bar` plugins defined in spec are not always listed in specified order.


### What is your fix for the problem, implemented in this PR?

My fix is to separate tests into for Ruby < 1.9 or not.

### Why did you choose this fix out of the possible options?

I chose this fix because this makes code easy to remove if we stop building Ruby < 1.9 in Travis CI.
