### PR TITLE
[Binstubs] Add --all options

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -319,6 +319,8 @@ module Bundler
       "Specify a different shebang executable name than the default (usually 'ruby')"
     method_option "standalone", :type => :boolean, :banner =>
       "Make binstubs that can work without the Bundler runtime"
+    method_option "all", :type => :boolean, :banner =>
+      "Install binstubs for all gems"
     def binstubs(*gems)
       require "bundler/cli/binstubs"
       Binstubs.new(options, gems).run

--- a/lib/bundler/cli/binstubs.rb
+++ b/lib/bundler/cli/binstubs.rb
@@ -16,7 +16,13 @@ module Bundler
       Bundler.settings.set_command_option_if_given :shebang, options["shebang"]
       installer = Installer.new(Bundler.root, Bundler.definition)
 
-      if gems.empty?
+      installer_opts = { :force => options[:force], :binstubs_cmd => true }
+
+      if options[:all]
+        raise InvalidOption, "Cannot specify --all with specific gems" unless gems.empty?
+        @gems = Bundler.definition.specs.map(&:name)
+        installer_opts.delete(:binstubs_cmd)
+      elsif gems.empty?
         Bundler.ui.error "`bundle binstubs` needs at least one gem to run."
         exit 1
       end
@@ -35,7 +41,7 @@ module Bundler
             installer.generate_standalone_bundler_executable_stubs(spec)
           end
         else
-          installer.generate_bundler_executable_stubs(spec, :force => options[:force], :binstubs_cmd => true)
+          installer.generate_bundler_executable_stubs(spec, installer_opts)
         end
       end
     end

--- a/spec/commands/binstubs_spec.rb
+++ b/spec/commands/binstubs_spec.rb
@@ -39,6 +39,18 @@ RSpec.describe "bundle binstubs <gem>" do
       expect(bundled_app("bin/rails")).to exist
     end
 
+    it "allows installing all binstubs" do
+      install_gemfile! <<-G
+        source "file://#{gem_repo1}"
+        gem "rails"
+      G
+
+      bundle! :binstubs, :all => true
+
+      expect(bundled_app("bin/rails")).to exist
+      expect(bundled_app("bin/rake")).to exist
+    end
+
     it "displays an error when used without any gem" do
       install_gemfile <<-G
         source "file://#{gem_repo1}"
@@ -48,6 +60,17 @@ RSpec.describe "bundle binstubs <gem>" do
       bundle "binstubs"
       expect(exitstatus).to eq(1) if exitstatus
       expect(out).to include("`bundle binstubs` needs at least one gem to run.")
+    end
+
+    it "displays an error when used with --all and gems" do
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem "rack"
+      G
+
+      bundle "binstubs rack", :all => true
+      expect(last_command).to be_failure
+      expect(last_command.bundler_err).to include("Cannot specify --all with specific gems")
     end
 
     context "when generating bundle binstub outside bundler" do


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was we have removed the `--binstubs` argument to `bundle install`, so saying "oh well, lets install all the bin stubs" became more tedious, requiring multiple calls to `bundle binstubs` and probably some swearing since you forgot what gem contains what binstub.

### What was your diagnosis of the problem?

My diagnosis was we need a one-liner to generate bin stubs for all gems.

### What is your fix for the problem, implemented in this PR?

My fix adds such an option to `bundle binstubs`!

### Why did you choose this fix out of the possible options?

I chose this fix because it keeps binstub generation in its own command, rather than continuing to piggy-back off of `install`