### PR TITLE
[CompactIndexClient::Updater] Use filesystem_access when copying files

### DIFF
--- a/lib/bundler/compact_index_client/updater.rb
+++ b/lib/bundler/compact_index_client/updater.rb
@@ -33,7 +33,9 @@ module Bundler
 
           # first try to fetch any new bytes on the existing file
           if retrying.nil? && local_path.file?
-            FileUtils.cp local_path, local_temp_path
+            SharedHelpers.filesystem_access(local_temp_path) do
+              FileUtils.cp local_path, local_temp_path
+            end
             headers["If-None-Match"] = etag_for(local_temp_path)
             headers["Range"] =
               if local_temp_path.size.nonzero?


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was users could see the error template when they do not have write permissions to their temporary directory.

Closes https://github.com/bundler/bundler/issues/6289

### What was your diagnosis of the problem?

My diagnosis was we need to use `SharedHelpers.filesystem_access` when writing files.

### What is your fix for the problem, implemented in this PR?

My fix wraps usage of `cp`