### PR TITLE
Replace hardcoded gemfile path with methods to discover Gemfile for bundle binstub

### DIFF
--- a/lib/bundler/templates/Executable.bundler
+++ b/lib/bundler/templates/Executable.bundler
@@ -8,7 +8,6 @@
 # this file is here to facilitate running it.
 #
 
-require "pathname"
 require "rubygems"
 
 m = Module.new do
@@ -41,7 +40,7 @@ m = Module.new do
   def gemfile
     gemfile = find_gemfile
     return unless gemfile
-    Pathname.new(gemfile).untaint.expand_path.to_s
+    File.expand_path(gemfile)
   end
 
   def find_gemfile
@@ -62,7 +61,7 @@ m = Module.new do
 
   def search_up(*names)
     previous = nil
-    current  = File.expand_path(Pathname.pwd).untaint
+    current  = File.expand_path(Dir.pwd)
 
     until !File.directory?(current) || current == previous
       names.each do |name|

--- a/lib/bundler/templates/Executable.bundler
+++ b/lib/bundler/templates/Executable.bundler
@@ -8,6 +8,7 @@
 # this file is here to facilitate running it.
 #
 
+require "pathname"
 require "rubygems"
 
 m = Module.new do
@@ -38,10 +39,39 @@ m = Module.new do
   end
 
   def gemfile
-    gemfile = ENV["BUNDLE_GEMFILE"]
-    return gemfile if gemfile && !gemfile.empty?
+    gemfile = find_gemfile
+    return unless gemfile
+    Pathname.new(gemfile).untaint.expand_path.to_s
+  end
 
-    File.expand_path("../<%= relative_gemfile_path %>", __FILE__)
+  def find_gemfile
+    given = ENV["BUNDLE_GEMFILE"]
+    return given if given && !given.empty?
+    find_file(*gemfile_names)
+  end
+
+  def gemfile_names
+    ["Gemfile", "gems.rb"]
+  end
+
+  def find_file(*names)
+    search_up(*names) do |filename|
+      return filename if File.file?(filename)
+    end
+  end
+
+  def search_up(*names)
+    previous = nil
+    current  = File.expand_path(Pathname.pwd).untaint
+
+    until !File.directory?(current) || current == previous
+      names.each do |name|
+        filename = File.join(current, name)
+        yield filename
+      end
+      previous = current
+      current = File.expand_path("..", current)
+    end
   end
 
   def lockfile


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Issues #6154 and #6162, in which Bundler v1.16.1 appeared to be looking for the wrong Gemfile when using Docker. Further investigation showed that this issue was not just limited to the use of Docker (see [non-Docker repro of 6154](https://gist.github.com/eanlain/83f97f919701c864fb68dfdcf813cf5a)).

### What was your diagnosis of the problem?

My diagnosis was that Bundler (v1.16.1) creates a binstub of itself every time `bundle install` is run and is storing the filepath of the last gemfile that `bundle install` was run with. 

In the event where no `ENV["BUNDLE_GEMFILE"]` is provided, the binstub, when executed (e.g. `bundle exec`), will try and use the gemfile of the last successful `bundle install`. For applications that use multiple gemfiles this has resulted in gems not being installed/loaded/run, the wrong gemfile being written to the Bundler binstub, and a persistent `bundle config gemfile` entry.

### What is your fix for the problem, implemented in this PR?

My fix adds methods to the `Executable.bundler` template that enable the Bundler binstub to discover gemfiles based on its current directory. Some code was adapted from `lib/bundler/shared_helpers.rb`, which provides methods like `default_gemfile` to discover gemfiles.

### Why did you choose this fix out of the possible options?

I chose this fix because it decouples the Bundler binstub's reliance on a specific Gemfile and instead enables dynamic discovery of a gemfile, which is more inline with the behavior in prior versions of Bundler.