### PR TITLE
Add two specs for choosing platform specific gems

### DIFF
--- a/spec/resolver/platform_spec.rb
+++ b/spec/resolver/platform_spec.rb
@@ -40,6 +40,20 @@ RSpec.describe "Resolving platform craziness" do
     should_resolve_as %w[foo-1.1.0]
   end
 
+  it "takes the ruby version if the platform version is incompatible" do
+    @index = build_index do
+      gem "bar", "1.0.0"
+      gem "foo", "1.0.0"
+      gem "foo", "1.0.0", "x64-mingw32" do
+        dep "bar", "< 1"
+      end
+    end
+    dep "foo"
+    platforms "x64-mingw32"
+
+    should_resolve_as %w[foo-1.0.0]
+  end
+
   it "takes the latest ruby gem if the platform specific gem doesn't match the required_ruby_version" do
     @index = build_index do
       gem "foo", "1.0.0"

--- a/spec/resolver/platform_spec.rb
+++ b/spec/resolver/platform_spec.rb
@@ -28,6 +28,35 @@ RSpec.describe "Resolving platform craziness" do
     end
   end
 
+  it "takes the latest ruby gem, even if an older platform specific version is available" do
+    @index = build_index do
+      gem "foo", "1.0.0"
+      gem "foo", "1.0.0", "x64-mingw32"
+      gem "foo", "1.1.0"
+    end
+    dep "foo"
+    platforms "x64-mingw32"
+
+    should_resolve_as %w[foo-1.1.0]
+  end
+
+  it "takes the latest ruby gem if the platform specific gem doesn't match the required_ruby_version" do
+    @index = build_index do
+      gem "foo", "1.0.0"
+      gem "foo", "1.0.0", "x64-mingw32"
+      gem "foo", "1.1.0"
+      gem "foo", "1.1.0", "x64-mingw32" do |s|
+        s.required_ruby_version = [">= 2.0", "< 2.4"]
+      end
+      gem "ruby\0", "2.5.1"
+    end
+    dep "foo"
+    dep "ruby\0", "2.5.1"
+    platforms "x64-mingw32"
+
+    should_resolve_as %w[foo-1.1.0]
+  end
+
   describe "with mingw32" do
     before :each do
       @index = build_index do


### PR DESCRIPTION
This is a follow-up to #5337. It adds two specs for choosing platform specific gems. The first spec succeeds, but the second spec fails currently.

### What was the end-user problem that led to this PR?

Bundler doesn't properly resolve platform gems with ruby version constraints.

rake-compiler [tags all fat binary gems](https://github.com/rake-compiler/rake-compiler/blob/b00d1ce46e316126c0ee8890888d1788faa2cee1/lib/rake/extensiontask.rb#L261-L264) with appropriate `required_ruby_version` constraints. The intention behind this tag is to give bundler a chance to select the most suitable gem for the given platform and ruby version. Unfortunately it doesn't work.

This leads to issues for all Windows users whenever a new Ruby version comes out. The intended effect (to make the install of gems easy) turns to the opposite, because the platform specific gem effectively blocks the installation of the "ruby" platform gem.

These issues can be seen at many popular gems with C extensions: [ffi #598](https://github.com/ffi/ffi/issues/598), [nokogiri #1706](https://github.com/sparklemotion/nokogiri/issues/1706), [pg](https://github.com/ged/ruby-pg)


### What was your diagnosis of the problem?

The first test case doesn't offer a x64-mingw32 gem in the latest version. Bundler therefore selects the latest "ruby" platform gem so that the installation succeeds. This is OK and expected.

The second test is very similar, but offers a x64-mingw32 gem in addition. This additional gem however is limited to ruby versions not matching the running ruby version. Bundler should exclude this gem therefore and should select the "ruby" platform gem as in the first test. However it doesn't resolve to the "ruby" platform gem, but to an older x64-mingw32 gem, which wasn't tagged by a `required_ruby_version` constraint to that point in time (and will not work with the latest ruby version in practice). That is the current situation with ffi and nokogiri.

The current workaround is to set `force_ruby_platform` to true, [but this has several negative consequences](https://github.com/bundler/bundler/issues/6233) since it's a global and not a per-gem setting. Also it has to be enabled manuelly by each (Windows) user. Insofar it's not a general solution.


### What is your fix for the problem, implemented in this PR?

### Why did you choose this fix out of the possible options?

I didn't dig deeper into bundlers internals, but my hope is that someone with more knowledge of bundler can solve this issue that way or at least give me a pointer where I could start to fix this.
