### PR TITLE
Add local git repository source option (`--local_git`) to plugin installation

### DIFF
--- a/lib/bundler/cli/plugin.rb
+++ b/lib/bundler/cli/plugin.rb
@@ -5,7 +5,7 @@ module Bundler
   class CLI::Plugin < Thor
     desc "install PLUGINS", "Install the plugin from the source"
     long_desc <<-D
-      Install plugins either from the rubygems source provided (with --source option) or from a remote/git source provided (with respectively --git and --local-git options). If no sources are provided, it uses Gem.sources
+      Install plugins either from the rubygems source provided (with --source option) or from a remote/git source provided (with respectively --git and --local_git options). If no sources are provided, it uses Gem.sources
    D
     method_option "source", :type => :string, :default => nil, :banner =>
       "URL of the RubyGems source to fetch the plugin from"
@@ -13,7 +13,7 @@ module Bundler
       "The version of the plugin to fetch"
     method_option "git", :type => :string, :default => nil, :banner =>
       "URL of the git repo to fetch from"
-    method_option "local-git", :type => :string, :default => nil, :banner =>
+    method_option "local_git", :type => :string, :default => nil, :banner =>
       "Path of the local git repo to fetch from"
     method_option "branch", :type => :string, :default => nil, :banner =>
       "The git branch to checkout"

--- a/lib/bundler/cli/plugin.rb
+++ b/lib/bundler/cli/plugin.rb
@@ -5,7 +5,7 @@ module Bundler
   class CLI::Plugin < Thor
     desc "install PLUGINS", "Install the plugin from the source"
     long_desc <<-D
-      Install plugins either from the rubygems source provided (with --source option) or from a remote/git source provided (with respectively --git and --local_git options). If no sources are provided, it uses Gem.sources
+      Install plugins either from the rubygems source provided (with --source option) or from a git source provided with --git (for remote repos) or --local_git (for local repos). If no sources are provided, it uses Gem.sources
    D
     method_option "source", :type => :string, :default => nil, :banner =>
       "URL of the RubyGems source to fetch the plugin from"

--- a/lib/bundler/cli/plugin.rb
+++ b/lib/bundler/cli/plugin.rb
@@ -5,7 +5,13 @@ module Bundler
   class CLI::Plugin < Thor
     desc "install PLUGINS", "Install the plugin from the source"
     long_desc <<-D
-      Install plugins either from the rubygems source provided (with --source option) or from a git source provided with (--git option). If no sources are provided, it uses Gem.sources
+      Install plugins from any of the sources provided:
+
+      - from rubygems (`--source` option)
+      - from a remote git source (`--git` option)
+      - from a local git repo (`--file /path/to/repo` option)
+
+      If no sources are provided, it uses Gem.sources.
    D
     method_option "source", :type => :string, :default => nil, :banner =>
       "URL of the RubyGems source to fetch the plugin from"
@@ -13,6 +19,8 @@ module Bundler
       "The version of the plugin to fetch"
     method_option "git", :type => :string, :default => nil, :banner =>
       "URL of the git repo to fetch from"
+    method_option "file", :type => :string, :default => nil, :banner =>
+      "Path of the local git repo to fetch from"
     method_option "branch", :type => :string, :default => nil, :banner =>
       "The git branch to checkout"
     method_option "ref", :type => :string, :default => nil, :banner =>

--- a/lib/bundler/cli/plugin.rb
+++ b/lib/bundler/cli/plugin.rb
@@ -5,13 +5,7 @@ module Bundler
   class CLI::Plugin < Thor
     desc "install PLUGINS", "Install the plugin from the source"
     long_desc <<-D
-      Install plugins from any of the sources provided:
-
-      - from rubygems (`--source` option)
-      - from a remote git source (`--git` option)
-      - from a local git repo (`--local-git /path/to/repo` option)
-
-      If no sources are provided, it uses Gem.sources.
+      Install plugins either from the rubygems source provided (with --source option) or from a remote/git source provided (with respectively --git and --local-git options). If no sources are provided, it uses Gem.sources
    D
     method_option "source", :type => :string, :default => nil, :banner =>
       "URL of the RubyGems source to fetch the plugin from"

--- a/lib/bundler/cli/plugin.rb
+++ b/lib/bundler/cli/plugin.rb
@@ -9,7 +9,7 @@ module Bundler
 
       - from rubygems (`--source` option)
       - from a remote git source (`--git` option)
-      - from a local git repo (`--file /path/to/repo` option)
+      - from a local git repo (`--local-git /path/to/repo` option)
 
       If no sources are provided, it uses Gem.sources.
    D
