### PR TITLE
Add documentation of spec.files to the new gem gemspec template

### DIFF
--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -28,6 +28,8 @@ Gem::Specification.new do |spec|
       "public gem pushes."
   end
 
+  # 'files' is the array of files that this gem should install.
+  # The `git ls-files -z` default will base this on all the files checked in to git.
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end


### PR DESCRIPTION
Resolves #6246

Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

Confusion during manually testing about why a file was not being installed as part of an in-development gem.

### What was your diagnosis of the problem?

User (me) did not understand how the `git ls-files -z`-based files specification in the autogenerated gemspec works, and that the expected file was not installed because it was not yet checked in to git.

### What is your fix for the problem, implemented in this PR?

A small amount of documentation to explain what spec.files does and how the default git-based value works.

### Why did you choose this fix out of the possible options?

I chose this fix because it's minimally intrusive and makes the new gem experience more newbie-friendly.
