### PR TITLE
Add man page for `bundle doctor`

### DIFF
--- a/man/bundle-doctor.ronn
+++ b/man/bundle-doctor.ronn
@@ -1,5 +1,5 @@
-bundle-doctor(1) -- Checks for missing OS dependencies
-======================================================
+bundle-doctor(1) -- Checks the bundle for common problems
+=========================================================
 
 ## SYNOPSIS
 
@@ -8,10 +8,17 @@ bundle-doctor(1) -- Checks for missing OS dependencies
 
 ## DESCRIPTION
 
-Scan the OS dependencies of each of the gems requested in your
-Gemfile(5). If missing OS dependencies are detected, Bundler prints
-them and exists status 1. Otherwise, Bundler prints a success message
-and exists status 0.
+Checks your Gemfile and gem environment for common problems. If issues
+are detected, Bundler prints them and exists status 1. Otherwise,
+Bundler prints a success message and exists status 0.
+
+Examples of common problems caught by bundle-doctor include:
+
+* Invalid Bundler settings
+* Mismatched Ruby versions
+* Mismatched platforms
+* Uninstalled gems
+* Missing dependencies
 
 ## OPTIONS
 

--- a/man/bundle-doctor.ronn
+++ b/man/bundle-doctor.ronn
@@ -9,8 +9,8 @@ bundle-doctor(1) -- Checks the bundle for common problems
 ## DESCRIPTION
 
 Checks your Gemfile and gem environment for common problems. If issues
-are detected, Bundler prints them and exists status 1. Otherwise,
-Bundler prints a success message and exists status 0.
+are detected, Bundler prints them and exits status 1. Otherwise,
+Bundler prints a success message and exits status 0.
 
 Examples of common problems caught by bundle-doctor include:
 

--- a/man/bundle-doctor.ronn
+++ b/man/bundle-doctor.ronn
@@ -1,0 +1,18 @@
+bundle-doctor(1) -- Checks for missing OS dependencies
+======================================================
+
+## SYNOPSIS
+
+`bundle doctor` [--quiet]
+
+## DESCRIPTION
+
+Scan the OS dependencies of each of the gems requested in your
+Gemfile(5). If missing OS dependencies are detected, Bundler prints
+them and exists status 1. Otherwise, Bundler prints a success message
+and exists status 0.
+
+## OPTIONS
+
+* `--quiet`:
+  Only output warnings and errors.

--- a/man/bundle-doctor.ronn
+++ b/man/bundle-doctor.ronn
@@ -4,6 +4,7 @@ bundle-doctor(1) -- Checks for missing OS dependencies
 ## SYNOPSIS
 
 `bundle doctor` [--quiet]
+                [--gemfile=GEMFILE]
 
 ## DESCRIPTION
 
@@ -16,3 +17,10 @@ and exists status 0.
 
 * `--quiet`:
   Only output warnings and errors.
+
+* `--gemfile=<gemfile>`:
+  The location of the Gemfile(5) which Bundler should use. This defaults
+  to a Gemfile(5) in the current working directory. In general, Bundler
+  will assume that the location of the Gemfile(5) is also the project's
+  root and will try to find `Gemfile.lock` and `vendor/cache` relative
+  to this location.


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The `bundle doctor` command was missing a man page (see https://github.com/bundler/bundler/issues/6243).

### What was your diagnosis of the problem?

Running `bundle help doctor` from the command line showed [the description from `cli.rb`](https://github.com/bundler/bundler/blob/723608f45866cee0f1b315551a8dde6a99efebc6/lib/bundler/cli.rb#L611-L620), but it wasn't displayed in the same format as commands with man pages. Documentation for `bundle doctor` was also missing from http://bundler.io/docs.

### What is your fix for the problem, implemented in this PR?

I added a man page for `bundle doctor`.

### Why did you choose this fix out of the possible options?

I chose this fix because the ["Writing docs for man pages" documentation](https://github.com/bundler/bundler/blob/master/doc/documentation/WRITING.md#what-goes-in-man-pages) says...

> Our goal is to have a man page for every command.