@@ -19,7 +19,7 @@ module Bundler
       "The version of the plugin to fetch"
     method_option "git", :type => :string, :default => nil, :banner =>
       "URL of the git repo to fetch from"
-    method_option "file", :type => :string, :default => nil, :banner =>
+    method_option "local-git", :type => :string, :default => nil, :banner =>
       "Path of the local git repo to fetch from"
     method_option "branch", :type => :string, :default => nil, :banner =>
       "The git branch to checkout"

--- a/lib/bundler/plugin/installer.rb
+++ b/lib/bundler/plugin/installer.rb
@@ -43,11 +43,16 @@ module Bundler
 
     private
 
+      # Rubocop misunderstands the semantics of this method, assuming an `else` code block
+      # that doesn't actually exist. See https://github.com/bbatsov/rubocop/issues/5702.
+      #
+      # rubocop:disable Style/GuardClause
       def check_sources_consistency!(options)
         if options[:git] && options[:'local-git']
           raise InvalidOption, "Remote and local plugin git sources can't be both specified"
         end
       end
+      # rubocop:enable Style/GuardClause
 
       def install_git(names, version, options)
         uri = options.delete(:git)

--- a/lib/bundler/plugin/installer.rb
+++ b/lib/bundler/plugin/installer.rb
@@ -44,7 +44,7 @@ module Bundler
     private
 
       # Rubocop misunderstands the semantics of this method, assuming an `else` code block
-      # that doesn't actually exist. See https://github.com/bbatsov/rubocop/issues/5702.
+      # that doesn't exist. See https://github.com/bbatsov/rubocop/issues/5702.
       #
       # rubocop:disable Style/GuardClause
       def check_sources_consistency!(options)

--- a/lib/bundler/plugin/installer.rb
+++ b/lib/bundler/plugin/installer.rb
@@ -60,13 +60,8 @@ module Bundler
       def install_all_sources(names, version, git_source_options, rubygems_source)
         source_list = SourceList.new
 
-        if git_source_options
-          source_list.add_git_source(git_source_options)
-        end
-
-        if rubygems_source
-          source_list.add_rubygems_source("remotes" => rubygems_source)
-        end
+        source_list.add_git_source(git_source_options) if git_source_options
+        source_list.add_rubygems_source("remotes" => rubygems_source) if rubygems_source
 
         deps = names.map {|name| Dependency.new name, version }
 

--- a/lib/bundler/plugin/installer.rb
+++ b/lib/bundler/plugin/installer.rb
@@ -54,8 +54,7 @@ module Bundler
         end
 
         if sources[:file]
-          file_uri = "file://#{URI.escape(sources[:file])}"
-          source_list.add_git_source(options.merge("uri" => file_uri))
+          source_list.add_git_source(options.merge("uri" => sources[:file]))
         end
 
         if sources[:source]

--- a/lib/bundler/plugin/installer.rb
+++ b/lib/bundler/plugin/installer.rb
@@ -19,7 +19,7 @@ module Bundler
         Bundler.settings.temporary(:lockfile_uses_separate_rubygems_sources => false, :disable_multisource => false) do
           if options[:git]
             install_git(names, version, options)
-          elsif options[:'local-git']
+          elsif options[:local_git]
             install_local_git(names, version, options)
           else
             sources = options[:source] || Bundler.rubygems.sources
@@ -48,7 +48,7 @@ module Bundler
       #
       # rubocop:disable Style/GuardClause
       def check_sources_consistency!(options)
-        if options[:git] && options[:'local-git']
+        if options[:git] && options[:local_git]
           raise InvalidOption, "Remote and local plugin git sources can't be both specified"
         end
       end
@@ -62,7 +62,7 @@ module Bundler
       end
 
       def install_local_git(names, version, options)
-        uri = options.delete(:'local-git')
+        uri = options.delete(:local_git)
         options["uri"] = uri
 
         install_all_sources(names, version, options, options[:source])

--- a/lib/bundler/plugin/installer.rb
+++ b/lib/bundler/plugin/installer.rb
@@ -48,7 +48,7 @@ module Bundler
       #
       # rubocop:disable Style/GuardClause
       def check_sources_consistency!(options)
-        if options[:git] && options[:local_git]
+        if options.key?(:git) && options.key?(:local_git)
           raise InvalidOption, "Remote and local plugin git sources can't be both specified"
         end
       end

