### PR TITLE
Use `__dir__` instead of `__FILE__` in newgem.gemspec template

### DIFF
--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -1,8 +1,10 @@
 <%- if RUBY_VERSION < "2.0.0" -%>
 # coding: utf-8
 
-<%- end -%>
 lib = File.expand_path("../lib", __FILE__)
+<%- else -%>
+lib = File.expand_path("lib", __dir__)
+<%- end -%>
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "<%= config[:namespaced_path] %>/version"
 

--- a/lib/bundler/templates/newgem/test/test_helper.rb.tt
+++ b/lib/bundler/templates/newgem/test/test_helper.rb.tt
@@ -1,4 +1,8 @@
+<%- if RUBY_VERSION < "2.0.0" -%>
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
+<%- else -%>
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+<%- end -%>
 require "<%= config[:namespaced_path] %>"
 
 require "minitest/autorun"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Since Ruby 2.0 we've had `__dir__` as well as `__FILE__`.

The initial gem codes written with `bundle gem` using Ruby 2.0 or higher is an old description using `__FILE__`.

### What was your diagnosis of the problem?

Ruby 1.9 is EOL, so I think that there is not much Gem to start developed using it.

### What is your fix for the problem, implemented in this PR?

This PR uses `__dir__` when starting Gem development (i.e. `bundle gem`) using Ruby 2.0 or higher version.
