### PR TITLE
Include bundler.gemspec in the gem because warbler breaks w/o it

### DIFF
--- a/bundler.gemspec
+++ b/bundler.gemspec
@@ -49,6 +49,8 @@ Gem::Specification.new do |s|
   s.files += Dir.glob("man/**/*")
   # Include the CHANGELOG.md, LICENSE.md, README.md manually
   s.files += %w[CHANGELOG.md LICENSE.md README.md]
+  # include the gemspec itself because warbler breaks w/o it
+  s.files += %w[bundler.gemspec]
 
   s.bindir        = "exe"
   s.executables   = %w[bundle bundler]


### PR DESCRIPTION
f06405 caused a regression with warbler, described in #6165 and jruby/warbler#421

If the fix is ok, it should probably be cherry-picked to 1-16-stable. 

### What was the end-user problem that led to this PR?

Upgrading from bundler v1.15.x to v1.16.0 causes warbler to break/abort with error.

### What was your diagnosis of the problem?

1. error message from warbler: missing file
2. see why file is missing
3. google to see if it's just me 😄 

### What is your fix for the problem, implemented in this PR?

Put the missing (from warblers point of view at least) back.

### Why did you choose this fix out of the possible options?

Seems easier than to fix warbler.
