### PR TITLE
Ensure git is executed inside the gemspec dir

### DIFF
--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -28,8 +28,8 @@ Gem::Specification.new do |spec|
       "public gem pushes."
   end
 
-  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
+  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Executables from bundled gems weren't available. 

```
Gem::Exception: can't find executable <EXEC-FILENAME> for gem <GEM-NAME>
  /Users/elia/.rvm/rubies/ruby-2.3.4/lib/ruby/site_ruby/2.3.0/bundler/rubygems_integration.rb:458:in `block in replace_bin_path'
  /Users/elia/.rvm/rubies/ruby-2.3.4/lib/ruby/site_ruby/2.3.0/bundler/rubygems_integration.rb:478:in `block in replace_bin_path'
…
```

### What was your diagnosis of the problem?

When a Gemfile was pointing to a local gem using git to list its files the git command
was executed from within the wrong dir.

### What is your fix for the problem, implemented in this PR?

Initially I added `-C #{__dir__}` to the `git ls-files -z` command.

### Why did you choose this fix out of the possible options?

Realized `-C` wasn't safe and opted for stuff already available in the corelib, i.e. `Dir.chrid` instead of, say, escaping with `shellwords`.

---

I know the line is long-ish, happy to fix it in the way you want