### PR TITLE
[CLI::Gem] Add a --rubocop option

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -542,6 +542,7 @@ module Bundler
     method_option :ext, :type => :boolean, :default => false, :desc => "Generate the boilerplate for C extension code"
     method_option :git, :type => :boolean, :default => true, :desc => "Initialize a git repo inside your library."
     method_option :mit, :type => :boolean, :desc => "Generate an MIT license file. Set a default with `bundle config set gem.mit true`."
+    method_option :rubocop, :type => :boolean, :desc => "Add rubocop to the generated Rakefile and gemspec. Set a default with `bundle config set gem.rubocop true`."
     method_option :test, :type => :string, :lazy_default => "rspec", :aliases => "-t", :banner => "rspec",
                          :desc => "Generate a test directory for your library, either rspec or minitest. Set a default with `bundle config set gem.test rspec`."
     def gem(name)

--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -100,7 +100,7 @@ module Bundler
         end
       end
 
-      config[:test_task] = config[:test] == "minitest" ? "test" : "spec"
+      config[:test_task] = config[:test] == "minitest" ? :test : :spec
 
       if ask_and_set(:mit, "Do you want to license your code permissively under the MIT license?",
         "This means that any other developer or company will be legally allowed to use your code " \
@@ -122,6 +122,15 @@ module Bundler
         config[:coc] = true
         Bundler.ui.info "Code of conduct enabled in config"
         templates.merge!("CODE_OF_CONDUCT.md.tt" => "CODE_OF_CONDUCT.md")
+      end
+
+      if ask_and_set(:rubocop, "Do you want to add rubocop as a dependency for gems you generate?",
+        "RuboCop is a static code analyzer that has out-of-the-box rules for many " \
+        "of the guidelines in the community style guide. " \
+        "For more information, see the RuboCop docs (https://docs.rubocop.org/en/stable/) " \
+        "and the Ruby Style Guides (https://github.com/rubocop-hq/ruby-style-guide).")
+        config[:rubocop] = true
+        Bundler.ui.info "RuboCop enabled in config"
       end
 
       templates.merge!("exe/newgem.tt" => "exe/#{name}") if config[:exe]

--- a/lib/bundler/templates/newgem/Gemfile.tt
+++ b/lib/bundler/templates/newgem/Gemfile.tt
@@ -10,3 +10,6 @@ gem "rake-compiler"
 <%- if config[:test] -%>
 gem "<%= config[:test] %>", "~> <%= config[:test_framework_version] %>"
 <%- end -%>
+<%- if config[:rubocop] -%>
+gem "rubocop"
+<%- end -%>

--- a/lib/bundler/templates/newgem/Rakefile.tt
+++ b/lib/bundler/templates/newgem/Rakefile.tt
@@ -1,4 +1,5 @@
 require "bundler/gem_tasks"
+<% default_task_names = [config[:test_task]] -%>
 <% if config[:test] == "minitest" -%>
 require "rake/testtask"
 
@@ -14,7 +15,15 @@ require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new(:spec)
 
 <% end -%>
+<% if config[:rubocop] -%>
+<% default_task_names << :rubocop -%>
+require "rubocop/rake_task"
+
+RuboCop::RakeTask.new
+
+<% end -%>
 <% if config[:ext] -%>
+<% default_task_names.unshift(:clobber, :compile) -%>
 require "rake/extensiontask"
 
 task :build => :compile
@@ -23,7 +32,5 @@ Rake::ExtensionTask.new("<%= config[:underscored_name] %>") do |ext|
   ext.lib_dir = "lib/<%= config[:namespaced_path] %>"
 end
 
-task :default => [:clobber, :compile, :<%= config[:test_task] %>]
-<% else -%>
-task :default => :<%= config[:test_task] %>
 <% end -%>
+task :default => <%= default_task_names.size == 1 ? default_task_names.first.inspect : default_task_names.inspect %>


### PR DESCRIPTION
Based upon #6451.

### What was the end-user problem that led to this PR?

The problem was I always have to remember how to add RuboCop to my Rakefile when I set up a new gem.

### What was your diagnosis of the problem?

My diagnosis was that RuboCop has become enough of a community standard that it makes sense to offer it in `bundle gem`.

### What is your fix for the problem, implemented in this PR?

My fix adds an option to `bundle gem` to add in RuboCop, in the same way options like `:coc`and `:mit` are handled.

### Why did you choose this fix out of the possible options?

I chose this fix because it does not require bundler have an opinion on _how_ rubocop is configured.