### PR TITLE
Verify buildable manpages and GitHub token before release

### DIFF
--- a/task/release.rake
+++ b/task/release.rake
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
-
 require "bundler/gem_tasks"
+
 task :build => ["build_metadata", "man:build", "generate_files"] do
   Rake::Task["build_metadata:clean"].tap(&:reenable).real_invoke
 end
-task :release => ["man:require", "man:build", "release:verify_github", "build_metadata"]
+
+["man:require", "release:verify_github"].reverse.each do |task|
+  Rake::Task["release"].prerequisites.unshift(task)
+end
 
 namespace :release do
   def gh_api_post(opts)

--- a/task/release.rake
+++ b/task/release.rake
@@ -43,10 +43,12 @@ namespace :release do
                                             end}"
     end
     JSON.parse(response.body)
+  rescue => e
+    puts "GitHub request error! Make sure your .netrc for api.github.com is valid.\n\n"
+    raise e
   end
 
   task :verify_github do
-    require "pp"
     gh_api_post :path => "/user"
   end
 

--- a/task/release.rake
+++ b/task/release.rake
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
+
 require "bundler/gem_tasks"
 
 task :build => ["build_metadata", "man:build", "generate_files"] do
   Rake::Task["build_metadata:clean"].tap(&:reenable).real_invoke
 end
 
-["man:require", "release:verify_github"].reverse.each do |task|
+["man:require", "release:verify_github"].reverse_each do |task|
   Rake::Task["release"].prerequisites.unshift(task)
 end
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

I rake `rake release`, and successfully released version 1.16.1, but I also saw an exception backtrace:
```
bundler 1.16.1 built to pkg/bundler-1.16.1.gem.
Tagged v1.16.1.
Pushed git commits and tags.
Pushed bundler 1.16.1 to rubygems.org
rake aborted!
https://api.github.com/user?access_token=
#<Net::HTTPUnauthorized 401 Unauthorized readbody=true>
{"message"=>"Bad credentials", "documentation_url"=>"https://developer.github.com/v3"}
task/release.rake:35:in `gh_api_post'
task/release.rake:46:in `block (2 levels) in <top (required)>'
/Users/andre/src/bundler/bundler/Rakefile:30:in `block in invoke'
/Users/andre/src/bundler/bundler/Rakefile:29:in `invoke'
Tasks: TOP => release => release:verify_github
(See full trace by running task with --trace)
```

### What was your diagnosis of the problem?

As far as I can tell, we were intending to check for ronn and a valid GitHub token _before_ building, tagging, and pushing the gem, as evidenced by this line: https://github.com/bundler/bundler/blob/8e8b8142c98254d42c710f06627624fe0126b104/task/release.rake#L7. However, the require on the first line of the file ran first, and the `task` method only allows you to add new task dependencies to the end of the list.

### What is your fix for the problem, implemented in this PR?

This code moves the tasks that were previously run at the end of the release task to the beginning, ensuring that release validation happens as intended.

### Why did you choose this fix out of the possible options?

After some googling, this seemed like the only way to add dependencies to the front of the list. I could have wiped out the entire release task and replaced it, but that seemed more likely to break if we ever change the Bundler gem_tasks release in the future.