### PR TITLE
[FriendlyErrors] Fallback to the original error if the friendly message raises

### DIFF
--- a/lib/bundler/friendly_errors.rb
+++ b/lib/bundler/friendly_errors.rb
@@ -45,6 +45,8 @@ module Bundler
           "Alternatively, you can increase the amount of memory the JVM is able to use by running Bundler with jruby -J-Xmx1024m -S bundle (JRuby defaults to 500MB)."
       else request_issue_report_for(error)
       end
+    rescue
+      raise error
     end
 
     def exit_status(error)


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

This would have made diagnosing https://github.com/bundler/bundler/issues/6220 much easier

### What was your diagnosis of the problem?

My diagnosis was we do a lot in our error handler, so it needs a fallback

### What is your fix for the problem, implemented in this PR?

My fix falls back to just re-raising the original error