### PR TITLE
Ignore to generate documentation of templates.

### DIFF
--- a/lib/bundler/templates/.document
+++ b/lib/bundler/templates/.document
@@ -1,0 +1,1 @@
+# Ignore all files in this directory


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

When users invoke `rdoc -o rdoc lib`, it generates documentation contains template files under the `lib/bundler/template` like `rdoc/lib/bundler/templates/newgem/bin/setup_tt.html`

These files are not useful for users.

### What is your fix for the problem, implemented in this PR?

I added `.document` file to its directory.
