### PR TITLE
Let users generate gemfiles inside paths whos parent contains a Gemfile

### DIFF
--- a/lib/bundler/cli/init.rb
+++ b/lib/bundler/cli/init.rb
@@ -36,11 +36,7 @@ module Bundler
   private
 
     def gemfile
-      @gemfile ||= begin
-        Bundler.default_gemfile
-      rescue GemfileNotFound
-        Bundler.feature_flag.init_gems_rb? ? "gems.rb" : "Gemfile"
-      end
+      @gemfile ||= Bundler.feature_flag.init_gems_rb? ? "gems.rb" : "Gemfile"
     end
   end
 end

--- a/spec/commands/init_spec.rb
+++ b/spec/commands/init_spec.rb
@@ -13,9 +13,26 @@ RSpec.describe "bundle init" do
     expect(bundled_app("gems.rb")).to be_file
   end
 
-  context "when a Gemfile already exists" do
+  context "when a Gemfile already exists", :bundler => "< 2" do
     before do
-      create_file "gems.rb", <<-G
+      create_file "Gemfile", <<-G
+        gem "rails"
+      G
+    end
+
+    it "does not change existing Gemfiles" do
+      expect { bundle :init }.not_to change { File.read(bundled_app("Gemfile")) }
+    end
+
+    it "notifies the user that an existing Gemfile already exists" do
+      bundle :init
+      expect(out).to include("Gemfile already exists")
+    end
+  end
+
+  context "when gems.rb already exists", :bundler => ">= 2" do
+    before do
+      create_file("gems.rb", <<-G)
         gem "rails"
       G
     end
@@ -24,13 +41,30 @@ RSpec.describe "bundle init" do
       expect { bundle :init }.not_to change { File.read(bundled_app("gems.rb")) }
     end
 
-    it "notifies the user that an existing Gemfile already exists" do
+    it "notifies the user that an existing gems.rb already exists" do
       bundle :init
       expect(out).to include("gems.rb already exists")
     end
   end
 
-  context "when a Gemfile exists in a parent directory" do
+  context "when a Gemfile exists in a parent directory", :bundler => "< 2" do
+    let(:subdir) { "child_dir" }
+
+    it "lets users generate a Gemfile in a child directory" do
+      bundle! :init
+
+      FileUtils.mkdir bundled_app(subdir)
+
+      Dir.chdir bundled_app(subdir) do
+        bundle! :init
+      end
+
+      expect(out).to include("Writing new Gemfile")
+      expect(bundled_app("#{subdir}/Gemfile")).to be_file
+    end
+  end
+
+  context "when a gems.rb file exists in a parent directory", :bundler => ">= 2" do
     let(:subdir) { "child_dir" }
 
     it "lets users generate a Gemfile in a child directory" do
@@ -44,23 +78,6 @@ RSpec.describe "bundle init" do
 
       expect(out).to include("Writing new gems.rb")
       expect(bundled_app("#{subdir}/gems.rb")).to be_file
-    end
-  end
-
-  context "when a gems.rb already exists" do
-    before do
-      create_file "gems.rb", <<-G
-        gem "rails"
-      G
-    end
-
-    it "does not change existing gem.rb files" do
-      expect { bundle :init }.not_to change { File.read(bundled_app("gems.rb")) }
-    end
-
-    it "notifies the user that an existing gems.rb already exists" do
-      bundle :init
-      expect(out).to include("gems.rb already exists")
     end
   end
 
@@ -110,28 +127,6 @@ RSpec.describe "bundle init" do
 
   context "when init_gems_rb setting is enabled" do
     before { bundle "config init_gems_rb true" }
-
-    it "generates a gems.rb file" do
-      bundle :init
-      expect(bundled_app("gems.rb")).to exist
-    end
-
-    context "when gems.rb already exists" do
-      before do
-        create_file("gems.rb", <<-G)
-          gem "rails"
-        G
-      end
-
-      it "does not change existing Gemfiles" do
-        expect { bundle :init }.not_to change { File.read(bundled_app("gems.rb")) }
-      end
-
-      it "notifies the user that an existing gems.rb already exists" do
-        bundle :init
-        expect(out).to include("gems.rb already exists")
-      end
-    end
 
     context "given --gemspec option", :bundler => "< 2" do
       let(:spec_file) { tmp.join("test.gemspec") }

--- a/spec/commands/init_spec.rb
+++ b/spec/commands/init_spec.rb
@@ -15,18 +15,35 @@ RSpec.describe "bundle init" do
 
   context "when a Gemfile already exists" do
     before do
-      gemfile <<-G
+      create_file "gems.rb", <<-G
         gem "rails"
       G
     end
 
     it "does not change existing Gemfiles" do
-      expect { bundle :init }.not_to change { File.read(bundled_app("Gemfile")) }
+      expect { bundle :init }.not_to change { File.read(bundled_app("gems.rb")) }
     end
 
     it "notifies the user that an existing Gemfile already exists" do
       bundle :init
-      expect(out).to include("Gemfile already exists")
+      expect(out).to include("gems.rb already exists")
+    end
+  end
+
+  context "when a Gemfile exists in a parent directory" do
+    let(:subdir) { "child_dir" }
+
+    it "lets users generate a Gemfile in a child directory" do
+      bundle! :init
+
+      FileUtils.mkdir bundled_app(subdir)
+
+      Dir.chdir bundled_app(subdir) do
+        bundle! :init
+      end
+
+      expect(out).to include("Writing new gems.rb")
+      expect(bundled_app("#{subdir}/gems.rb")).to be_file
     end
   end
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Users are unable to generate a new Gemfile with `bundle init` if there is a Gemfile in any
parent folder.

Closes #6205 

### What is your fix for the problem, implemented in this PR?

Don't use `SharedHelpers.default_gemfile` as that searches up the paths for a Gemfile. Instead only check the current directory.
