### PR TITLE
Fix bundle lock when default gemfile is present

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -337,7 +337,8 @@ module Bundler
       end
 
       preserve_unknown_sections ||= !updating_major && (Bundler.frozen_bundle? || !(unlocking? || @unlocking_bundler))
-      return if lockfiles_equal?(@lockfile_contents, contents, preserve_unknown_sections)
+
+      return if file && File.exist?(file) && lockfiles_equal?(@lockfile_contents, contents, preserve_unknown_sections)
 
       if Bundler.frozen_bundle?
         Bundler.ui.error "Cannot write a changed lockfile while frozen."

--- a/spec/commands/lock_spec.rb
+++ b/spec/commands/lock_spec.rb
@@ -97,6 +97,14 @@ RSpec.describe "bundle lock" do
     expect { read_lockfile }.to raise_error(Errno::ENOENT)
   end
 
+  it "writes to custom location using --lockfile when a default lockfile is present" do
+    bundle "install"
+    bundle "lock --lockfile=lock"
+
+    expect(out).to match(/Writing lockfile to.+lock/)
+    expect(read_lockfile("lock")).to eq(@lockfile)
+  end
+
   it "update specific gems using --update" do
     lockfile @lockfile.gsub("2.3.2", "2.3.1").gsub("10.0.2", "10.0.1")
 


### PR DESCRIPTION
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was on running `bundle lock --lockfile=AlternativeGemfile.lock` if a default lockfile already exists then `AlternativeGemfile.lock` is not created.

### What was your diagnosis of the problem?

My diagnosis was that the [lock](https://github.com/bundler/bundler/blob/master/lib/bundler/definition.rb#L340) function does not check the file but for contents, so a new file is not created in case of an existing lockfile.

### What is your fix for the problem, implemented in this PR?

My fix was to check for the file existence.

Closes #6460 
