### PR TITLE
[Source::RubyGems] Allow installing when the path is `.`

### DIFF
--- a/lib/bundler/source/rubygems.rb
+++ b/lib/bundler/source/rubygems.rb
@@ -485,7 +485,10 @@ module Bundler
         else
           uri = spec.remote.uri
           Bundler.ui.confirm("Fetching #{version_message(spec)}")
-          Bundler.rubygems.download_gem(spec, uri, download_path)
+          rubygems_local_path = Bundler.rubygems.download_gem(spec, uri, download_path)
+          if rubygems_local_path != local_path
+            FileUtils.mv(rubygems_local_path, local_path)
+          end
           cache_globally(spec, local_path)
         end
       end

--- a/spec/install/path_spec.rb
+++ b/spec/install/path_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe "bundle install" do
       if type == :env
         ENV["BUNDLE_PATH"] = location
       elsif type == :global
-        bundle "config path #{location}", "no-color" => nil
+        bundle! "config path #{location}", "no-color" => nil
       end
     end
 
@@ -109,6 +109,16 @@ RSpec.describe "bundle install" do
 
         expect(vendored_gems("gems/rack-1.0.0")).to be_directory
         expect(bundled_app("vendor2")).not_to be_directory
+        expect(the_bundle).to include_gems "rack 1.0.0"
+      end
+
+      it "installs gems to ." do
+        set_bundle_path(type, ".")
+        bundle! "config --global disable_shared_gems true"
+
+        bundle! :install
+
+        expect([bundled_app("cache/rack-1.0.0.gem"), bundled_app("gems/rack-1.0.0"), bundled_app("specifications/rack-1.0.0.gemspec")]).to all exist
         expect(the_bundle).to include_gems "rack 1.0.0"
       end
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was `bundle install` would fail when the path was configured to be the current working directory.

Fixes #6475.

### What was your diagnosis of the problem?

My diagnosis was `Gem::RemoteFetcher` caches `.gem` files differently when `Dir.pwd == download_dir`

### What is your fix for the problem, implemented in this PR?

My fix moves the file rubygems has downloaded to the cache directory we expect.

### Why did you choose this fix out of the possible options?

I chose this fix because it does not re-implement logic in rubygems, and it keeps the directory structure bundler generates consistent.