### PR TITLE
Rename Bundler.frozen? to avoid Object method conflict

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -136,7 +136,7 @@ module Bundler
       end
     end
 
-    def frozen?
+    def frozen_bundle?
       frozen = settings[:deployment]
       frozen ||= settings[:frozen] unless feature_flag.deployment_means_frozen?
       frozen

--- a/lib/bundler/cli/check.rb
+++ b/lib/bundler/cli/check.rb
@@ -26,7 +26,7 @@ module Bundler
         not_installed.each {|s| Bundler.ui.error " * #{s.name} (#{s.version})" }
         Bundler.ui.warn "Install missing gems with `bundle install`"
         exit 1
-      elsif !Bundler.default_lockfile.file? && Bundler.frozen?
+      elsif !Bundler.default_lockfile.file? && Bundler.frozen_bundle?
         Bundler.ui.error "This bundle has been frozen, but there is no #{Bundler.default_lockfile.relative_path_from(SharedHelpers.pwd)} present"
         exit 1
       else

--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -23,7 +23,7 @@ module Bundler
 
       check_trust_policy
 
-      if options[:deployment] || options[:frozen] || Bundler.frozen?
+      if options[:deployment] || options[:frozen] || Bundler.frozen_bundle?
         unless Bundler.default_lockfile.exist?
           flag   = "--deployment flag" if options[:deployment]
           flag ||= "--frozen flag"     if options[:frozen]
@@ -63,7 +63,7 @@ module Bundler
       definition.validate_runtime!
 
       installer = Installer.install(Bundler.root, definition, options)
-      Bundler.load.cache if Bundler.app_cache.exist? && !options["no-cache"] && !Bundler.frozen?
+      Bundler.load.cache if Bundler.app_cache.exist? && !options["no-cache"] && !Bundler.frozen_bundle?
 
       Bundler.ui.confirm "Bundle complete! #{dependencies_count_for(definition)}, #{gems_installed_for(definition)}."
       Bundler::CLI::Common.output_without_groups_message

--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -213,7 +213,7 @@ module Bundler
     end
 
     def check_for_deployment_mode
-      return unless Bundler.frozen?
+      return unless Bundler.frozen_bundle?
       suggested_command = if Bundler.settings.locations("frozen")[:global]
         "bundle config --delete frozen"
       elsif Bundler.settings.locations("deployment").keys.&([:global, :local]).any?

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -112,7 +112,7 @@ module Bundler
       end
       @unlocking ||= @unlock[:ruby] ||= (!@locked_ruby_version ^ !@ruby_version)
 
-      add_current_platform unless Bundler.frozen?
+      add_current_platform unless Bundler.frozen_bundle?
 
       converge_path_sources_to_gemspec_sources
       @path_changes = converge_paths
@@ -244,7 +244,7 @@ module Bundler
     def resolve
       @resolve ||= begin
         last_resolve = converge_locked_specs
-        if Bundler.frozen?
+        if Bundler.frozen_bundle?
           Bundler.ui.debug "Frozen, using resolution from the lockfile"
           last_resolve
         elsif !unlocking? && nothing_changed?
@@ -335,10 +335,10 @@ module Bundler
         end
       end
 
-      preserve_unknown_sections ||= !updating_major && (Bundler.frozen? || !(unlocking? || @unlocking_bundler))
+      preserve_unknown_sections ||= !updating_major && (Bundler.frozen_bundle? || !(unlocking? || @unlocking_bundler))
       return if lockfiles_equal?(@lockfile_contents, contents, preserve_unknown_sections)
 
-      if Bundler.frozen?
+      if Bundler.frozen_bundle?
         Bundler.ui.error "Cannot write a changed lockfile while frozen."
         return
       end
@@ -681,7 +681,7 @@ module Bundler
     end
 
     def converge_dependencies
-      frozen = Bundler.frozen?
+      frozen = Bundler.frozen_bundle?
       (@dependencies + @locked_deps.values).each do |dep|
         locked_source = @locked_deps[dep.name]
         # This is to make sure that if bundler is installing in deployment mode and

--- a/lib/bundler/injector.rb
+++ b/lib/bundler/injector.rb
@@ -13,7 +13,7 @@ module Bundler
     end
 
     def inject(gemfile_path, lockfile_path)
-      if Bundler.frozen?
+      if Bundler.frozen_bundle?
         # ensure the lock and Gemfile are synced
         Bundler.definition.ensure_equivalent_gemfile_and_lockfile(true)
       end

--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -70,7 +70,7 @@ module Bundler
       create_bundle_path
 
       ProcessLock.lock do
-        if Bundler.frozen?
+        if Bundler.frozen_bundle?
           @definition.ensure_equivalent_gemfile_and_lockfile(options[:deployment])
         end
 
@@ -90,7 +90,7 @@ module Bundler
         end
         install(options)
 
-        lock unless Bundler.frozen?
+        lock unless Bundler.frozen_bundle?
         Standalone.new(options[:standalone], @definition).generate if options[:standalone]
       end
     end

--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -10,7 +10,7 @@ module Bundler
     end
 
     def setup(*groups)
-      @definition.ensure_equivalent_gemfile_and_lockfile if Bundler.frozen?
+      @definition.ensure_equivalent_gemfile_and_lockfile if Bundler.frozen_bundle?
 
       groups.map!(&:to_sym)
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was `Bundler` overrode the `Object#frozen?` method to mean something else, breaking anything that checks that method to determine if an object is frozen.

Closes #6252.

### What was your diagnosis of the problem?

My diagnosis was the method name had to be changed.