### PR TITLE
Correctly set `loaded_from` when use installed gem

### DIFF
--- a/lib/bundler/source/rubygems.rb
+++ b/lib/bundler/source/rubygems.rb
@@ -107,6 +107,8 @@ module Bundler
         end
 
         if installed?(spec) && !force
+          spec.loaded_from ||= loaded_from(spec)
+
           print_using_message "Using #{version_message(spec)}"
           return nil # no post-install message
         end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

In bundler 1.16.0, the following script using `bundler/inline` fails.

```ruby
# script.rb
require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails"
  gem "arel", github: "rails/arel"
end
```

```
$ ruby script.rb
(snip)

.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.16.0/lib/bundler/runtime.rb:28:in `block in setup': rake-12.2.1 is missing. Run `bundle install` to get it. (Bundler::GemNotFound)
	from .rbenv/versions/2.4.1/lib/ruby/2.4.0/forwardable.rb:229:in `each'
	from .rbenv/versions/2.4.1/lib/ruby/2.4.0/forwardable.rb:229:in `each'
	from .rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.16.0/lib/bundler/runtime.rb:26:in `map'
	from .rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.16.0/lib/bundler/runtime.rb:26:in `setup'
	from .rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.16.0/lib/bundler/inline.rb:70:in `gemfile'
	from script.rb:3:in `<main>'
```

### What was your diagnosis of the problem?

My diagnosis was that `loaded_from` was not set when using installed gem.

### What is your fix for the problem, implemented in this PR?

My fix is set `loaded_from` when `loaded_from` is nil

### Why did you choose this fix out of the possible options?

In my understanding, it seems there are no other options, so I chose this fix.
