### PR TITLE
Fix failing exec spec that is blocking 1.16.2

### DIFF
--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -610,13 +610,7 @@ RSpec.describe "bundle exec" do
       let(:executable) { super() << "\nclass Err < Exception\ndef backtrace; end;\nend\nraise Err" }
       let(:exit_code) { 1 }
       let(:expected) { super() << "\nbundler: failed to load command: #{path} (#{path})" }
-      let(:expected_err) do
-        if ENV["BUNDLER_SPEC_SUB_VERSION"] == "1.98"
-          "Err: Err"
-        else
-          "bundler: failed to load command: #{path} (#{path})\nErr: Err"
-        end
-      end
+      let(:expected_err) { "Err: Err" }
 
       it_behaves_like "it runs"
     end
@@ -625,13 +619,7 @@ RSpec.describe "bundle exec" do
       let(:executable) { super() << "\nclass Err < Exception\ndef backtrace; end;\nend\nraise Err" }
       let(:exit_code) { 1 }
       let(:expected_err) { "bundler: failed to load command: #{path} (#{path})\nErr: Err" }
-      let(:expected) do
-        if ENV["BUNDLER_SPEC_SUB_VERSION"] == "1.98"
-          super() << "\nbundler: failed to load command: #{path} (#{path})"
-        else
-          super()
-        end
-      end
+      let(:expected) { super() }
 
       it_behaves_like "it runs"
     end


### PR DESCRIPTION
### Overview

There is a test that is [failing in travis](https://travis-ci.org/bundler/bundler/builds/365371973) which is preventing v1.16.2 from being released. The spec in question is checking the `BUNDLER_SPEC_SUB_VERSION` env var and changes the assertion of the test depending on the stubbed version. The issue is that the 1-16-stable branch does not really use `BUNDLER_SPEC_SUB_VERSION` and the spec is assuming it's testing Bundler 2.

### What is your fix for the problem, implemented in this PR?

Checking for `BUNDLER_SPEC_SUB_VERSION` is not really necessary in the first place because the test is already scoped for Bundler 1 & 2 (using rspec tags). This PR removes the checking for `BUNDLER_SPEC_SUB_VERSION﻿`.