### PR TITLE
Fix failure when exception backtrace is nil

### DIFF
--- a/lib/bundler/cli/exec.rb
+++ b/lib/bundler/cli/exec.rb
@@ -77,7 +77,7 @@ module Bundler
     rescue Exception => e # rubocop:disable Lint/RescueException
       Bundler.ui = ui
       Bundler.ui.error "bundler: failed to load command: #{cmd} (#{file})"
-      backtrace = e.backtrace.take_while {|bt| !bt.start_with?(__FILE__) }
+      backtrace = e.backtrace ? e.backtrace.take_while {|bt| !bt.start_with?(__FILE__) } : []
       abort "#{e.class}: #{e.message}\n  #{backtrace.join("\n  ")}"
     end
 

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -624,9 +624,13 @@ RSpec.describe "bundle exec" do
     context "the executable raises an error without a backtrace", :bundler => "2" do
       let(:executable) { super() << "\nclass Err < Exception\ndef backtrace; end;\nend\nraise Err" }
       let(:exit_code) { 1 }
-      let(:expected) { super() << "\nbundler: failed to load command: #{path} (#{path})" }
-      let(:expected_err) do
-        "bundler: failed to load command: #{path} (#{path})\nErr: Err"
+      let(:expected_err) { "bundler: failed to load command: #{path} (#{path})\nErr: Err" }
+      let(:expected) do
+        if ENV["BUNDLER_SPEC_SUB_VERSION"] == "1.98"
+          super() << "\nbundler: failed to load command: #{path} (#{path})"
+        else
+          super()
+        end
       end
 
       it_behaves_like "it runs"

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -610,7 +610,7 @@ RSpec.describe "bundle exec" do
       let(:executable) { super() << "\nclass Err < Exception\ndef backtrace; end;\nend\nraise Err" }
       let(:exit_code) { 1 }
       let(:expected_err) do
-        if LessThanProc.with(RUBY_VERSION).call("1.9")
+        if ENV["BUNDLER_SPEC_SUB_VERSION"] == "1.98"
           "Err: Err"
         else
           "bundler: failed to load command: #{path} (#{path})\nErr: Err"

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -609,6 +609,7 @@ RSpec.describe "bundle exec" do
     context "the executable raises an error without a backtrace", :bundler => "< 2" do
       let(:executable) { super() << "\nclass Err < Exception\ndef backtrace; end;\nend\nraise Err" }
       let(:exit_code) { 1 }
+      let(:expected) { super() << "\nbundler: failed to load command: #{path} (#{path})" }
       let(:expected_err) do
         if ENV["BUNDLER_SPEC_SUB_VERSION"] == "1.98"
           "Err: Err"
@@ -623,6 +624,7 @@ RSpec.describe "bundle exec" do
     context "the executable raises an error without a backtrace", :bundler => "2" do
       let(:executable) { super() << "\nclass Err < Exception\ndef backtrace; end;\nend\nraise Err" }
       let(:exit_code) { 1 }
+      let(:expected) { super() << "\nbundler: failed to load command: #{path} (#{path})" }
       let(:expected_err) do
         "bundler: failed to load command: #{path} (#{path})\nErr: Err"
       end

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -610,7 +610,11 @@ RSpec.describe "bundle exec" do
       let(:executable) { super() << "\nclass Err < Exception\ndef backtrace; end;\nend\nraise Err" }
       let(:exit_code) { 1 }
       let(:expected_err) do
-        "bundler: failed to load command: #{path} (#{path})\nErr: Err"
+        if LessThanProc.with(RUBY_VERSION).call("1.9")
+          "Err: Err"
+        else
+          "bundler: failed to load command: #{path} (#{path})\nErr: Err"
+        end
       end
 
       it_behaves_like "it runs"

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -606,6 +606,26 @@ RSpec.describe "bundle exec" do
       it_behaves_like "it runs"
     end
 
+    context "the executable raises an error without a backtrace", :bundler => "< 2" do
+      let(:executable) { super() << "\nclass Err < Exception\ndef backtrace; end;\nend\nraise Err" }
+      let(:exit_code) { 1 }
+      let(:expected_err) do
+        "bundler: failed to load command: #{path} (#{path})\nErr: Err"
+      end
+
+      it_behaves_like "it runs"
+    end
+
+    context "the executable raises an error without a backtrace", :bundler => "2" do
+      let(:executable) { super() << "\nclass Err < Exception\ndef backtrace; end;\nend\nraise Err" }
+      let(:exit_code) { 1 }
+      let(:expected_err) do
+        "bundler: failed to load command: #{path} (#{path})\nErr: Err"
+      end
+
+      it_behaves_like "it runs"
+    end
+
     context "when the file uses the current ruby shebang" do
       let(:shebang) { "#!#{Gem.ruby}" }
       it_behaves_like "it runs"


### PR DESCRIPTION
Resolves #6342 
### What was the end-user problem that led to this PR?

Instead of throwing a readable error, Bundler failed and generated an issue report template (see details in #6342).

### What was your diagnosis of the problem?

My diagnosis was that nil safety is hard in Ruby.

### What is your fix for the problem, implemented in this PR?

To check whether backtrace is nil before sending it a `take_while` method.

### Why did you choose this fix out of the possible options?

I chose this fix because I see no other solutions.
