### PR TITLE
Don't GPG-sign test setup commits

### DIFF
--- a/spec/bundler/gem_helper_spec.rb
+++ b/spec/bundler/gem_helper_spec.rb
@@ -197,6 +197,7 @@ RSpec.describe Bundler::GemHelper do
           `git init`
           `git config user.email "you@example.com"`
           `git config user.name "name"`
+          `git config commit.gpgsign false`
           `git config push.default simple`
         end
 

--- a/spec/support/builders.rb
+++ b/spec/support/builders.rb
@@ -653,6 +653,7 @@ module Spec
           `git add *`
           `git config user.email "lol@wut.com"`
           `git config user.name "lolwut"`
+          `git config commit.gpgsign false`
           `git commit -m 'OMG INITIAL COMMIT'`
         end
       end


### PR DESCRIPTION
Running `bin/rake spec` in the Bundler repository causes a bunch of failures if `commit.gpgsign` is set in the global Git configuration.


Bundler's tests were making Git commits and trying to GPG sign them.


Set `commit.gpgsign` to `false` when initializing a Git repository in the tests.


I chose this fix because the alternative would be to pass `--no-gpg-sign` every time a commit is made in the tests, which would have a bigger maintenance impact.