### PR TITLE
Workaround for rubygems&bundler release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,9 +110,17 @@ matrix:
   allow_failures:
     # Remove 1.8.7-2.1.10 matrix after merging bundler-1.16.1 into rubygems-2.7.x
     - rvm: 2.1.10
+      env: RGV=v2.2.5
     - rvm: 2.0.0
+      env: RGV=v2.2.5
     - rvm: 1.9.3
+      env: RGV=v2.2.5
     - rvm: 1.8.7
+      env: RGV=v2.2.5
+    - rvm: 2.0.0
+      env: RGV=v2.1.11
+    - rvm: 1.9.3
+      env: RGV=v2.1.11
 
     - rvm: 1.8.7
       env: RGV=v2.0.14

--- a/.travis.yml
+++ b/.travis.yml
@@ -108,6 +108,12 @@ matrix:
       env: RGV=master
 
   allow_failures:
+    # Remove 1.8.7-2.1.10 matrix after merging bundler-1.16.1 into rubygems-2.7.x
+    - rvm: 2.1.10
+    - rvm: 2.0.0
+    - rvm: 1.9.3
+    - rvm: 1.8.7
+
     - rvm: 1.8.7
       env: RGV=v2.0.14
     - rvm: 1.8.7


### PR DESCRIPTION
### What is your fix for the problem, implemented in this PR?

The current 1-16-stable branch is the complex status for Travis environment. So We hard to fix it. Because it has two rubygems versions(RGV=vx.y.z and rvm installation version) and two bundler versions(bundler-1.16.0 as default gems and test target version).

### Why did you choose this fix out of the possible options?

Above situation caused that Rubygems bundles bundler-1.16.0. So, We can resolve it status with Rubygems 2.7.4 and Bundler-1.16.1 as default gems installed by rubygems installer.

@segiddins How about this? 