### PR TITLE
Added license info to main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,7 @@ While some Bundler contributors are compensated by Ruby Together, the project ma
 ### Code of Conduct
 
 Everyone interacting in the Bundler project’s codebases, issue trackers, chat rooms, and mailing lists is expected to follow the [Bundler code of conduct](https://github.com/bundler/bundler/blob/master/CODE_OF_CONDUCT.md).
+
+###License
+
+[MIT License](https://github.com/bundler/bundler/blob/master/LICENSE.md)


### PR DESCRIPTION
Thought about doing this for a while but completely forgot about it. Added a link out to the MIT license from the bottom of the README. (Since it's considered a general best practice for info to be included in a README, and want to make sure the README is as complete as possible.)

