### PR TITLE
Update error message on bundle add in case of duplication

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -109,10 +109,16 @@ module Bundler
             return if dep.type == :development
 
             update_prompt = ""
+            change_version = ". You may also need to change the version requirement specified in the Gemfile if it's too restrictive."
 
             if File.basename(@gemfile) == "injected gems"
-              update_prompt = ". If you want to update the gem version, run `bundle update #{current.name}`. " \
-                              "You may also need to change the version requirement specified in the Gemfile if it's too restrictive"
+              if dep.requirements_list.include?(">= 0") && !current.requirements_list.include?(">= 0")
+                update_prompt = ". Gem already added"
+              else
+                update_prompt = ". If you want to update the gem version, run `bundle update #{current.name}`"
+
+                update_prompt += change_version unless current.requirements_list.include?(">= 0")
+              end
             end
 
             raise GemfileError, "You cannot specify the same gem twice with different version requirements.\n" \

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -103,13 +103,19 @@ module Bundler
       # if there's already a dependency with this name we try to prefer one
       if current = @dependencies.find {|d| d.name == dep.name }
         deleted_dep = @dependencies.delete(current) if current.type == :development
-
         if current.requirement != dep.requirement
           unless deleted_dep
             return if dep.type == :development
-            raise GemfileError, "You cannot specify the same gem twice with different version requirements.\n" \
-                            "You specified: #{current.name} (#{current.requirement}) and #{dep.name} (#{dep.requirement}). " \
-                            "If you want to update the gem version, run `bundle update #{current.name}`. You may need to change the version requirement specified in the Gemfile if it's too restrictive"
+
+            # If no version is specified on adding gem
+            if "#{dep.requirement}" == ">= 0"
+              raise GemfileError, "Gem `#{current.name}` is already added.\n" \
+                              "If you want to update the gem version, run `bundle update #{current.name}`."
+            else
+              raise GemfileError, "You cannot specify the same gem twice with different version requirements.\n" \
+                              "You specified: #{current.name} (#{current.requirement}) and #{dep.name} (#{dep.requirement}). " \
+                              "If you want to update the gem version, run `bundle update #{current.name}`. You may need to change the version requirement specified in the Gemfile if it's too restrictive"
+            end
           end
 
         else

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -108,9 +108,9 @@ module Bundler
             return if dep.type == :development
 
             # If no version is specified on adding gem
-            if "#{dep.requirement}" == ">= 0"
+            if dep.requirement.to_s == ">= 0"
               raise GemfileError, "Gem `#{current.name}` is already added.\n" \
-                              "If you want to update the gem version, run `bundle update #{current.name}`."
+                              "If you want to update the gem version, run `bundle update #{current.name}`"
             else
               raise GemfileError, "You cannot specify the same gem twice with different version requirements.\n" \
                               "You specified: #{current.name} (#{current.requirement}) and #{dep.name} (#{dep.requirement}). " \

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -109,15 +109,14 @@ module Bundler
             return if dep.type == :development
 
             update_prompt = ""
-            change_version = ". You may also need to change the version requirement specified in the Gemfile if it's too restrictive."
 
-            if File.basename(@gemfile) == "injected gems"
+            if File.basename(@gemfile) == Injector::INJECTED_GEMS
               if dep.requirements_list.include?(">= 0") && !current.requirements_list.include?(">= 0")
                 update_prompt = ". Gem already added"
               else
                 update_prompt = ". If you want to update the gem version, run `bundle update #{current.name}`"
 
-                update_prompt += change_version unless current.requirements_list.include?(">= 0")
+                update_prompt += ". You may also need to change the version requirement specified in the Gemfile if it's too restrictive." unless current.requirements_list.include?(">= 0")
               end
             end
 

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -108,7 +108,8 @@ module Bundler
           unless deleted_dep
             return if dep.type == :development
             raise GemfileError, "You cannot specify the same gem twice with different version requirements.\n" \
