### PR TITLE
allow requirement 2.3 to match versions 2.3.x

### DIFF
--- a/lib/bundler/ruby_version.rb
+++ b/lib/bundler/ruby_version.rb
@@ -88,7 +88,7 @@ module Bundler
       raise ArgumentError, "Can only diff with a RubyVersion, not a #{other.class}" unless other.is_a?(RubyVersion)
       if engine != other.engine && @input_engine
         [:engine, engine, other.engine]
-      elsif versions.empty? || !matches?(versions, other.gem_version) || versions_string(other.versions).match(/^#{versions_string(versions)}/).nil?
+      elsif versions.empty? || (!matches?(versions, other.gem_version) && versions_string(other.versions).match(/^#{versions_string(versions)}/).nil?)
         [:version, versions_string(versions), versions_string(other.versions)]
       elsif @input_engine && !matches?(engine_versions, other.engine_gem_version)
         [:engine_version, versions_string(engine_versions), versions_string(other.engine_versions)]

--- a/lib/bundler/ruby_version.rb
+++ b/lib/bundler/ruby_version.rb
@@ -88,7 +88,7 @@ module Bundler
       raise ArgumentError, "Can only diff with a RubyVersion, not a #{other.class}" unless other.is_a?(RubyVersion)
       if engine != other.engine && @input_engine
         [:engine, engine, other.engine]
-      elsif versions.empty? || !matches?(versions, other.gem_version)
+      elsif versions.empty? || !matches?(versions, other.gem_version) || versions_string(other.versions).match(/^#{versions_string(versions)}/).nil?
         [:version, versions_string(versions), versions_string(other.versions)]
       elsif @input_engine && !matches?(engine_versions, other.engine_gem_version)
         [:engine_version, versions_string(engine_versions), versions_string(other.engine_versions)]


### PR DESCRIPTION

### What was the end-user problem that led to this PR?

suggested solution for #6327 (allow to lock ruby major version)
 
> instead of doing `ruby '~> 2.3.4'` which `rvm` does not support without setuping custom aliases.
> it would be nice and simpler to just set `ruby '2.3'`
> 
> but bundler complains the version don't match
>
> `Your Ruby version is 2.3.6, but your Gemfile specified 2.3`
>
> in my opinion, 2.3.x should match 2.3


### What was your diagnosis of the problem?

version with patchlevel should match major version requirement

### What is your fix for the problem, implemented in this PR?

if the required version front match the other, than its only a patch-level difference
this should also support versions 2.3.6.1 to match 2.3.6

### Why did you choose this fix out of the possible options?

I ran the code through the debugger as deep as 
```
[242, 251] in /home/mathieu/.rvm/rubies/ruby-2.3.6/lib/ruby/site_ruby/2.3.0/rubygems/requirement.rb
   242: 
   243:   def satisfied_by? version
   244:     raise ArgumentError, "Need a Gem::Version: #{version.inspect}" unless
   245:       Gem::Version === version
   246:     # #28965: syck has a bug with unquoted '=' YAML.loading as YAML::DefaultKey
=> 247:     requirements.all? { |op, rv| (OPS[op] || OPS["="]).call version, rv }
   248:   end
```
and this appeared to be the right place to handle it, not break other version match than the ruby version and yep

