### PR TITLE
Fix warning in rubygems testing re __FILE__

### DIFF
--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -570,8 +570,10 @@ module Bundler
       @replaced_methods.each do |(sym, klass), method|
         redefine_method(klass, sym, method)
       end
-      post_reset_hooks.reject! do |proc|
-        proc.binding.eval("__FILE__") == __FILE__
+      if Binding.public_method_defined?(:source_location)
+        post_reset_hooks.reject! {|proc| proc.binding.source_location == __FILE__ }
+      else
+        post_reset_hooks.reject! {|proc| proc.binding.eval("__FILE__") == __FILE__ }
       end
       @replaced_methods.clear
     end


### PR DESCRIPTION
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

Testing with trunk & rubygems, many warnings of:
`rubygems/lib/rubygems.rb:940: warning: __FILE__ in eval may not return location in binding; use Binding#source_location instead`

### What was your diagnosis of the problem?

Updates for warnings & 'security' in trunk are showing issues that should be addressed.

### What is your fix for the problem, implemented in this PR?

It's one line...

### Why did you choose this fix out of the possible options?

Unaware of other options...

Not sure if this will work with all ruby versions.  Did not test my fork...