-                            "You specified: #{current.name} (#{current.requirement}) and #{dep.name} (#{dep.requirement})"
+                            "You specified: #{current.name} (#{current.requirement}) and #{dep.name} (#{dep.requirement}). " \
+                            "You can also update the gem by running `bundle update #{current.name}`"
           end
 
         else

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -109,7 +109,7 @@ module Bundler
             return if dep.type == :development
             raise GemfileError, "You cannot specify the same gem twice with different version requirements.\n" \
                             "You specified: #{current.name} (#{current.requirement}) and #{dep.name} (#{dep.requirement}). " \
-                            "You can also update the gem by running `bundle update #{current.name}`"
+                            "If you want to update the gem version, run `bundle update #{current.name}`. You may need to change the version requirement specified in the Gemfile if it's too restrictive"
           end
 
         else

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -108,15 +108,21 @@ module Bundler
           unless deleted_dep
             return if dep.type == :development
 
-            # If no version is specified on adding gem
-            raise GemfileError, "Gem `#{current.name}` is already added" if dep.requirement.to_s == ">= 0"
+            update_prompt = ""
+
+            if File.basename(@gemfile) == "injected gems"
+              update_prompt = ". If you want to update the gem version, run `bundle update #{current.name}`. " \
+                              "You may also need to change the version requirement specified in the Gemfile if it's too restrictive"
+            end
 
             raise GemfileError, "You cannot specify the same gem twice with different version requirements.\n" \
-                            "You specified: #{current.name} (#{current.requirement}) and #{dep.name} (#{dep.requirement}). " \
-                            "If you want to update the gem version, run `bundle update #{current.name}`. You may need to change the version requirement specified in the Gemfile if it's too restrictive"
+                            "You specified: #{current.name} (#{current.requirement}) and #{dep.name} (#{dep.requirement})" \
+                             "#{update_prompt}"
           end
+
         else
           Bundler.ui.warn "Your Gemfile lists the gem #{current.name} (#{current.requirement}) more than once.\n" \
+                          "You should probably keep only one of them.\n" \
                           "Remove any duplicate entries and specify the gem only once (per group).\n" \
                           "While it's not a problem now, it could cause errors if you change the version of one of them later."
         end

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -103,24 +103,21 @@ module Bundler
       # if there's already a dependency with this name we try to prefer one
       if current = @dependencies.find {|d| d.name == dep.name }
         deleted_dep = @dependencies.delete(current) if current.type == :development
+
         if current.requirement != dep.requirement
           unless deleted_dep
             return if dep.type == :development
 
             # If no version is specified on adding gem
-            if dep.requirement.to_s == ">= 0"
-              raise GemfileError, "Gem `#{current.name}` is already added.\n" \
-                              "If you want to update the gem version, run `bundle update #{current.name}`"
-            else
-              raise GemfileError, "You cannot specify the same gem twice with different version requirements.\n" \
-                              "You specified: #{current.name} (#{current.requirement}) and #{dep.name} (#{dep.requirement}). " \
-                              "If you want to update the gem version, run `bundle update #{current.name}`. You may need to change the version requirement specified in the Gemfile if it's too restrictive"
-            end
-          end
+            raise GemfileError, "Gem `#{current.name}` is already added" if dep.requirement.to_s == ">= 0"
 
+            raise GemfileError, "You cannot specify the same gem twice with different version requirements.\n" \
+                            "You specified: #{current.name} (#{current.requirement}) and #{dep.name} (#{dep.requirement}). " \
+                            "If you want to update the gem version, run `bundle update #{current.name}`. You may need to change the version requirement specified in the Gemfile if it's too restrictive"
+          end
         else
           Bundler.ui.warn "Your Gemfile lists the gem #{current.name} (#{current.requirement}) more than once.\n" \
-                          "You should probably keep only one of them.\n" \
+                          "Remove any duplicate entries and specify the gem only once (per group).\n" \
                           "While it's not a problem now, it could cause errors if you change the version of one of them later."
         end
 

--- a/lib/bundler/injector.rb
+++ b/lib/bundler/injector.rb
@@ -2,8 +2,10 @@
 
 module Bundler
   class Injector
