### PR TITLE
Fix source_location call in PR 6237 and commit fbb1ff7

### DIFF
--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -571,7 +571,7 @@ module Bundler
         redefine_method(klass, sym, method)
       end
       if Binding.public_method_defined?(:source_location)
-        post_reset_hooks.reject! {|proc| proc.binding.source_location == __FILE__ }
+        post_reset_hooks.reject! {|proc| proc.binding.source_location[0] == __FILE__ }
       else
         post_reset_hooks.reject! {|proc| proc.binding.eval("__FILE__") == __FILE__ }
       end


### PR DESCRIPTION
Thanks to @nobu for pointing out the error (which was mine).  `source_location` returns an array, not a string.
