### PR TITLE
Fixed failing examples with Ruby 2.5.

### DIFF
--- a/spec/bundler/definition_spec.rb
+++ b/spec/bundler/definition_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Bundler::Definition do
       build_lib "foo", "1.0", :path => lib_path("foo")
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "file://localhost#{gem_repo1}"
         gem "foo", :path => "#{lib_path("foo")}"
       G
 
@@ -55,7 +55,7 @@ RSpec.describe Bundler::Definition do
               rack (= 1.0)
 
         GEM
-          remote: file:#{gem_repo1}/
+          remote: file://localhost#{gem_repo1}/
           specs:
             rack (1.0.0)
 
@@ -115,7 +115,7 @@ RSpec.describe Bundler::Definition do
       end
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "file://localhost#{gem_repo1}"
         gem "foo", :path => "#{lib_path("foo")}"
       G
 
@@ -130,7 +130,7 @@ RSpec.describe Bundler::Definition do
               rack (= 1.0)
 
         GEM
-          remote: file:#{gem_repo1}/
+          remote: file://localhost#{gem_repo1}/
           specs:
             rack (1.0.0)
 
@@ -184,7 +184,7 @@ RSpec.describe Bundler::Definition do
 
     it "for a rubygems gem" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "file://localhost#{gem_repo1}"
         gem "foo"
       G
 
@@ -193,7 +193,7 @@ RSpec.describe Bundler::Definition do
       expect(out).to match(/using resolution from the lockfile/)
       lockfile_should_be <<-G
         GEM
-          remote: file:#{gem_repo1}/
+          remote: file://localhost#{gem_repo1}/
           specs:
             foo (1.0)
 

--- a/spec/commands/lock_spec.rb
+++ b/spec/commands/lock_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "bundle lock" do
 
   before :each do
     gemfile <<-G
-      source "file://#{repo}"
+      source "file://localhost#{repo}"
       gem "rails"
       gem "with_license"
       gem "foo"
@@ -21,7 +21,7 @@ RSpec.describe "bundle lock" do
 
     @lockfile = strip_lockfile <<-L
       GEM
-        remote: file:#{repo}/
+        remote: file://localhost#{repo}/
         specs:
           actionmailer (2.3.2)
             activesupport (= 2.3.2)
@@ -228,7 +228,7 @@ RSpec.describe "bundle lock" do
     end
 
     gemfile <<-G
-      source "file:#{gem_repo4}"
+      source "file://localhost#{gem_repo4}"
 
       gem "mixlib-shellout"
       gem "gssapi"
@@ -238,7 +238,7 @@ RSpec.describe "bundle lock" do
 
     expect(the_bundle.lockfile).to read_as(strip_whitespace(<<-G))
       GEM
-        remote: file:#{gem_repo4}/
+        remote: file://localhost#{gem_repo4}/
         specs:
           ffi (1.9.14-x86-mingw32)
           gssapi (1.2.0)
@@ -263,7 +263,7 @@ RSpec.describe "bundle lock" do
 
     expect(the_bundle.lockfile).to read_as(strip_whitespace(<<-G))
       GEM
-        remote: file:#{gem_repo4}/
+        remote: file://localhost#{gem_repo4}/
         specs:
           ffi (1.9.14)
           ffi (1.9.14-x86-mingw32)

--- a/spec/install/gemfile/gemspec_spec.rb
+++ b/spec/install/gemfile/gemspec_spec.rb
@@ -426,7 +426,7 @@ RSpec.describe "bundle install from an existing gemspec" do
         %w[ruby jruby].each do |platform|
           simulate_platform(platform) do
             install_gemfile <<-G
-              source "file://#{gem_repo2}"
+              source "file://localhost#{gem_repo2}"
               gemspec
             G
           end
@@ -450,7 +450,7 @@ RSpec.describe "bundle install from an existing gemspec" do
                     platform_specific
 
               GEM
