### PR TITLE
Fix `bundle gem` generating unparsable ruby

### DIFF
--- a/lib/bundler/templates/newgem/lib/newgem.rb.tt
+++ b/lib/bundler/templates/newgem/lib/newgem.rb.tt
@@ -6,7 +6,7 @@ require "<%= config[:namespaced_path] %>/<%= config[:underscored_name] %>"
 <%- config[:constant_array].each_with_index do |c, i| -%>
 <%= "  " * i %>module <%= c %>
 <%- end -%>
-<%= "  " * config[:constant_array].size %>class Error < StandardError; end %>
+<%= "  " * config[:constant_array].size %>class Error < StandardError; end
 <%= "  " * config[:constant_array].size %># Your code goes here...
 <%- (config[:constant_array].size-1).downto(0) do |i| -%>
 <%= "  " * i %>end

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -311,7 +311,7 @@ RSpec.describe "bundle gem" do
     end
 
     it "creates a base error class" do
-      expect(bundled_app("test_gem/lib/test_gem.rb").read).to include("class Error < StandardError")
+      expect(bundled_app("test_gem/lib/test_gem.rb").read).to match(/class Error < StandardError; end$/)
     end
 
     it "runs rake without problems" do


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that the main file in a gem generated by `bundle gem` can't be inspected via `rubocop`.

### What was your diagnosis of the problem?

My diagnosis was `bundler` was generating unparsable ruby in the generated gem.

### What is your fix for the problem, implemented in this PR?

My fix was to change the offending template to generate valid ruby code.

### Why did you choose this fix out of the possible options?

I chose this fix because it's the only one, really.