### PR TITLE
Fix failing spec in the bundle exec system gem spec

### DIFF
--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -786,7 +786,7 @@ __FILE__: #{path.to_s.inspect}
           expect(bundle!("exec ruby #{file}", :artifice => nil)).to eq(expected)
           # Ignore expectation for default bundler gem conflict.
           unless ENV["BUNDLER_SPEC_SUB_VERSION"]
-            expect(run!(file.read, :no_lib => true, :artifice => nil)).to eq(expected)
+            expect(run!(file.read, :artifice => nil)).to eq(expected)
           end
         end
 


### PR DESCRIPTION
### What was your diagnosis of the problem?

There is an issue where a spec was failing because it was activating the version of Bundler inside of RubyGems and not the development version that we're working on.

This would cause the Lockfile to raise an error because we were generating a Bundler 2 lockfile in our tests but Bundler 1 was being activated making it complain.

### What is your fix for the problem, implemented in this PR?

Add the Bundler development dir in the Ruby include argument.

### Why did you choose this fix out of the possible options?

This error is raising in CI and is preventing PRs from being merged.

See https://travis-ci.org/bundler/bundler/jobs/333434747
