### PR TITLE
[Source::RubyGems] Ensure the bindir exists before installing

### DIFF
--- a/lib/bundler/source/rubygems.rb
+++ b/lib/bundler/source/rubygems.rb
@@ -144,6 +144,8 @@ module Bundler
             bin_path     = Bundler.system_bindir
           end
 
+          Bundler.mkdir_p bin_path unless spec.executables.empty? || Bundler.rubygems.provides?(">= 2.7.5")
+
           installed_spec = nil
           Bundler.rubygems.preserve_paths do
             installed_spec = Bundler::RubyGemsGemInstaller.at(


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was occasional failures on CI w/ ruby 2.5

### What was your diagnosis of the problem?

My diagnosis was that there was a race condition in the rubygems installer, see https://github.com/rubygems/rubygems/pull/2148 for the fix there.

### What is your fix for the problem, implemented in this PR?

My fix will ensure that directory is created before we get into that rubygems code path