-    def self.inject(deps, options = {})
-      injector = new(deps, options)
+    INJECTED_GEMS = "injected gems".freeze
+
+    def self.inject(new_deps, options = {})
+      injector = new(new_deps, options)
       injector.inject(Bundler.default_gemfile, Bundler.default_lockfile)
     end
 
@@ -36,8 +38,9 @@ module Bundler
         @deps -= builder.dependencies
 
         # add new deps to the end of the in-memory Gemfile
-        # Set conservative versioning to false because we want to let the resolver resolve the version first
-        builder.eval_gemfile("injected gems", build_gem_lines(false)) if @deps.any?
+        # Set conservative versioning to false because
+        # we want to let the resolver resolve the version first
+        builder.eval_gemfile(INJECTED_GEMS, build_gem_lines(false)) if @deps.any?
 
         # resolve to see if the new deps broke anything
         @definition = builder.to_definition(lockfile_path, {})

--- a/spec/commands/add_spec.rb
+++ b/spec/commands/add_spec.rb
@@ -205,8 +205,9 @@ RSpec.describe "bundle add" do
 
       bundle "add 'rack'"
 
+      expect(out).to include("Gem already added.")
       expect(out).to include("You cannot specify the same gem twice with different version requirements")
-      expect(out).to include("If you want to update the gem version, run `bundle update rack`. You may also need to change the version requirement specified in the Gemfile if it's too restrictive")
+      expect(out).not_to include("If you want to update the gem version, run `bundle update rack`. You may also need to change the version requirement specified in the Gemfile if it's too restrictive")
     end
   end
 
@@ -220,7 +221,8 @@ RSpec.describe "bundle add" do
       bundle "add 'rack' --version=1.1"
 
       expect(out).to include("You cannot specify the same gem twice with different version requirements")
-      expect(out).to include("If you want to update the gem version, run `bundle update rack`. You may also need to change the version requirement specified in the Gemfile if it's too restrictive")
+      expect(out).to include("If you want to update the gem version, run `bundle update rack`.")
+      expect(out).not_to include("You may also need to change the version requirement specified in the Gemfile if it's too restrictive")
     end
   end
 end

--- a/spec/commands/add_spec.rb
+++ b/spec/commands/add_spec.rb
@@ -182,8 +182,8 @@ RSpec.describe "bundle add" do
 
       bundle "add 'rack' --version=1.1"
 
-      expect(out).to include "You cannot specify the same gem twice with different version requirements"
-      expect(out).to include "If you want to update the gem version, run `bundle update rack`. You may need to change the version requirement specified in the Gemfile if it's too restrictive"
+      expect(out).to include("You cannot specify the same gem twice with different version requirements")
+      expect(out).to include("If you want to update the gem version, run `bundle update rack`. You may need to change the version requirement specified in the Gemfile if it's too restrictive")
     end
 
     it "without version requirements" do
@@ -195,7 +195,6 @@ RSpec.describe "bundle add" do
       bundle "add 'rack'"
 
       expect(out).to include("Gem `rack` is already added.")
-      expect(out).to include("If you want to update the gem version, run `bundle update rack`.")
     end
   end
 end

--- a/spec/commands/add_spec.rb
+++ b/spec/commands/add_spec.rb
@@ -172,4 +172,16 @@ RSpec.describe "bundle add" do
       expect(out).to include("You specified: weakling (~> 0.0.1) and weakling (>= 0).")
     end
   end
+
+  it "throws an error if a gem is added which is already specified in Gemfile" do
+    install_gemfile <<-G
+      source "file://#{gem_repo2}"
+      gem "rack", "1.0"
+    G
+
+    bundle "add 'rack'"
+
+    expect(out).to include "You cannot specify the same gem twice with different version requirements"
+    expect(out).to include "If you want to update the gem version, run `bundle update rack`. You may need to change the version requirement specified in the Gemfile if it's too restrictive"
+  end
 end

--- a/spec/commands/add_spec.rb
+++ b/spec/commands/add_spec.rb
@@ -173,15 +173,29 @@ RSpec.describe "bundle add" do
     end
   end
 
