### PR TITLE
Link out directly to contributor guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ To get in touch with the Bundler core team and other Bundler users, please see [
 
 ### Contributing
 
-If you'd like to contribute to Bundler, that's awesome, and we <3 you. There's a guide to contributing to Bundler (both code and general help) over in [our documentation section](doc/README.md).
+If you'd like to contribute to Bundler, that's awesome, and we <3 you. We've put together [the Bundler contributor guide](https://github.com/bundler/bundler/blob/master/doc/contributing/README.md) with all of the information you need to get started.
+
 
 While some Bundler contributors are compensated by Ruby Together, the project maintainers make decisions independent of Ruby Together. As a project, we welcome contributions regardless of the author’s affiliation with Ruby Together.
 


### PR DESCRIPTION
Hey team,

The "Contributing" section confusingly sends contributors over to the "Documentation" README, and from there, contributors have to click on "Overview" to actually get to the guidelines. Since it's easier to cut out those two steps, I've rephrased a sentence and provide the direct link to the contributor guidelines here.

Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was...
...that it wasn't clear why contributors had to complete two steps to get to the contributor guidelines. And because it isn't clear once they get to "Documentation" which link is the actual guideline, it's much simpler to link out to it directly from the Bundler README.
### What was your diagnosis of the problem?

My diagnosis was...
....to cut out the middle man, so to speak.

### What is your fix for the problem, implemented in this PR?

My fix...

1. rephrase a sentence
2. link out directly to the contributor guidelines README

### Why did you choose this fix out of the possible options?

I chose this fix because...
...it's easy to implement and makes the most sense from the user's POV.