### PR TITLE
Fix to check if stderr was closed before writing to it

### DIFF
--- a/lib/bundler/ui/shell.rb
+++ b/lib/bundler/ui/shell.rb
@@ -109,6 +109,8 @@ module Bundler
       end
 
       def tell_err(message, color = nil, newline = nil)
+        return if @shell.send(:stderr).closed?
+
         newline ||= message.to_s !~ /( |\t)\Z/
         message = word_wrap(message) if newline.is_a?(Hash) && newline[:wrap]
 

--- a/spec/bundler/ui/shell_spec.rb
+++ b/spec/bundler/ui/shell_spec.rb
@@ -59,6 +59,15 @@ RSpec.describe Bundler::UI::Shell do
       it "prints to stderr" do
         expect { subject.error("error!!!") }.to output("error!!!\n").to_stderr
       end
+
+      context "when stderr is closed" do
+        it "doesn't report anything" do
+          output = capture(:stderr, :closed => true) do
+            subject.error("Something went wrong")
+          end
+          expect(output).to_not eq("Something went wrong\n")
+        end
+      end
     end
   end
 end

--- a/spec/support/streams.rb
+++ b/spec/support/streams.rb
@@ -2,14 +2,18 @@
 
 require "stringio"
 
-def capture(*streams)
-  streams.map!(&:to_s)
+def capture(*args)
+  opts = args.pop if args.last.is_a?(Hash)
+  opts ||= {}
+
+  args.map!(&:to_s)
   begin
     result = StringIO.new
-    streams.each {|stream| eval "$#{stream} = result" }
+    result.close if opts[:closed]
+    args.each {|stream| eval "$#{stream} = result" }
     yield
   ensure
-    streams.each {|stream| eval("$#{stream} = #{stream.upcase}") }
+    args.each {|stream| eval("$#{stream} = #{stream.upcase}") }
   end
   result.string
 end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

See https://github.com/bundler/bundler/issues/6190

### What was your diagnosis of the problem?

The error is happening because we're not checking if stderr is closed prior to writing to it.

### What is your fix for the problem, implemented in this PR?

My fix is to add a check to determine if stderr was closed.

### Why did you choose this fix out of the possible options?

I chose to fix it here for a start and discuss with others if more checks were needed. Maybe we need to check if stderr is closed for all references of `$stderr.puts` and replace `abort` with `$stderr.puts` and `exit(1)`?