-  it "throws an error if a gem is added which is already specified in Gemfile" do
-    install_gemfile <<-G
-      source "file://#{gem_repo2}"
-      gem "rack", "1.0"
-    G
+  context "throws an error if a gem is added which is already specified in Gemfile" do
+    it "with version requirements" do
+      install_gemfile <<-G
+        source "file://#{gem_repo2}"
+        gem "rack", "1.0"
+      G
 
-    bundle "add 'rack'"
+      bundle "add 'rack' --version=1.1"
 
-    expect(out).to include "You cannot specify the same gem twice with different version requirements"
-    expect(out).to include "If you want to update the gem version, run `bundle update rack`. You may need to change the version requirement specified in the Gemfile if it's too restrictive"
+      expect(out).to include "You cannot specify the same gem twice with different version requirements"
+      expect(out).to include "If you want to update the gem version, run `bundle update rack`. You may need to change the version requirement specified in the Gemfile if it's too restrictive"
+    end
+
+    it "without version requirements" do
+      install_gemfile <<-G
+        source "file://#{gem_repo2}"
+        gem "rack", "1.0"
+      G
+
+      bundle "add 'rack'"
+
+      expect(out).to include("Gem `rack` is already added.")
+      expect(out).to include("If you want to update the gem version, run `bundle update rack`.")
+    end
   end
 end

--- a/spec/commands/add_spec.rb
+++ b/spec/commands/add_spec.rb
@@ -193,9 +193,8 @@ RSpec.describe "bundle add" do
 
       bundle "add 'rack' --version=1.1"
 
-      expect(out).to include("Gem `rack` is already added.")
       expect(out).to include("You cannot specify the same gem twice with different version requirements")
-      expect(out).to include("If you want to update the gem version, run `bundle update rack`. You may need to change the version requirement specified in the Gemfile if it's too restrictive")
+      expect(out).to include("If you want to update the gem version, run `bundle update rack`. You may also need to change the version requirement specified in the Gemfile if it's too restrictive")
     end
 
     it "without version requirements" do
@@ -206,9 +205,8 @@ RSpec.describe "bundle add" do
 
       bundle "add 'rack'"
 
-      expect(out).to include("Gem `rack` is already added.")
       expect(out).to include("You cannot specify the same gem twice with different version requirements")
-      expect(out).to include("If you want to update the gem version, run `bundle update rack`. You may need to change the version requirement specified in the Gemfile if it's too restrictive")
+      expect(out).to include("If you want to update the gem version, run `bundle update rack`. You may also need to change the version requirement specified in the Gemfile if it's too restrictive")
     end
   end
 
@@ -221,9 +219,8 @@ RSpec.describe "bundle add" do
 
       bundle "add 'rack' --version=1.1"
 
-      expect(out).to include("Gem `rack` is already added.")
       expect(out).to include("You cannot specify the same gem twice with different version requirements")
-      expect(out).to include("If you want to update the gem version, run `bundle update rack`. You may need to change the version requirement specified in the Gemfile if it's too restrictive")
+      expect(out).to include("If you want to update the gem version, run `bundle update rack`. You may also need to change the version requirement specified in the Gemfile if it's too restrictive")
     end
   end
 end

--- a/spec/commands/add_spec.rb
+++ b/spec/commands/add_spec.rb
@@ -173,19 +173,8 @@ RSpec.describe "bundle add" do
     end
   end
 
-  it "installs gem if a gem is added with same version requirements as specified in Gemfile" do
-    install_gemfile <<-G
-      source "file://#{gem_repo2}"
-      gem "rack"
-    G
-
-    bundle "add 'rack'"
-
-    expect(out).to include("Fetching source index from file:#{gem_repo2}")
-  end
-
-  context "throws an error if a gem is added which is already specified in Gemfile with version" do
-    it "with different version requirement" do
+  describe "when a gem is added which is already specified in Gemfile with version" do
+    it "shows an error when added with different version requirement" do
       install_gemfile <<-G
         source "file://#{gem_repo2}"
         gem "rack", "1.0"
@@ -197,7 +186,7 @@ RSpec.describe "bundle add" do
       expect(out).to include("If you want to update the gem version, run `bundle update rack`. You may also need to change the version requirement specified in the Gemfile if it's too restrictive")
     end
 