-                remote: file:#{gem_repo2}/
+                remote: file://localhost#{gem_repo2}/
                 specs:
                   platform_specific (1.0)
                   platform_specific (1.0-java)
@@ -480,7 +480,7 @@ RSpec.describe "bundle install from an existing gemspec" do
                   foo (1.0)
 
               GEM
-                remote: file:#{gem_repo2}/
+                remote: file://localhost#{gem_repo2}/
                 specs:
                   platform_specific (1.0)
                   platform_specific (1.0-java)
@@ -512,7 +512,7 @@ RSpec.describe "bundle install from an existing gemspec" do
                   foo (1.0)
 
               GEM
-                remote: file:#{gem_repo2}/
+                remote: file://localhost#{gem_repo2}/
                 specs:
                   indirect_platform_specific (1.0)
                     platform_specific
@@ -545,7 +545,7 @@ RSpec.describe "bundle install from an existing gemspec" do
             expect(the_bundle).to include_gems "foo 1.0", "platform_specific 1.0 RUBY"
             expect(lockfile).to eq strip_whitespace(<<-L)
               GEM
-                remote: file:#{gem_repo2}/
+                remote: file://localhost#{gem_repo2}/
                 specs:
                   platform_specific (1.0)
                   platform_specific (1.0-java)
@@ -576,7 +576,7 @@ RSpec.describe "bundle install from an existing gemspec" do
             expect(the_bundle).to include_gems "foo 1.0", "platform_specific 1.0 RUBY"
             expect(lockfile).to eq strip_whitespace(<<-L)
               GEM
-                remote: file:#{gem_repo2}/
+                remote: file://localhost#{gem_repo2}/
                 specs:
                   platform_specific (1.0)
                   platform_specific (1.0-java)
@@ -608,7 +608,7 @@ RSpec.describe "bundle install from an existing gemspec" do
             expect(the_bundle).to include_gems "foo 1.0", "indirect_platform_specific 1.0", "platform_specific 1.0 RUBY"
             expect(lockfile).to eq strip_whitespace(<<-L)
               GEM
-                remote: file:#{gem_repo2}/
+                remote: file://localhost#{gem_repo2}/
                 specs:
                   indirect_platform_specific (1.0)
                     platform_specific

--- a/spec/install/gemfile/sources_spec.rb
+++ b/spec/install/gemfile/sources_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
       before do
         gemfile <<-G
-          source "file://#{gem_repo3}"
-          source "file://#{gem_repo1}"
+          source "file://localhost#{gem_repo3}"
+          source "file://localhost#{gem_repo1}"
           gem "rack-obama"
           gem "rack"
         G
@@ -33,7 +33,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
         expect(out).to have_major_deprecation a_string_including("Your Gemfile contains multiple primary sources.")
         expect(out).to include("Warning: the gem 'rack' was found in multiple sources.")
-        expect(out).to include("Installed from: file:#{gem_repo1}")
+        expect(out).to include("Installed from: file://localhost#{gem_repo1}")
         expect(the_bundle).to include_gems("rack-obama 1.0.0", "rack 1.0.0", :source => "remote1")
       end
 
@@ -50,8 +50,8 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
       before do
         gemfile <<-G
-          source "file://#{gem_repo3}"
-          source "file://#{gem_repo1}"
+          source "file://localhost#{gem_repo3}"
+          source "file://localhost#{gem_repo1}"
           gem "rack-obama"
           gem "rack", "1.0.0" # force it to install the working version in repo1
         G
@@ -63,7 +63,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
         expect(out).to have_major_deprecation a_string_including("Your Gemfile contains multiple primary sources.")
         expect(out).to include("Warning: the gem 'rack' was found in multiple sources.")
-        expect(out).to include("Installed from: file:#{gem_repo1}")
+        expect(out).to include("Installed from: file://localhost#{gem_repo1}")
         expect(the_bundle).to include_gems("rack-obama 1.0.0", "rack 1.0.0", :source => "remote1")
       end
     end
