### PR TITLE
Unregister the bundler default spec in the tests

### DIFF
--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "bundle exec" do
       gem "rack"
     G
 
-    bundle "exec 'cd #{tmp("gems")} && rackup'"
+    bundle "exec 'cd #{tmp("gems")} && rackup'", :env => { :RUBYOPT => "-r#{spec_dir.join("support/hax")}" }
 
     expect(out).to include("1.0.0")
   end
@@ -42,7 +42,7 @@ RSpec.describe "bundle exec" do
 
   it "works when exec'ing to ruby" do
     install_gemfile 'gem "rack"'
-    bundle "exec ruby -e 'puts %{hi}'"
+    bundle "exec ruby -e 'puts %{hi}'", :env => { :RUBYOPT => "-r#{spec_dir.join("support/hax")}" }
     expect(out).to eq("hi")
   end
 
@@ -76,7 +76,9 @@ RSpec.describe "bundle exec" do
     G
 
     install_gemfile ""
-    sys_exec("#{Gem.ruby} #{command.path}")
+    with_env_vars "RUBYOPT" => "-r#{spec_dir.join("support/hax")}" do
+      sys_exec "#{Gem.ruby} #{command.path}"
+    end
 
     if Bundler.current_ruby.ruby_2?
       expect(out).to eq("")
@@ -237,7 +239,7 @@ RSpec.describe "bundle exec" do
     G
     [true, false].each do |l|
       bundle! "config disable_exec_load #{l}"
-      bundle "exec rackup"
+      bundle "exec rackup", :env => { :RUBYOPT => "-r#{spec_dir.join("support/hax")}" }
       expect(last_command.stderr).to include "rack is not part of the bundle. Add it to your Gemfile."
     end
   end
@@ -339,14 +341,14 @@ RSpec.describe "bundle exec" do
       end
 
       it "works when unlocked" do
-        bundle "exec 'cd #{tmp("gems")} && rackup'"
+        bundle "exec 'cd #{tmp("gems")} && rackup'", :env => { :RUBYOPT => "-r#{spec_dir.join("support/hax")}" }
         expect(out).to eq("1.0.0")
         expect(out).to include("1.0.0")
       end
 
       it "works when locked" do
         expect(the_bundle).to be_locked
-        bundle "exec 'cd #{tmp("gems")} && rackup'"
+        bundle "exec 'cd #{tmp("gems")} && rackup'", :env => { :RUBYOPT => "-r#{spec_dir.join("support/hax")}" }
         expect(out).to include("1.0.0")
       end
     end
@@ -472,7 +474,7 @@ RSpec.describe "bundle exec" do
       Bundler.rubygems.extend(Monkey)
       G
       bundle "install --deployment"
-      bundle "exec ruby -e '`#{bindir.join("bundler")} -v`; puts $?.success?'"
+      bundle "exec ruby -e '`#{bindir.join("bundler")} -v`; puts $?.success?'", :env => { :RUBYOPT => "-r#{spec_dir.join("support/hax")}" }
       expect(out).to match("true")
     end
   end
@@ -512,7 +514,7 @@ RSpec.describe "bundle exec" do
     let(:expected) { [exec, args, rack, process].join("\n") }
     let(:expected_err) { "" }
 
-    subject { bundle "exec #{path} arg1 arg2" }
+    subject { bundle "exec #{path} arg1 arg2", :env => { :RUBYOPT => "-r#{spec_dir.join("support/hax")}" } }
 
     shared_examples_for "it runs" do
       it "like a normally executed executable" do

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe "bundle gem" do
 
   it "generates a valid gemspec" do
     in_app_root
-    bundle "gem newgem --bin"
+    bundle! "gem newgem --bin"
 
     process_file(bundled_app("newgem", "newgem.gemspec")) do |line|
       # Simulate replacing TODOs with real values
@@ -211,7 +211,7 @@ RSpec.describe "bundle gem" do
     end
 
     Dir.chdir(bundled_app("newgem")) do
-      system_gems ["rake-10.0.2"], :path => :bundle_path
+      system_gems ["rake-10.0.2", :bundler], :path => :bundle_path
       bundle! "exec rake build"
     end
 

--- a/spec/commands/pristine_spec.rb
+++ b/spec/commands/pristine_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe "bundle pristine" do
     end
 
     it "does not delete the bundler gem" do
+      ENV["BUNDLER_SPEC_KEEP_DEFAULT_BUNDLER_GEM"] = "true"
       system_gems :bundler
       bundle! "install"
       bundle! "pristine", :system_bundler => true

