### PR TITLE
 [Travis] Test against Ruby 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ env:
   # We need to know if changes to rubygems will break bundler on release
   - RGV=master
   # Test the latest rubygems release with all of our supported rubies
-  - RGV=v2.7.1
+  - RGV=v2.7.4
 
 matrix:
   include:
@@ -53,9 +53,9 @@ matrix:
       env: RGV=master
     # 1.x mode (we want to keep stuff passing in 1.x mode for now)
     - rvm: 2.4.2
-      env: RGV=v2.7.1 BUNDLER_SPEC_SUB_VERSION=1.98
+      env: RGV=v2.7.4 BUNDLER_SPEC_SUB_VERSION=1.98
     - rvm: 1.8.7
-      env: RGV=v2.7.1 BUNDLER_SPEC_SUB_VERSION=1.98
+      env: RGV=v2.7.4 BUNDLER_SPEC_SUB_VERSION=1.98
 
   allow_failures:
     - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ addons:
       secure: "TrzIv116JLGUxm6PAUskCYrv8KTDguncKROVwbnjVPKTGDAgoDderd8JUdDEXrKoZ9qGLD2TPYKExt9/QDl71E+qHdWnVqWv4HKCUk2P9z/VLKzHuggOUBkCXiJUhjywUieCJhI3N92bfq2EjSBbu2/OFHqWOjLQ+QCooTEBjv8="
 
 rvm:
+  - 2.5.0
   - 2.4.2
   - 2.3.5
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ addons:
 
 rvm:
   - 2.5.0
-  - 2.4.2
-  - 2.3.5
+  - 2.4.3
+  - 2.3.6
 
 # Rubygems versions MUST be available as rake tasks
 # see Rakefile:125 for the list of possible RGV values

--- a/Rakefile
+++ b/Rakefile
@@ -147,7 +147,7 @@ begin
       rubyopt = ENV["RUBYOPT"]
       # When editing this list, also edit .travis.yml!
       branches = %w[master]
-      releases = %w[v1.3.6 v1.3.7 v1.4.2 v1.5.3 v1.6.2 v1.7.2 v1.8.29 v2.0.14 v2.1.11 v2.2.5 v2.4.8 v2.5.2 v2.6.8 v2.6.14 v2.7.1]
+      releases = %w[v1.3.6 v1.3.7 v1.4.2 v1.5.3 v1.6.2 v1.7.2 v1.8.29 v2.0.14 v2.1.11 v2.2.5 v2.4.8 v2.5.2 v2.6.8 v2.6.14 v2.7.4]
       (branches + releases).each do |rg|
         desc "Run specs with RubyGems #{rg}"
         RSpec::Core::RakeTask.new(rg) do |t|

--- a/lib/bundler/current_ruby.rb
+++ b/lib/bundler/current_ruby.rb
@@ -18,6 +18,7 @@ module Bundler
       2.3
       2.4
       2.5
+      2.6
     ].freeze
 
     KNOWN_MAJOR_VERSIONS = KNOWN_MINOR_VERSIONS.map {|v| v.split(".", 2).first }.uniq.freeze


### PR DESCRIPTION
The problem was Ruby 2.5 was released yesterday! So this updates Bundler to test against it on CI, as well as acknowledging 2.6 as a new minor.