### PR TITLE
Use Gem::Util.inflate instead of Gem.inflate

### DIFF
--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -96,11 +96,11 @@ module Bundler
 
       uri = URI.parse("#{remote_uri}#{Gem::MARSHAL_SPEC_DIR}#{spec_file_name}.rz")
       if uri.scheme == "file"
-        Bundler.load_marshal Gem.inflate(Gem.read_binary(uri.path))
+        Bundler.load_marshal Gem::Util.inflate(Gem.read_binary(uri.path))
       elsif cached_spec_path = gemspec_cached_path(spec_file_name)
         Bundler.load_gemspec(cached_spec_path)
       else
-        Bundler.load_marshal Gem.inflate(downloader.fetch(uri).body)
+        Bundler.load_marshal Gem::Util.inflate(downloader.fetch(uri).body)
       end
     rescue MarshalError
       raise HTTPError, "Gemspec #{spec} contained invalid data.\n" \

--- a/lib/bundler/fetcher/index.rb
+++ b/lib/bundler/fetcher/index.rb
@@ -29,11 +29,11 @@ module Bundler
 
         uri = URI.parse("#{remote_uri}#{Gem::MARSHAL_SPEC_DIR}#{spec_file_name}.rz")
         if uri.scheme == "file"
-          Bundler.load_marshal Gem.inflate(Gem.read_binary(uri.path))
+          Bundler.load_marshal Gem::Util.inflate(Gem.read_binary(uri.path))
         elsif cached_spec_path = gemspec_cached_path(spec_file_name)
           Bundler.load_gemspec(cached_spec_path)
         else
-          Bundler.load_marshal Gem.inflate(downloader.fetch(uri).body)
+          Bundler.load_marshal Gem::Util.inflate(downloader.fetch(uri).body)
         end
       rescue MarshalError
         raise HTTPError, "Gemspec #{spec} contained invalid data.\n" \

--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -132,7 +132,7 @@ module Bundler
     end
 
     def inflate(obj)
-      Gem.inflate(obj)
+      Gem::Util.inflate(obj)
     end
 
     def sources=(val)

--- a/spec/install/gems/resolving_spec.rb
+++ b/spec/install/gems/resolving_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "bundle install with install-time dependencies" do
     build_repo2
 
     path = "#{gem_repo2}/#{Gem::MARSHAL_SPEC_DIR}/actionpack-2.3.2.gemspec.rz"
-    spec = Marshal.load(Gem.inflate(File.read(path)))
+    spec = Marshal.load(Gem::Util.inflate(File.read(path)))
     spec.dependencies.each do |d|
       d.instance_variable_set(:@type, :fail)
     end

--- a/spec/support/artifice/compact_index.rb
+++ b/spec/support/artifice/compact_index.rb
@@ -10,7 +10,7 @@ class CompactIndexAPI < Endpoint
     def load_spec(name, version, platform, gem_repo)
       full_name = "#{name}-#{version}"
       full_name += "-#{platform}" if platform != "ruby"
-      Marshal.load(Gem.inflate(File.open(gem_repo.join("quick/Marshal.4.8/#{full_name}.gemspec.rz")).read))
+      Marshal.load(Gem::Util.inflate(File.open(gem_repo.join("quick/Marshal.4.8/#{full_name}.gemspec.rz")).read))
     end
 
     def etag_response

--- a/spec/support/artifice/endpoint.rb
+++ b/spec/support/artifice/endpoint.rb
@@ -68,7 +68,7 @@ class Endpoint < Sinatra::Base
     def load_spec(name, version, platform, gem_repo)
       full_name = "#{name}-#{version}"
       full_name += "-#{platform}" if platform != "ruby"
-      Marshal.load(Gem.inflate(File.open(gem_repo.join("quick/Marshal.4.8/#{full_name}.gemspec.rz")).read))
+      Marshal.load(Gem::Util.inflate(File.open(gem_repo.join("quick/Marshal.4.8/#{full_name}.gemspec.rz")).read))
     end
   end
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

When  I released RubyGems 3.0, users can not use bundler with it.

### What was your diagnosis of the problem?

bundler still uses deprecated methods with https://github.com/rubygems/rubygems/pull/2214

### What is your fix for the problem, implemented in this PR?

Replace `Gem.inflate` to `Gem::Util.inflate`

