### PR TITLE
Stop requesting changelogs in PRs

### DIFF
--- a/doc/development/PULL_REQUESTS.md
+++ b/doc/development/PULL_REQUESTS.md
@@ -34,7 +34,3 @@ Please ensure that the commit messages included in the pull request __do not__ h
 If you want to use these mechanisms, please instead include them in the pull request description. This prevents multiple notifications or references being created on commit rebases or pull request/branch force pushes.
 
 Additionally, do not use `[ci skip]` or `[skip ci]` mechanisms in your pull request titles/descriptions or commit messages. Every potential commit and pull request should run through Bundler's CI system. This applies to all changes/commits (ex. even a change to just documentation or the removal of a comment).
-
-## CHANGELOG.md
-
-Don't forget to add your changes into the CHANGELOG! If you're submitting documentation, note the changes under the "Documentation" heading.


### PR DESCRIPTION
We added this requirement before the changelog was automated. Now that the changelog generated by a script, it's not helpful for PRs to update the changelog anymore, so we shouldn't expect it anymore.

### What was the end-user problem that led to this PR?

We had to [ask a PR to remove a changelog entry](https://github.com/bundler/bundler/pull/6157#discussion_r149701953), even though the PR was following [the docs](https://github.com/bundler/bundler/blob/374caf6ede2cf4de7d2196aa2e2adef782bea5bd/doc/development/PULL_REQUESTS.md#changelogmd).

### What was your diagnosis of the problem?

It looks like we failed to update the docs when we automated generating the changelog.

### What is your fix for the problem, implemented in this PR?

Removing the changelog requirement from the docs hopefully means that future PRs will not include changelog entries, and we can generate future changelogs automatically.

### Why did you choose this fix out of the possible options?

I chose this fix because it seemed like the smallest change that would accomplish the goal.

/cc @mattbrictson 