### PR TITLE
Improve yanked gem error message

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -175,7 +175,7 @@ module Bundler
           raise GemNotFound, "Your bundle is locked to #{locked_gem}, but that version could not " \
                              "be found in any of the sources listed in your Gemfile. If you haven't changed sources, " \
                              "that means the author of #{locked_gem} has removed it. You'll need to update your bundle " \
-                             "to a different version of #{locked_gem} that hasn't been removed in order to install."
+                             "to a different version of #{gem_name} that hasn't been removed in order to install."
         end
         unless specs["bundler"].any?
           bundler = sources.metadata_source.specs.search(Gem::Dependency.new("bundler", VERSION)).last

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -175,7 +175,7 @@ module Bundler
           raise GemNotFound, "Your bundle is locked to #{locked_gem}, but that version could not " \
                              "be found in any of the sources listed in your Gemfile. If you haven't changed sources, " \
                              "that means the author of #{locked_gem} has removed it. You'll need to update your bundle " \
-                             "to a different version of #{gem_name} that hasn't been removed in order to install."
+                             "to a version other than #{locked_gem} that hasn't been removed in order to install."
         end
         unless specs["bundler"].any?
           bundler = sources.metadata_source.specs.search(Gem::Dependency.new("bundler", VERSION)).last


### PR DESCRIPTION
The problem was that the error message for a yanked Gem told the user to:

> update your bundle to a different version of foo (1.0)

This is slightly misleading because in this example, foo 1.0 is the version that has been yanked. They should use any verion of foo **other** than 1.0.


My diagnosis was that the error message interpolated the gem specification (which converts to a string as "NAME (VERSION)") rather than just the name of the gem in this instance.


My fix was to change that occurrence of the gem specification to just the gem name.


I chose this fix because it was the only way that occurred to me to do it.