### PR TITLE
check permissions in doctor command

### DIFF
--- a/lib/bundler/cli/doctor.rb
+++ b/lib/bundler/cli/doctor.rb
@@ -103,13 +103,13 @@ module Bundler
     def check_for_files_not_owned_by_current_user_but_still_rw
       return unless files_not_owned_by_current_user_but_still_rw.any?
       Bundler.ui.warn "Files exist in Bundler home that are owned by another " \
-        "user, but are stil readable/writable. These files are: #{files_not_owned_by_current_user_but_still_rw.join("\n")}"
+        "user, but are stil readable/writable. These files are:\n - #{files_not_owned_by_current_user_but_still_rw.join("\n - ")}"
     end
 
     def check_for_files_not_readable_or_writable
       return unless files_not_readable_or_writable.any?
       Bundler.ui.warn "Files exist in Bundler home that are not " \
-        "readable/writable to the current user. These files are: #{files_not_readable_or_writable.join("\n")}"
+        "readable/writable to the current user. These files are:\n - #{files_not_readable_or_writable.join("\n - ")}"
     end
 
     def files_not_readable_or_writable

--- a/lib/bundler/cli/doctor.rb
+++ b/lib/bundler/cli/doctor.rb
@@ -98,10 +98,15 @@ module Bundler
     def check_home_permissions
       require "find"
       files_not_readable_or_writable = []
+      files_not_rw_and_owned_by_different_user = []
       files_not_owned_by_current_user_but_still_rw = []
       Find.find(Bundler.home.to_s).each do |f|
         if !File.writable?(f) || !File.readable?(f)
-          files_not_readable_or_writable << f
+          if File.stat(f).uid != Process.uid
+            files_not_rw_and_owned_by_different_user << f
+          else
+            files_not_readable_or_writable << f
+          end
         elsif File.stat(f).uid != Process.uid
           files_not_owned_by_current_user_but_still_rw << f
         end
@@ -111,6 +116,13 @@ module Bundler
       if files_not_owned_by_current_user_but_still_rw.any?
         Bundler.ui.warn "Files exist in the Bundler home that are owned by another " \
           "user, but are still readable/writable. These files are:\n - #{files_not_owned_by_current_user_but_still_rw.join("\n - ")}"
+
+        ok = false
+      end
+
+      if files_not_rw_and_owned_by_different_user.any?
+        Bundler.ui.warn "Files exist in the Bundler home that are owned by another " \
+          "user, and are not readable/writable. These files are:\n - #{files_not_rw_and_owned_by_different_user.join("\n - ")}"
 
         ok = false
       end

--- a/lib/bundler/cli/doctor.rb
+++ b/lib/bundler/cli/doctor.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rbconfig"
+require "find"
 
 module Bundler
   class CLI::Doctor
@@ -61,6 +62,7 @@ module Bundler
     end
 
     def run
+      check_home_permissions
       Bundler.ui.level = "error" if options[:quiet]
       Bundler.settings.validate!
       check!
@@ -88,6 +90,38 @@ module Bundler
         raise ProductionError, message
       else
         Bundler.ui.info "No issues found with the installed bundle"
+      end
+    end
+
+  private
+
+    def check_home_permissions
+      check_for_files_not_owned_by_current_user_but_still_rw
+      check_for_files_not_readable_or_writable
+    end
+
+    def check_for_files_not_owned_by_current_user_but_still_rw
+      return unless any_files_not_owned_by_current_user_but_still_rw?
+      Bundler.ui.warn "Files exist in Bundler home that are owned by another " \
+        "user, but are stil readable/writable"
+    end
+
+    def check_for_files_not_readable_or_writable
+      return unless any_files_not_readable_or_writable?
+      raise ProductionError, "Files exist in Bundler home that are not " \
+        "readable/writable to the current user"
+    end
+
+    def any_files_not_readable_or_writable?
+      Find.find(Bundler.home.to_s).any? do |f|
+        !(File.writable?(f) && File.readable?(f))
+      end
+    end
+
+    def any_files_not_owned_by_current_user_but_still_rw?
+      Find.find(Bundler.home.to_s).any? do |f|
+        (File.stat(f).uid != Process.uid) &&
+          (File.writable?(f) && File.readable?(f))
       end
     end
   end

--- a/lib/bundler/cli/doctor.rb
+++ b/lib/bundler/cli/doctor.rb
@@ -117,7 +117,7 @@ module Bundler
 
       if files_not_readable_or_writable.any?
         Bundler.ui.warn "Files exist in the Bundler home that are not " \