--- a/spec/install/gemfile/sources_spec.rb
+++ b/spec/install/gemfile/sources_spec.rb
@@ -435,12 +435,11 @@ RSpec.describe "bundle install with gems on multiple sources" do
       end
 
       it "does not unlock the non-path gem after install" do
-        bundle :install
+        bundle! :install
 
-        bundle %(exec ruby -e 'puts "OK"')
+        bundle! %(exec ruby -e 'puts "OK"'), :env => { :RUBYOPT => "-r#{spec_dir.join("support/hax")}" }
 
         expect(out).to include("OK")
-        expect(exitstatus).to eq(0) if exitstatus
       end
     end
   end

--- a/spec/runtime/gem_tasks_spec.rb
+++ b/spec/runtime/gem_tasks_spec.rb
@@ -36,7 +36,9 @@ RSpec.describe "require 'bundler/gem_tasks'" do
   end
 
   it "adds 'pkg' to rake/clean's CLOBBER" do
-    require "bundler/gem_tasks"
-    expect(CLOBBER).to include("pkg")
+    with_gem_path_as(Spec::Path.base_system_gems.to_s) do
+      sys_exec! %('#{Gem.ruby}' -rrake -e 'load "Rakefile"; puts CLOBBER.inspect')
+    end
+    expect(last_command.stdout).to eq '["pkg"]'
   end
 end

--- a/spec/runtime/require_spec.rb
+++ b/spec/runtime/require_spec.rb
@@ -264,13 +264,13 @@ RSpec.describe "Bundler.require" do
 
   describe "using bundle exec" do
     it "requires the locked gems" do
-      bundle "exec ruby -e 'Bundler.require'"
+      bundle "exec ruby -e 'Bundler.require'", :env => { :RUBYOPT => "-r#{spec_dir.join("support/hax")}" }
       expect(out).to eq("two")
 
-      bundle "exec ruby -e 'Bundler.require(:bar)'"
+      bundle "exec ruby -e 'Bundler.require(:bar)'", :env => { :RUBYOPT => "-r#{spec_dir.join("support/hax")}" }
       expect(out).to eq("baz\nqux")
 
-      bundle "exec ruby -e 'Bundler.require(:default, :bar)'"
+      bundle "exec ruby -e 'Bundler.require(:default, :bar)'", :env => { :RUBYOPT => "-r#{spec_dir.join("support/hax")}" }
       expect(out).to eq("baz\nqux\ntwo")
     end
   end

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -763,7 +763,7 @@ end
     G
 
     ENV["GEM_HOME"] = ""
-    bundle %(exec ruby -e "require 'set'")
+    bundle %(exec ruby -e "require 'set'"), :env => { :RUBYOPT => "-r#{spec_dir.join("support/hax")}" }
 
     expect(err).to lack_errors
   end
@@ -1078,7 +1078,7 @@ end
         gem "bundler", :path => "#{File.expand_path("..", lib)}"
       G
 
-      bundle %(exec ruby -e "require 'bundler'; Bundler.setup")
+      bundle %(exec ruby -e "require 'bundler'; Bundler.setup"), :env => { :RUBYOPT => "-r#{spec_dir.join("support/hax")}" }
       expect(err).to lack_errors
     end
   end
@@ -1236,6 +1236,7 @@ end
       end
 
       let(:activation_warning_hack) { strip_whitespace(<<-RUBY) }
+        require #{spec_dir.join("support/hax").to_s.dump}
         require "rubygems"
 
         if Gem::Specification.instance_methods.map(&:to_sym).include?(:activate)
@@ -1279,8 +1280,9 @@ end
 
       it "activates no gems with bundle exec" do
         install_gemfile! ""
+        # ensure we clean out the default gems, bceause bundler's allowed to be activated
         create_file("script.rb", code)
-        bundle! "exec ruby ./script.rb", :env => { :RUBYOPT => activation_warning_hack_rubyopt }
+        bundle! "exec ruby ./script.rb", :env => { :RUBYOPT => activation_warning_hack_rubyopt + " -rbundler/setup" }
         expect(last_command.stdout).to eq("{}")
       end
 

--- a/spec/runtime/with_clean_env_spec.rb
+++ b/spec/runtime/with_clean_env_spec.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 RSpec.describe "Bundler.with_env helpers" do
+  def bundle_exec_ruby!(code, *args)
+    opts = args.last.is_a?(Hash) ? args.pop : {}
+    env = opts[:env] ||= {}
+    env[:RUBYOPT] ||= "-r#{spec_dir.join("support/hax")}"
+    args.push opts
+    bundle! "exec '#{Gem.ruby}' -e #{code}", *args
+  end
+
   describe "Bundler.original_env" do
     before do
       bundle "config path vendor/bundle"