--- a/lib/bundler/plugin/installer.rb
+++ b/lib/bundler/plugin/installer.rb
@@ -14,12 +14,10 @@ module Bundler
       def install(names, options)
         version = options[:version] || [">= 0"]
         Bundler.settings.temporary(:lockfile_uses_separate_rubygems_sources => false, :disable_multisource => false) do
-          if options[:git]
-            install_git(names, version, options)
-          else
-            sources = options[:source] || Bundler.rubygems.sources
-            install_rubygems(names, version, sources)
-          end
+          sources = extract_sources_from_options!(options)
+          source_list = prepare_source_list(sources, options)
+          definition = create_definition(names, source_list, version)
+          install_definition(definition)
         end
       end
 
@@ -38,40 +36,37 @@ module Bundler
 
     private
 
-      def install_git(names, version, options)
-        uri = options.delete(:git)
-        options["uri"] = uri
+      def extract_sources_from_options!(options)
+        sources = {}
 
-        source_list = SourceList.new
-        source_list.add_git_source(options)
+        sources[:git] = options.delete(:git) if options[:git]
+        sources[:source] = options.delete(:source) if options[:source]
 
-        # To support both sources
-        if options[:source]
-          source_list.add_rubygems_source("remotes" => options[:source])
-        end
-
-        deps = names.map {|name| Dependency.new name, version }
-
-        definition = Definition.new(nil, deps, source_list, true)
-        install_definition(definition)
+        sources
       end
 
-      # Installs the plugin from rubygems source and returns the path where the
-      # plugin was installed
-      #
-      # @param [String] name of the plugin gem to search in the source
-      # @param [Array] version of the gem to install
-      # @param [String, Array<String>] source(s) to resolve the gem
-      #
-      # @return [Hash] map of names to the specs of plugins installed
-      def install_rubygems(names, version, sources)
-        deps = names.map {|name| Dependency.new name, version }
-
+      def prepare_source_list(sources, options)
         source_list = SourceList.new
-        source_list.add_rubygems_source("remotes" => sources)
 
-        definition = Definition.new(nil, deps, source_list, true)
-        install_definition(definition)
+        if sources[:git]
+          source_list.add_git_source(options.merge("uri" => sources[:git]))
+        end
+
+        if sources[:source]
+          source_list.add_rubygems_source("remotes" => sources[:source])
+        end
+
+        if sources.empty?
+          sources = Bundler.rubygems.sources
+          source_list.add_rubygems_source("remotes" => sources)
+        end
+
+        source_list
+      end
+
+      def create_definition(names, source_list, version)
+        deps = names.map {|name| Dependency.new name, version }
+        Definition.new(nil, deps, source_list, true)
       end
 
       # Installs the plugins and deps from the provided specs and returns map of

--- a/lib/bundler/plugin/installer.rb
+++ b/lib/bundler/plugin/installer.rb
@@ -19,7 +19,7 @@ module Bundler
         Bundler.settings.temporary(:lockfile_uses_separate_rubygems_sources => false, :disable_multisource => false) do
           if options[:git]
             install_git(names, version, options)
-          elsif options[:file]
+          elsif options[:'local-git']
             install_local_git(names, version, options)
           else
             sources = options[:source] || Bundler.rubygems.sources
@@ -44,7 +44,7 @@ module Bundler
     private
 
       def check_sources_consistency!(options)
-        if options[:git] && options[:file]
+        if options[:git] && options[:'local-git']
           raise InvalidOption, "Remote and local plugin git sources can't be both specified"
         end
       end
@@ -57,7 +57,7 @@ module Bundler
       end
 
       def install_local_git(names, version, options)
-        uri = options.delete(:file)
+        uri = options.delete(:'local-git')
         options["uri"] = uri
 
         install_all_sources(names, version, options, options[:source])

--- a/lib/bundler/plugin/installer.rb
+++ b/lib/bundler/plugin/installer.rb
@@ -40,6 +40,7 @@ module Bundler
         sources = {}
 
         sources[:git] = options.delete(:git) if options[:git]
+        sources[:file] = options.delete(:file) if options[:file]
         sources[:source] = options.delete(:source) if options[:source]
 
         sources
@@ -50,6 +51,11 @@ module Bundler
 
         if sources[:git]
           source_list.add_git_source(options.merge("uri" => sources[:git]))
+        end
+
+        if sources[:file]
+          file_uri = "file://#{URI.escape(sources[:file])}"
+          source_list.add_git_source(options.merge("uri" => file_uri))
         end
 
         if sources[:source]

