### PR TITLE
Be more precise when replacing Bundler version in lock file.

### DIFF
--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -657,7 +657,7 @@ RSpec.describe "bundle update --bundler" do
       source "file:#{gem_repo4}"
       gem "rack"
     G
-    lockfile lockfile.sub(Bundler::VERSION, "1.0.0")
+    lockfile lockfile.sub(/(^\s*)#{Bundler::VERSION}($)/, '\11.0.0\2')
 
     FileUtils.rm_r gem_repo4
 


### PR DESCRIPTION
Lets say the current Bundler version is 1.16.0. If the test suite is, by a chance, executed in directory which contains such version string, this path is stored in Gemfile.lock file. Later, the test tries to replace
the version of Bundler in the lock file, but instead, it replaces the version in path. Be more careful what should be actually replaced.

This is related to #6185 although it does not resolve the original concern.