### PR TITLE
Do not blow up when installing on a readonly filesystem without a hom…

### DIFF
--- a/lib/bundler/plugin/index.rb
+++ b/lib/bundler/plugin/index.rb
@@ -29,7 +29,12 @@ module Bundler
         @hooks = {}
         @load_paths = {}
 
-        load_index(global_index_file, true)
+        begin
+          load_index(global_index_file, true)
+        rescue GenericSystemCallError
+          # no need to fail when on a read-only FS, for example
+          nil
+        end
         load_index(local_index_file) if SharedHelpers.in_bundle?
       end
 

--- a/spec/bundler/plugin/index_spec.rb
+++ b/spec/bundler/plugin/index_spec.rb
@@ -175,4 +175,12 @@ RSpec.describe Bundler::Plugin::Index do
       include_examples "it cleans up"
     end
   end
+
+  describe "readonly disk without home" do
+    it "ignores being unable to create temp home dir" do
+      expect_any_instance_of(Bundler::Plugin::Index).to receive(:global_index_file).
+        and_raise(Bundler::GenericSystemCallError.new("foo", "bar"))
+      Bundler::Plugin::Index.new
+    end
+  end
 end


### PR DESCRIPTION
…e directory

fixes https://github.com/bundler/bundler/issues/6461

```
docker run --read-only ruby ruby -r bundler/cli -e "puts Bundler::VERSION; Bundler::CLI.start(['exec', 'ruby', '-v'], :debug => true)"
/usr/local/lib/ruby/site_ruby/2.5.0/bundler.rb:193:in `rescue in tmp_home_path': `/root` is not writable. (Bundler::GenericSystemCallError)
Bundler also failed to create a temporary home directory at `/tmp/bundler/home':
There was an error accessing `/tmp/bundler/home`.
The underlying system error is Errno::EROFS: Read-only file system @ dir_s_mkdir - /tmp/bundler
  from /usr/local/lib/ruby/site_ruby/2.5.0/bundler.rb:181:in `tmp_home_path'
  from /usr/local/lib/ruby/site_ruby/2.5.0/bundler.rb:172:in `user_home'
  from /usr/local/lib/ruby/site_ruby/2.5.0/bundler.rb:197:in `user_bundle_path'
  from /usr/local/lib/ruby/site_ruby/2.5.0/bundler/plugin.rb:99:in `global_root'
  from /usr/local/lib/ruby/site_ruby/2.5.0/bundler/plugin/index.rb:73:in `global_index_file'
  from /usr/local/lib/ruby/site_ruby/2.5.0/bundler/plugin/index.rb:32:in `initialize'
  from /usr/local/lib/ruby/site_ruby/2.5.0/bundler/plugin.rb:78:in `new'
```

@segiddins 