### PR TITLE
add `--paths` option to `bundle list` command.

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -285,6 +285,7 @@ module Bundler
     if Bundler.feature_flag.list_command?
       desc "list", "List all gems in the bundle"
       method_option "name-only", :type => :boolean, :banner => "print only the gem names"
+      method_option "paths", :type => :boolean, :banner => "print the path to each gem in the bundle"
       def list
         require "bundler/cli/list"
         List.new(options).run

--- a/lib/bundler/cli/list.rb
+++ b/lib/bundler/cli/list.rb
@@ -9,6 +9,7 @@ module Bundler
     def run
       specs = Bundler.load.specs.reject {|s| s.name == "bundler" }.sort_by(&:name)
       return specs.each {|s| Bundler.ui.info s.name } if @options["name-only"]
+      return specs.each {|s| Bundler.ui.info s.full_gem_path } if @options["paths"]
 
       return Bundler.ui.info "No gems in the Gemfile" if specs.empty?
       Bundler.ui.info "Gems included by the bundle:"

--- a/lib/bundler/cli/list.rb
+++ b/lib/bundler/cli/list.rb
@@ -8,6 +8,8 @@ module Bundler
 
     def run
       specs = Bundler.load.specs.reject {|s| s.name == "bundler" }.sort_by(&:name)
+
+      return Bundler.ui.error "The `--name-only` and `--paths` options cannot be used together" if @options["name-only"] && @options["paths"]
       return specs.each {|s| Bundler.ui.info s.name } if @options["name-only"]
       return specs.each {|s| Bundler.ui.info s.full_gem_path } if @options["paths"]
 

--- a/lib/bundler/cli/list.rb
+++ b/lib/bundler/cli/list.rb
@@ -9,7 +9,7 @@ module Bundler
     def run
       specs = Bundler.load.specs.reject {|s| s.name == "bundler" }.sort_by(&:name)
 
-      return Bundler.ui.error "The `--name-only` and `--paths` options cannot be used together" if @options["name-only"] && @options["paths"]
+      raise InvalidOption, "The `--name-only` and `--paths` options cannot be used together" if @options["name-only"] && @options["paths"]
       return specs.each {|s| Bundler.ui.info s.name } if @options["name-only"]
       return specs.each {|s| Bundler.ui.info s.full_gem_path } if @options["paths"]
 

--- a/man/bundle-list.ronn
+++ b/man/bundle-list.ronn
@@ -13,3 +13,5 @@ Prints a list of all the gems in the bundle including their version.
 
 * `--name-only`:
   Print only the name of each gem.
+* `--paths`:
+  Print the path to each gem in the bundle.

--- a/spec/commands/list_spec.rb
+++ b/spec/commands/list_spec.rb
@@ -8,6 +8,13 @@ RSpec.describe "bundle list", :bundler => "2" do
     G
   end
 
+  context "with name-only and paths option" do
+    it "raises an error" do
+      bundle "list --name-only --paths"
+      expect(out).to eq "The `--name-only` and `--paths` options cannot be used together"
+    end
+  end
+
   context "with name-only option" do
     it "prints only the name of the gems in the bundle" do
       bundle "list --name-only"
@@ -17,16 +24,34 @@ RSpec.describe "bundle list", :bundler => "2" do
 
   context "with paths option" do
     before do
+      build_repo2 do
+        build_gem "bar"
+      end
+
+      build_git "git_test", "1.0.0", :path => lib_path("git_test")
+
+      build_lib("gemspec_test", :path => tmp.join("gemspec_test")) do |s|
+        s.write("Gemfile", "source :rubygems\ngemspec")
+        s.add_dependency "bar", "=1.0.0"
+      end
+
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "file://#{gem_repo2}"
         gem "rack"
         gem "rails"
+        gem "git_test", :git => "#{lib_path("git_test")}"
+        gemspec :path => "#{tmp.join("gemspec_test")}"
       G
+
+      bundle! "install"
     end
+
     it "prints the path of each gem in the bundle" do
       bundle "list --paths"
       expect(out).to match(%r{.*\/rails\-2\.3\.2})
-      expect(out).to match(%r{.*\/rack\-1\.0\.0})
+      expect(out).to match(%r{.*\/rack\-1\.2})
+      expect(out).to match(%r{.*\/git_test\-\w})
+      expect(out).to match(%r{.*\/gemspec_test})
     end
   end
 

--- a/spec/commands/list_spec.rb
+++ b/spec/commands/list_spec.rb
@@ -15,6 +15,21 @@ RSpec.describe "bundle list", :bundler => "2" do
     end
   end
 
+  context "with paths option" do
+    before do
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem "rack"
+        gem "rails"
+      G
+    end
+    it "prints the path of each gem in the bundle" do
+      bundle "list --paths"
+      expect(out).to match(%r{.*\/rails\-2\.3\.2})
+      expect(out).to match(%r{.*\/rack\-1\.0\.0})
+    end
+  end
+
   context "when no gems are in the gemfile" do
     before do
       install_gemfile <<-G


### PR DESCRIPTION
See #6172 

This option mimics the `--paths` options in `bundle show` which is
being removed in Bundler 2.

Example Usage:

```
  $ bundle list --paths
  /Users/c/Desktop/Projects/testapp/.bundle/ruby/2.4.0/gems/actioncable-5.1.4
  /Users/c/Desktop/Projects/testapp/.bundle/ruby/2.4.0/gems/actionmailer-5.1.4
  /Users/c/Desktop/Projects/testapp/.bundle/ruby/2.4.0/gems/actionpack-5.1.4
  /Users/c/Desktop/Projects/testapp/.bundle/ruby/2.4.0/gems/actionview-5.1.4
```