### PR TITLE
Setup custom Gemfile path before loading bundler for binstubs

### DIFF
--- a/lib/bundler/templates/Executable
+++ b/lib/bundler/templates/Executable
@@ -8,12 +8,12 @@
 # this file is here to facilitate running it.
 #
 
-bundle_binstub = File.expand_path("../bundle", __FILE__)
-load(bundle_binstub) if File.file?(bundle_binstub)
-
 require "pathname"
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../<%= relative_gemfile_path %>",
   Pathname.new(__FILE__).realpath)
+
+bundle_binstub = File.expand_path("../bundle", __FILE__)
+load(bundle_binstub) if File.file?(bundle_binstub)
 
 require "rubygems"
 require "bundler/setup"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

While you have several gemfiles: `Gemfile` and `Gemfile.tools`.
and generates binstubs for gems from second gemfile: `BUNDLE_GEMFILE=Gemfile.tools bundle binstubs rubocop`
when you invoke those bin `bin/rubocop`
then you see error like:

```bash
/usr/local/opt/rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/bundler-1.16.0/lib/bundler/rubygems_integration.rb:458:in `block in replace_bin_path': can't find executable rubocop for gem rubocop. rubocop is not currently included in the bundle, perhaps you meant to add it to your Gemfile? (Gem::Exception)
	from /usr/local/opt/rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/bundler-1.16.0/lib/bundler/rubygems_integration.rb:489:in `block in replace_bin_path'
	from bin/rubocop:21:in `<main>'
```

### What was your diagnosis of the problem?

When you have generated `bin/bundler` by rails or by `bundler` it has setup of `BUNDLE_GEMFILE` by default as `Gemfile` or by gemfile which has been setup on `bundle binstub bundler`.

So your binstub for rubocop could not change it. 

### What is your fix for the problem, implemented in this PR?

I propose to use`BUNDLE_GEMFILE` from gem's binstub over bundler's binstub version

### Why did you choose this fix out of the possible options?

This was default behavior before #5878 introduced. Just added some fix to related PR.