### PR TITLE
Better error message for `bundle install` git failure

### DIFF
--- a/lib/bundler/source/git/git_proxy.rb
+++ b/lib/bundler/source/git/git_proxy.rb
@@ -29,7 +29,9 @@ module Bundler
           msg = String.new
           msg << "Git error: command `git #{command}` in directory #{SharedHelpers.pwd} has failed."
           msg << "\n#{extra_info}" if extra_info
-          msg << "\nIf this error persists you could try removing the cache directory '#{path}'" if path && path.exist?
+          msg << "\nIf this error persists you could try the following:"
+          msg << "\n  * Removing the cache directory '#{path}'" if path && path.exist?
+          msg << "\n  * Removing your 'Gemfile.lock' (or 'gems.rb.locked') file"
           super msg
         end
       end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that I wouldn't manage to run `bundle install` and would keep getting the following error.

```
Fetching gem metadata from https://rubygems.org/.......
Fetching https://github.com/decidim/decidim
fatal: No se pudo analizar el objeto 'ff36d24dbe1cf7aa99e5eeea1ff38e6aeeb2af92'.
Git error: command `git reset --hard ff36d24dbe1cf7aa99e5eeea1ff38e6aeeb2af92` in directory
/home/deivid/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/bundler/gems/decidim-ff36d24dbe1c has failed.
If this error persists you could try removing the cache directory
'/home/deivid/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/cache/bundler/git/decidim-9495d3039168996748af12c0fdb04debdea1039
``` 

None of the advice in there would work. I left some `puts` around in `git_proxy.rb` but I wasn't able to figure out the problem. At some point, I tried to delete the lock file and rebundle and it worked!
 
You can see the log of the full session here:  https://gist.github.com/deivid-rodriguez/effda7c001b97522ab53fc18d7b6bf53.

### What was your diagnosis of the problem?

My diagnosis was that the advice in the error message could be improved since the solution that worked for me is included.

### What is your fix for the problem, implemented in this PR?

Change the error message to include removing the `Gemfile.lock` file.

### Why did you choose this fix out of the possible options?

Because it was the one that worked for me.