### PR TITLE
[GitProxy] Fail gracefully when resetting to the given revision fails

### DIFF
--- a/lib/bundler/source/git/git_proxy.rb
+++ b/lib/bundler/source/git/git_proxy.rb
@@ -131,7 +131,12 @@ module Bundler
           # method 2
           SharedHelpers.chdir(destination) do
             git_retry %(fetch --force --quiet --tags "#{path}")
-            git "reset --hard #{@revision}"
+
+            begin
+              git "reset --hard #{@revision}"
+            rescue GitCommandError
+              raise MissingGitRevisionError.new(@revision, URICredentialsFilter.credential_filtered_uri(uri))
+            end
 
             if submodules
               git_retry "submodule update --init --recursive"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

See https://github.com/bundler/bundler/issues/6324 for context.

The problem was when a git gem referenced a branch, and you tried to install on a machine without the revision in the lockfile cached, Bundler would print the following error:

```
Git error: command `git reset --hard cb70aded58b9215a495f0509e49daef930eec478` in directory
/home/deivid/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/bundler/gems/decidim-cb70aded58b9 has failed.
If this error persists you could try removing the cache directory
'/home/deivid/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/cache/bundler/git/decidim-9495d3039168996748af12c0fdb04debdea10392'
```

The problem was that removing the cache directory doesn't help.

### What was your diagnosis of the problem?

My diagnosis was we needed to print a `RevisionNotFound` error when that `git reset --hard` failed.

### What is your fix for the problem, implemented in this PR?

My fix rescues git command failures resulting from that `git reset --hard` and re-raises a more appropriate error message:

```
Revision cb70aded58b9215a495f0509e49daef930eec478 does not exist in the repository https://github.com/decidim/decidim. Maybe you misspelled it?
```

### Why did you choose this fix out of the possible options?

I chose this fix because it didn't involve bubbling information up from the git proxy to the definition. Ideally we'd re-rescue this error somewhere and suggest a `bundle update --source`, but that can be done in a separate PR.