### PR TITLE
Document `# frozen_string_literal` in `bundle init` Gemfile

### DIFF
--- a/man/bundle-init.ronn
+++ b/man/bundle-init.ronn
@@ -12,16 +12,18 @@ adding a [`Gemfile(5)`][Gemfile(5)] to a gem with a gemspec, the `--gemspec` opt
 automatically add each dependency listed in the gemspec file to the newly
 created [`Gemfile(5)`][Gemfile(5)].
 
-One of the lines included in the default [`Gemfile(5)`][Gemfile(5)]
-generated is `# frozen_string_literal: true`. This is a magic comment
-supported for the first time in Ruby 2.3. The presence of this line
-results in all string literals in the file being implicitly frozen.
-Frozen string literals will be the default in Ruby 3.
-
 ## OPTIONS
 
 * `--gemspec`:
   Use the specified .gemspec to create the [`Gemfile(5)`][Gemfile(5)]
+
+## FILES
+
+Included in the default [`Gemfile(5)`][Gemfile(5)]
+generated is the line `# frozen_string_literal: true`. This is a magic comment
+supported for the first time in Ruby 2.3. The presence of this line
+results in all string literals in the file being implicitly frozen.
+Frozen string literals will be the default in Ruby 3.
 
 ## SEE ALSO
 

--- a/man/bundle-init.ronn
+++ b/man/bundle-init.ronn
@@ -23,7 +23,6 @@ Included in the default [`Gemfile(5)`][Gemfile(5)]
 generated is the line `# frozen_string_literal: true`. This is a magic comment
 supported for the first time in Ruby 2.3. The presence of this line
 results in all string literals in the file being implicitly frozen.
-Frozen string literals will be the default in Ruby 3.
 
 ## SEE ALSO
 

--- a/man/bundle-init.ronn
+++ b/man/bundle-init.ronn
@@ -12,7 +12,11 @@ adding a [`Gemfile(5)`][Gemfile(5)] to a gem with a gemspec, the `--gemspec` opt
 automatically add each dependency listed in the gemspec file to the newly
 created [`Gemfile(5)`][Gemfile(5)].
 
-One of the lines included in the default [`Gemfile(5)`][Gemfile(5)] generated is `# frozen_string_literal: true`. This is a magic comment supported for the first time in Ruby 2.3. The presence of this line results in all string literals in the file being implicitly frozen. Frozen string literals will be the default in Ruby 3.
+One of the lines included in the default [`Gemfile(5)`][Gemfile(5)]
+generated is `# frozen_string_literal: true`. This is a magic comment
+supported for the first time in Ruby 2.3. The presence of this line
+results in all string literals in the file being implicitly frozen.
+Frozen string literals will be the default in Ruby 3.
 
 ## OPTIONS
 

--- a/man/bundle-init.ronn
+++ b/man/bundle-init.ronn
@@ -12,7 +12,13 @@ adding a [`Gemfile(5)`][Gemfile(5)] to a gem with a gemspec, the `--gemspec` opt
 automatically add each dependency listed in the gemspec file to the newly
 created [`Gemfile(5)`][Gemfile(5)].
 
+One of the lines included in the default [`Gemfile(5)`][Gemfile(5)] generated is `# frozen_string_literal: true`. This is a magic comment supported for the first time in Ruby 2.3. The presence of this line results in all string literals in the file being implicitly frozen. Frozen string literals will be the default in Ruby 3.
+
 ## OPTIONS
 
 * `--gemspec`:
   Use the specified .gemspec to create the [`Gemfile(5)`][Gemfile(5)]
+
+## SEE ALSO
+
+[Gemfile(5)](http://bundler.io/man/gemfile.5.html)


### PR DESCRIPTION
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

An enhancement request to bundle-init docu as per - issue 6140 

### What was your diagnosis of the problem?

n/a

### What is your fix for the problem, implemented in this PR?

Updated the man/bundle-init.ronn file to include brief description of frozen string literal, and added a SEE ALSO section with link to Gemfile(5) webpage

### Why did you choose this fix out of the possible options?

File edited to try and reflect the previous discussion regarding what was required. 