-          "readable/writable to the current user. These files are:\n - #{files_not_readable_or_writable.join("\n - ")}"
+          "readable/writable by the current user. These files are:\n - #{files_not_readable_or_writable.join("\n - ")}"
 
         ok = false
       end

--- a/lib/bundler/cli/doctor.rb
+++ b/lib/bundler/cli/doctor.rb
@@ -110,7 +110,7 @@ module Bundler
       ok = true
       if files_not_owned_by_current_user_but_still_rw.any?
         Bundler.ui.warn "Files exist in the Bundler home that are owned by another " \
-          "user, but are stil readable/writable. These files are:\n - #{files_not_owned_by_current_user_but_still_rw.join("\n - ")}"
+          "user, but are still readable/writable. These files are:\n - #{files_not_owned_by_current_user_but_still_rw.join("\n - ")}"
 
         ok = false
       end

--- a/lib/bundler/cli/doctor.rb
+++ b/lib/bundler/cli/doctor.rb
@@ -101,25 +101,25 @@ module Bundler
     end
 
     def check_for_files_not_owned_by_current_user_but_still_rw
-      return unless any_files_not_owned_by_current_user_but_still_rw?
+      return unless files_not_owned_by_current_user_but_still_rw.any?
       Bundler.ui.warn "Files exist in Bundler home that are owned by another " \
-        "user, but are stil readable/writable"
+        "user, but are stil readable/writable. These files are: #{files_not_owned_by_current_user_but_still_rw.join("\n")}"
     end
 
     def check_for_files_not_readable_or_writable
-      return unless any_files_not_readable_or_writable?
-      raise ProductionError, "Files exist in Bundler home that are not " \
-        "readable/writable to the current user"
+      return unless files_not_readable_or_writable.any?
+      Bundler.ui.warn "Files exist in Bundler home that are not " \
+        "readable/writable to the current user. These files are: #{files_not_readable_or_writable.join("\n")}"
     end
 
-    def any_files_not_readable_or_writable?
-      Find.find(Bundler.home.to_s).any? do |f|
+    def files_not_readable_or_writable
+      Find.find(Bundler.home.to_s).select do |f|
         !(File.writable?(f) && File.readable?(f))
       end
     end
 
-    def any_files_not_owned_by_current_user_but_still_rw?
-      Find.find(Bundler.home.to_s).any? do |f|
+    def files_not_owned_by_current_user_but_still_rw
+      Find.find(Bundler.home.to_s).select do |f|
         (File.stat(f).uid != Process.uid) &&
           (File.writable?(f) && File.readable?(f))
       end

--- a/spec/commands/doctor_spec.rb
+++ b/spec/commands/doctor_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "bundle doctor" do
     E
   end
 
-  it "exits with an error if home contains files that are not read/write" do
+  it "exits with an error if home contains files that are not readable/writable" do
     stat = double("stat")
     unwritable_file = double("file")
     doctor = Bundler::CLI::Doctor.new({})

--- a/spec/commands/doctor_spec.rb
+++ b/spec/commands/doctor_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "bundle doctor" do
     allow(File).to receive(:readable?).with(unwritable_file) { false }
     expect { doctor.run }.not_to raise_error
     expect(@stdout.string).to include(
-      "Files exist in Bundler home that are not readable/writable to the current user. These files are: #{unwritable_file}"
+      "Files exist in Bundler home that are not readable/writable to the current user. These files are:\n - #{unwritable_file}"
     )
   end
 
@@ -81,6 +81,8 @@ RSpec.describe "bundle doctor" do
     allow(File).to receive(:writable?).with(unwritable_file) { true }
     allow(File).to receive(:readable?).with(unwritable_file) { true }
     expect { Bundler::CLI::Doctor.new({}).run }.not_to raise_error
-    expect(@stdout.string).to include("Files exist in Bundler home that are owned by another user, but are stil readable/writable. These files are: #{unwritable_file}")
+    expect(@stdout.string).to include(
+      "Files exist in Bundler home that are owned by another user, but are stil readable/writable. These files are:\n - #{unwritable_file}"
+    )
   end
 end

--- a/spec/commands/doctor_spec.rb
+++ b/spec/commands/doctor_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "bundle doctor" do
     allow(File).to receive(:readable?).with(unwritable_file) { false }
     expect { doctor.run }.not_to raise_error
     expect(@stdout.string).to include(
-      "Files exist in the Bundler home that are not readable/writable to the current user. These files are:\n - #{unwritable_file}"
+      "Files exist in the Bundler home that are not readable/writable by the current user. These files are:\n - #{unwritable_file}"
     )
     expect(@stdout.string).not_to include("No issues")
   end