@@ -240,9 +240,9 @@ RSpec.describe "bundle install with gems on multiple sources" do
         context "and in yet another source" do
           before do
             gemfile <<-G
-              source "file://#{gem_repo1}"
-              source "file://#{gem_repo2}"
-              source "file://#{gem_repo3}" do
+              source "file://localhost#{gem_repo1}"
+              source "file://localhost#{gem_repo2}"
+              source "file://localhost#{gem_repo3}" do
                 gem "depends_on_rack"
               end
             G
@@ -253,7 +253,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
             bundle :install
             expect(out).to have_major_deprecation a_string_including("Your Gemfile contains multiple primary sources.")
             expect(out).to include("Warning: the gem 'rack' was found in multiple sources.")
-            expect(out).to include("Installed from: file:#{gem_repo2}")
+            expect(out).to include("Installed from: file://localhost#{gem_repo2}")
             expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0")
           end
         end

--- a/spec/install/gems/flex_spec.rb
+++ b/spec/install/gems/flex_spec.rb
@@ -247,19 +247,19 @@ RSpec.describe "bundle flex_install" do
     it "updates the lockfile", :bundler => "< 2" do
       build_repo2
       install_gemfile! <<-G
-        source "file://#{gem_repo1}"
+        source "file://localhost#{gem_repo1}"
         gem "rack"
       G
       install_gemfile! <<-G
-        source "file://#{gem_repo1}"
-        source "file://#{gem_repo2}"
+        source "file://localhost#{gem_repo1}"
+        source "file://localhost#{gem_repo2}"
         gem "rack"
       G
 
       lockfile_should_be <<-L
       GEM
-        remote: file:#{gem_repo1}/
-        remote: file:#{gem_repo2}/
+        remote: file://localhost#{gem_repo1}/
+        remote: file://localhost#{gem_repo2}/
         specs:
           rack (1.0.0)
 

--- a/spec/install/gems/mirror_spec.rb
+++ b/spec/install/gems/mirror_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "bundle install with a mirror configured" do
   describe "when the mirror does not match the gem source" do
     before :each do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "file://localhost#{gem_repo1}"
 
         gem "rack"
       G
@@ -13,7 +13,7 @@ RSpec.describe "bundle install with a mirror configured" do
 
     it "installs from the normal location" do
       bundle :install
-      expect(out).to include("Fetching source index from file:#{gem_repo1}")
+      expect(out).to include("Fetching source index from file://localhost#{gem_repo1}")
       expect(the_bundle).to include_gems "rack 1.0"
     end
   end
@@ -22,17 +22,17 @@ RSpec.describe "bundle install with a mirror configured" do
     before :each do
       gemfile <<-G
         # This source is bogus and doesn't have the gem we're looking for
-        source "file://#{gem_repo2}"
+        source "file://localhost#{gem_repo2}"
 
         gem "rack"
       G
-      bundle "config --local mirror.file://#{gem_repo2} file://#{gem_repo1}"
+      bundle "config --local mirror.file://localhost#{gem_repo2} file://localhost#{gem_repo1}"
     end
 
     it "installs the gem from the mirror" do
       bundle :install
-      expect(out).to include("Fetching source index from file:#{gem_repo1}")
-      expect(out).not_to include("Fetching source index from file:#{gem_repo2}")
+      expect(out).to include("Fetching source index from file://localhost#{gem_repo1}")
+      expect(out).not_to include("Fetching source index from file://localhost#{gem_repo2}")
       expect(the_bundle).to include_gems "rack 1.0"
     end
   end

--- a/spec/lock/lockfile_bundler_1_spec.rb
+++ b/spec/lock/lockfile_bundler_1_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
 
   it "generates a simple lockfile for a single source, gem" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "file://localhost#{gem_repo1}"
 
       gem "rack"
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file:#{gem_repo1}/
+        remote: file://localhost#{gem_repo1}/
         specs:
           rack (1.0.0)
 
@@ -37,7 +37,7 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
         specs:
 
       GEM