@@ -12,8 +20,8 @@ RSpec.describe "Bundler.with_env helpers" do
       code = "print Bundler.original_env['PATH']"
       path = `getconf PATH`.strip + "#{File::PATH_SEPARATOR}/foo"
       with_path_as(path) do
-        result = bundle("exec '#{Gem.ruby}' -e #{code.dump}")
-        expect(result).to eq(path)
+        bundle_exec_ruby!(code.dump)
+        expect(last_command.stdboth).to eq(path)
       end
     end
 
@@ -21,8 +29,8 @@ RSpec.describe "Bundler.with_env helpers" do
       code = "print Bundler.original_env['GEM_PATH']"
       gem_path = ENV["GEM_PATH"] + ":/foo"
       with_gem_path_as(gem_path) do
-        result = bundle("exec '#{Gem.ruby}' -e #{code.inspect}")
-        expect(result).to eq(gem_path)
+        bundle_exec_ruby!(code.dump)
+        expect(last_command.stdboth).to eq(gem_path)
       end
     end
 
@@ -38,7 +46,7 @@ RSpec.describe "Bundler.with_env helpers" do
       RB
       path = `getconf PATH`.strip + File::PATH_SEPARATOR + File.dirname(Gem.ruby)
       with_path_as(path) do
-        bundle!("exec '#{Gem.ruby}' #{bundled_app("exe.rb")} 2")
+        bundle! "exec '#{Gem.ruby}' #{bundled_app("exe.rb")} 2", :env => { :RUBYOPT => "-r#{spec_dir.join("support/hax")}" }
       end
       expect(err).to eq <<-EOS.strip
 2 false
@@ -49,9 +57,10 @@ RSpec.describe "Bundler.with_env helpers" do
 
     it "removes variables that bundler added" do
       system_gems :bundler
+      system_gems :bundler, :path => :bundle_path # to ensure the bundler under test is the one activated...
       original = ruby!('puts ENV.to_a.map {|e| e.join("=") }.sort.join("\n")')
       code = 'puts Bundler.original_env.to_a.map {|e| e.join("=") }.sort.join("\n")'
-      bundle!("exec '#{Gem.ruby}' -e #{code.inspect}", :system_bundler => true)
+      bundle! "exec '#{Gem.ruby}' -e #{code.dump}", :system_bundler => true
       expect(out).to eq original
     end
   end
@@ -66,30 +75,30 @@ RSpec.describe "Bundler.with_env helpers" do
     it "should delete BUNDLE_PATH" do
       code = "print Bundler.clean_env.has_key?('BUNDLE_PATH')"
       ENV["BUNDLE_PATH"] = "./foo"
-      result = bundle("exec '#{Gem.ruby}' -e #{code.inspect}")
-      expect(result).to eq("false")
+      bundle_exec_ruby! code.dump
+      expect(last_command.stdboth).to eq "false"
     end
 
     it "should remove '-rbundler/setup' from RUBYOPT" do
       code = "print Bundler.clean_env['RUBYOPT']"
       ENV["RUBYOPT"] = "-W2 -rbundler/setup"
-      result = bundle("exec '#{Gem.ruby}' -e #{code.inspect}")
-      expect(result).not_to include("-rbundler/setup")
+      bundle_exec_ruby! code.dump
+      expect(last_command.stdboth).not_to include("-rbundler/setup")
     end
 
     it "should clean up RUBYLIB" do
       code = "print Bundler.clean_env['RUBYLIB']"
       ENV["RUBYLIB"] = root.join("lib").to_s + File::PATH_SEPARATOR + "/foo"
-      result = bundle("exec '#{Gem.ruby}' -e #{code.inspect}")
-      expect(result).to eq("/foo")
+      bundle_exec_ruby! code.dump
+      expect(last_command.stdboth).to eq("/foo")
     end
 
     it "should restore the original MANPATH" do
       code = "print Bundler.clean_env['MANPATH']"
       ENV["MANPATH"] = "/foo"
       ENV["BUNDLER_ORIG_MANPATH"] = "/foo-original"
-      result = bundle("exec '#{Gem.ruby}' -e #{code.inspect}")
-      expect(result).to eq("/foo-original")
+      bundle_exec_ruby! code.dump
+      expect(last_command.stdboth).to eq("/foo-original")
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,11 +3,18 @@
 $:.unshift File.expand_path("..", __FILE__)
 $:.unshift File.expand_path("../../lib", __FILE__)
 