-    it "without version requirements" do
+    it "shows error when added without version requirements" do
       install_gemfile <<-G
         source "file://#{gem_repo2}"
         gem "rack", "1.0"
@@ -211,8 +200,8 @@ RSpec.describe "bundle add" do
     end
   end
 
-  context "throws an error if a gem is added which is already specified in Gemfile without version" do
-    it "with different version requirements" do
+  describe "when a gem is added which is already specified in Gemfile without version" do
+    it "shows an error when added with different version requirement" do
       install_gemfile <<-G
         source "file://#{gem_repo2}"
         gem "rack"

--- a/spec/commands/add_spec.rb
+++ b/spec/commands/add_spec.rb
@@ -173,8 +173,19 @@ RSpec.describe "bundle add" do
     end
   end
 
-  context "throws an error if a gem is added which is already specified in Gemfile" do
-    it "with version requirements" do
+  it "installs gem if a gem is added with same version requirements as specified in Gemfile" do
+    install_gemfile <<-G
+      source "file://#{gem_repo2}"
+      gem "rack"
+    G
+
+    bundle "add 'rack'"
+
+    expect(out).to include("Fetching source index from file:#{gem_repo2}")
+  end
+
+  context "throws an error if a gem is added which is already specified in Gemfile with version" do
+    it "with different version requirement" do
       install_gemfile <<-G
         source "file://#{gem_repo2}"
         gem "rack", "1.0"
@@ -182,6 +193,7 @@ RSpec.describe "bundle add" do
 
       bundle "add 'rack' --version=1.1"
 
+      expect(out).to include("Gem `rack` is already added.")
       expect(out).to include("You cannot specify the same gem twice with different version requirements")
       expect(out).to include("If you want to update the gem version, run `bundle update rack`. You may need to change the version requirement specified in the Gemfile if it's too restrictive")
     end
@@ -195,6 +207,23 @@ RSpec.describe "bundle add" do
       bundle "add 'rack'"
 
       expect(out).to include("Gem `rack` is already added.")
+      expect(out).to include("You cannot specify the same gem twice with different version requirements")
+      expect(out).to include("If you want to update the gem version, run `bundle update rack`. You may need to change the version requirement specified in the Gemfile if it's too restrictive")
+    end
+  end
+
+  context "throws an error if a gem is added which is already specified in Gemfile without version" do
+    it "with different version requirements" do
+      install_gemfile <<-G
+        source "file://#{gem_repo2}"
+        gem "rack"
+      G
+
+      bundle "add 'rack' --version=1.1"
+
+      expect(out).to include("Gem `rack` is already added.")
+      expect(out).to include("You cannot specify the same gem twice with different version requirements")
+      expect(out).to include("If you want to update the gem version, run `bundle update rack`. You may need to change the version requirement specified in the Gemfile if it's too restrictive")
     end
   end
 end

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -321,6 +321,28 @@ RSpec.describe "bundle install with gem sources" do
       expect(File.exist?(bundled_app("Gemfile.lock"))).to eq(true)
     end
 
+    it "throws an error if a gem is added twice in Gemfile without version requirements" do
+      install_gemfile <<-G
+        source "file://#{gem_repo2}"
+        gem "rack"
+        gem "rack"
+      G
+
+      expect(out).to include("Your Gemfile lists the gem rack (>= 0) more than once.")
+      expect(out).to include("You should probably keep only one of them")
+    end
+
+    it "throws an error if a gem is added twice in Gemfile with version requirements" do
+      install_gemfile <<-G
+        source "file://#{gem_repo2}"
+        gem "rack", "1.0"
+        gem "rack", "1.1"
+      G
+
+      expect(out).to include("You cannot specify the same gem twice with different version requirements")
+      expect(out).to include("If you want to update the gem version, run `bundle update rack`. You may need to change the version requirement specified in the Gemfile if it's too restrictive")
+    end
+
     it "gracefully handles error when rubygems server is unavailable" do
       install_gemfile <<-G, :artifice => nil
         source "file://#{gem_repo1}"

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -345,8 +345,10 @@ RSpec.describe "bundle install with gem sources" do
         expect(out).to include("Remove any duplicate entries and specify the gem only once (per group).")
         expect(out).to include("While it's not a problem now, it could cause errors if you change the version of one of them later.")
       end
