### PR TITLE
Filter git uri credentials in source description

### DIFF
--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -21,6 +21,7 @@ module Bundler
         %w[ref branch tag revision].each {|k| options[k] = options[k].to_s if options[k] }
 
         @uri        = options["uri"] || ""
+        @safe_uri   = URICredentialsFilter.credential_filtered_uri(@uri)
         @branch     = options["branch"]
         @ref        = options["ref"] || options["branch"] || options["tag"] || "master"
         @submodules = options["submodules"]
@@ -77,7 +78,7 @@ module Bundler
                 nil
               end
 
-        "#{uri} (at #{at}#{rev})"
+        "#{@safe_uri} (at #{at}#{rev})"
       end
 
       def name

--- a/spec/bundler/source/git_spec.rb
+++ b/spec/bundler/source/git_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.describe Bundler::Source::Git do
+  before do
+    allow(Bundler).to receive(:root) { Pathname.new("root") }
+  end
+
+  let(:uri) { "https://github.com/foo/bar.git" }
+  let(:options) do
+    { "uri" => uri }
+  end
+
+  subject { described_class.new(options) }
+
+  describe "#to_s" do
+    it "returns a description" do
+      expect(subject.to_s).to eq "https://github.com/foo/bar.git (at master)"
+    end
+
+    context "when the URI contains credentials" do
+      let(:uri) { "https://my-secret-token:x-oauth-basic@github.com/foo/bar.git" }
+
+      it "filters credentials" do
+        expect(subject.to_s).to eq "https://x-oauth-basic@github.com/foo/bar.git (at master)"
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was HTTP basic auth credentials were leaking into Bundler's output when used in git sources

### What was your diagnosis of the problem?

My diagnosis was we needed to filter credentials in `Git#to_s`

### Why did you choose this fix out of the possible options?

I chose this fix because it doesn't require updating every place that uses `Source#to_s`, and is symmetric with what the rubygems source does to filter creds