--- a/spec/commands/doctor_spec.rb
+++ b/spec/commands/doctor_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe "bundle doctor" do
     allow(File).to receive(:readable?).with(unwritable_file) { true }
     expect { Bundler::CLI::Doctor.new({}).run }.not_to raise_error
     expect(@stdout.string).to include(
-      "Files exist in the Bundler home that are owned by another user, but are stil readable/writable. These files are:\n - #{unwritable_file}"
+      "Files exist in the Bundler home that are owned by another user, but are still readable/writable. These files are:\n - #{unwritable_file}"
     )
     expect(@stdout.string).not_to include("No issues")
   end

--- a/spec/commands/doctor_spec.rb
+++ b/spec/commands/doctor_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "find"
 require "stringio"
 require "bundler/cli"
 require "bundler/cli/doctor"
@@ -68,8 +69,9 @@ RSpec.describe "bundle doctor" do
     allow(File).to receive(:readable?).with(unwritable_file) { false }
     expect { doctor.run }.not_to raise_error
     expect(@stdout.string).to include(
-      "Files exist in Bundler home that are not readable/writable to the current user. These files are:\n - #{unwritable_file}"
+      "Files exist in the Bundler home that are not readable/writable to the current user. These files are:\n - #{unwritable_file}"
     )
+    expect(@stdout.string).not_to include("No issues")
   end
 
   it "exits with a warning if home contains files that are read/write but not owned by current user" do
@@ -82,7 +84,8 @@ RSpec.describe "bundle doctor" do
     allow(File).to receive(:readable?).with(unwritable_file) { true }
     expect { Bundler::CLI::Doctor.new({}).run }.not_to raise_error
     expect(@stdout.string).to include(
-      "Files exist in Bundler home that are owned by another user, but are stil readable/writable. These files are:\n - #{unwritable_file}"
+      "Files exist in the Bundler home that are owned by another user, but are stil readable/writable. These files are:\n - #{unwritable_file}"
     )
+    expect(@stdout.string).not_to include("No issues")
   end
 end

--- a/spec/commands/doctor_spec.rb
+++ b/spec/commands/doctor_spec.rb
@@ -6,6 +6,19 @@ require "bundler/cli/doctor"
 
 RSpec.describe "bundle doctor" do
   before(:each) do
+    install_gemfile! <<-G
+      source "file://#{gem_repo1}"
+      gem "rack"
+    G
+
+    stat = double("stat")
+    unwritable_file = double("file")
+    allow(Find).to receive(:find).with(Bundler.home.to_s) { [unwritable_file] }
+    allow(File).to receive(:stat).with(unwritable_file) { stat }
+    allow(stat).to receive(:uid) { Process.uid }
+    allow(File).to receive(:writable?).with(unwritable_file) { true }
+    allow(File).to receive(:readable?).with(unwritable_file) { true }
+
     @stdout = StringIO.new
 
     [:error, :warn].each do |method|
@@ -17,21 +30,11 @@ RSpec.describe "bundle doctor" do
   end
 
   it "exits with no message if the installed gem has no C extensions" do
-    install_gemfile! <<-G
-      source "file://#{gem_repo1}"
-      gem "rack"
-    G
-
     expect { Bundler::CLI::Doctor.new({}).run }.not_to raise_error
     expect(@stdout.string).to be_empty
   end
 
   it "exits with no message if the installed gem's C extension dylib breakage is fine" do
-    install_gemfile! <<-G
-      source "file://#{gem_repo1}"
-      gem "rack"
-    G
-
     doctor = Bundler::CLI::Doctor.new({})
     expect(doctor).to receive(:bundles_for_gem).exactly(2).times.and_return ["/path/to/rack/rack.bundle"]
     expect(doctor).to receive(:dylibs).exactly(2).times.and_return ["/usr/lib/libSystem.dylib"]
@@ -42,11 +45,6 @@ RSpec.describe "bundle doctor" do
   end
 
   it "exits with a message if one of the linked libraries is missing" do
-    install_gemfile! <<-G
-      source "file://#{gem_repo1}"
-      gem "rack"
-    G
-
     doctor = Bundler::CLI::Doctor.new({})
     expect(doctor).to receive(:bundles_for_gem).exactly(2).times.and_return ["/path/to/rack/rack.bundle"]
     expect(doctor).to receive(:dylibs).exactly(2).times.and_return ["/usr/local/opt/icu4c/lib/libicui18n.57.1.dylib"]