+require "rubygems"
+module Gem
+  if defined?(@path_to_default_spec_map)
+    @path_to_default_spec_map.delete_if do |_path, spec|
+      spec.name == "bundler"
+    end
+  end
+end
+
 begin
-  require "rubygems"
   require File.expand_path("../support/path.rb", __FILE__)
   spec = Gem::Specification.load(Spec::Path.gemspec.to_s)
-  Gem.remove_unresolved_default_spec(spec) if Gem.respond_to?(:remove_unresolved_default_spec)
   rspec = spec.dependencies.find {|d| d.name == "rspec" }
   gem "rspec", rspec.requirement.to_s
   require "rspec"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,15 +3,11 @@
 $:.unshift File.expand_path("..", __FILE__)
 $:.unshift File.expand_path("../../lib", __FILE__)
 
-require "rubygems"
-require "bundler/psyched_yaml"
-require "bundler/vendored_fileutils"
-require "uri"
-require "digest"
-require File.expand_path("../support/path.rb", __FILE__)
-
 begin
+  require "rubygems"
+  require File.expand_path("../support/path.rb", __FILE__)
   spec = Gem::Specification.load(Spec::Path.gemspec.to_s)
+  Gem.remove_unresolved_default_spec(spec) if Gem.respond_to?(:remove_unresolved_default_spec)
   rspec = spec.dependencies.find {|d| d.name == "rspec" }
   gem "rspec", rspec.requirement.to_s
   require "rspec"
@@ -19,6 +15,11 @@ begin
 rescue LoadError
   abort "Run rake spec:deps to install development dependencies"
 end
+
+require "bundler/psyched_yaml"
+require "bundler/vendored_fileutils"
+require "uri"
+require "digest"
 
 if File.expand_path(__FILE__) =~ %r{([^\w/\.-])}
   abort "The bundler specs cannot be run from a path that contains special characters (particularly #{$1.inspect})"
@@ -101,8 +102,6 @@ RSpec.configure do |config|
 
   original_wd  = Dir.pwd
   original_env = ENV.to_hash.delete_if {|k, _v| k.start_with?(Bundler::EnvironmentPreserver::BUNDLER_PREFIX) }
-  original_default_specs = Dir[File.join(Gem.default_dir, "specifications", "default", "bundler*")]
-  original_site_ruby_dirs = $LOAD_PATH.select {|path| path =~ /site_ruby/ }.map {|path| File.join(path, "bundler*") }.compact.map {|path| Dir[path] }.flatten
 
   config.expect_with :rspec do |c|
     c.syntax = :expect
@@ -110,11 +109,6 @@ RSpec.configure do |config|
 
   config.before :all do
     build_repo1
-    (original_default_specs + original_site_ruby_dirs).each {|s| FileUtils.mv(s, s + ".org") }
-  end
-
-  config.after :all do
-    (original_default_specs + original_site_ruby_dirs).each {|s| FileUtils.mv(s + ".org", s) if File.exist?(s + ".org") }
   end
 
   config.before :each do

--- a/spec/support/hax.rb
+++ b/spec/support/hax.rb
@@ -12,6 +12,12 @@ module Gem
     @local = new(ENV["BUNDLER_SPEC_PLATFORM"]) if ENV["BUNDLER_SPEC_PLATFORM"]
   end
   @platforms = [Gem::Platform::RUBY, Gem::Platform.local]
+
+  if defined?(@path_to_default_spec_map)
+    @path_to_default_spec_map.delete_if do |_path, spec|
+      spec.name == "bundler"
+    end
+  end
 end
 
 if ENV["BUNDLER_SPEC_VERSION"]

--- a/spec/support/hax.rb
+++ b/spec/support/hax.rb
@@ -13,7 +13,7 @@ module Gem
   end
   @platforms = [Gem::Platform::RUBY, Gem::Platform.local]
 
-  if defined?(@path_to_default_spec_map)
+  if defined?(@path_to_default_spec_map) && !ENV["BUNDLER_SPEC_KEEP_DEFAULT_BUNDLER_GEM"]
     @path_to_default_spec_map.delete_if do |_path, spec|
       spec.name == "bundler"
     end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was the specs would fail when the version did not match that installed as a default gem.

### What was your diagnosis of the problem?

My diagnosis was we needed to unregister the default spec when running tests.

### Why did you choose this fix out of the possible options?

I chose this fix because it avoids actually touching any of the installed files, meaning we're not relying upon the tests exiting cleanly & being able to restore them.
