### PR TITLE
Update brew install for groff

### DIFF
--- a/doc/development/SETUP.md
+++ b/doc/development/SETUP.md
@@ -10,7 +10,7 @@ Bundler doesn't use a Gemfile to list development dependencies, because when we 
 
     And for OS X (with brew installed):
 
-        $ brew install graphviz homebrew/dupes/groff
+        $ brew install graphviz groff
 
 3. You may also have to install the `bsdmainutils` package on linux if your distribution does not include the `col` command.
 
@@ -26,7 +26,7 @@ Bundler doesn't use a Gemfile to list development dependencies, because when we 
 
 6. Set up a shell alias to run Bundler from your clone, e.g. a Bash alias ([follow these instructions](https://www.moncefbelyamani.com/create-aliases-in-bash-profile-to-assign-shortcuts-for-common-terminal-commands/) for adding aliases to your `~/.bashrc` profile):
 
-        $ alias dbundle='/path/to/bundler/repo/bin/bundle
+        $ alias dbundle='/path/to/bundler/repo/bin/bundle'
 
 ## Debugging with `pry`
 


### PR DESCRIPTION
[dupes](https://github.com/Homebrew/homebrew-dupes) tap is deprecated, `groff` is now in [hombrew-core](https://github.com/Homebrew/homebrew-core/blob/master/Formula/groff.rb).

Also fixed a missing single quote while I was at it :)