### PR TITLE
Added `--gemfile` option to `bundle update`

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -233,6 +233,8 @@ module Bundler
     D
     method_option "full-index", :type => :boolean, :banner =>
       "Fall back to using the single-file index of all gems"
+    method_option "gemfile", :type => :string, :banner =>
+      "Use the specified gemfile instead of Gemfile"
     method_option "group", :aliases => "-g", :type => :array, :banner =>
       "Update a specific group"
     method_option "jobs", :aliases => "-j", :type => :numeric, :banner =>

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -57,6 +57,19 @@ RSpec.describe "bundle update" do
     end
   end
 
+  describe "with --gemfile" do
+    it "creates lock files based on the Gemfile name" do
+      gemfile bundled_app("OmgFile"), <<-G
+        source "file://#{gem_repo1}"
+        gem "rack", "1.0"
+      G
+
+      bundle! "update --gemfile OmgFile", :all => bundle_update_requires_all?
+
+      expect(bundled_app("OmgFile.lock")).to exist
+    end
+  end
+
   context "when update_requires_all_flag is set" do
     before { bundle! "config update_requires_all_flag true" }
 

--- a/spec/install/gemfile_spec.rb
+++ b/spec/install/gemfile_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe "bundle install" do
 
       bundle :install, :gemfile => bundled_app("NotGemfile")
 
+      # Specify BUNDLE_GEMFILE for `the_bundle`
+      # to retrieve the proper Gemfile
       ENV["BUNDLE_GEMFILE"] = "NotGemfile"
       expect(the_bundle).to include_gems "rack 1.0.0"
     end

--- a/spec/update/gemfile_spec.rb
+++ b/spec/update/gemfile_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "bundle update" do
       G
 
       bundle! :install, :gemfile => bundled_app("NotGemfile")
-      bundle! :update, :all => bundle_update_requires_all?, :gemfile => bundled_app("NotGemfile")
+      bundle! :update, :gemfile => bundled_app("NotGemfile"), :all => bundle_update_requires_all?
 
       ENV["BUNDLE_GEMFILE"] = "NotGemfile"
       expect(the_bundle).to include_gems "rack 1.0.0"
@@ -26,6 +26,7 @@ RSpec.describe "bundle update" do
       bundle "config --local gemfile #{bundled_app("NotGemfile")}"
       bundle! :install
     end
+
     it "uses the gemfile to update" do
       bundle! "update", :all => bundle_update_requires_all?
       bundle "list"
@@ -44,11 +45,12 @@ RSpec.describe "bundle update" do
   end
 
   context "with prefer_gems_rb set" do
+    before { bundle! "config prefer_gems_rb true" }
+    
     it "prefers gems.rb to Gemfile" do
       create_file("gems.rb", "gem 'bundler'")
       create_file("Gemfile", "raise 'wrong Gemfile!'")
 
-      bundle! "config prefer_gems_rb true"
       bundle! :install
       bundle! :update, :all => bundle_update_requires_all?
 

--- a/spec/update/gemfile_spec.rb
+++ b/spec/update/gemfile_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe "bundle update" do
 
       expect(out).to include("rack (1.0.0)")
     end
+
     it "uses the gemfile while in a subdirectory" do
       bundled_app("subdir").mkpath
       Dir.chdir(bundled_app("subdir")) do
@@ -48,7 +49,7 @@ RSpec.describe "bundle update" do
 
   context "with prefer_gems_rb set" do
     before { bundle! "config prefer_gems_rb true" }
-    
+
     it "prefers gems.rb to Gemfile" do
       create_file("gems.rb", "gem 'bundler'")
       create_file("Gemfile", "raise 'wrong Gemfile!'")

--- a/spec/update/gemfile_spec.rb
+++ b/spec/update/gemfile_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+RSpec.describe "bundle update" do
+  context "with --gemfile" do
+    it "finds the gemfile" do
+      gemfile bundled_app("NotGemfile"), <<-G
+        source "file://#{gem_repo1}"
+        gem 'rack'
+      G
+
+      bundle! :install, :gemfile => bundled_app("NotGemfile")
+      bundle! :update, :all => bundle_update_requires_all?, :gemfile => bundled_app("NotGemfile")
+
+      ENV["BUNDLE_GEMFILE"] = "NotGemfile"
+      expect(the_bundle).to include_gems "rack 1.0.0"
+    end
+  end
+
+  context "with gemfile set via config" do
+    before do
+      gemfile bundled_app("NotGemfile"), <<-G
+        source "file://#{gem_repo1}"
+        gem 'rack'
+      G
+
+      bundle "config --local gemfile #{bundled_app("NotGemfile")}"
+      bundle! :install
+    end
+    it "uses the gemfile to update" do
+      bundle! "update", :all => bundle_update_requires_all?
+      bundle "list"
+
+      expect(out).to include("rack (1.0.0)")
+    end
+    it "uses the gemfile while in a subdirectory" do
+      bundled_app("subdir").mkpath
+      Dir.chdir(bundled_app("subdir")) do
+        bundle! "update", :all => bundle_update_requires_all?
+        bundle "list"
+
+        expect(out).to include("rack (1.0.0)")
+      end
+    end
+  end
+
+  context "with prefer_gems_rb set" do
+    it "prefers gems.rb to Gemfile" do
+      create_file("gems.rb", "gem 'bundler'")
+      create_file("Gemfile", "raise 'wrong Gemfile!'")
+
+      bundle! "config prefer_gems_rb true"
+      bundle! :install
+      bundle! :update, :all => bundle_update_requires_all?
+
+      expect(bundled_app("gems.rb")).to be_file
+      expect(bundled_app("Gemfile.lock")).not_to be_file
+
+      expect(the_bundle).to include_gem "bundler #{Bundler::VERSION}"
+    end
+  end
+end

--- a/spec/update/gemfile_spec.rb
+++ b/spec/update/gemfile_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe "bundle update" do
       bundle! :install, :gemfile => bundled_app("NotGemfile")
       bundle! :update, :gemfile => bundled_app("NotGemfile"), :all => bundle_update_requires_all?
 
+      # Specify BUNDLE_GEMFILE for `the_bundle`
+      # to retrieve the proper Gemfile
       ENV["BUNDLE_GEMFILE"] = "NotGemfile"
       expect(the_bundle).to include_gems "rack 1.0.0"
     end


### PR DESCRIPTION
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was that `BUNDLE_GEMFILE` is not respected when `.bundle/config` specifies an alternate Gemfile. However, my specific issue is that `bundle install --gemfile Gemfile2` is an option, but `bundle update` won't let me specify an alternate Gemfile.

### What was your diagnosis of the problem?

My diagnosis was that Bundler copies `BUNDLE_GEMFILE` environment variable to `BUNDLE_ORIG_GEMFILE` and always uses `.bundle/config`. Simplest solution was to add parity to `bundle update` rather than diagnose why environment variables don't override `.bundle/config` settings across the board.

### What is your fix for the problem, implemented in this PR?

My fix is to add the `--gemfile` option to `bundle update` for parity with `bundle install`.

### Why did you choose this fix out of the possible options?

I chose this fix because this allows installing and updating alternative Gemfiles without untangling environment variables. It's the most direct use case that I'm having this issue with.

Ideally, the environment variables specified for a command should be respected and override settings in `.bundle/config` (https://github.com/bundler/bundler/issues/6270).