@@ -57,5 +55,32 @@ RSpec.describe "bundle doctor" do
        * bundler: /usr/local/opt/icu4c/lib/libicui18n.57.1.dylib
        * rack: /usr/local/opt/icu4c/lib/libicui18n.57.1.dylib
     E
+  end
+
+  it "exits with an error if home contains files that are not read/write" do
+    stat = double("stat")
+    unwritable_file = double("file")
+    doctor = Bundler::CLI::Doctor.new({})
+    allow(Find).to receive(:find).with(Bundler.home.to_s) { [unwritable_file] }
+    allow(File).to receive(:stat).with(unwritable_file) { stat }
+    allow(stat).to receive(:uid) { Process.uid }
+    allow(File).to receive(:writable?).with(unwritable_file) { false }
+    allow(File).to receive(:readable?).with(unwritable_file) { false }
+    expect { doctor.run }.to raise_error(
+      Bundler::ProductionError,
+      "Files exist in Bundler home that are not readable/writable to the current user"
+    )
+  end
+
+  it "exits with a warning if home contains files that are read/write but not owned by current user" do
+    stat = double("stat")
+    unwritable_file = double("file")
+    allow(Find).to receive(:find).with(Bundler.home.to_s) { [unwritable_file] }
+    allow(File).to receive(:stat).with(unwritable_file) { stat }
+    allow(stat).to receive(:uid) { 0o0000 }
+    allow(File).to receive(:writable?).with(unwritable_file) { true }
+    allow(File).to receive(:readable?).with(unwritable_file) { true }
+    expect { Bundler::CLI::Doctor.new({}).run }.not_to raise_error
+    expect(@stdout.string).to include("Files exist in Bundler home that are owned by another user, but are stil readable/writable")
   end
 end

--- a/spec/commands/doctor_spec.rb
+++ b/spec/commands/doctor_spec.rb
@@ -12,14 +12,6 @@ RSpec.describe "bundle doctor" do
       gem "rack"
     G
 
-    stat = double("stat")
-    unwritable_file = double("file")
-    allow(Find).to receive(:find).with(Bundler.home.to_s) { [unwritable_file] }
-    allow(File).to receive(:stat).with(unwritable_file) { stat }
-    allow(stat).to receive(:uid) { Process.uid }
-    allow(File).to receive(:writable?).with(unwritable_file) { true }
-    allow(File).to receive(:readable?).with(unwritable_file) { true }
-
     @stdout = StringIO.new
 
     [:error, :warn].each do |method|
@@ -30,78 +22,89 @@ RSpec.describe "bundle doctor" do
     end
   end
 
-  it "exits with no message if the installed gem has no C extensions" do
-    expect { Bundler::CLI::Doctor.new({}).run }.not_to raise_error
-    expect(@stdout.string).to be_empty
+  context "when all files in home are readable/writable" do
+    before(:each) do
+      stat = double("stat")
+      unwritable_file = double("file")
+      allow(Find).to receive(:find).with(Bundler.home.to_s) { [unwritable_file] }
+      allow(File).to receive(:stat).with(unwritable_file) { stat }
+      allow(stat).to receive(:uid) { Process.uid }
+      allow(File).to receive(:writable?).with(unwritable_file) { true }
+      allow(File).to receive(:readable?).with(unwritable_file) { true }
+    end
+
+    it "exits with no message if the installed gem has no C extensions" do
+      expect { Bundler::CLI::Doctor.new({}).run }.not_to raise_error
+      expect(@stdout.string).to be_empty
+    end
+
+    it "exits with no message if the installed gem's C extension dylib breakage is fine" do
+      doctor = Bundler::CLI::Doctor.new({})
+      expect(doctor).to receive(:bundles_for_gem).exactly(2).times.and_return ["/path/to/rack/rack.bundle"]
+      expect(doctor).to receive(:dylibs).exactly(2).times.and_return ["/usr/lib/libSystem.dylib"]
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with("/usr/lib/libSystem.dylib").and_return(true)
+      expect { doctor.run }.not_to(raise_error, @stdout.string)
+      expect(@stdout.string).to be_empty
+    end
+
+    it "exits with a message if one of the linked libraries is missing" do
+      doctor = Bundler::CLI::Doctor.new({})
+      expect(doctor).to receive(:bundles_for_gem).exactly(2).times.and_return ["/path/to/rack/rack.bundle"]
+      expect(doctor).to receive(:dylibs).exactly(2).times.and_return ["/usr/local/opt/icu4c/lib/libicui18n.57.1.dylib"]
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with("/usr/local/opt/icu4c/lib/libicui18n.57.1.dylib").and_return(false)
+      expect { doctor.run }.to raise_error(Bundler::ProductionError, strip_whitespace(<<-E).strip), @stdout.string
+        The following gems are missing OS dependencies:
+         * bundler: /usr/local/opt/icu4c/lib/libicui18n.57.1.dylib
+         * rack: /usr/local/opt/icu4c/lib/libicui18n.57.1.dylib
+      E
+    end
   end
 