-        remote: file://#{gem_repo1}/
+        remote: file://localhost#{gem_repo1}/
         specs:
           rack (1.0.0)
 
@@ -53,14 +53,14 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
     L
 
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "file://localhost#{gem_repo1}"
 
       gem "rack"
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file:#{gem_repo1}/
+        remote: file://localhost#{gem_repo1}/
         specs:
           rack (1.0.0)
 
@@ -80,7 +80,7 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
 
     lockfile <<-L
       GEM
-        remote: file:#{gem_repo1}/
+        remote: file://localhost#{gem_repo1}/
         specs:
           rack (1.0.0)
 
@@ -95,14 +95,14 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
     L
 
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "file://localhost#{gem_repo1}"
 
       gem "rack"
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file:#{gem_repo1}/
+        remote: file://localhost#{gem_repo1}/
         specs:
           rack (1.0.0)
 
@@ -120,7 +120,7 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
   it "updates the lockfile's bundler version if not present" do
     lockfile <<-L
       GEM
-        remote: file:#{gem_repo1}/
+        remote: file://localhost#{gem_repo1}/
         specs:
           rack (1.0.0)
 
@@ -132,14 +132,14 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
     L
 
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "file://localhost#{gem_repo1}"
 
       gem "rack", "> 0"
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file:#{gem_repo1}/
+        remote: file://localhost#{gem_repo1}/
         specs:
           rack (1.0.0)
 
@@ -157,7 +157,7 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
   it "outputs a warning if the current is older than lockfile's bundler version" do
     lockfile <<-L
       GEM
-        remote: file:#{gem_repo1}/
+        remote: file://localhost#{gem_repo1}/
         specs:
           rack (1.0.0)
 
@@ -173,7 +173,7 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
 
     simulate_bundler_version "9999999.0.0" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "file://localhost#{gem_repo1}"
 
         gem "rack"
       G
@@ -185,7 +185,7 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
 
     lockfile_should_be <<-G
       GEM
-        remote: file:#{gem_repo1}/
+        remote: file://localhost#{gem_repo1}/
         specs:
           rack (1.0.0)
 
@@ -204,7 +204,7 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
   it "errors if the current is a major version older than lockfile's bundler version" do
     lockfile <<-L
       GEM
-        remote: file:#{gem_repo1}/
+        remote: file://localhost#{gem_repo1}/
         specs:
           rack (1.0.0)
 
@@ -219,7 +219,7 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
     L
 
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "file://localhost#{gem_repo1}"
 
       gem "rack"
     G
@@ -269,7 +269,7 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
   it "warns when updating bundler major version" do
     lockfile <<-L
       GEM
-        remote: file:#{gem_repo1}/
+        remote: file://localhost#{gem_repo1}/
         specs:
           rack (1.0.0)
 
@@ -285,7 +285,7 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
 
     simulate_bundler_version "9999999.0.0" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "file://localhost#{gem_repo1}"
 
         gem "rack"
       G
@@ -296,7 +296,7 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
 
     lockfile_should_be <<-G
       GEM
-        remote: file:#{gem_repo1}/
+        remote: file://localhost#{gem_repo1}/
         specs:
           rack (1.0.0)
 
@@ -314,14 +314,14 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
 
   it "generates a simple lockfile for a single source, gem with dependencies" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "file://localhost#{gem_repo1}"
 
       gem "rack-obama"
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file:#{gem_repo1}/
+        remote: file://localhost#{gem_repo1}/
         specs:
           rack (1.0.0)
           rack-obama (1.0)
@@ -340,14 +340,14 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
 
   it "generates a simple lockfile for a single source, gem with a version requirement" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "file://localhost#{gem_repo1}"
 
       gem "rack-obama", ">= 1.0"
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file:#{gem_repo1}/
+        remote: file://localhost#{gem_repo1}/
         specs:
           rack (1.0.0)
           rack-obama (1.0)
