### PR TITLE
Remove comment with timestamp on `bundle add`

### DIFF
--- a/lib/bundler/injector.rb
+++ b/lib/bundler/injector.rb
@@ -84,9 +84,6 @@ module Bundler
     def append_to(gemfile_path, new_gem_lines)
       gemfile_path.open("a") do |f|
         f.puts
-        if @options["timestamp"] || @options["timestamp"].nil?
-          f.puts "# Added at #{Time.now} by #{`whoami`.chomp}:"
-        end
         f.puts new_gem_lines
       end
     end


### PR DESCRIPTION
As discussed on #6193 this PR simply removes the comment timestamp when adding a gem via command line.
