### PR TITLE
[CLI] Skip the outdated bundler check when MD5 is not available

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -718,6 +718,8 @@ module Bundler
       command_name = current_command.name
       return if PARSEABLE_COMMANDS.include?(command_name)
 
+      return unless SharedHelpers.md5_available?
+
       latest = Fetcher::CompactIndex.
                new(nil, Source::Rubygems::Remote.new(URI("https://rubygems.org")), nil).
                send(:compact_index_client).


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was Bundler would try to do the outdated version check on FIPS systems, leading to an exception.

Closes #6032.

### What was your diagnosis of the problem?

My diagnosis was we needed to skip the check when MD5 is unavailable.

### Why did you choose this fix out of the possible options?

I chose this fix because using `#available?` would make network requests, which is not acceptable.