### PR TITLE
Raise an error when attempting to set an expectation on nil

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -114,6 +114,10 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 
+  config.mock_with :rspec do |mocks|
+    mocks.allow_message_expectations_on_nil = false
+  end
+
   config.before :all do
     build_repo1
   end


### PR DESCRIPTION
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was we could accidentally set an expectation on `nil`, leading to an RSpec warning

### What was your diagnosis of the problem?

My diagnosis was we should just error when we do so