### PR TITLE
[Init] Check if the current directory is writeable

### DIFF
--- a/lib/bundler/cli/init.rb
+++ b/lib/bundler/cli/init.rb
@@ -13,6 +13,11 @@ module Bundler
         exit 1
       end
 
+      unless File.writable?(Dir.pwd)
+        Bundler.ui.error "Can not create #{gemfile} as the current directory is not writable."
+        exit 1
+      end
+
       if options[:gemspec]
         gemspec = File.expand_path(options[:gemspec])
         unless File.exist?(gemspec)

--- a/spec/commands/init_spec.rb
+++ b/spec/commands/init_spec.rb
@@ -64,6 +64,22 @@ RSpec.describe "bundle init" do
     end
   end
 
+  context "when the dir is not writable by the current user" do
+    let(:subdir) { "child_dir" }
+
+    it "notifies the user that it can not write to it" do
+      FileUtils.mkdir bundled_app(subdir)
+      FileUtils.chmod "a-w", bundled_app(subdir)
+
+      Dir.chdir bundled_app(subdir) do
+        bundle :init
+      end
+
+      expect(out).to include("directory is not writable")
+      expect(bundled_app(subdir)).to be_empty
+    end
+  end
+
   context "when a gems.rb file exists in a parent directory", :bundler => ">= 2" do
     let(:subdir) { "child_dir" }
 

--- a/spec/commands/init_spec.rb
+++ b/spec/commands/init_spec.rb
@@ -64,12 +64,14 @@ RSpec.describe "bundle init" do
     end
   end
 
-  context "when the dir is not writable by the current user", :bundler => ">= 2" do
+  context "when the dir is not writable by the current user" do
     let(:subdir) { "child_dir" }
 
     it "notifies the user that it can not write to it" do
       FileUtils.mkdir bundled_app(subdir)
-      FileUtils.chmod "a-w", bundled_app(subdir)
+      # chmod a-w it
+      mode = File.stat(bundled_app(subdir)).mode ^ 0o222
+      FileUtils.chmod mode, bundled_app(subdir)
 
       Dir.chdir bundled_app(subdir) do
         bundle :init

--- a/spec/commands/init_spec.rb
+++ b/spec/commands/init_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "bundle init" do
     end
   end
 
-  context "when the dir is not writable by the current user" do
+  context "when the dir is not writable by the current user", :bundler => ">= 2" do
     let(:subdir) { "child_dir" }
 
     it "notifies the user that it can not write to it" do
@@ -76,7 +76,7 @@ RSpec.describe "bundle init" do
       end
 
       expect(out).to include("directory is not writable")
-      expect(bundled_app(subdir)).to be_empty
+      expect(Dir[bundled_app("#{subdir}/*")]).to be_empty
     end
   end
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that when running `bundle init` inside a directory which is not writable by the current user (e.g. `/` as demonstrated in #6219) Bundler prints out an `EACCES` error with a huge backtrace.  In the mentioned PR @segiddins suggested to print out a better error message.  This PR addresses that.

### What was your diagnosis of the problem?

See [this comment on said PR](https://github.com/bundler/bundler/issues/6219#issuecomment-359002919).

### What is your fix for the problem, implemented in this PR?

My fix is simple: adding a check whether the current directory is writeable before trying to create `gems.rb`/`Gemfile`.  If that's not the case, print out an error and exit.

### Why did you choose this fix out of the possible options?

I chose this fix because... it was really simple to implement.