### PR TITLE
Deprecate safe_level of `ERB.new` in Ruby 2.6

### DIFF
--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -135,7 +135,11 @@ module Bundler
         end
 
         File.open(binstub_path, "w", 0o777 & ~File.umask) do |f|
-          f.puts ERB.new(template, nil, "-").result(binding)
+          if RUBY_VERSION >= "2.6"
+            f.puts ERB.new(template, :trim_mode => "-").result(binding)
+          else
+            f.puts ERB.new(template, nil, "-").result(binding)
+          end
         end
       end
 
@@ -171,7 +175,11 @@ module Bundler
         executable_path = Pathname(spec.full_gem_path).join(spec.bindir, executable).relative_path_from(bin_path)
         executable_path = executable_path
         File.open "#{bin_path}/#{executable}", "w", 0o755 do |f|
-          f.puts ERB.new(template, nil, "-").result(binding)
+          if RUBY_VERSION >= "2.6"
+            f.puts ERB.new(template, :trim_mode => "-").result(binding)
+          else
+            f.puts ERB.new(template, nil, "-").result(binding)
+          end
         end
       end
     end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The interface of `ERB.new` will change from Ruby 2.6.

> 2nd, 3rd and 4th arguments of ERB.new are deprecated. 2nd
> argument (safe_level) will be dropped in the future and
>  some of those arguments (trim_mode, eoutvar) are changed to
> keyword arguments. [Feature #14256]

https://github.com/ruby/ruby/blob/v2_6_0_preview1/NEWS#stdlib-updates-outstanding-ones-only

The following addresses are related commits.

- ruby/ruby@cc777d0
- ruby/ruby@8b9a3ea

This change will cause the users to see a warning as described below.

### What was your diagnosis of the problem?

In Ruby 2.6, a warning is displayed when using the interface of Ruby 2.5 or lower.

This warning can also be confirmed in Travis CI.

```console
/home/travis/.rvm/gems/ruby-head/gems/rspec-core-3.7.1/lib/rspec/core/configuration_options.rb:171:
warning: Passing safe_level with the 2nd argument of ERB.new is
deprecated. Do not use it, and specify other arguments as keyword
arguments.
/home/travis/.rvm/gems/ruby-head/gems/rspec-core-3.7.1/lib/rspec/core/configuration_options.rb:171:
warning: Passing trim_mode with the 3rd argument of ERB.new is
deprecated. Use keyword argument like ERB.new(str, trim_mode: ...)
instead.
```

https://travis-ci.org/bundler/bundler/jobs/348560176#L1137-L1138

### What is your fix for the problem, implemented in this PR?

This PR suppresses the above deprecation warnings of ruby-head (Ruby 2.6) .

### Why did you choose this fix out of the possible options?

Switch `ERB.new` interface using `RUBY_VERSION`. Because Bundler supports multiple Ruby versions, it need to use the appropriate interface.
