### PR TITLE
Use realpath in clean_load_path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ addons:
       secure: "TrzIv116JLGUxm6PAUskCYrv8KTDguncKROVwbnjVPKTGDAgoDderd8JUdDEXrKoZ9qGLD2TPYKExt9/QDl71E+qHdWnVqWv4HKCUk2P9z/VLKzHuggOUBkCXiJUhjywUieCJhI3N92bfq2EjSBbu2/OFHqWOjLQ+QCooTEBjv8="
 
 rvm:
-  - 2.5.0
+  - 2.5.1
   - 2.4.3
   - 2.3.6
 

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -344,9 +344,10 @@ module Bundler
 
     def resolve_path(path)
       expanded = File.expand_path(path)
+      return expanded unless File.respond_to?(:realpath)
 
-      if File.respond_to?(:realpath)
-        expanded = File.realpath(expanded) until expanded == File.realpath(expanded)
+      while File.exist?(expanded) && File.realpath(expanded) != expanded
+        expanded = File.realpath(expanded)
       end
 
       expanded

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -336,7 +336,11 @@ module Bundler
       loaded_gem_paths = Bundler.rubygems.loaded_gem_paths
 
       $LOAD_PATH.reject! do |p|
-        next if File.expand_path(p).start_with?(bundler_lib)
+        expanded_p = File.expand_path(p)
+        next if expanded_p.start_with?(bundler_lib)
+        if File.exist?(expanded_p) && File.respond_to?(:realpath)
+          next if File.realpath(expanded_p).start_with?(bundler_lib)
+        end
         loaded_gem_paths.delete(p)
       end
       $LOAD_PATH.uniq!

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -344,7 +344,11 @@ module Bundler
 
     def resolve_path(path)
       expanded = File.expand_path(path)
-      expanded = File.realpath(expanded) until expanded == File.realpath(expanded)
+
+      if File.respond_to?(:realpath)
+        expanded = File.realpath(expanded) until expanded == File.realpath(expanded)
+      end
+
       expanded
     end
 

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -324,7 +324,7 @@ module Bundler
     end
 
     def bundler_ruby_lib
-      File.expand_path("../..", __FILE__)
+      resolve_path File.expand_path("../..", __FILE__)
     end
 
     def clean_load_path

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -336,14 +336,16 @@ module Bundler
       loaded_gem_paths = Bundler.rubygems.loaded_gem_paths
 
       $LOAD_PATH.reject! do |p|
-        expanded_p = File.expand_path(p)
-        next if expanded_p.start_with?(bundler_lib)
-        if File.exist?(expanded_p) && File.respond_to?(:realpath)
-          next if File.realpath(expanded_p).start_with?(bundler_lib)
-        end
+        next if resolve_path(p).start_with?(bundler_lib)
         loaded_gem_paths.delete(p)
       end
       $LOAD_PATH.uniq!
+    end
+
+    def resolve_path(path)
+      expanded = File.expand_path(path)
+      expanded = File.realpath(expanded) until expanded == File.realpath(expanded)
+      expanded
     end
 
     def prints_major_deprecations?

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -857,6 +857,50 @@ end
     expect(out).to eq("true\ntrue")
   end
 
+  context "with bundler is located in symlinked GEM_HOME" do
+    let(:gem_home) { Dir.mktmpdir }
+    let(:symlinked_gem_home) { Tempfile.new("gem_home") }
+    let(:bundler_dir) { File.expand_path("../../..", __FILE__) }
+    let(:bundler_lib) { File.join(bundler_dir, "lib") }
+
+    before do
+      FileUtils.ln_sf(gem_home, symlinked_gem_home.path)
+      gems_dir = File.join(gem_home, "gems")
+      specifications_dir = File.join(gem_home, "specifications")
+      Dir.mkdir(gems_dir)
+      Dir.mkdir(specifications_dir)
+
+      FileUtils.ln_s(bundler_dir, File.join(gems_dir, "bundler-#{Bundler::VERSION}"))
+
+      gemspec = File.read("#{bundler_dir}/bundler.gemspec").
+                sub("Bundler::VERSION", %("#{Bundler::VERSION}"))
+      gemspec = gemspec.lines.reject {|line| line =~ %r{lib/bundler/version} }.join
+
+      File.open(File.join(specifications_dir, "bundler.gemspec"), "wb") do |f|
+        f.write(gemspec)
+      end
+    end
+
+    it "should succesfully require 'bundler/setup'" do
+      install_gemfile ""
+
+      ENV["GEM_PATH"] = symlinked_gem_home.path
+
+      ruby <<-R
+        if $LOAD_PATH.include?("#{bundler_lib}")
+          # We should use bundler from GEM_PATH for this test, so we should
+          # remove path to the bundler source tree
+          $LOAD_PATH.delete("#{bundler_lib}")
+        else
+          raise "We don't have #{bundler_lib} in $LOAD_PATH"
+        end
+        puts (require 'bundler/setup')
+      R
+
+      expect(out).to eql("true")
+    end
+  end
+
   it "stubs out Gem.refresh so it does not reveal system gems" do
     system_gems "rack-1.0.0"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,8 +31,9 @@ require "digest"
 # Delete any copies of Bundler that have been dumped into site_ruby without
 # a gemspec. RubyGems cannot manage that Bundler, and so our tricks to make
 # sure that the correct version of Bundler loads will stop working.
