### PR TITLE
Update rubygems 2.7 branch to 2.7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ env:
   # We need to know if changes to rubygems will break bundler on release
   - RGV=master
   # Test the latest rubygems release with all of our supported rubies
-  - RGV=v2.7.1
+  - RGV=v2.7.2
 
 matrix:
   include:
@@ -52,9 +52,9 @@ matrix:
       env: RGV=master
     # 1.x mode (we want to keep stuff passing in 1.x mode for now)
     - rvm: 2.4.2
-      env: RGV=v2.7.1 BUNDLER_SPEC_SUB_VERSION=1.98
+      env: RGV=v2.7.2 BUNDLER_SPEC_SUB_VERSION=1.98
     - rvm: 1.8.7
-      env: RGV=v2.7.1 BUNDLER_SPEC_SUB_VERSION=1.98
+      env: RGV=v2.7.2 BUNDLER_SPEC_SUB_VERSION=1.98
 
   allow_failures:
     - rvm: ruby-head

--- a/Rakefile
+++ b/Rakefile
@@ -147,7 +147,7 @@ begin
       rubyopt = ENV["RUBYOPT"]
       # When editing this list, also edit .travis.yml!
       branches = %w[master]
-      releases = %w[v1.3.6 v1.3.7 v1.4.2 v1.5.3 v1.6.2 v1.7.2 v1.8.29 v2.0.14 v2.1.11 v2.2.5 v2.4.8 v2.5.2 v2.6.8 v2.6.14 v2.7.1]
+      releases = %w[v1.3.6 v1.3.7 v1.4.2 v1.5.3 v1.6.2 v1.7.2 v1.8.29 v2.0.14 v2.1.11 v2.2.5 v2.4.8 v2.5.2 v2.6.8 v2.6.14 v2.7.2]
       (branches + releases).each do |rg|
         desc "Run specs with RubyGems #{rg}"
         RSpec::Core::RakeTask.new(rg) do |t|


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Update rubygems 2.7 branch to 2.7.2. This should trigger travis build to check that everything works. I think, build should be break.
