### PR TITLE
[FIX] skip bundler gem when warning when an explicitly updated spec d…

### DIFF
--- a/lib/bundler/cli/update.rb
+++ b/lib/bundler/cli/update.rb
@@ -68,6 +68,8 @@ module Bundler
 
       if locked_gems = Bundler.definition.locked_gems
         gems.each do |name|
+          next if name == "bundler"
+
           locked_version = locked_gems.specs.find {|s| s.name == name }.version
           new_version = Bundler.definition.specs[name].first
           new_version &&= new_version.version


### PR DESCRIPTION
…oes not get a newer version (618c09b59d1318958c23b1b0031c68c93186851a)

Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was when running bundle update --group xxx 

### What was your diagnosis of the problem?

My diagnosis was that bundler was taken into consideration and fails the updating process

### What is your fix for the problem, implemented in this PR?

My fix is to skip bundler when checking whether to warn when an explicitly updated spec does not get a newer version

### Why did you choose this fix out of the possible options?

I chose this fix because it is a rather new code (added in v1.16.0) and it is rather simple and doesn't require lots of changes in code. Another option would be to revert the lines added between 1.15.4 and 16.0.0 altogether. Up to the maintainers to decide.
