### PR TITLE
Resolver: treat dependencies with prerelease versions as slightly constrained

### DIFF
--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -249,7 +249,8 @@ module Bundler
           if all <= 1
             all - 1_000_000
           else
-            search = search_for(dependency).size
+            search = search_for(dependency)
+            search = @prerelease_specified[dependency.name] ? search.count : search.count {|s| !s.version.prerelease? }
             search - all
           end
         end

--- a/spec/resolver/basic_spec.rb
+++ b/spec/resolver/basic_spec.rb
@@ -42,6 +42,13 @@ RSpec.describe "Resolving" do
     should_resolve_as %w[a-1.0.0 b-2.0.0 c-1.0.0 d-1.0.0]
   end
 
+  it "prefers non-prerelease resolutions in sort order" do
+    @index = optional_prereleases_index
+    dep "a"
+    dep "b"
+    should_resolve_as %w[a-1.0.0 b-1.5.0]
+  end
+
   it "resolves a index with root level conflict on child" do
     @index = a_index_with_root_conflict_on_child
     dep "i18n", "~> 0.4"

--- a/spec/support/indexes.rb
+++ b/spec/support/indexes.rb
@@ -401,5 +401,20 @@ module Spec
         gem("d", %w[1.0.0 2.0.0])
       end
     end
+
+    def optional_prereleases_index
+      build_index do
+        gem("a", %w[1.0.0])
+
+        gem("a", "2.0.0") do
+          dep "b", ">= 2.0.0.pre"
+        end
+
+        gem("b", %w[0.9.0 1.5.0 2.0.0.pre])
+
+        # --- Pre-release support
+        gem "rubygems\0", ["1.3.2"]
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/bundler/bundler/issues/6181.

In Bundler 1.15.4, the way we checked for pre-releases meant that dependencies with a lot of them sorted as more constrained than those with few/none. When we moved to our updated resolution strategy in 1.16.0 we accidentally lost that behaviour.

I'm not wild about this PR, but it fixes the resolver regression. It's unsatisfying because it would be nice to believe the resolver will always resolve performantly, regardless of the sort order thrown at it, but clearly that isn't the case.

Conceptually, this can be justified as "when two resolutions are possible, we prefer the one that does not require one dependency to be at a pre-release version".

If others are happy with this I can write a test for it.