### PR TITLE
Correctly re-install extensions when running `pristine` for a git source

### DIFF
--- a/lib/bundler/cli/pristine.rb
+++ b/lib/bundler/cli/pristine.rb
@@ -30,6 +30,7 @@ module Bundler
           FileUtils.rm_rf spec.full_gem_path
         when Source::Git
           source.remote!
+          FileUtils.rm_rf spec.extension_dir if spec.have_extensions?
           FileUtils.rm_rf spec.full_gem_path
         else
           Bundler.ui.warn("Cannot pristine #{gem_name}. Gem is sourced from local path.")

--- a/spec/commands/pristine_spec.rb
+++ b/spec/commands/pristine_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "bundle pristine" do
       build_gem "baz-dev", "1.0.0"
       build_gem "very_simple_binary", &:add_c_extension
       build_git "foo", :path => lib_path("foo")
+      build_git "git_with_ext", :path => lib_path("git_with_ext"), &:add_c_extension
       build_lib "bar", :path => lib_path("bar")
     end
 
@@ -22,6 +23,7 @@ RSpec.describe "bundle pristine" do
       gem "weakling"
       gem "very_simple_binary"
       gem "foo", :git => "#{lib_path("foo")}"
+      gem "git_with_ext", :git => "#{lib_path("git_with_ext")}"
       gem "bar", :path => "#{lib_path("bar")}"
 
       gemspec
@@ -152,6 +154,23 @@ RSpec.describe "bundle pristine" do
     let(:c_ext_dir)          { Pathname.new(very_simple_binary.full_gem_path).join("ext") }
     let(:build_opt)          { "--with-ext-lib=#{c_ext_dir}" }
     before { bundle "config build.very_simple_binary -- #{build_opt}" }
+
+    # This just verifies that the generated Makefile from the c_ext gem makes
+    # use of the build_args from the bundle config
+    it "applies the config when installing the gem" do
+      bundle! "pristine"
+
+      makefile_contents = File.read(c_ext_dir.join("Makefile").to_s)
+      expect(makefile_contents).to match(/libpath =.*#{c_ext_dir}/)
+      expect(makefile_contents).to match(/LIBPATH =.*-L#{c_ext_dir}/)
+    end
+  end
+
+  context "when a build config exists for a git sourced gem" do
+    let(:git_with_ext) { Bundler.definition.specs["git_with_ext"].first }
+    let(:c_ext_dir)          { Pathname.new(git_with_ext.full_gem_path).join("ext") }
+    let(:build_opt)          { "--with-ext-lib=#{c_ext_dir}" }
+    before { bundle "config build.git_with_ext -- #{build_opt}" }
 
     # This just verifies that the generated Makefile from the c_ext gem makes
     # use of the build_args from the bundle config


### PR DESCRIPTION
Unfortunately, I was unable to figure out how to prevent it from reloading
the built extension from the global cache in 2.0. That means this is 1.16
only for now. I will investigate more.

Resolves #6294