### PR TITLE
To use dynamic expectation with same versioned bundler installed as default gems

### DIFF
--- a/spec/commands/binstubs_spec.rb
+++ b/spec/commands/binstubs_spec.rb
@@ -100,6 +100,9 @@ RSpec.describe "bundle binstubs <gem>" do
         bundle! "binstubs bundler rack prints_loaded_gems"
       end
 
+      # When environment has a same version of bundler as default gems.
+      # `system_gems "bundler-x.y.z"` will detect system binstub.
+      # We need to avoid it by virtual version of bundler.
       let(:system_bundler_version) { Gem::Version.new(Bundler::VERSION).bump.to_s }
 
       context "when system bundler was used" do

--- a/spec/commands/binstubs_spec.rb
+++ b/spec/commands/binstubs_spec.rb
@@ -102,9 +102,15 @@ RSpec.describe "bundle binstubs <gem>" do
 
       let(:system_bundler_version) { Gem::Version.new(Bundler::VERSION).bump.to_s }
 
-      it "runs bundler" do
-        sys_exec! "#{bundled_app("bin/bundle")} install"
-        expect(out).to eq %(system bundler #{system_bundler_version}\n["install"])
+      context "when system bundler was used" do
+        # Support master branch of bundler
+        if ENV["BUNDLER_SPEC_SUB_VERSION"]
+          let(:system_bundler_version) { Bundler::VERSION }
+        end
+        it "runs bundler" do
+          sys_exec! "#{bundled_app("bin/bundle")} install"
+          expect(out).to eq %(system bundler #{system_bundler_version}\n["install"])
+        end
       end
 
       context "when BUNDLER_VERSION is set" do

--- a/spec/commands/binstubs_spec.rb
+++ b/spec/commands/binstubs_spec.rb
@@ -176,7 +176,9 @@ RSpec.describe "bundle binstubs <gem>" do
         let(:system_bundler_version) { :bundler }
         it "loads all gems" do
           sys_exec! bundled_app("bin/print_loaded_gems").to_s
-          if Bundler.load.specs["bundler"][0].default_gem?
+          # RG < 2.0.14 didn't have a `Gem::Specification#default_gem?`
+          # This is dirty detection for old RG versions.
+          if File.dirname(Bundler.load.specs["bundler"][0].loaded_from) =~ %r{specifications/default}
             expect(out).to eq %(["prints_loaded_gems-1.0", "rack-1.2"])
           else
             expect(out).to eq %(["bundler-#{Bundler::VERSION}", "prints_loaded_gems-1.0", "rack-1.2"])

--- a/spec/commands/licenses_spec.rb
+++ b/spec/commands/licenses_spec.rb
@@ -12,7 +12,14 @@ RSpec.describe "bundle licenses" do
   it "prints license information for all gems in the bundle" do
     bundle "licenses"
 
-    expect(out).to include("bundler: Unknown")
+    loaded_bundler_spec = Bundler.load.specs["bundler"]
+    if loaded_bundler_spec.size > 0
+      expected = loaded_bundler_spec[0].license
+    else
+      expected = "Unknown"
+    end
+
+    expect(out).to include("bundler: #{expected}")
     expect(out).to include("with_license: MIT")
   end
 

--- a/spec/commands/licenses_spec.rb
+++ b/spec/commands/licenses_spec.rb
@@ -13,10 +13,10 @@ RSpec.describe "bundle licenses" do
     bundle "licenses"
 
     loaded_bundler_spec = Bundler.load.specs["bundler"]
-    if loaded_bundler_spec.size > 0
-      expected = loaded_bundler_spec[0].license
+    expected = if !loaded_bundler_spec.empty?
+      loaded_bundler_spec[0].license
     else
-      expected = "Unknown"
+      "Unknown"
     end
 
     expect(out).to include("bundler: #{expected}")

--- a/spec/commands/pristine_spec.rb
+++ b/spec/commands/pristine_spec.rb
@@ -46,9 +46,7 @@ RSpec.describe "bundle pristine" do
       bundle! "install"
       bundle! "pristine", :system_bundler => true
       bundle! "-v", :system_bundler => true
-      # An old rubygems couldn't handle a correct version of vendoered bundler.
-      bundler_version = Gem::VERSION < "2.1" ? "1.16.0" : Bundler::VERSION
-      expect(out).to end_with(bundler_version)
+      expect(out).to end_with(Bundler::VERSION)
     end
   end
 

--- a/spec/commands/show_spec.rb
+++ b/spec/commands/show_spec.rb
@@ -64,10 +64,10 @@ RSpec.describe "bundle show", :bundler => "< 2" do
       bundle "show --verbose"
 
       loaded_bundler_spec = Bundler.load.specs["bundler"]
-      if loaded_bundler_spec.size > 0
-        expected = loaded_bundler_spec[0].homepage
+      expected = if !loaded_bundler_spec.empty?
+        loaded_bundler_spec[0].homepage
       else
-        expected = "No website available."
+        "No website available."
       end
 
       expect(out).to include("* actionmailer (2.3.2)")

--- a/spec/commands/show_spec.rb
+++ b/spec/commands/show_spec.rb
@@ -63,9 +63,16 @@ RSpec.describe "bundle show", :bundler => "< 2" do
     it "prints summary of gems" do
       bundle "show --verbose"
 
+      loaded_bundler_spec = Bundler.load.specs["bundler"]
+      if loaded_bundler_spec.size > 0
+        expected = loaded_bundler_spec[0].homepage
+      else
+        expected = "No website available."
+      end
+
       expect(out).to include("* actionmailer (2.3.2)")
       expect(out).to include("\tSummary:  This is just a fake gem for testing")
-      expect(out).to include("\tHomepage: No website available.")
+      expect(out).to include("\tHomepage: #{expected}")
       expect(out).to include("\tStatus:   Up to date")
     end
   end

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -159,8 +159,8 @@ RSpec.describe "Bundler.setup" do
 
       load_path = clean_load_path(out.split("\n"))
 
-      if Bundler.load.specs["bundler"].size > 0
-        load_path.delete_if{|path| path =~ /bundler/ }
+      unless Bundler.load.specs["bundler"].empty?
+        load_path.delete_if {|path| path =~ /bundler/ }
       end
 
       expect(load_path).to start_with(

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -159,6 +159,10 @@ RSpec.describe "Bundler.setup" do
 
       load_path = clean_load_path(out.split("\n"))
 
+      if Bundler.load.specs["bundler"].size > 0
+        load_path.delete_if{|path| path =~ /bundler/ }
+      end
+
       expect(load_path).to start_with(
         "/gems/rails-2.3.2/lib",
         "/gems/activeresource-2.3.2/lib",


### PR DESCRIPTION
I fixed test fails with bundler-1.16.1 as default gems.

https://travis-ci.org/rubygems/rubygems/jobs/339325369

When the system has a same version of bundler as default gems(Currently it's 1.16.1), It conflicts on command invocation in bundler's examples. I added two workarounds.

1. Bump virtual version of bundler in `binstubs_spec.rb`
2. In other examples, I modified expected variables when it was installed bundler as default gems.