-  it "exits with no message if the installed gem's C extension dylib breakage is fine" do
-    doctor = Bundler::CLI::Doctor.new({})
-    expect(doctor).to receive(:bundles_for_gem).exactly(2).times.and_return ["/path/to/rack/rack.bundle"]
-    expect(doctor).to receive(:dylibs).exactly(2).times.and_return ["/usr/lib/libSystem.dylib"]
-    allow(File).to receive(:exist?).and_call_original
-    allow(File).to receive(:exist?).with("/usr/lib/libSystem.dylib").and_return(true)
-    expect { doctor.run }.not_to(raise_error, @stdout.string)
-    expect(@stdout.string).to be_empty
-  end
+  context "when home contains files that are not readable/writable" do
+    before(:each) do
+      @stat = double("stat")
+      @unwritable_file = double("file")
+      allow(Find).to receive(:find).with(Bundler.home.to_s) { [@unwritable_file] }
+      allow(File).to receive(:stat).with(@unwritable_file) { @stat }
+    end
 
-  it "exits with a message if one of the linked libraries is missing" do
-    doctor = Bundler::CLI::Doctor.new({})
-    expect(doctor).to receive(:bundles_for_gem).exactly(2).times.and_return ["/path/to/rack/rack.bundle"]
-    expect(doctor).to receive(:dylibs).exactly(2).times.and_return ["/usr/local/opt/icu4c/lib/libicui18n.57.1.dylib"]
-    allow(File).to receive(:exist?).and_call_original
-    allow(File).to receive(:exist?).with("/usr/local/opt/icu4c/lib/libicui18n.57.1.dylib").and_return(false)
-    expect { doctor.run }.to raise_error(Bundler::ProductionError, strip_whitespace(<<-E).strip), @stdout.string
-      The following gems are missing OS dependencies:
-       * bundler: /usr/local/opt/icu4c/lib/libicui18n.57.1.dylib
-       * rack: /usr/local/opt/icu4c/lib/libicui18n.57.1.dylib
-    E
-  end
+    it "exits with an error if home contains files that are not readable/writable" do
+      allow(@stat).to receive(:uid) { Process.uid }
+      allow(File).to receive(:writable?).with(@unwritable_file) { false }
+      allow(File).to receive(:readable?).with(@unwritable_file) { false }
+      expect { Bundler::CLI::Doctor.new({}).run }.not_to raise_error
+      expect(@stdout.string).to include(
+        "Files exist in the Bundler home that are not readable/writable by the current user. These files are:\n - #{@unwritable_file}"
+      )
+      expect(@stdout.string).not_to include("No issues")
+    end
 
-  it "exits with an error if home contains files that are not readable/writable" do
-    stat = double("stat")
-    unwritable_file = double("file")
-    doctor = Bundler::CLI::Doctor.new({})
-    allow(Find).to receive(:find).with(Bundler.home.to_s) { [unwritable_file] }
-    allow(File).to receive(:stat).with(unwritable_file) { stat }
-    allow(stat).to receive(:uid) { Process.uid }
-    allow(File).to receive(:writable?).with(unwritable_file) { false }
-    allow(File).to receive(:readable?).with(unwritable_file) { false }
-    expect { doctor.run }.not_to raise_error
-    expect(@stdout.string).to include(
-      "Files exist in the Bundler home that are not readable/writable by the current user. These files are:\n - #{unwritable_file}"
-    )
-    expect(@stdout.string).not_to include("No issues")
-  end
+    context "when home contains files that are not owned by the current process" do
+      before(:each) do
+        allow(@stat).to receive(:uid) { 0o0000 }
+      end
 
