### PR TITLE
Fix some rescue calls that do not specifiy error type.

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -189,7 +189,7 @@ module Bundler
         end
         tmp_home_path.join(login).tap(&:mkpath)
       end
-    rescue => e
+    rescue RuntimeError => e
       raise e.exception("#{warning}\nBundler also failed to create a temporary home directory at `#{path}':\n#{e}")
     end
 
@@ -426,7 +426,7 @@ EOF
 
     def load_marshal(data)
       Marshal.load(data)
-    rescue => e
+    rescue StandardError => e
       raise MarshalError, "#{e.class}: #{e.message}"
     end
 

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -745,7 +745,7 @@ module Bundler
       end
 
       Bundler.ui.warn "The latest bundler is #{latest}, but you are currently running #{current}.\n#{suggestion}"
-    rescue
+    rescue RuntimeError
       nil
     end
   end

--- a/lib/bundler/endpoint_specification.rb
+++ b/lib/bundler/endpoint_specification.rb
@@ -123,7 +123,7 @@ module Bundler
           @required_ruby_version = Gem::Requirement.new(v)
         end
       end
-    rescue => e
+    rescue StandardError => e
       raise GemspecError, "There was an error parsing the metadata for the gem #{name} (#{version}): #{e.class}\n#{e}\nThe metadata was #{data.inspect}"
     end
 

--- a/lib/bundler/env.rb
+++ b/lib/bundler/env.rb
@@ -64,7 +64,7 @@ module Bundler
       File.read(filename.to_s).strip
     rescue Errno::ENOENT
       "<No #{filename} found>"
-    rescue => e
+    rescue RuntimeError => e
       "#{e.class}: #{e.message}"
     end
 

--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -178,7 +178,7 @@ module Bundler
           # engine_version raises on unknown engines
           engine_version = begin
                              ruby.engine_versions
-                           rescue
+                           rescue RuntimeError
                              "???"
                            end
           agent << " #{ruby.engine}/#{ruby.versions_string(engine_version)}"

--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -160,7 +160,7 @@ module Bundler
       sh %W[git tag -m Version\ #{version} #{version_tag}]
       Bundler.ui.confirm "Tagged #{version_tag}."
       yield if block_given?
-    rescue
+    rescue RuntimeError
       Bundler.ui.error "Untagging #{version_tag} due to error."
       sh_with_status %W[git tag -d #{version_tag}]
       raise

--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -220,7 +220,7 @@ module Bundler
     def processor_count
       require "etc"
       Etc.nprocessors
-    rescue Runtimeerror
+    rescue StandardError
       1
     end
 

--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -220,7 +220,7 @@ module Bundler
     def processor_count
       require "etc"
       Etc.nprocessors
-    rescue
+    rescue Runtimeerror
       1
     end
 

--- a/lib/bundler/installer/gem_installer.rb
+++ b/lib/bundler/installer/gem_installer.rb
@@ -21,7 +21,7 @@ module Bundler
       raise
     rescue Errno::ENOSPC
       return false, out_of_space_message
-    rescue => e
+    rescue StandardError => e
       return false, specific_failure_message(e)
     end
 

--- a/lib/bundler/installer/parallel_installer.rb
+++ b/lib/bundler/installer/parallel_installer.rb
@@ -161,7 +161,7 @@ module Bundler
       )
       success, message = begin
         gem_installer.install_from_spec
-      rescue => e
+      rescue RuntimeError => e
         raise e, "#{e}\n\n#{require_tree_for_spec(spec_install.spec)}"
       end
       if success

--- a/lib/bundler/mirror.rb
+++ b/lib/bundler/mirror.rb
@@ -152,7 +152,7 @@ module Bundler
             socket.connect_nonblock(address)
           rescue Errno::EINPROGRESS
             wait_for_writtable_socket(socket, address, timeout)
-          rescue # Connection failed somehow, again
+          rescue RuntimeError # Connection failed somehow, again
             false
           end
         end
@@ -172,7 +172,7 @@ module Bundler
         socket.connect_nonblock(address)
       rescue Errno::EISCONN
         true
-      rescue # Connection failed
+      rescue StandardError # Connection failed
         false
       end
     end

--- a/lib/bundler/plugin.rb
+++ b/lib/bundler/plugin.rb
@@ -86,7 +86,7 @@ module Bundler
       installed_specs = Installer.new.install_definition(definition)
 
       save_plugins plugins, installed_specs, builder.inferred_plugins
-    rescue => e
+    rescue RuntimeError => e
       unless e.is_a?(GemfileError)
         Bundler.ui.error "Failed to install plugin: #{e.message}\n  #{e.backtrace[0]}"
       end
@@ -284,7 +284,7 @@ module Bundler
       load path.join(PLUGIN_FILE_NAME)
 
       @loaded_plugin_names << name
-    rescue => e
+    rescue RuntimeError => e
       Bundler.ui.error "Failed loading plugin #{name}: #{e.message}"
       raise
     end

--- a/lib/bundler/plugin/index.rb
+++ b/lib/bundler/plugin/index.rb
@@ -58,7 +58,7 @@ module Bundler
         @plugin_paths[name] = path
         @load_paths[name] = load_paths
         save_index
-      rescue
+      rescue StandardError
         @commands = old_commands
         raise
       end

--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -79,7 +79,7 @@ module Bundler
             required_file = file
             begin
               Kernel.require file
-            rescue => e
+            rescue RuntimeError => e
               raise e if e.is_a?(LoadError) # we handle this a little later
               raise Bundler::GemRequireError.new e,
                 "There was an error while trying to load the gem '#{file}'."

--- a/task/release.rake
+++ b/task/release.rake
@@ -34,7 +34,7 @@ namespace :release do
     if response.code.to_i >= 400
       raise "#{uri}\n#{response.inspect}\n#{begin
                                               JSON.parse(response.body)
-                                            rescue
+                                            rescue JSON::ParseError
                                               response.body
                                             end}"
     end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem I noticed was in style, several instances of `rescue` clauses that do not specify an exception type. This is noted in in the Ruby Style Guide as [Avoid rescuing the Exception class](https://github.com/bbatsov/ruby-style-guide#no-blind-rescues).

### What was your diagnosis of the problem?

My diagnosis was that at least some of those are leftover style. They are noted in `.rubocop_todo.yml`. To make sure, I asked on Slack.

### What is your fix for the problem, implemented in this PR?

My fix is to make as many of them more specific, specifying at least `StandardError`, and trying to be more specific.

### Why did you choose this fix out of the possible options?

No other ways of addressing this came to mind. I'd be happy to consider.