--- a/lib/bundler/plugin/installer.rb
+++ b/lib/bundler/plugin/installer.rb
@@ -14,8 +14,7 @@ module Bundler
       def install(names, options)
         version = options[:version] || [">= 0"]
         Bundler.settings.temporary(:lockfile_uses_separate_rubygems_sources => false, :disable_multisource => false) do
-          sources = extract_sources_from_options!(options)
-          source_list = prepare_source_list(sources, options)
+          source_list = prepare_source_list(options)
           definition = create_definition(names, source_list, version)
           install_definition(definition)
         end
@@ -36,32 +35,24 @@ module Bundler
 
     private
 
-      def extract_sources_from_options!(options)
-        sources = {}
-
-        sources[:git] = options.delete(:git) if options[:git]
-        sources[:file] = options.delete(:file) if options[:file]
-        sources[:source] = options.delete(:source) if options[:source]
-
-        sources
-      end
-
-      def prepare_source_list(sources, options)
+      def prepare_source_list(options)
         source_list = SourceList.new
 
-        if sources[:git]
-          source_list.add_git_source(options.merge("uri" => sources[:git]))
+        if options[:git]
+          uri = options.delete(:git)
+          source_list.add_git_source(options.merge("uri" => uri))
         end
 
-        if sources[:file]
-          source_list.add_git_source(options.merge("uri" => sources[:file]))
+        if options[:file]
+          uri = options.delete(:file)
+          source_list.add_git_source(options.merge("uri" => uri))
         end
 
-        if sources[:source]
+        if options[:source]
           source_list.add_rubygems_source("remotes" => sources[:source])
         end
 
-        if sources.empty?
+        if options[:source].nil? && source_list.git_sources.empty?
           sources = Bundler.rubygems.sources
           source_list.add_rubygems_source("remotes" => sources)
         end

--- a/spec/bundler/plugin/installer_spec.rb
+++ b/spec/bundler/plugin/installer_spec.rb
@@ -29,6 +29,14 @@ RSpec.describe Bundler::Plugin::Installer do
           to eq("new-plugin" => spec)
       end
 
+      it "returns the installed spec after installing file plugins" do
+        allow(installer).to receive(:install_local_git).
+          and_return("new-plugin" => spec)
+
+        expect(installer.install(["new-plugin"], :file => "/phony/path/repo")).
+          to eq("new-plugin" => spec)
+      end
+
       it "returns the installed spec after installing rubygems plugins" do
         allow(installer).to receive(:install_rubygems).
           and_return("new-plugin" => spec)
@@ -55,6 +63,29 @@ RSpec.describe Bundler::Plugin::Installer do
 
         let(:result) do
           installer.install(["ga-plugin"], :git => "file://#{lib_path("ga-plugin")}")
+        end
+
+        it "returns the installed spec after installing" do
+          spec = result["ga-plugin"]
+          expect(spec.full_name).to eq "ga-plugin-1.0"
+        end
+
+        it "has expected full gem path" do
+          rev = revision_for(lib_path("ga-plugin"))
+          expect(result["ga-plugin"].full_gem_path).
+            to eq(Bundler::Plugin.root.join("bundler", "gems", "ga-plugin-#{rev[0..11]}").to_s)
+        end
+      end
+
+      context "file plugins" do
+        before do
+          build_git "ga-plugin", :path => lib_path("ga-plugin") do |s|
+            s.write "plugins.rb"
+          end
+        end
+
+        let(:result) do
+          installer.install(["ga-plugin"], :file => lib_path("ga-plugin").to_s)
         end
 
         it "returns the installed spec after installing" do

--- a/spec/bundler/plugin/installer_spec.rb
+++ b/spec/bundler/plugin/installer_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Bundler::Plugin::Installer do
         allow(installer).to receive(:install_local_git).
           and_return("new-plugin" => spec)
 
-        expect(installer.install(["new-plugin"], :'local-git' => "/phony/path/repo")).
+        expect(installer.install(["new-plugin"], :local_git => "/phony/path/repo")).
           to eq("new-plugin" => spec)
       end
 
@@ -85,7 +85,7 @@ RSpec.describe Bundler::Plugin::Installer do
         end
 
         let(:result) do
-          installer.install(["ga-plugin"], :'local-git' => lib_path("ga-plugin").to_s)
+          installer.install(["ga-plugin"], :local_git => lib_path("ga-plugin").to_s)
         end
 
         it "returns the installed spec after installing" do

