### PR TITLE
[man] fix typo on bundle-binstubs

### DIFF
--- a/man/bundle-binstubs.ronn
+++ b/man/bundle-binstubs.ronn
@@ -7,7 +7,7 @@ bundle-binstubs(1) -- Install the binstubs of the listed gems
 
 ## DESCRIPTION
 
-Binstubs are scripts that wrap aroung executables. Bundler creates a
+Binstubs are scripts that wrap around executables. Bundler creates a
 small Ruby file (a binstub) that loads Bundler, runs the command,
 and puts it into `bin/`. Binstubs are a shortcut-or alternative-
 to always using `bundle exec`. This gives you a file that can by run


### PR DESCRIPTION
Typo found while i was packaging 1.16.1 for Debian