### PR TITLE
Fix calling undefined `Gem::Util.inflate` in RubyGemsIntegration for old RubyGems versions

### DIFF
--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -132,7 +132,11 @@ module Bundler
     end
 
     def inflate(obj)
-      Gem::Util.inflate(obj)
+      if defined?(Gem::Util)
+        Gem::Util.inflate(obj)
+      else
+        Gem.inflate(obj)
+      end
     end
 
     def sources=(val)


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

RubyGems integration is calling `Gem::Util.inflate` which is not available in all supported versions of RubyGems.

### What was your diagnosis of the problem?

See https://travis-ci.org/bundler/bundler/jobs/368919903

### What is your fix for the problem, implemented in this PR?

Check if `Gem::Util` is defined, and if not, fallback to using the old way calling `inflate` in RubyGems
