### PR TITLE
Correctly re-install extensions when running `pristine` for a git source

### DIFF
--- a/lib/bundler/cli/pristine.rb
+++ b/lib/bundler/cli/pristine.rb
@@ -30,6 +30,10 @@ module Bundler
           FileUtils.rm_rf spec.full_gem_path
         when Source::Git
           source.remote!
+          if extension_cache_path = source.extension_cache_path(spec)
+            FileUtils.rm_rf extension_cache_path
+          end
+          FileUtils.rm_rf spec.extension_dir
           FileUtils.rm_rf spec.full_gem_path
         else
           Bundler.ui.warn("Cannot pristine #{gem_name}. Gem is sourced from local path.")

--- a/lib/bundler/source.rb
+++ b/lib/bundler/source.rb
@@ -54,6 +54,15 @@ module Bundler
       instance_of?(Bundler::Source::Path)
     end
 
+    def extension_cache_path(spec)
+      return unless Bundler.feature_flag.global_gem_cache?
+      return unless source_slug = extension_cache_slug(spec)
+      Bundler.user_cache.join(
+        "extensions", Gem::Platform.local.to_s, Bundler.ruby_scope,
+        source_slug, spec.full_name
+      )
+    end
+
   private
 
     def version_color(spec_version, locked_spec_version)
@@ -76,15 +85,6 @@ module Bundler
       else
         Bundler.ui.info message
       end
-    end
-
-    def extension_cache_path(spec)
-      return unless Bundler.feature_flag.global_gem_cache?
-      return unless source_slug = extension_cache_slug(spec)
-      Bundler.user_cache.join(
-        "extensions", Gem::Platform.local.to_s, Bundler.ruby_scope,
-        source_slug, spec.full_name
-      )
     end
 
     def extension_cache_slug(_)

--- a/spec/commands/pristine_spec.rb
+++ b/spec/commands/pristine_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "bundle pristine" do
       build_gem "baz-dev", "1.0.0"
       build_gem "very_simple_binary", &:add_c_extension
       build_git "foo", :path => lib_path("foo")
+      build_git "git_with_ext", :path => lib_path("git_with_ext"), &:add_c_extension
       build_lib "bar", :path => lib_path("bar")
     end
 
@@ -22,6 +23,7 @@ RSpec.describe "bundle pristine" do
       gem "weakling"
       gem "very_simple_binary"
       gem "foo", :git => "#{lib_path("foo")}"
+      gem "git_with_ext", :git => "#{lib_path("git_with_ext")}"
       gem "bar", :path => "#{lib_path("bar")}"
 
       gemspec
@@ -154,6 +156,23 @@ RSpec.describe "bundle pristine" do
     let(:c_ext_dir)          { Pathname.new(very_simple_binary.full_gem_path).join("ext") }
     let(:build_opt)          { "--with-ext-lib=#{c_ext_dir}" }
     before { bundle "config build.very_simple_binary -- #{build_opt}" }
+
+    # This just verifies that the generated Makefile from the c_ext gem makes
+    # use of the build_args from the bundle config
+    it "applies the config when installing the gem" do
+      bundle! "pristine"
+
+      makefile_contents = File.read(c_ext_dir.join("Makefile").to_s)
+      expect(makefile_contents).to match(/libpath =.*#{c_ext_dir}/)
+      expect(makefile_contents).to match(/LIBPATH =.*-L#{c_ext_dir}/)
+    end
+  end
+
+  context "when a build config exists for a git sourced gem" do
+    let(:git_with_ext) { Bundler.definition.specs["git_with_ext"].first }
+    let(:c_ext_dir)          { Pathname.new(git_with_ext.full_gem_path).join("ext") }
+    let(:build_opt)          { "--with-ext-lib=#{c_ext_dir}" }
+    before { bundle "config build.git_with_ext -- #{build_opt}" }
 
     # This just verifies that the generated Makefile from the c_ext gem makes
     # use of the build_args from the bundle config


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

I have a gem with a native extension that is installed via git. I had to recompile it due to some needed build arguments.

### The problem was...

Running `bundle pristine` would not recompile it as expected.

### My diagnosis was...

After digging into the source, I discovered that the built extension lived in a different location than the cloned git repo. `bundle pristine` was only removing the git repo so the built extension was not getting rebuilt.

### My fix...

Update `bundle pristine` to also remove the built extension. For 2.0, this also required removing the built extension cache. Without doing that, the built extension directory would just be recreated from the cache.

### I chose this fix because...

As far as I know, it's the only solution.


Resolves #6294