### PR TITLE
Fix NoMethodError during `bundle update --group`

### DIFF
--- a/lib/bundler/cli/update.rb
+++ b/lib/bundler/cli/update.rb
@@ -68,7 +68,9 @@ module Bundler
 
       if locked_gems = Bundler.definition.locked_gems
         gems.each do |name|
-          locked_version = locked_gems.specs.find {|s| s.name == name }.version
+          locked_version = locked_gems.specs.find {|s| s.name == name }
+          locked_version &&= locked_version.version
+          next unless locked_version
           new_version = Bundler.definition.specs[name].first
           new_version &&= new_version.version
           if !new_version

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -195,6 +195,23 @@ RSpec.describe "bundle update" do
         expect(the_bundle).not_to include_gems "foo 2.0"
       end
     end
+
+    context "when bundler itself is a transitive dependency" do
+      it "executes without error" do
+        install_gemfile <<-G
+          source "file://#{gem_repo1}"
+          gem "activesupport", :group => :development
+          gem "rack"
+        G
+        update_repo2 do
+          build_gem "activesupport", "3.0"
+        end
+        bundle "update --group development"
+        expect(the_bundle).to include_gems "activesupport 2.3.5"
+        expect(the_bundle).to include_gems "bundler #{Bundler::VERSION}"
+        expect(the_bundle).not_to include_gems "rack 1.2"
+      end
+    end
   end
 
   describe "in a frozen bundle" do


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

#6156: NoMethodError: undefined method `version' for nil:NilClass 

### What was your diagnosis of the problem?

The `bundler` gem does not participate in the lockfile, but it can still be included in the list of dependencies that are being updated by `bundle update` if `--group` is specified.

For example, if a Gemfile contains `bundler-audit` (which depends on `bundler`) in the `:development` group, then updating with the option `--group=development` will naturally include `bundler` in the list of gems to evaluate for updating.

The trouble is that since `bundler` is excluded from the lockfile, searching the locked gems for a gemspec for bundler will return `nil`. This caused the following error during `bundle update`:

    NoMethodError: undefined method `version' for nil:NilClass

### What is your fix for the problem, implemented in this PR?

This PR solves this bug by skipping over gems (i.e `bundler`) that are not in the lockfile when comparing gem versions at the conclusion of the upgrade command.

Fixes #6156.

### Why did you choose this fix out of the possible options?

I chose this fix because the bug seems to have been introduced by 618c09b59d1318958c23b1b0031c68c93186851a. My fix takes place within the new feature that was added in that commit, so it seems safe and unlikely to have side-effects.