### PR TITLE
Add explicit source when available in the error msg upon failure

### DIFF
--- a/lib/bundler/installer/gem_installer.rb
+++ b/lib/bundler/installer/gem_installer.rb
@@ -44,7 +44,12 @@ module Bundler
     end
 
     def gem_install_message
-      "Make sure that `gem install #{spec.name} -v '#{spec.version}'` succeeds before bundling."
+      remotes = spec.source.remotes
+      if remotes.size == 1
+        "Make sure that `gem install #{spec.name} -v '#{spec.version}' --source '#{remotes.first}'` succeeds before bundling."
+      else
+        "Make sure that `gem install #{spec.name} -v '#{spec.version}'` succeeds before bundling."
+      end
     end
 
     def spec_settings

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -348,14 +348,14 @@ RSpec.describe "bundle install with gem sources" do
       end
 
       install_gemfile <<-G, :full_index => true
-        source "file://#{gem_repo2}"
+        source "file:\/\/localhost#{gem_repo2}"
 
         gem "ajp-rails", "0.0.0"
       G
 
       expect(last_command.stdboth).not_to match(/Error Report/i)
       expect(last_command.bundler_err).to include("An error occurred while installing ajp-rails (0.0.0), and Bundler cannot continue.").
-        and include("Make sure that `gem install ajp-rails -v '0.0.0'` succeeds before bundling.")
+        and include("Make sure that `gem install ajp-rails -v '0.0.0' --source 'file://localhost#{gem_repo2}/'` succeeds before bundling.")
     end
 
     it "doesn't blow up when the local .bundle/config is empty" do


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

My bundling failed and the command that `bundler` output was wrong-ish, in the sense that my gem was suppose to come from a different source.

### What was your diagnosis of the problem?

The error message was not explicit.

### What is your fix for the problem, implemented in this PR?

Bundler now explicitly print the source when there's just one. I think it's a good case just to print it when there's one. If there are more it's ambiguous, so we fallback to the old way. Maybe we could have a warning there that the command might not be exactly what the user wants.

### Why did you choose this fix out of the possible options?

See previous answer. I didn't find any easier ways of getting the source url.
Let me know if there are better implementations :)
