### PR TITLE
Fix specs against RubyGems master

### DIFF
--- a/spec/commands/add_spec.rb
+++ b/spec/commands/add_spec.rb
@@ -51,8 +51,9 @@ RSpec.describe "bundle add" do
     end
 
     it "adds multiple version constraints when specified" do
-      bundle "add 'foo' --version='< 3.0, > 1.1'"
-      expect(bundled_app("Gemfile").read).to match(/gem "foo", "< 3.0", "> 1.1"/)
+      requirements = ["< 3.0", "> 1.0"]
+      bundle "add 'foo' --version='#{requirements.join(", ")}'"
+      expect(bundled_app("Gemfile").read).to match(/gem "foo", #{Gem::Requirement.new(requirements).as_list.map(&:dump).join(', ')}/)
       expect(the_bundle).to include_gems "foo 2.0"
     end
   end

--- a/spec/install/gems/resolving_spec.rb
+++ b/spec/install/gems/resolving_spec.rb
@@ -166,8 +166,9 @@ RSpec.describe "bundle install with install-time dependencies" do
       end
 
       describe "with a compound requirement" do
-        let(:ruby_requirement) { %("< 5000", "> 0.1") }
-        let(:error_message_requirement) { "< 5000, > 0.1" }
+        let(:reqs) { ["> 0.1", "< 5000"] }
+        let(:ruby_requirement) { reqs.map(&:dump).join(", ") }
+        let(:error_message_requirement) { Gem::Requirement.new(reqs).to_s }
 
         it_behaves_like "ruby version conflicts"
       end


### PR DESCRIPTION
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was the specs on master are broken running against RubyGems master

### What was your diagnosis of the problem?

My diagnosis was This was broken by RubyGems changing how requirements are sorted.

### What is your fix for the problem, implemented in this PR?

My fix uses `Gem::Requirement` to get the same sorting rubygems has

### Why did you choose this fix out of the possible options?

I chose this fix because the sorting is different between rubygems versions