### PR TITLE
Document parameters and return value of Injector#inject

### DIFF
--- a/lib/bundler/injector.rb
+++ b/lib/bundler/injector.rb
@@ -12,6 +12,9 @@ module Bundler
       @options = options
     end
 
+    # @param [Pathname] gemfile_path The Gemfile in which to inject the new dependency.
+    # @param [Pathname] lockfile_path The lockfile in which to inject the new dependency.
+    # @return [Array]
     def inject(gemfile_path, lockfile_path)
       if Bundler.frozen_bundle?
         # ensure the lock and Gemfile are synced
@@ -82,7 +85,7 @@ module Bundler
     end
 
     def append_to(gemfile_path, new_gem_lines)
-      File.open(gemfile_path, "a") do |f|
+      gemfile_path.open("a") do |f|
         f.puts
         f.puts new_gem_lines
       end

--- a/lib/bundler/injector.rb
+++ b/lib/bundler/injector.rb
@@ -82,7 +82,7 @@ module Bundler
     end
 
     def append_to(gemfile_path, new_gem_lines)
-      gemfile_path.open("a") do |f|
+      File.open(gemfile_path, "a") do |f|
         f.puts
         f.puts new_gem_lines
       end


### PR DESCRIPTION
Summary: Use File.open instead of Kernel.open to avoid private method call when using Bundler::Injector in Ruby script.

### What was the end-user problem that led to this PR?

My app should allow users to install extensions at runtime. When using `Bundler::Injector`'s `inject` in a Ruby script, the internal method `append_to` fails with the error below.

Calling system('bundle inject GEM VERSION') is not feasible in my use case, since I want to inject the gem in a secondary Gemfile.

### What was your diagnosis of the problem?

The error that occurs when trying to inject a dependency through a call to `Bundler::Injector.inject`:

`bundler-1.16.1/lib/bundler/injector.rb:85:in 'append_to': private method `open' called for "Gemfile.local":String (NoMethodError)`

### What is your fix for the problem, implemented in this PR?

My fix replaces Kernel.open with File.open to open the Gemfile.

### Why did you choose this fix out of the possible options?

I chose this fix because it does not break current `bundle inject GEM VERSION` CLI behavior and does not introduce additional dependencies.