--- a/spec/bundler/plugin/installer_spec.rb
+++ b/spec/bundler/plugin/installer_spec.rb
@@ -29,11 +29,11 @@ RSpec.describe Bundler::Plugin::Installer do
           to eq("new-plugin" => spec)
       end
 
-      it "returns the installed spec after installing file plugins" do
+      it "returns the installed spec after installing local git plugins" do
         allow(installer).to receive(:install_local_git).
           and_return("new-plugin" => spec)
 
-        expect(installer.install(["new-plugin"], :file => "/phony/path/repo")).
+        expect(installer.install(["new-plugin"], :'local-git' => "/phony/path/repo")).
           to eq("new-plugin" => spec)
       end
 
@@ -77,7 +77,7 @@ RSpec.describe Bundler::Plugin::Installer do
         end
       end
 
-      context "file plugins" do
+      context "local git plugins" do
         before do
           build_git "ga-plugin", :path => lib_path("ga-plugin") do |s|
             s.write "plugins.rb"
@@ -85,7 +85,7 @@ RSpec.describe Bundler::Plugin::Installer do
         end
 
         let(:result) do
-          installer.install(["ga-plugin"], :file => lib_path("ga-plugin").to_s)
+          installer.install(["ga-plugin"], :'local-git' => lib_path("ga-plugin").to_s)
         end
 
         it "returns the installed spec after installing" do

--- a/spec/plugins/install_spec.rb
+++ b/spec/plugins/install_spec.rb
@@ -128,14 +128,14 @@ RSpec.describe "bundler plugin install" do
         s.write "plugins.rb"
       end
 
-      bundle "plugin install foo --file #{lib_path("foo-1.0")}"
+      bundle "plugin install foo --local-git #{lib_path("foo-1.0")}"
 
       expect(out).to include("Installed plugin foo")
       plugin_should_be_installed("foo")
     end
 
     it "raises an error when both git and local git sources are specified" do
-      bundle "plugin install foo --file /phony/path/project --git git@gitphony.com:/repo/project"
+      bundle "plugin install foo --local-git /phony/path/project --git git@gitphony.com:/repo/project"
 
       expect(exitstatus).not_to eq(0) if exitstatus
       expect(out).to eq("Remote and local plugin git sources can't be both specified")

--- a/spec/plugins/install_spec.rb
+++ b/spec/plugins/install_spec.rb
@@ -122,6 +122,17 @@ RSpec.describe "bundler plugin install" do
       expect(out).to include("Installed plugin foo")
       plugin_should_be_installed("foo")
     end
+
+    it "installs form a local git source" do
+      build_git "foo" do |s|
+        s.write "plugins.rb"
+      end
+
+      bundle "plugin install foo --file #{lib_path("foo-1.0")}"
+
+      expect(out).to include("Installed plugin foo")
+      plugin_should_be_installed("foo")
+    end
   end
 
   context "Gemfile eval" do

--- a/spec/plugins/install_spec.rb
+++ b/spec/plugins/install_spec.rb
@@ -133,6 +133,13 @@ RSpec.describe "bundler plugin install" do
       expect(out).to include("Installed plugin foo")
       plugin_should_be_installed("foo")
     end
+
+    it "raises an error when both git and local git sources are specified" do
+      bundle "plugin install foo --file /phony/path/project --git git@gitphony.com:/repo/project"
+
+      expect(exitstatus).not_to eq(0) if exitstatus
+      expect(out).to eq("Remote and local plugin git sources can't be both specified")
+    end
   end
 
   context "Gemfile eval" do

--- a/spec/plugins/install_spec.rb
+++ b/spec/plugins/install_spec.rb
@@ -128,14 +128,14 @@ RSpec.describe "bundler plugin install" do
         s.write "plugins.rb"
       end
 
-      bundle "plugin install foo --local-git #{lib_path("foo-1.0")}"
+      bundle "plugin install foo --local_git #{lib_path("foo-1.0")}"
 
       expect(out).to include("Installed plugin foo")
       plugin_should_be_installed("foo")
     end
 
     it "raises an error when both git and local git sources are specified" do
-      bundle "plugin install foo --local-git /phony/path/project --git git@gitphony.com:/repo/project"
+      bundle "plugin install foo --local_git /phony/path/project --git git@gitphony.com:/repo/project"
 
       expect(exitstatus).not_to eq(0) if exitstatus
       expect(out).to eq("Remote and local plugin git sources can't be both specified")


### PR DESCRIPTION
Convenience option for installing plugins from a local repository, using the local path:

    bundle plugin install --file /path/to/bundler-dependency_graph bundler-dependency_graph

Closes #5445.