### PR TITLE
Document the order Bundler loads settings

### DIFF
--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -7,10 +7,14 @@ bundle-config(1) -- Set bundler configuration options
 
 ## DESCRIPTION
 
-This command allows you to interact with bundler's configuration system.
-Bundler retrieves its configuration from the local application (`app/.bundle/config`),
-environment variables, and the user's home directory (`~/.bundle/config`),
-in that order of priority.
+This command allows you to interact with Bundler's configuration system.
+
+Bundler loads configuration settings in this order:
+
+1. Local config (`app/.bundle/config`)
+2. Environmental variables (`ENV`)
+3. Global config (`~/.bundle/config`)
+4. Bundler default config
 
 Executing `bundle config` with no parameters will print a list of all
 bundler configuration for the current bundle, and where that configuration
@@ -76,7 +80,7 @@ The options that can be configured are:
 
 ## BUILD OPTIONS
 
-You can use `bundle config` to give bundler the flags to pass to the gem
+You can use `bundle config` to give Bundler the flags to pass to the gem
 installer every time bundler tries to install a particular gem.
 
 A very common example, the `mysql` gem, requires Snow Leopard users to


### PR DESCRIPTION
Parsed out the information in the first graph in order to help users understand the order of priority Bundler follows when loading config settings.

Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was...
...[confusion from end users](https://github.com/bundler/bundler/issues/6270) about the order that Bundler loads settings in. 

Before:
```
This command allows you to interact with bundler's configuration system.
Bundler retrieves its configuration from the local application (`app/.bundle/config`),
environment variables, and the user's home directory (`~/.bundle/config`),
in that order of priority.
```

### What was your diagnosis of the problem?

My diagnosis was...
...[Colby pointed out how the bundle-config doc](https://github.com/bundler/bundler/issues/6334) needed to be updated to reflect this. After reviewing the `bundle-config` doc, it appears there was some information about how Bundler loads config settings, but it wasn't complete and as apparent to users. So I decided to separate the graph out and document the settings as a list so users could spot that easier.


### What is your fix for the problem, implemented in this PR?

My fix...
...was to verify the order of priority of settings and write them out as a list.

After:
```
This command allows you to interact with Bundler's configuration system.

Bundler loads configuration settings in this order:

1. Local config (`app/.bundle/config`)
2. Environmental variables (`ENV`)
3. Global config (`~/.bundle/config`)
4. Bundler default config
```

### Why did you choose this fix out of the possible options?

I chose this fix because...
it was clear that the document had to be updated, and lists are easier for readability.

fixes #6334 