### PR TITLE
handle gzip corruption errors in the compact index client

### DIFF
--- a/lib/bundler/compact_index_client/updater.rb
+++ b/lib/bundler/compact_index_client/updater.rb
@@ -83,6 +83,8 @@ module Bundler
           "Bundler does not have write access to create a temp directory " \
           "within #{Dir.tmpdir}. Bundler must have write access to your " \
           "systems temp directory to function properly. "
+      rescue Zlib::GzipFile::Error
+        raise Bundler::HTTPError
       end
 
       def etag_for(path)

--- a/spec/bundler/compact_index_client/updater_spec.rb
+++ b/spec/bundler/compact_index_client/updater_spec.rb
@@ -5,16 +5,16 @@ require "bundler/compact_index_client"
 require "bundler/compact_index_client/updater"
 
 RSpec.describe Bundler::CompactIndexClient::Updater do
-  subject(:updater) { described_class.new(fetcher) }
-
   let(:fetcher) { double(:fetcher) }
+  let(:local_path) { Pathname("/tmp/localpath") }
+  let(:remote_path) { double(:remote_path) }
+
+  subject(:updater) { described_class.new(fetcher) }
 
   context "when the ETag header is missing" do
     # Regression test for https://github.com/bundler/bundler/issues/5463
 
     let(:response) { double(:response, :body => "") }
-    let(:local_path) { Pathname("/tmp/localpath") }
-    let(:remote_path) { double(:remote_path) }
 
     it "MisMatchedChecksumError is raised" do
       # Twice: #update retries on failure
@@ -28,10 +28,21 @@ RSpec.describe Bundler::CompactIndexClient::Updater do
     end
   end
 
+  context "when the download is corrupt" do
+    let(:response) { double(:response, :body => "") }
+
+    it "raises HTTPError" do
+      expect(response).to receive(:[]).with("Content-Encoding") { "gzip" }
+      expect(fetcher).to receive(:call) { response }
+
+      expect do
+        updater.update(local_path, remote_path)
+      end.to raise_error(Bundler::HTTPError)
+    end
+  end
+
   context "when bundler doesn't have permissions on Dir.tmpdir" do
     let(:response) { double(:response, :body => "") }
-    let(:local_path) { Pathname("/tmp/localpath") }
-    let(:remote_path) { double(:remote_path) }
 
     it "Errno::EACCES is raised" do
       allow(Dir).to receive(:mktmpdir) { raise Errno::EACCES }


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Bundler will raise an exception and crash if the Gzip that the Compact Client Index downloaded was corrupt.

### What was your diagnosis of the problem?

See #6261 

### What is your fix for the problem, implemented in this PR?

Handle the exception and allow Bundler to continue without crashing