@@ -396,13 +396,13 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
 
   it "generates lockfiles with multiple requirements" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "file://localhost#{gem_repo1}"
       gem "net-sftp"
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file:#{gem_repo1}/
+        remote: file://localhost#{gem_repo1}/
         specs:
           net-sftp (1.1.1)
             net-ssh (>= 1.0.0, < 1.99.0)
@@ -453,7 +453,7 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
     build_lib "omg", :path => lib_path("omg")
 
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "file://localhost#{gem_repo1}"
 
       platforms :#{not_local_tag} do
         gem "omg", :path => "#{lib_path("omg")}"
@@ -469,7 +469,7 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
         specs:
 
       GEM
-        remote: file://#{gem_repo1}/
+        remote: file://localhost#{gem_repo1}/
         specs:
           rack (1.0.0)
 
@@ -640,7 +640,7 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
     bar = build_git "bar"
 
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "file://localhost#{gem_repo1}"
 
       gem "rack"
       gem "foo", :path => "#{lib_path("foo-1.0")}"
@@ -660,7 +660,7 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
           foo (1.0)
 
       GEM
-        remote: file:#{gem_repo1}/
+        remote: file://localhost#{gem_repo1}/
         specs:
           rack (1.0.0)
 
@@ -679,7 +679,7 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
 
   it "lists gems alphabetically" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "file://localhost#{gem_repo1}"
 
       gem "thin"
       gem "actionpack"
@@ -688,7 +688,7 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
 
     lockfile_should_be <<-G
       GEM
-        remote: file:#{gem_repo1}/
+        remote: file://localhost#{gem_repo1}/
         specs:
           actionpack (2.3.2)
             activesupport (= 2.3.2)
@@ -714,14 +714,14 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
 
   it "orders dependencies' dependencies in alphabetical order" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "file://localhost#{gem_repo1}"
 
       gem "rails"
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file:#{gem_repo1}/
+        remote: file://localhost#{gem_repo1}/
         specs:
           actionmailer (2.3.2)
             activesupport (= 2.3.2)
@@ -753,13 +753,13 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
 
   it "orders dependencies by version" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "file://localhost#{gem_repo1}"
       gem 'double_deps'
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file:#{gem_repo1}/
+        remote: file://localhost#{gem_repo1}/
         specs:
           double_deps (1.0)
             net-ssh
@@ -779,14 +779,14 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
 
   it "does not add the :require option to the lockfile" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "file://localhost#{gem_repo1}"
 
       gem "rack-obama", ">= 1.0", :require => "rack/obama"
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file:#{gem_repo1}/
+        remote: file://localhost#{gem_repo1}/
         specs:
           rack (1.0.0)
           rack-obama (1.0)
@@ -805,14 +805,14 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
 
   it "does not add the :group option to the lockfile" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "file://localhost#{gem_repo1}"
 
       gem "rack-obama", ">= 1.0", :group => :test
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file:#{gem_repo1}/
+        remote: file://localhost#{gem_repo1}/
         specs:
           rack (1.0.0)
           rack-obama (1.0)
@@ -943,7 +943,7 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
   it "keeps existing platforms in the lockfile" do
     lockfile <<-G
       GEM
-        remote: file:#{gem_repo1}/
+        remote: file://localhost#{gem_repo1}/
         specs:
           rack (1.0.0)
 
@@ -958,7 +958,7 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
     G
 
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "file://localhost#{gem_repo1}"
 
       gem "rack"
     G
@@ -967,7 +967,7 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
 
     lockfile_should_be <<-G
       GEM
-        remote: file:#{gem_repo1}/
+        remote: file://localhost#{gem_repo1}/
         specs:
           rack (1.0.0)
 
@@ -991,13 +991,13 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
     simulate_platform "universal-java-16"
 
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "file://localhost#{gem_repo1}"
       gem "platform_specific"
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file:#{gem_repo1}/
+        remote: file://localhost#{gem_repo1}/
         specs:
           platform_specific (1.0-java)
 
