### PR TITLE
Add config variable and check for platform warnings

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -878,7 +878,7 @@ module Bundler
         dep = Dependency.new(dep, ">= 0") unless dep.respond_to?(:name)
         next if !remote && !dep.current_platform?
         platforms = dep.gem_platforms(sorted_platforms)
-        if platforms.empty?
+        if platforms.empty? && !Bundler.settings[:disable_platform_warnings]
           mapped_platforms = dep.platforms.map {|p| Dependency::PLATFORM_MAP[p] }
           Bundler.ui.warn \
             "The dependency #{dep} will be unused by any of the platforms Bundler is installing for. " \

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -26,6 +26,7 @@ module Bundler
       disable_exec_load
       disable_local_branch_check
       disable_multisource
+      disable_platform_warnings
       disable_shared_gems
       disable_version_check
       error_on_stderr

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -167,7 +167,7 @@ learn more about their operation in [bundle install(1)][bundle-install(1)].
    instead of warnings.
    Use `bundle config --delete disable_multisource` to unset.
 * `disable_platform_warnings` (`BUNDLE_DISABLE_PLATFORM_WARNINGS`):
-   Whether Bundler should show platform warnings.
+   Disable warnings during bundle install when a dependency is unused on the current platform.
 * `disable_shared_gems` (`BUNDLE_DISABLE_SHARED_GEMS`):
    Stop Bundler from accessing gems installed to RubyGems' normal location.
 * `disable_version_check` (`BUNDLE_DISABLE_VERSION_CHECK`):

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -166,6 +166,8 @@ learn more about their operation in [bundle install(1)][bundle-install(1)].
    When set, Gemfiles containing multiple sources will produce errors
    instead of warnings.
    Use `bundle config --delete disable_multisource` to unset.
+* `disable_platform_warnings` (`BUNDLE_DISABLE_PLATFORM_WARNINGS`):
+   Whether Bundler should show platform warnings.
 * `disable_shared_gems` (`BUNDLE_DISABLE_SHARED_GEMS`):
    Stop Bundler from accessing gems installed to RubyGems' normal location.
 * `disable_version_check` (`BUNDLE_DISABLE_VERSION_CHECK`):

