### PR TITLE
Ensure that autoloads are resolved in the real working directory

### DIFF
--- a/lib/bundler/source/git/git_proxy.rb
+++ b/lib/bundler/source/git/git_proxy.rb
@@ -221,6 +221,7 @@ module Bundler
 
         def in_path(&blk)
           checkout unless path.exist?
+          _ = URICredentialsFilter # load it before we chdir
           SharedHelpers.chdir(path, &blk)
         end
 


### PR DESCRIPTION
Fixes an issue on 2.5.0-dev where using local git overrides would cause an exception because the default bundler had been loaded

### What was the end-user problem that led to this PR?

The problem was Bundler was failing 8 specs against ruby trunk.

### What was your diagnosis of the problem?

My diagnosis was when the autoload for `URICredentialsFilter` fired in a `chdir` block, the default bundler gem was getting activated.

### What is your fix for the problem, implemented in this PR?

My fix eagerly trips that auto-load in the git proxy.

### Why did you choose this fix out of the possible options?

I chose this fix because it's a one-liner.