### PR TITLE
Allow test execution in paths containing dash.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,7 +21,7 @@ rescue LoadError
   abort "Run rake spec:deps to install development dependencies"
 end
 
-if File.expand_path(__FILE__) =~ %r{([^\w/\.])}
+if File.expand_path(__FILE__) =~ %r{([^\w/\.-])}
   abort "The bundler specs cannot be run from a path that contains special characters (particularly #{$1.inspect})"
 end
 


### PR DESCRIPTION
PR #5036 added restriction on what characters can be contained in path,
from where the specs are executed. But they dissallows even dash, which
is hopefully handled just fine on all systems.

This patch fixes #6185 by relaxing the restriction a bit and allowing
path to contain dash.
