### PR TITLE
Support setting up a bundle without loading most of Bundler

### DIFF
--- a/spec/bundler/rubygems_integration_spec.rb
+++ b/spec/bundler/rubygems_integration_spec.rb
@@ -111,4 +111,33 @@ RSpec.describe Bundler::RubygemsIntegration do
       end
     end
   end
+
+  describe "#setup" do
+    let(:script) do
+      <<-EOF
+      require 'bundler/rubygems_integration'
+      if defined?(Bundler::Runtime)
+        $stderr.puts("Bundler::Runtime should not be defined")
+        exit 1
+      end
+      class MySpec < Gem::Specification
+        attr_accessor :load_paths
+      end
+
+      spec = MySpec.new do |s|
+        s.name = "to-validate"
+        s.version = "1.0.0"
+        s.loaded_from = __FILE__
+        s.load_paths = ["/foo/bar"]
+      end
+
+      Bundler.rubygems.setup([spec])
+      puts $LOAD_PATH.join("\n")
+EOF
+    end
+
+    it "runs without the rest of Bundler loaded" do
+      expect(ruby(script)).to include("/foo/bar\n")
+    end
+  end
 end


### PR DESCRIPTION
While working on our internal developer CLIs at Stripe I noticed that a simple `require 'bundler'` was adding hundreds of milliseconds to our commands. I wrote something that copies the behavior of `Bundler.setup` using information cached in a file and refreshed when the Gemfile changes. This has made our CLIs much more responsive but I had to resort to awful monkeypatching to keep this working when RubygemsIntegration added a dependency on `Bundler.feature_flags`.

This PR makes the portions of RubygemsIntegration used in `Bundler.setup` runnable without loading the majority of the Bundler codebase. It also moves portions of the `setup` logic that don't interact with the rest of Bundler into RubygemsIntegration. This makes it easier to use RubygemsIntegration without the time penalty of requiring all of Bundler.

Making RubygemsIntegration.setup runnable without the rest of Bundler is a step towards making something like Bundler's standalone feature load much faster. I think it'd be great to get to a place where most of the Bundler codebase does not need to be loaded for a simple `bundle exec`. 