-  it "exits with an error if home contains files that are not readable/writable and are not owned by the current user" do
-    stat = double("stat")
-    unwritable_file = double("file")
-    doctor = Bundler::CLI::Doctor.new({})
-    allow(Find).to receive(:find).with(Bundler.home.to_s) { [unwritable_file] }
-    allow(File).to receive(:stat).with(unwritable_file) { stat }
-    allow(stat).to receive(:uid) { 0o0000 }
-    allow(File).to receive(:writable?).with(unwritable_file) { false }
-    allow(File).to receive(:readable?).with(unwritable_file) { false }
-    expect { doctor.run }.not_to raise_error
-    expect(@stdout.string).to include(
-      "Files exist in the Bundler home that are owned by another user, and are not readable/writable. These files are:\n - #{unwritable_file}"
-    )
-    expect(@stdout.string).not_to include("No issues")
-  end
+      it "exits with an error if home contains files that are not readable/writable and are not owned by the current user" do
+        allow(File).to receive(:writable?).with(@unwritable_file) { false }
+        allow(File).to receive(:readable?).with(@unwritable_file) { false }
+        expect { Bundler::CLI::Doctor.new({}).run }.not_to raise_error
+        expect(@stdout.string).to include(
+          "Files exist in the Bundler home that are owned by another user, and are not readable/writable. These files are:\n - #{@unwritable_file}"
+        )
+        expect(@stdout.string).not_to include("No issues")
+      end
 
-  it "exits with a warning if home contains files that are read/write but not owned by current user" do
-    stat = double("stat")
-    unwritable_file = double("file")
-    allow(Find).to receive(:find).with(Bundler.home.to_s) { [unwritable_file] }
-    allow(File).to receive(:stat).with(unwritable_file) { stat }
-    allow(stat).to receive(:uid) { 0o0000 }
-    allow(File).to receive(:writable?).with(unwritable_file) { true }
-    allow(File).to receive(:readable?).with(unwritable_file) { true }
-    expect { Bundler::CLI::Doctor.new({}).run }.not_to raise_error
-    expect(@stdout.string).to include(
-      "Files exist in the Bundler home that are owned by another user, but are still readable/writable. These files are:\n - #{unwritable_file}"
-    )
-    expect(@stdout.string).not_to include("No issues")
+      it "exits with a warning if home contains files that are read/write but not owned by current user" do
+        allow(File).to receive(:writable?).with(@unwritable_file) { true }
+        allow(File).to receive(:readable?).with(@unwritable_file) { true }
+        expect { Bundler::CLI::Doctor.new({}).run }.not_to raise_error
+        expect(@stdout.string).to include(
+          "Files exist in the Bundler home that are owned by another user, but are still readable/writable. These files are:\n - #{@unwritable_file}"
+        )
+        expect(@stdout.string).not_to include("No issues")
+      end
+    end
   end
 end

--- a/spec/commands/doctor_spec.rb
+++ b/spec/commands/doctor_spec.rb
@@ -66,9 +66,9 @@ RSpec.describe "bundle doctor" do
     allow(stat).to receive(:uid) { Process.uid }
     allow(File).to receive(:writable?).with(unwritable_file) { false }
     allow(File).to receive(:readable?).with(unwritable_file) { false }
-    expect { doctor.run }.to raise_error(
-      Bundler::ProductionError,
-      "Files exist in Bundler home that are not readable/writable to the current user"
+    expect { doctor.run }.not_to raise_error
+    expect(@stdout.string).to include(
+      "Files exist in Bundler home that are not readable/writable to the current user. These files are: #{unwritable_file}"
     )
   end
 
@@ -81,6 +81,6 @@ RSpec.describe "bundle doctor" do
     allow(File).to receive(:writable?).with(unwritable_file) { true }
     allow(File).to receive(:readable?).with(unwritable_file) { true }
     expect { Bundler::CLI::Doctor.new({}).run }.not_to raise_error
-    expect(@stdout.string).to include("Files exist in Bundler home that are owned by another user, but are stil readable/writable")
+    expect(@stdout.string).to include("Files exist in Bundler home that are owned by another user, but are stil readable/writable. These files are: #{unwritable_file}")
   end
 end


### PR DESCRIPTION
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was...
#5786 

> We should have a check in bundle doctor for the file/folder permissions in the Bundler home directory.

>We should print a warning if there are any files/folders that is owned by another user but is readable/writable but prints an error when a file cannot be read or written to.

### What is your fix for the problem, implemented in this PR?

Created private method ```check_home_permissions``` that will print a warning if there are any files/folders that are owned by another user but are readable/writable, and print an error when the 
bundler home dir contains a file cannot be read or written to 

### Why did you choose this fix out of the possible options?

I chose this fix because it's what was requested in the open issue.