--- a/spec/install/gemfile/platform_spec.rb
+++ b/spec/install/gemfile/platform_spec.rb
@@ -230,21 +230,46 @@ RSpec.describe "bundle install with platform conditionals" do
     expect(out).not_to match(/Could not find gem 'some_gem/)
   end
 
-  it "prints a helpful warning when a dependency is unused on any platform" do
-    simulate_platform "ruby"
-    simulate_ruby_engine "ruby"
+  context "when disable_platform_warnings is false (by default)" do
+    before { bundle! "config disable_platform_warnings false" }
 
-    gemfile <<-G
-      source "file://#{gem_repo1}"
+    it "prints a helpful warning when a dependency is unused on any platform" do
+      simulate_platform "ruby"
+      simulate_ruby_engine "ruby"
 
-      gem "rack", :platform => [:mingw, :mswin, :x64_mingw, :jruby]
-    G
+      gemfile <<-G
+        source "file://#{gem_repo1}"
 
-    bundle! "install"
+        gem "rack", :platform => [:mingw, :mswin, :x64_mingw, :jruby]
+      G
 
-    expect(out).to include <<-O.strip
-The dependency #{Gem::Dependency.new("rack", ">= 0")} will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for x86-mingw32, x86-mswin32, x64-mingw32, java. To add those platforms to the bundle, run `bundle lock --add-platform x86-mingw32 x86-mswin32 x64-mingw32 java`.
-    O
+      bundle! "install"
+
+      expect(out).to include <<-O.strip
+  The dependency #{Gem::Dependency.new("rack", ">= 0")} will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for x86-mingw32, x86-mswin32, x64-mingw32, java. To add those platforms to the bundle, run `bundle lock --add-platform x86-mingw32 x86-mswin32 x64-mingw32 java`.
+      O
+    end
+  end
+
+  context "when disable_platform_warnings is true" do
+    before { bundle! "config disable_platform_warnings true" }
+
+    it "doesnot print the warning when a dependency is unused on any platform" do
+      simulate_platform "ruby"
+      simulate_ruby_engine "ruby"
+
+      gemfile <<-G
+        source "file://#{gem_repo1}"
+
+        gem "rack", :platform => [:mingw, :mswin, :x64_mingw, :jruby]
+      G
+
+      bundle! "install"
+
+      expect(out).not_to include <<-O.strip
+  The dependency #{Gem::Dependency.new("rack", ">= 0")} will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for x86-mingw32, x86-mswin32, x64-mingw32, java. To add those platforms to the bundle, run `bundle lock --add-platform x86-mingw32 x86-mswin32 x64-mingw32 java`.
+      O
+    end
   end
 end
 

--- a/spec/install/gemfile/platform_spec.rb
+++ b/spec/install/gemfile/platform_spec.rb
@@ -230,31 +230,27 @@ RSpec.describe "bundle install with platform conditionals" do
     expect(out).not_to match(/Could not find gem 'some_gem/)
   end
 
-  context "when disable_platform_warnings is false (by default)" do
-    before { bundle! "config disable_platform_warnings false" }
+  it "prints a helpful warning when a dependency is unused on any platform" do
+    simulate_platform "ruby"
+    simulate_ruby_engine "ruby"
 
-    it "prints a helpful warning when a dependency is unused on any platform" do
-      simulate_platform "ruby"
-      simulate_ruby_engine "ruby"
+    gemfile <<-G
+      source "file://#{gem_repo1}"
 
-      gemfile <<-G
-        source "file://#{gem_repo1}"
+      gem "rack", :platform => [:mingw, :mswin, :x64_mingw, :jruby]
+    G
 
-        gem "rack", :platform => [:mingw, :mswin, :x64_mingw, :jruby]
-      G
+    bundle! "install"
 
-      bundle! "install"
-
-      expect(out).to include <<-O.strip
-  The dependency #{Gem::Dependency.new("rack", ">= 0")} will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for x86-mingw32, x86-mswin32, x64-mingw32, java. To add those platforms to the bundle, run `bundle lock --add-platform x86-mingw32 x86-mswin32 x64-mingw32 java`.
-      O
-    end
+    expect(out).to include <<-O.strip
+The dependency #{Gem::Dependency.new("rack", ">= 0")} will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for x86-mingw32, x86-mswin32, x64-mingw32, java. To add those platforms to the bundle, run `bundle lock --add-platform x86-mingw32 x86-mswin32 x64-mingw32 java`.
+    O
   end
 
   context "when disable_platform_warnings is true" do
     before { bundle! "config disable_platform_warnings true" }
 
-    it "doesnot print the warning when a dependency is unused on any platform" do
+    it "does not print the warning when a dependency is unused on any platform" do
       simulate_platform "ruby"
       simulate_ruby_engine "ruby"
 
@@ -266,9 +262,7 @@ RSpec.describe "bundle install with platform conditionals" do
 
       bundle! "install"
 
-      expect(out).not_to include <<-O.strip
-  The dependency #{Gem::Dependency.new("rack", ">= 0")} will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for x86-mingw32, x86-mswin32, x64-mingw32, java. To add those platforms to the bundle, run `bundle lock --add-platform x86-mingw32 x86-mswin32 x64-mingw32 java`.
-      O
+      expect(out).not_to match(/The dependency (.*) will be unused/)
     end
   end
 end


### PR DESCRIPTION
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The user needed a way to turn off platform warnings.

### What was your diagnosis of the problem?

Creating a config variable to solve the above problem.

### What is your fix for the problem, implemented in this PR?

Added a key `disable_platform_warnings` in settings and placed check at the relevant place to disable warnings.

### Why did you choose this fix out of the possible options?

We will by default show warnings but the user might want to disable them, so using a config variable looked a good option.

Fixes #6124 