+    end
 
-      it "version of one dependency is not specified" do
+    context "throws an error if a gem is added twice in Gemfile" do
+      it "when version of one dependency is not specified" do
         install_gemfile <<-G
           source "file://#{gem_repo2}"
           gem "rack"
@@ -357,7 +359,7 @@ RSpec.describe "bundle install with gem sources" do
         expect(out).to include("You specified: rack (>= 0) and rack (= 1.0).")
       end
 
-      it "different versions of both dependencies are specified" do
+      it "when different versions of both dependencies are specified" do
         install_gemfile <<-G
           source "file://#{gem_repo2}"
           gem "rack", "1.0"

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -321,39 +321,51 @@ RSpec.describe "bundle install with gem sources" do
       expect(File.exist?(bundled_app("Gemfile.lock"))).to eq(true)
     end
 
-    it "throws a warning if a gem is added twice in Gemfile without version requirements" do
-      install_gemfile <<-G
-        source "file://#{gem_repo2}"
-        gem "rack"
-        gem "rack"
-      G
-
-      expect(out).to include("Your Gemfile lists the gem rack (>= 0) more than once.")
-      expect(out).to include("Remove any duplicate entries and specify the gem only once (per group).")
-      expect(out).to include("While it's not a problem now, it could cause errors if you change the version of one of them later.")
-    end
-
-    context "throws an error if a gem is added twice in Gemfile with version requirements" do
-      it "version of one dependency is not specified" do
+    context "throws a warning if a gem is added twice in Gemfile" do
+      it "without version requirements" do
         install_gemfile <<-G
           source "file://#{gem_repo2}"
-          gem "rack", "1.0"
+          gem "rack"
           gem "rack"
         G
 
-        expect(out).to include("Gem `rack` is already added")
+        expect(out).to include("Your Gemfile lists the gem rack (>= 0) more than once.")
+        expect(out).to include("Remove any duplicate entries and specify the gem only once (per group).")
+        expect(out).to include("While it's not a problem now, it could cause errors if you change the version of one of them later.")
       end
 
-      it "version of both dependencies are specified" do
+      it "with same versions" do
+        install_gemfile <<-G
+          source "file://#{gem_repo2}"
+          gem "rack", "1.0"
+          gem "rack", "1.0"
+        G
+
+        expect(out).to include("Your Gemfile lists the gem rack (= 1.0) more than once.")
+        expect(out).to include("Remove any duplicate entries and specify the gem only once (per group).")
+        expect(out).to include("While it's not a problem now, it could cause errors if you change the version of one of them later.")
+      end
+
+      it "version of one dependency is not specified" do
+        install_gemfile <<-G
+          source "file://#{gem_repo2}"
+          gem "rack"
+          gem "rack", "1.0"
+        G
+
+        expect(out).to include("You cannot specify the same gem twice with different version requirements")
+        expect(out).to include("You specified: rack (>= 0) and rack (= 1.0).")
+      end
+
+      it "different versions of both dependencies are specified" do
         install_gemfile <<-G
           source "file://#{gem_repo2}"
           gem "rack", "1.0"
           gem "rack", "1.1"
         G
-        p out
+
         expect(out).to include("You cannot specify the same gem twice with different version requirements")
         expect(out).to include("You specified: rack (= 1.0) and rack (= 1.1).")
-        expect(out).to include("Remove any duplicate entries and specify the gem only once (per group).")
       end
     end
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

If the user tries to add a gem giving version requirement then bundler throws an error if the gem is already present.

### What was your diagnosis of the problem?

The error displayed is very descriptive but if the user is specifying a gem version maybe he wants to update the gem.

### What is your fix for the problem, implemented in this PR?

Added an instructive message to inform the user that gem can also be updated.

### Why did you choose this fix out of the possible options?

This seemed to be the best informative message.

Closes #6341 