-Dir.glob(File.join(RbConfig::CONFIG["sitelibdir"], "bundler*")).each do |f|
-  FileUtils.rm_rf f
+require "fileutils"
+Dir.glob(File.join(RbConfig::CONFIG["sitelibdir"], "bundler*")).each do |file|
+  FileUtils.rm_rf(file)
 end
 
 if File.expand_path(__FILE__) =~ %r{([^\w/\.-])}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,13 +12,6 @@ module Gem
   end
 end
 
-# Delete any copies of Bundler that have been dumped into site_ruby without
-# a gemspec. RubyGems cannot manage that Bundler, and so our tricks to make
-# sure that the correct version of Bundler loads will stop working.
-Dir.glob(File.join(RbConfig::CONFIG["sitelibdir"], "bundler*")).each do |f|
-  FileUtils.rm_rf f
-end
-
 begin
   require File.expand_path("../support/path.rb", __FILE__)
   spec = Gem::Specification.load(Spec::Path.gemspec.to_s)
@@ -34,6 +27,13 @@ require "bundler/psyched_yaml"
 require "bundler/vendored_fileutils"
 require "uri"
 require "digest"
+
+# Delete any copies of Bundler that have been dumped into site_ruby without
+# a gemspec. RubyGems cannot manage that Bundler, and so our tricks to make
+# sure that the correct version of Bundler loads will stop working.
+Dir.glob(File.join(RbConfig::CONFIG["sitelibdir"], "bundler*")).each do |f|
+  FileUtils.rm_rf f
+end
 
 if File.expand_path(__FILE__) =~ %r{([^\w/\.-])}
   abort "The bundler specs cannot be run from a path that contains special characters (particularly #{$1.inspect})"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,13 @@ module Gem
   end
 end
 
+# Delete any copies of Bundler that have been dumped into site_ruby without
+# a gemspec. RubyGems cannot manage that Bundler, and so our tricks to make
+# sure that the correct version of Bundler loads will stop working.
+Dir.glob(File.join(RbConfig::CONFIG["sitelibdir"], "bundler*")).each do |f|
+  FileUtils.rm_rf f
+end
+
 begin
   require File.expand_path("../support/path.rb", __FILE__)
   spec = Gem::Specification.load(Spec::Path.gemspec.to_s)


### PR DESCRIPTION
see #6465, basically we're not rejecting `bundler_lib` because we have symlink there and real path in `$LOAD_PATH`
```
$ irb
2.5.1 :001 > require 'bundler/setup'
# what happens next will shock you
From: /real_path/.rvm/gems/ruby-2.5.1/gems/bundler-1.16.2/lib/bundler/shared_helpers.rb @ line 339 Bundler::SharedHelpers#clean_load_path:

    330: def clean_load_path
    331:   # handle 1.9 where system gems are always on the load path
    332:   return unless defined?(::Gem)
    333:
    334:   bundler_lib = bundler_ruby_lib
    335:
    336:   loaded_gem_paths = Bundler.rubygems.loaded_gem_paths
    337:
    338:   binding.pry
 => 339:   $LOAD_PATH.reject! do |p|
    340:     path = File.expand_path(p)
    341:     path = File.realpath(path) if File.exist?(path)
    342:     next if path.start_with?(bundler_lib)
    343:     loaded_gem_paths.delete(p)
    344:   end
    345:   $LOAD_PATH.uniq!
    346: end

[1] pry(#<Bundler::Runtime>)> bundler_lib
=> "/real_path/.rvm/gems/ruby-2.5.1/gems/bundler-1.16.2/lib"
[2] pry(#<Bundler::Runtime>)> loaded_gem_paths
=> ["/symlinked_path/.rvm/gems/ruby-2.5.1@global/gems/did_you_mean-1.2.0/lib",
 "/symlinked_path/.rvm/gems/ruby-2.5.1/gems/bundler-1.16.2/lib",
 "/symlinked_path/.rvm/gems/ruby-2.5.1/gems/byebug-10.0.2/lib",
 "/symlinked_path/.rvm/gems/ruby-2.5.1/extensions/x86_64-linux/2.5.0/byebug-10.0.2",
 "/symlinked_path/.rvm/gems/ruby-2.5.1/gems/coderay-1.1.2/lib",
 "/symlinked_path/.rvm/gems/ruby-2.5.1/gems/method_source-0.9.0/lib",
 "/symlinked_path/.rvm/gems/ruby-2.5.1/gems/pry-0.11.3/lib",
 "/symlinked_path/.rvm/gems/ruby-2.5.1/gems/pry-byebug-3.6.0/lib",
 "/real_path/.rvm/rubies/ruby-2.5.1/lib/ruby/gems/2.5.0/gems/fileutils-1.0.2/lib",
 "/real_path/.rvm/rubies/ruby-2.5.1/lib/ruby/gems/2.5.0/gems/psych-3.0.2/lib",
 "/real_path/.rvm/rubies/ruby-2.5.1/lib/ruby/gems/2.5.0/extensions/x86_64-linux/2.5.0/psych-3.0.2"]
```