### PR TITLE
Stop printing “failed to update” message when changing sources

### DIFF
--- a/lib/bundler/cli/update.rb
+++ b/lib/bundler/cli/update.rb
@@ -68,13 +68,13 @@ module Bundler
 
       if locked_gems = Bundler.definition.locked_gems
         gems.each do |name|
-          locked_version = locked_gems.specs.find {|s| s.name == name }
-          locked_source = locked_version && locked_version.source
-          locked_version &&= locked_version.version
+          locked_spec = locked_gems.specs.find {|s| s.name == name }
+          locked_source = locked_spec && locked_spec.source
+          locked_version = locked_spec.version
           next unless locked_version
-          new_version = Bundler.definition.specs[name].first
-          new_source = new_version && new_version.source
-          new_version &&= new_version.version
+          new_spec = Bundler.definition.specs[name].first
+          new_source = new_spec && new_spec.source
+          new_version = new_spec.version
           next if locked_source != new_source
           if !new_version
             Bundler.ui.warn "Bundler attempted to update #{name} but it was removed from the bundle"

--- a/lib/bundler/cli/update.rb
+++ b/lib/bundler/cli/update.rb
@@ -73,7 +73,7 @@ module Bundler
           locked_source = locked_spec.source
           locked_version = locked_spec.version
           new_spec = Bundler.definition.specs[name].first
-          new_source = new_spec && new_spec.source
+          new_source = new_spec.source.to_s
           new_version = new_spec.version
           next if locked_source != new_source
           if !new_version

--- a/lib/bundler/cli/update.rb
+++ b/lib/bundler/cli/update.rb
@@ -69,10 +69,13 @@ module Bundler
       if locked_gems = Bundler.definition.locked_gems
         gems.each do |name|
           locked_version = locked_gems.specs.find {|s| s.name == name }
+          locked_source = locked_version && locked_version.source
           locked_version &&= locked_version.version
           next unless locked_version
           new_version = Bundler.definition.specs[name].first
+          new_source = new_version && new_version.source
           new_version &&= new_version.version
+          next if locked_source != new_source
           if !new_version
             Bundler.ui.warn "Bundler attempted to update #{name} but it was removed from the bundle"
           elsif new_version < locked_version

--- a/lib/bundler/cli/update.rb
+++ b/lib/bundler/cli/update.rb
@@ -69,9 +69,9 @@ module Bundler
       if locked_gems = Bundler.definition.locked_gems
         gems.each do |name|
           locked_spec = locked_gems.specs.find {|s| s.name == name }
-          locked_source = locked_spec && locked_spec.source
+          next unless locked_spec
+          locked_source = locked_spec.source
           locked_version = locked_spec.version
-          next unless locked_version
           new_spec = Bundler.definition.specs[name].first
           new_source = new_spec && new_spec.source
           new_version = new_spec.version

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -473,6 +473,22 @@ RSpec.describe "bundle update in more complicated situations" do
     expect(the_bundle).to include_gems "thin 2.0", "rack 10.0", "rack-obama 1.0"
   end
 
+  it "will not warn when an explicitly updated git gem changes sha but not version" do
+    build_git "foo"
+
+    install_gemfile! <<-G
+      gem "foo", :git => '#{lib_path("foo-1.0")}'
+    G
+
+    update_git "foo" do |s|
+      s.write "lib/foo2.rb", "puts :foo2"
+    end
+
+    bundle! "update foo"
+
+    expect(last_command.stdboth).not_to include "attempted to update"
+  end
+
   it "will not warn when changing gem sources but not versions" do
     build_git "rack"
 

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -473,6 +473,23 @@ RSpec.describe "bundle update in more complicated situations" do
     expect(the_bundle).to include_gems "thin 2.0", "rack 10.0", "rack-obama 1.0"
   end
 
+  it "will not warn when changing gem sources but not versions" do
+    build_git "rack"
+
+    install_gemfile! <<-G
+      gem "rack", :git => '#{lib_path("rack-1.0")}'
+    G
+
+    gemfile <<-G
+      source "file://#{gem_repo1}"
+      gem "rack"
+    G
+
+    bundle! "update rack"
+
+    expect(last_command.stdboth).not_to include "attempted to update"
+  end
+
   it "will update only from pinned source" do
     install_gemfile <<-G
       source "file://#{gem_repo2}"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was `bundle update` shows incorrect message when updating git gems

Closes #6325 

### What was your diagnosis of the problem?

My diagnosis was we need to check if the source has changed

### What is your fix for the problem, implemented in this PR?

My fix only prints the message when the source has not changed

Note that is does not yet fix the "updated the git sha" case, since the locked spec and the new spec actually share the same source object!