@@ -1014,19 +1014,19 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
 
   it "does not add duplicate gems" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "file://localhost#{gem_repo1}"
       gem "rack"
     G
 
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "file://localhost#{gem_repo1}"
       gem "rack"
       gem "activesupport"
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file:#{gem_repo1}/
+        remote: file://localhost#{gem_repo1}/
         specs:
           activesupport (2.3.5)
           rack (1.0.0)
@@ -1045,14 +1045,14 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
 
   it "does not add duplicate dependencies" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "file://localhost#{gem_repo1}"
       gem "rack"
       gem "rack"
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file:#{gem_repo1}/
+        remote: file://localhost#{gem_repo1}/
         specs:
           rack (1.0.0)
 
@@ -1069,14 +1069,14 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
 
   it "does not add duplicate dependencies with versions" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "file://localhost#{gem_repo1}"
       gem "rack", "1.0"
       gem "rack", "1.0"
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file:#{gem_repo1}/
+        remote: file://localhost#{gem_repo1}/
         specs:
           rack (1.0.0)
 
@@ -1093,14 +1093,14 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
 
   it "does not add duplicate dependencies in different groups" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "file://localhost#{gem_repo1}"
       gem "rack", "1.0", :group => :one
       gem "rack", "1.0", :group => :two
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file:#{gem_repo1}/
+        remote: file://localhost#{gem_repo1}/
         specs:
           rack (1.0.0)
 
@@ -1117,7 +1117,7 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
 
   it "raises if two different versions are used" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "file://localhost#{gem_repo1}"
       gem "rack", "1.0"
       gem "rack", "1.1"
     G
@@ -1128,7 +1128,7 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
 
   it "raises if two different sources are used" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "file://localhost#{gem_repo1}"
       gem "rack"
       gem "rack", :git => "git://hubz.com"
     G
@@ -1139,13 +1139,13 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
 
   it "works correctly with multiple version dependencies" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "file://localhost#{gem_repo1}"
       gem "rack", "> 0.9", "< 1.0"
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file:#{gem_repo1}/
+        remote: file://localhost#{gem_repo1}/
         specs:
           rack (0.9.1)
 
@@ -1162,14 +1162,14 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
 
   it "captures the Ruby version in the lockfile" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "file://localhost#{gem_repo1}"
       ruby '#{RUBY_VERSION}'
       gem "rack", "> 0.9", "< 1.0"
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file:#{gem_repo1}/
+        remote: file://localhost#{gem_repo1}/
         specs:
           rack (0.9.1)
 
@@ -1198,7 +1198,7 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
     revision = revision_for(lib_path("omg"))
 
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "file://localhost#{gem_repo1}"
       gem "omg", :git => "#{lib_path("omg")}", :branch => 'master'
     G
 
@@ -1222,7 +1222,7 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
           omg (1.0)
 
       GEM
-        remote: file:#{gem_repo1}/
+        remote: file://localhost#{gem_repo1}/
         specs:
 
       PLATFORMS
@@ -1249,7 +1249,7 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
           omg (1.0)
 
       GEM
-        remote: file:#{gem_repo1}/
+        remote: file://localhost#{gem_repo1}/
         specs:
 
       PLATFORMS
@@ -1266,7 +1266,7 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
   it "raises a helpful error message when the lockfile is missing deps" do
     lockfile <<-L
       GEM
-        remote: file:#{gem_repo1}/
+        remote: file://localhost#{gem_repo1}/
         specs:
           rack_middleware (1.0)
 
@@ -1295,7 +1295,7 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
       build_repo2
 
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "file://localhost#{gem_repo2}"
         gem "rack"
       G
       set_lockfile_mtime_to_known_value
@@ -1357,7 +1357,7 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
   it "refuses to install if Gemfile.lock contains conflict markers" do
     lockfile <<-L
       GEM
-        remote: file://#{gem_repo1}/
+        remote: file://localhost#{gem_repo1}/
         specs:
       <<<<<<<
           rack (1.0.0)
@@ -1376,7 +1376,7 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
     L
 
     install_gemfile(<<-G)
