### PR TITLE
Make `bundle clean` clean extension directories

### DIFF
--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -163,6 +163,7 @@ module Bundler
       gem_dirs             = Dir["#{Gem.dir}/gems/*"]
       gem_files            = Dir["#{Gem.dir}/cache/*.gem"]
       gemspec_files        = Dir["#{Gem.dir}/specifications/*.gemspec"]
+      extension_dirs       = Dir["#{Gem.dir}/extensions/*/*/*"]
       spec_gem_paths       = []
       # need to keep git sources around
       spec_git_paths       = @definition.spec_git_paths
@@ -170,6 +171,7 @@ module Bundler
       spec_gem_executables = []
       spec_cache_paths     = []
       spec_gemspec_paths   = []
+      spec_extension_paths = []
       specs.each do |spec|
         spec_gem_paths << spec.full_gem_path
         # need to check here in case gems are nested like for the rails git repo
@@ -181,6 +183,7 @@ module Bundler
         end
         spec_cache_paths << spec.cache_file
         spec_gemspec_paths << spec.spec_file
+        spec_extension_paths << spec.extension_dir if spec.respond_to?(:extension_dir)
         spec_git_cache_dirs << spec.source.cache_path.to_s if spec.source.is_a?(Bundler::Source::Git)
       end
       spec_gem_paths.uniq!
@@ -192,6 +195,7 @@ module Bundler
       stale_gem_dirs       = gem_dirs - spec_gem_paths
       stale_gem_files      = gem_files - spec_cache_paths
       stale_gemspec_files  = gemspec_files - spec_gemspec_paths
+      stale_extension_dirs = extension_dirs - spec_extension_paths
 
       removed_stale_gem_dirs = stale_gem_dirs.collect {|dir| remove_dir(dir, dry_run) }
       removed_stale_git_dirs = stale_git_dirs.collect {|dir| remove_dir(dir, dry_run) }
@@ -204,8 +208,10 @@ module Bundler
             FileUtils.rm(file) if File.exist?(file)
           end
         end
-        stale_git_cache_dirs.each do |cache_dir|
-          SharedHelpers.filesystem_access(cache_dir) do |dir|
+
+        stale_dirs = stale_git_cache_dirs + stale_extension_dirs
+        stale_dirs.each do |stale_dir|
+          SharedHelpers.filesystem_access(stale_dir) do |dir|
             FileUtils.rm_rf(dir) if File.exist?(dir)
           end
         end

--- a/spec/commands/clean_spec.rb
+++ b/spec/commands/clean_spec.rb
@@ -733,4 +733,39 @@ RSpec.describe "bundle clean" do
     expect(vendored_gems("bundler/gems/extensions")).to exist
     expect(vendored_gems("bundler/gems/very_simple_git_binary-1.0-#{revision[0..11]}")).to exist
   end
+
+  it "removes extension directories", :rubygems => "2.2" do
+    gemfile <<-G
+      source "file://#{gem_repo1}"
+
+      gem "thin"
+      gem "very_simple_binary"
+      gem "simple_binary"
+    G
+
+    bundle! "install", forgotten_command_line_options(:path => "vendor/bundle")
+
+    very_simple_binary_extensions_dir =
+      Pathname.glob("#{vendored_gems}/extensions/*/*/very_simple_binary-1.0").first
+
+    simple_binary_extensions_dir =
+      Pathname.glob("#{vendored_gems}/extensions/*/*/simple_binary-1.0").first
+
+    expect(very_simple_binary_extensions_dir).to exist
+    expect(simple_binary_extensions_dir).to exist
+
+    gemfile <<-G
+      source "file://#{gem_repo1}"
+
+      gem "thin"
+      gem "simple_binary"
+    G
+
+    bundle! "install"
+    bundle! :clean
+    expect(out).to eq("Removing very_simple_binary (1.0)")
+
+    expect(very_simple_binary_extensions_dir).not_to exist
+    expect(simple_binary_extensions_dir).to exist
+  end
 end

--- a/spec/support/builders.rb
+++ b/spec/support/builders.rb
@@ -182,6 +182,7 @@ module Spec
         end
 
         build_gem "very_simple_binary", &:add_c_extension
+        build_gem "simple_binary", &:add_c_extension
 
         build_gem "bundler", "0.9" do |s|
           s.executables = "bundle"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that `bundle clean` command doesn't remove gem extensions (#5596)

### What was your diagnosis of the problem?

I've looked into `Bundler::Runtime#clean` and realized that extension dirs are not removed

### What is your fix for the problem, implemented in this PR?

My fix is to tweak `Bundler::Runtime#clean` to remove extensions dirs
as well.

### Why did you choose this fix out of the possible options?

I chose this fix because I didn't see any other option.