### PR TITLE
Update `config` page link to the recent version

### DIFF
--- a/man/bundle-gem.ronn
+++ b/man/bundle-gem.ronn
@@ -75,4 +75,4 @@ configuration file using the following names:
 
 ## SEE ALSO
 
-* [bundle-config](http://bundler.io/v1.14/bundle_config.html)
+* [bundle-config](http://bundler.io/v1.16/bundle_config.html)


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

In the `man/bundle-gem.ronn`, we are using a hard-coded version number to link the `bundle-config` doc, which is `v1.14` in this case. Ref: https://bundler.io/v1.16/man/bundle-gem.1.html


### What is your fix for the problem, implemented in this PR?

<del>This commit updates the link and uses a relative path so it will always point to the recent version.</del>

Edit: This commit updates the link to the current stable version.