-      source "file://#{gem_repo1}"
+      source "file://localhost#{gem_repo1}"
       gem "rack"
     G
 

--- a/spec/plugins/source/example_spec.rb
+++ b/spec/plugins/source/example_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "real source plugins" do
       build_lib "a-path-gem"
 
       gemfile <<-G
-        source "file://#{gem_repo2}" # plugin source
+        source "file://localhost#{gem_repo2}" # plugin source
         source "#{lib_path("a-path-gem-1.0")}", :type => :mpath do
           gem "a-path-gem"
         end
@@ -78,7 +78,7 @@ RSpec.describe "real source plugins" do
             a-path-gem (1.0)
 
         GEM
-          remote: file:#{gem_repo2}/
+          remote: file://localhost#{gem_repo2}/
           specs:
 
         PLATFORMS
@@ -346,7 +346,7 @@ RSpec.describe "real source plugins" do
       build_git "ma-gitp-gem"
 
       gemfile <<-G
-        source "file://#{gem_repo2}" # plugin source
+        source "file://localhost#{gem_repo2}" # plugin source
         source "file://#{lib_path("ma-gitp-gem-1.0")}", :type => :gitp do
           gem "ma-gitp-gem"
         end
@@ -372,7 +372,7 @@ RSpec.describe "real source plugins" do
             ma-gitp-gem (1.0)
 
         GEM
-          remote: file:#{gem_repo2}/
+          remote: file://localhost#{gem_repo2}/
           specs:
 
         PLATFORMS

--- a/spec/plugins/source/example_spec.rb
+++ b/spec/plugins/source/example_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe "real source plugins" do
 
       lockfile_should_be <<-G
         GEM
-          remote: file:#{gem_repo2}/
+          remote: file://localhost#{gem_repo2}/
           specs:
 
         PLUGIN SOURCE
@@ -392,7 +392,7 @@ RSpec.describe "real source plugins" do
 
       lockfile_should_be <<-G
         GEM
-          remote: file:#{gem_repo2}/
+          remote: file://localhost#{gem_repo2}/
           specs:
 
         PLUGIN SOURCE

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -1145,7 +1145,7 @@ end
     def lock_with(ruby_version = nil)
       lock = <<-L
         GEM
-          remote: file:#{gem_repo1}/
+          remote: file://localhost#{gem_repo1}/
           specs:
             rack (1.0.0)
 
@@ -1172,7 +1172,7 @@ end
     before do
       install_gemfile <<-G
         ruby ">= 0"
-        source "file:#{gem_repo1}"
+        source "file://localhost#{gem_repo1}"
         gem "rack"
       G
       lockfile lock_with(ruby_version)

--- a/spec/update/git_spec.rb
+++ b/spec/update/git_spec.rb
@@ -291,7 +291,7 @@ RSpec.describe "bundle update" do
       @git = build_git "foo", :path => lib_path("bar")
 
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "file://localhost#{gem_repo2}"
         git "#{lib_path("bar")}" do
           gem 'foo'
         end
@@ -319,7 +319,7 @@ RSpec.describe "bundle update" do
             foo (2.0)
 
         GEM
-          remote: file:#{gem_repo2}/
+          remote: file://localhost#{gem_repo2}/
           specs:
             rack (1.0.0)
 

--- a/spec/update/git_spec.rb
+++ b/spec/update/git_spec.rb
@@ -349,7 +349,7 @@ RSpec.describe "bundle update" do
 
       lockfile_should_be <<-G
         GEM
-          remote: file:#{gem_repo2}/
+          remote: file://localhost#{gem_repo2}/
           specs:
             rack (1.0.0)
 


### PR DESCRIPTION
(It targets 1-16-stable branch. I will create another pull request for master)

It's introduced by `URI::Generic` changes.

see  https://github.com/ruby/ruby/commit/ed48bfa5e8770a345424abd7f24f94ea9bbf5973

I added a hostname to examples that expect `file:` string in result messages.