### PR TITLE
Explain spec files and output a link to bundler.io guides

### DIFF
--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -160,8 +160,7 @@ module Bundler
       open_editor(options["edit"], target.join("#{name}.gemspec")) if options[:edit]
 
       Bundler.ui.info "Gem '#{name}' was successfully created. " \
-        "For detailed information on further steps please visit https://bundler.io/guides/creating_gem.html"
-
+        "For detailed information on further steps pleaseg visit https://bundler.io/guides/creating_gem.html"
     rescue Errno::EEXIST => e
       raise GenericSystemCallError.new(e, "There was a conflict while creating the new gem.")
     end

--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -160,7 +160,7 @@ module Bundler
       open_editor(options["edit"], target.join("#{name}.gemspec")) if options[:edit]
 
       Bundler.ui.info "Gem '#{name}' was successfully created. " \
-        "For detailed information on further steps please visit https://bundler.io/guides/creating_gem.html"
+        "For more information on making a RubyGem visit https://bundler.io/guides/creating_gem.html"
     rescue Errno::EEXIST => e
       raise GenericSystemCallError.new(e, "There was a conflict while creating the new gem.")
     end

--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -158,6 +158,10 @@ module Bundler
 
       # Open gemspec in editor
       open_editor(options["edit"], target.join("#{name}.gemspec")) if options[:edit]
+
+      Bundler.ui.info "Gem '#{name}' was successfully created. " \
+        "For detailed information on further steps please visit https://bundler.io/guides/creating_gem.html"
+
     rescue Errno::EEXIST => e
       raise GenericSystemCallError.new(e, "There was a conflict while creating the new gem.")
     end

--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -160,7 +160,7 @@ module Bundler
       open_editor(options["edit"], target.join("#{name}.gemspec")) if options[:edit]
 
       Bundler.ui.info "Gem '#{name}' was successfully created. " \
-        "For detailed information on further steps pleaseg visit https://bundler.io/guides/creating_gem.html"
+        "For detailed information on further steps please visit https://bundler.io/guides/creating_gem.html"
     rescue Errno::EEXIST => e
       raise GenericSystemCallError.new(e, "There was a conflict while creating the new gem.")
     end

--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   end
 
   # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` default will base this on all the files checked in to git.
+  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end

--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
       "public gem pushes."
   end
 
+  # Specify which files should be added to the gem when it is released.
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end

--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   end
 
   # Specify which files should be added to the gem when it is released.
+  # The `git ls-files -z` default will base this on all the files checked in to git.
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end


### PR DESCRIPTION
Resolves #6246 

### What was the end-user problem that led to this PR?

1. There is no helpful comment about `spec.files` method in a new gem's gemspec.
2. `$ bundle gem gem_name` is missing link to further reading about developing, testing and releasing the newly created gem.

### What is your fix for the problem, implemented in this PR?

1. Add a comment in the `newgem.gemspec.tt`
2. Add a message after new gem generation with link to [bundler.io guides](https://bundler.io/guides/creating_gem.html)

Example: 
```bash
๛  ~/code/oss/tmp $  ../bundler/bin/bundle gem new_gem
Creating gem 'new_gem'...
      create  new_gem/Gemfile
      create  new_gem/lib/new_gem.rb
      create  new_gem/lib/new_gem/version.rb
      create  new_gem/new_gem.gemspec
      create  new_gem/Rakefile
      create  new_gem/README.md
      create  new_gem/bin/console
      create  new_gem/bin/setup
      create  new_gem/.gitignore
Initializing git repo in /Users/nesaulov/code/oss/tmp/new_gem
Gem 'new_gem' was successfully created. For detailed information on further steps please visit https://bundler.io/guides/creating_gem.html
๛  ~/code/oss/tmp $
```