### PR TITLE
Add `bundle remove`

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -166,9 +166,9 @@ module Bundler
       Check.new(options).run
     end
 
-    desc "remove [GEMS] [OPTIONS]", "Removes the gem from the Gemfile"
+    desc "remove [GEM [GEM ...]]", "Removes gems from the Gemfile"
     long_desc <<-D
-      Removes the specified gems from the Gemfile. If the gem is not found, Bundler prints a error message and if gem could not be removed due to any reason Bundler will display a warning.
+      Removes the given gems from the Gemfile while ensuring that the resulting Gemfile is still valid. If the gem is not found, Bundler prints a error message and if gem could not be removed due to any reason Bundler will display a warning.
     D
     method_option "install", :type => :boolean, :banner =>
       "Runs 'bundle install' after removing the gems from the Gemfile"

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -166,12 +166,12 @@ module Bundler
       Check.new(options).run
     end
 
-    desc "remove [GEMS]", "Removes the gem from gemfile"
+    desc "remove [GEMS] [OPTIONS]", "Removes the gem from gemfile"
     long_desc <<-D
-      Removes gems from the Gemfile. If a gem is not found, Bundler prints a error message and if gem could not be removed due to any reason Bundler warns the user.
+      Removes gems from the Gemfile. If a gem is not found, Bundler prints a error message and if gem could not be removed due to any reason Bundler displays warning.
     D
     method_option "install", :type => :boolean, :banner =>
-      "Removes gems from bundle"
+      "Runs 'bundle install' after removing the gems from the gemfile"
     def remove(*gems)
       require "bundler/cli/remove"
       Remove.new(gems, options).run

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -168,10 +168,10 @@ module Bundler
 
     desc "remove [GEMS] [OPTIONS]", "Removes the gem from the Gemfile"
     long_desc <<-D
-      Removes the specified gems from the Gemfile in the current directory. If a gem is not found, Bundler prints a error message and if gem could not be removed due to any reason Bundler displays warning.
+      Removes the specified gems from the Gemfile. If the gem is not found, Bundler prints a error message and if gem could not be removed due to any reason Bundler will display a warning.
     D
     method_option "install", :type => :boolean, :banner =>
-      "Runs 'bundle install' after removing the gems from the gemfile"
+      "Runs 'bundle install' after removing the gems from the Gemfile"
     def remove(*gems)
       require "bundler/cli/remove"
       Remove.new(gems, options).run

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -166,13 +166,13 @@ module Bundler
       Check.new(options).run
     end
 
-    desc "remove [GEM_NAME]", "Removes the gem from gemfile"
+    desc "remove [GEMS]", "Removes the gem from gemfile"
     long_desc <<-D
-      Scans the gemfile for the gem and removes it. If not found, Bundler prints a error message.
+      Scans the gemfile for the gems and removes them. If not found, Bundler prints a error message.
     D
-    def remove(gem_name)
+    def remove(*gems)
       require "bundler/cli/remove"
-      Remove.new(gem_name).run
+      Remove.new(gems).run
     end
 
     desc "install [OPTIONS]", "Install the current environment to the system"

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -170,9 +170,11 @@ module Bundler
     long_desc <<-D
       Scans the gemfile for the gems and removes them. If not found, Bundler prints a error message.
     D
+    method_option "install", :type => :boolean, :banner =>
+      "Remove gem from bundle"
     def remove(*gems)
       require "bundler/cli/remove"
-      Remove.new(gems).run
+      Remove.new(gems, options).run
     end
 
     desc "install [OPTIONS]", "Install the current environment to the system"

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -166,9 +166,9 @@ module Bundler
       Check.new(options).run
     end
 
-    desc "remove [GEMS] [OPTIONS]", "Removes the gem from gemfile"
+    desc "remove [GEMS] [OPTIONS]", "Removes the gem from the Gemfile"
     long_desc <<-D
-      Removes gems from the Gemfile. If a gem is not found, Bundler prints a error message and if gem could not be removed due to any reason Bundler displays warning.
+      Removes the specified gems from the Gemfile in the current directory. If a gem is not found, Bundler prints a error message and if gem could not be removed due to any reason Bundler displays warning.
     D
     method_option "install", :type => :boolean, :banner =>
       "Runs 'bundle install' after removing the gems from the gemfile"

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -166,6 +166,15 @@ module Bundler
       Check.new(options).run
     end
 
+    desc "remove [GEM_NAME]", "Removes the gem from gemfile"
+    long_desc <<-D
+      Scans the gemfile for the gem and removes it. If not found, Bundler prints a error message.
+    D
+    def remove(gem_name)
+      require "bundler/cli/remove"
+      Remove.new(gem_name).run
+    end
+
     desc "install [OPTIONS]", "Install the current environment to the system"
     long_desc <<-D
       Install will install all of the gems in the current bundle, making them available

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -168,10 +168,10 @@ module Bundler
 
     desc "remove [GEMS]", "Removes the gem from gemfile"
     long_desc <<-D
-      Scans the gemfile for the gems and removes them. If not found, Bundler prints a error message.
+      Removes gems from the Gemfile. If a gem is not found, Bundler prints a error message and if gem could not be removed due to any reason Bundler warns the user.
     D
     method_option "install", :type => :boolean, :banner =>
-      "Remove gem from bundle"
+      "Removes gems from bundle"
     def remove(*gems)
       require "bundler/cli/remove"
       Remove.new(gems, options).run

--- a/lib/bundler/cli/remove.rb
+++ b/lib/bundler/cli/remove.rb
@@ -11,6 +11,7 @@ module Bundler
       # Raise error if no gems are specified
       raise InvalidOption, "Please specify gems to remove." if @gems.empty?
 
+      # remove requested gems
       removed_deps = Injector.remove(@gems, {})
 
       # Remove gems from .bundle if install flag is specified

--- a/lib/bundler/cli/remove.rb
+++ b/lib/bundler/cli/remove.rb
@@ -8,13 +8,11 @@ module Bundler
     end
 
     def run
-      # Raise error if no gems are specified
       raise InvalidOption, "Please specify gems to remove." if @gems.empty?
 
       # remove requested gems
       Injector.remove(@gems, {})
 
-      # Remove gems from .bundle if install flag is specified
       Installer.install(Bundler.root, Bundler.definition) if @options["install"]
     end
   end

--- a/lib/bundler/cli/remove.rb
+++ b/lib/bundler/cli/remove.rb
@@ -16,6 +16,7 @@ module Bundler
       # Remove gems from .bundle if install flag is specified
       Installer.install(Bundler.root, Bundler.definition) if @options["install"]
 
+      # print success for removed gems
       removed_deps.each {|dep| Bundler.ui.confirm "#{SharedHelpers.pretty_dependency(dep)} was removed." }
     end
   end

--- a/lib/bundler/cli/remove.rb
+++ b/lib/bundler/cli/remove.rb
@@ -16,7 +16,7 @@ module Bundler
       # Remove gems from .bundle if install flag is specified
       Installer.install(Bundler.root, Bundler.definition) if @options["install"]
 
-      removed_deps.each {|dep| Bundler.ui.confirm "#{dep.name}(#{dep.requirement}) was removed." }
+      removed_deps.each {|dep| Bundler.ui.confirm "#{SharedHelpers.pretty_dependency(dep)} was removed." }
     end
   end
 end

--- a/lib/bundler/cli/remove.rb
+++ b/lib/bundler/cli/remove.rb
@@ -14,18 +14,12 @@ module Bundler
       # store removed gems to display on successfull removal
       @removed_deps = builder.remove_gems(@gems)
 
-      # resolve to see if the after removing dep broke anything
+      # remove gems from lockfile
       @definition = builder.to_definition(Bundler.default_lockfile, {})
-      @definition.resolve_remotely!
-
-      # since nothing broke, we can remove those gems from the gemfile
-      remove_gems_from_gemfile
-
-      # since we resolved successfully, write out the lockfile
       @definition.lock(Bundler.default_lockfile)
 
-      # invalidate the cached Bundler.definition
-      Bundler.reset_paths!
+      # remove those gems from the gemfile
+      remove_gems_from_gemfile
 
       # TODO: Discuss about using this,
       # currently gems are not removed from .bundle
@@ -64,11 +58,10 @@ module Bundler
           inside_group += line unless line.match(re)
         end
 
-        if inside_group =~ /gem / && !group
-          lines += whole_group
-          inside_group = ""
-          whole_group = ""
-        end
+        next unless inside_group =~ /gem / && !group
+        lines += whole_group
+        inside_group = ""
+        whole_group = ""
       end
 
       File.open(Bundler.default_gemfile, "w") do |file|

--- a/lib/bundler/cli/remove.rb
+++ b/lib/bundler/cli/remove.rb
@@ -9,7 +9,7 @@ module Bundler
 
     def run
       # Raise error if no gems are specified
-      raise InvalidOption, "Please specify gems to remove" if @gems.empty?
+      raise InvalidOption, "Please specify gems to remove." if @gems.empty?
 
       removed_deps = Injector.remove(@gems, {})
 

--- a/lib/bundler/cli/remove.rb
+++ b/lib/bundler/cli/remove.rb
@@ -12,13 +12,10 @@ module Bundler
       raise InvalidOption, "Please specify gems to remove." if @gems.empty?
 
       # remove requested gems
-      removed_deps = Injector.remove(@gems, {})
+      Injector.remove(@gems, {})
 
       # Remove gems from .bundle if install flag is specified
       Installer.install(Bundler.root, Bundler.definition) if @options["install"]
-
-      # print success for removed gems
-      removed_deps.each {|dep| Bundler.ui.confirm "#{SharedHelpers.pretty_dependency(dep)} was removed." }
     end
   end
 end

--- a/lib/bundler/cli/remove.rb
+++ b/lib/bundler/cli/remove.rb
@@ -2,77 +2,21 @@
 
 module Bundler
   class CLI::Remove
-    def initialize(gems)
+    def initialize(gems, options)
       @gems = gems
-      @removed_deps = []
+      @options = options
     end
 
     def run
-      builder = Dsl.new
-      builder.eval_gemfile(Bundler.default_gemfile)
+      # Raise error if no gems are specified
+      raise InvalidOption, "Please specify gems to remove" if @gems.empty?
 
-      # store removed gems to display on successfull removal
-      @removed_deps = builder.remove_gems(@gems)
+      removed_deps = Injector.remove(@gems, {})
 
-      # remove gems from lockfile
-      @definition = builder.to_definition(Bundler.default_lockfile, {})
-      @definition.lock(Bundler.default_lockfile)
+      # Remove gems from .bundle if install flag is specified
+      Installer.install(Bundler.root, Bundler.definition) if @options["install"]
 
-      # remove those gems from the gemfile
-      remove_gems_from_gemfile
-
-      # TODO: Discuss about using this,
-      # currently gems are not removed from .bundle
-      # Installer.install(Bundler.root, Bundler.definition)
-
-      display_removed_gems
-    end
-
-  private
-
-    def remove_gems_from_gemfile
-      # store patterns of all gems to be removed
-      patterns = []
-      @gems.each do |g|
-        patterns << /gem "#{g}"/
-      end
-
-      # create a union of patterns to match any of them
-      re = Regexp.union(patterns)
-
-      lines = ""
-      group = false
-      whole_group = ""
-      inside_group = ""
-      IO.readlines(Bundler.default_gemfile).map do |line|
-        group = true if line =~ /group /
-
-        lines += line if !line.match(re) && !group
-
-        next unless group
-        whole_group += line unless line.match(re)
-
-        if line =~ /end/
-          group = false
-        elsif line !~ /group /
-          inside_group += line unless line.match(re)
-        end
-
-        next unless inside_group =~ /gem / && !group
-        lines += whole_group
-        inside_group = ""
-        whole_group = ""
-      end
-
-      File.open(Bundler.default_gemfile, "w") do |file|
-        file.puts lines
-      end
-    end
-
-    def display_removed_gems
-      @removed_deps.each do |dep|
-        Bundler.ui.confirm "#{dep.name}(#{dep.requirement}) was removed."
-      end
+      removed_deps.each {|dep| Bundler.ui.confirm "#{dep.name}(#{dep.requirement}) was removed." }
     end
   end
 end

--- a/lib/bundler/cli/remove.rb
+++ b/lib/bundler/cli/remove.rb
@@ -10,7 +10,6 @@ module Bundler
     def run
       raise InvalidOption, "Please specify gems to remove." if @gems.empty?
 
-      # remove requested gems
       Injector.remove(@gems, {})
 
       Installer.install(Bundler.root, Bundler.definition) if @options["install"]

--- a/lib/bundler/cli/remove.rb
+++ b/lib/bundler/cli/remove.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Bundler
+  class CLI::Remove
+    def initialize(gem_name)
+      @gem_name = gem_name
+    end
+
+    def run
+      builder = Dsl.new
+      builder.eval_gemfile(Bundler.default_gemfile)
+
+      removed_dep = builder.remove_gem(@gem_name)
+
+      # resolve to see if the after removing dep broke anything
+      @definition = builder.to_definition(Bundler.default_lockfile, {})
+      @definition.resolve_remotely!
+
+      # since nothing broke, we can remove those gems from the gemfile
+      remove_gem_from_gemfile
+
+      # since we resolved successfully, write out the lockfile
+      @definition.lock(Bundler.default_lockfile)
+
+      # invalidate the cached Bundler.definition
+      Bundler.reset_paths!
+
+      Installer.install(Bundler.root, Bundler.definition)
+
+      Bundler.ui.confirm "#{removed_dep.name}(#{removed_dep.requirement}) was removed."
+    end
+
+  private
+
+    def remove_gem_from_gemfile
+      lines = ""
+      IO.readlines(Bundler.default_gemfile).map do |line|
+        lines += line unless line =~ /gem "#{@gem_name}"/
+      end
+
+      File.open(Bundler.default_gemfile, "w") do |file|
+        file.puts lines
+      end
+    end
+  end
+end

--- a/lib/bundler/cli/remove.rb
+++ b/lib/bundler/cli/remove.rb
@@ -35,10 +35,16 @@ module Bundler
   private
 
     def remove_gems_from_gemfile
+      patterns = []
+      @gems.each do |g|
+        patterns << /gem "#{g}"/
+      end
+
+      re = Regexp.union(patterns)
+
       lines = ""
       IO.readlines(Bundler.default_gemfile).map do |line|
-        # Todo: Do this for all gems
-        lines += line unless line =~ /gem "#{@gems[0]}"/
+        lines += line unless line.match(re)
       end
 
       File.open(Bundler.default_gemfile, "w") do |file|

--- a/lib/bundler/dependency.rb
+++ b/lib/bundler/dependency.rb
@@ -7,8 +7,7 @@ require "bundler/rubygems_ext"
 module Bundler
   class Dependency < Gem::Dependency
     attr_reader :autorequire
-    attr_reader :groups
-    attr_reader :platforms
+    attr_reader :groups, :platforms, :gemfile
 
     PLATFORM_MAP = {
       :ruby     => Gem::Platform::RUBY,
@@ -87,6 +86,7 @@ module Bundler
       @platforms      = Array(options["platforms"])
       @env            = options["env"]
       @should_include = options.fetch("should_include", true)
+      @gemfile        = options["gemfile"]
 
       @autorequire = Array(options["require"] || []) if options.key?("require")
     end

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -16,7 +16,7 @@ module Bundler
     VALID_PLATFORMS = Bundler::Dependency::PLATFORM_MAP.keys.freeze
 
     VALID_KEYS = %w[group groups git path glob name branch ref tag require submodules
-                    platform platforms type source install_if].freeze
+                    platform platforms type source install_if gemfile].freeze
 
     attr_reader :gemspecs
     attr_accessor :dependencies
@@ -93,6 +93,7 @@ module Bundler
 
     def gem(name, *args)
       options = args.last.is_a?(Hash) ? args.pop.dup : {}
+      options["gemfile"] = @gemfile
       version = args || [">= 0"]
 
       normalize_options(name, version, options)

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -91,17 +91,23 @@ module Bundler
       end
     end
 
-    def remove_gem(gem_name)
-      dep_to_remove = @dependencies.find {|d| d.name == gem_name }
+    def remove_gems(gems)
+      removed_deps = []
 
-      if dep_to_remove.nil?
-        raise GemfileError, "You cannot remove a gem which not specified in Gemfile.\n" \
-                          "#{gem_name} is not specified in Gemfile so not removed."
+      gems.each do |gem_name|
+        deleted_dep = @dependencies.find {|d| d.name == gem_name }
+
+        if deleted_dep.nil?
+          raise GemfileError, "You cannot remove a gem which not specified in Gemfile.\n" \
+                            "#{gem_name} is not specified in Gemfile so not removed."
+        end
+
+        @dependencies.delete(deleted_dep)
+
+        removed_deps << deleted_dep
       end
 
-      @dependencies.delete(dep_to_remove)
-
-      dep_to_remove
+      removed_deps
     end
 
     def gem(name, *args)

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -91,6 +91,19 @@ module Bundler
       end
     end
 
+    def remove_gem(gem_name)
+      dep_to_remove = @dependencies.find {|d| d.name == gem_name }
+
+      if dep_to_remove.nil?
+        raise GemfileError, "You cannot remove a gem which not specified in Gemfile.\n" \
+                          "#{gem_name} is not specified in Gemfile so not removed."
+      end
+
+      @dependencies.delete(dep_to_remove)
+
+      dep_to_remove
+    end
+
     def gem(name, *args)
       options = args.last.is_a?(Hash) ? args.pop.dup : {}
       version = args || [">= 0"]

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -99,7 +99,7 @@ module Bundler
 
         if deleted_dep.nil?
           raise GemfileError, "You cannot remove a gem which not specified in Gemfile.\n" \
-                            "#{gem_name} is not specified in Gemfile so not removed."
+                            "`#{gem_name}` is not specified in Gemfile so not removed."
         end
 
         @dependencies.delete(deleted_dep)

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -91,25 +91,6 @@ module Bundler
       end
     end
 
-    def remove_gems(gems)
-      removed_deps = []
-
-      gems.each do |gem_name|
-        deleted_dep = @dependencies.find {|d| d.name == gem_name }
-
-        if deleted_dep.nil?
-          raise GemfileError, "You cannot remove a gem which not specified in Gemfile.\n" \
-                            "`#{gem_name}` is not specified in Gemfile so not removed."
-        end
-
-        @dependencies.delete(deleted_dep)
-
-        removed_deps << deleted_dep
-      end
-
-      removed_deps
-    end
-
     def gem(name, *args)
       options = args.last.is_a?(Hash) ? args.pop.dup : {}
       version = args || [">= 0"]

--- a/lib/bundler/injector.rb
+++ b/lib/bundler/injector.rb
@@ -67,15 +67,10 @@ module Bundler
 
       definition = builder.to_definition(lockfile_path, {})
 
+      # remove gems from each gemfiles we have
       definition.gemfiles.each do |path|
         # print success for removed gems
-        removed_deps = evaluate_gemfile(path)
-
-        if removed_deps.empty?
-          Bundler.ui.warn "No gems were removed."
-        else
-          removed_deps.each {|dep| Bundler.ui.confirm "#{SharedHelpers.pretty_dependency(dep, false, true)} was removed." }
-        end
+        evaluate_gemfile(path).each {|dep| Bundler.ui.confirm "#{SharedHelpers.pretty_dependency(dep, false, true)} was removed." }
       end
     end
 
@@ -131,9 +126,11 @@ module Bundler
     # evalutes a gemfile to remove the specified gem
     # from it.
     def evaluate_gemfile(gemfile_path)
-      # get initial gemfile snap shot
+      # get initial snap shot of the gemfile
       initial_gemfile = IO.readlines(gemfile_path)
 
+      # inform user of the the gemfile currently
+      # being evaluated
       Bundler.ui.info "Removing gems from #{gemfile_path}"
 
       # evaluate the Gemfile we have
@@ -170,11 +167,8 @@ module Bundler
         deleted_dep = builder.dependencies.find {|d| d.name == gem_name }
 
         if deleted_dep.nil?
-          # TODO: keeping this here yet needs to be discussed
-          # Bundler.ui.warn "`#{gem_name}` is not specified in Gemfile so not removed."
-          # return []
-          raise GemfileError, "You cannot remove a gem which not specified in Gemfile.\n" \
-                            "`#{gem_name}` is not specified in Gemfile so not removed."
+          Bundler.ui.warn "`#{gem_name}` is not specified in Gemfile so not removed."
+          return []
         end
 
         builder.dependencies.delete(deleted_dep)

--- a/lib/bundler/injector.rb
+++ b/lib/bundler/injector.rb
@@ -71,11 +71,21 @@ module Bundler
 
       remove_gems_from_gemfile(@new_deps, gemfile_path)
 
+      # evalute the new gemfile to look for any failure cases
+      builder2 = Dsl.new
+      builder2.eval_gemfile(Bundler.default_gemfile)
+
+      # record gems which could not be removed due to some reasons
+      errored_gems = builder2.dependencies & removed_deps
+
+      # warn user regarding those gems
+      Bundler.ui.warn "#{errored_gems.map(&:name).join(", ")} could not be removed." unless errored_gems.empty?
+
       # write out the lockfile
       @definition.lock(lockfile_path)
 
-      # return removed deps
-      removed_deps
+      # return actual removed deps
+      removed_deps - errored_gems
     end
 
   private

--- a/lib/bundler/injector.rb
+++ b/lib/bundler/injector.rb
@@ -139,7 +139,7 @@ module Bundler
 
       cleaned_gemfile = remove_gems_from_gemfile(@deps, gemfile_path)
 
-      write_to_gemfile(gemfile_path, cleaned_gemfile)
+      SharedHelpers.write_to_gemfile(gemfile_path, cleaned_gemfile)
 
       # check for errors
       # including extra gems being removed
@@ -191,12 +191,6 @@ module Bundler
       new_gemfile.join.chomp
     end
 
-    # @param [Pathname] gemfile_path  The Gemfile from which to remove dependencies.
-    # @param [String]  contents       Content to written to Gemfile.
-    def write_to_gemfile(gemfile_path, contents)
-      SharedHelpers.filesystem_access(gemfile_path) {|g| File.open(g, "w") {|file| file.puts contents } }
-    end
-
     # @param [Array] gemfile       Array of gemfile contents.
     # @param [String] block_name   Name of block name to look for.
     def remove_nested_blocks(gemfile, block_name)
@@ -235,7 +229,7 @@ module Bundler
       # if some extra gems were removed then raise error
       # and revert Gemfile to original
       unless extra_removed_gems.empty?
-        write_to_gemfile(gemfile_path, initial_gemfile.join)
+        SharedHelpers.write_to_gemfile(gemfile_path, initial_gemfile.join)
 
         raise InvalidOption, "Gems could not be removed. #{extra_removed_gems.join(", ")} would also have been removed. Bundler cannot continue."
       end

--- a/lib/bundler/injector.rb
+++ b/lib/bundler/injector.rb
@@ -69,7 +69,7 @@ module Bundler
 
       # remove gems from each gemfiles we have
       definition.gemfiles.each do |path|
-        deps = evaluate_gemfile(path)
+        deps = remove_deps(path)
 
         show_warning("No gems were removed from the gemfile.") if deps.empty?
 
@@ -128,7 +128,7 @@ module Bundler
 
     # evalutes a gemfile to remove the specified gem
     # from it.
-    def evaluate_gemfile(gemfile_path)
+    def remove_deps(gemfile_path)
       # get initial snap shot of the gemfile
       initial_gemfile = IO.readlines(gemfile_path)
 
@@ -170,8 +170,7 @@ module Bundler
         deleted_dep = builder.dependencies.find {|d| d.name == gem_name }
 
         if deleted_dep.nil?
-          show_warning "`#{gem_name}` is not specified in Gemfile so not removed."
-          next
+          raise GemfileError, "`#{gem_name}` is not specified in Gemfile so could not be removed."
         end
 
         builder.dependencies.delete(deleted_dep)
@@ -186,7 +185,7 @@ module Bundler
     # @param [Pathname] gemfile_path The Gemfile from which to remove dependencies.
     def remove_gems_from_gemfile(gems, gemfile_path)
       # store patterns of all gems to be removed
-      patterns = /gem\s+(['"])#{Regexp.union(gems)}\1|gem\((['"])#{Regexp.union(gems)}\2\)/
+      patterns = /gem\s+(['"])#{Regexp.union(gems)}\1|gem\s*\((['"])#{Regexp.union(gems)}\2\)/
 
       # remove lines which match the regex
       new_gemfile = IO.readlines(gemfile_path).reject {|line| line.match(patterns) }

--- a/lib/bundler/injector.rb
+++ b/lib/bundler/injector.rb
@@ -123,28 +123,22 @@ module Bundler
     # evalutes a gemfile to remove the specified gem
     # from it.
     def remove_deps(gemfile_path)
-      # get initial snap shot of the gemfile
       initial_gemfile = IO.readlines(gemfile_path)
 
-      # inform user of the the gemfile currently
-      # being evaluated
       Bundler.ui.info "Removing gems from #{gemfile_path}"
 
       # evaluate the Gemfile we have
       builder = Dsl.new
       builder.eval_gemfile(gemfile_path)
 
-      # remove gems from dependencies
       removed_deps = remove_gems_from_dependencies(builder, @deps, gemfile_path)
 
       # abort the opertion if no gems were removed
       # no need to operate on gemfile furthur
       return [] if removed_deps.empty?
 
-      # gemfile after removing requested gems
       cleaned_gemfile = remove_gems_from_gemfile(@deps, gemfile_path)
 
-      # write the new gemfile
       write_to_gemfile(gemfile_path, cleaned_gemfile)
 
       # check for errors
@@ -179,7 +173,6 @@ module Bundler
     # @param [Array] gems            Array of names of gems to be removed.
     # @param [Pathname] gemfile_path The Gemfile from which to remove dependencies.
     def remove_gems_from_gemfile(gems, gemfile_path)
-      # store patterns of all gems to be removed
       patterns = /gem\s+(['"])#{Regexp.union(gems)}\1|gem\s*\((['"])#{Regexp.union(gems)}\2\)/
 
       # remove lines which match the regex
@@ -193,7 +186,6 @@ module Bundler
         end
       end
 
-      # remove any empty (and nested) blocks
       %w[group source env install_if].each {|block| remove_nested_blocks(new_gemfile, block) }
 
       new_gemfile.join.chomp
@@ -251,7 +243,6 @@ module Bundler
       # record gems which could not be removed due to some reasons
       errored_deps = builder.dependencies.select {|d| d.gemfile == gemfile_path } & removed_deps.select {|d| d.gemfile == gemfile_path }
 
-      # warn user regarding those gems
       show_warning "#{errored_deps.map(&:name).join(", ")} could not be removed." unless errored_deps.empty?
 
       # return actual removed dependencies

--- a/lib/bundler/injector.rb
+++ b/lib/bundler/injector.rb
@@ -249,7 +249,7 @@ module Bundler
       end
 
       # record gems which could not be removed due to some reasons
-      errored_deps = builder.dependencies & removed_deps
+      errored_deps = builder.dependencies.select {|d| d.gemfile == gemfile_path } & removed_deps.select {|d| d.gemfile == gemfile_path }
 
       # warn user regarding those gems
       show_warning "#{errored_deps.map(&:name).join(", ")} could not be removed." unless errored_deps.empty?

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -195,13 +195,14 @@ module Bundler
         "\nEither installing with `--full-index` or running `bundle update #{spec.name}` should fix the problem."
     end
 
-    def pretty_dependency(dep, print_source = false)
+    def pretty_dependency(dep, print_source = false, print_requirements = false)
       msg = String.new(dep.name)
       msg << " (#{dep.requirement})" unless dep.requirement == Gem::Requirement.default
       if dep.is_a?(Bundler::Dependency)
         platform_string = dep.platforms.join(", ")
         msg << " " << platform_string if !platform_string.empty? && platform_string != Gem::Platform::RUBY
       end
+      msg << " (#{dep.requirement})" if print_requirements && dep.requirement
       msg << " from the `#{dep.source}` source" if print_source && dep.source
       msg
     end

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -197,12 +197,13 @@ module Bundler
 
     def pretty_dependency(dep, print_source = false, print_requirements = false)
       msg = String.new(dep.name)
-      msg << " (#{dep.requirement})" unless dep.requirement == Gem::Requirement.default
+      msg << " (#{dep.requirement})" if dep.requirement != Gem::Requirement.default || print_requirements
+
       if dep.is_a?(Bundler::Dependency)
         platform_string = dep.platforms.join(", ")
         msg << " " << platform_string if !platform_string.empty? && platform_string != Gem::Platform::RUBY
       end
-      msg << " (#{dep.requirement})" if print_requirements && dep.requirement
+
       msg << " from the `#{dep.source}` source" if print_source && dep.source
       msg
     end

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -226,6 +226,10 @@ module Bundler
       Digest(name)
     end
 
+    def write_to_gemfile(gemfile_path, contents)
+      filesystem_access(gemfile_path) {|g| File.open(g, "w") {|file| file.puts contents } }
+    end
+
   private
 
     def validate_bundle_path

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -195,9 +195,9 @@ module Bundler
         "\nEither installing with `--full-index` or running `bundle update #{spec.name}` should fix the problem."
     end
 
-    def pretty_dependency(dep, print_source = false, print_requirements = false)
+    def pretty_dependency(dep, print_source = false)
       msg = String.new(dep.name)
-      msg << " (#{dep.requirement})" if dep.requirement != Gem::Requirement.default || print_requirements
+      msg << " (#{dep.requirement})" unless dep.requirement == Gem::Requirement.default
 
       if dep.is_a?(Bundler::Dependency)
         platform_string = dep.platforms.join(", ")

--- a/man/bundle-remove.ronn
+++ b/man/bundle-remove.ronn
@@ -1,0 +1,16 @@
+bundle-remove(1) -- Removes gem specified in Gemfile
+===========================================================================
+
+## SYNOPSIS
+
+`bundle remove [GEMS]`
+
+## DESCRIPTION
+
+Removes a set of specified gems.
+
+Example:
+
+bundle remove rails
+
+bundle remove rails rack

--- a/man/bundle-remove.ronn
+++ b/man/bundle-remove.ronn
@@ -14,7 +14,7 @@ If gem could not be removed due to any reason Bundler warns the user.
 ## OPTIONS
 
 * `--install`:
-  Remove gems from bundle.
+  Runs 'bundle install' after removing the gems from the gemfile.
 
 Example:
 

--- a/man/bundle-remove.ronn
+++ b/man/bundle-remove.ronn
@@ -7,14 +7,14 @@ bundle-remove(1) -- Removes gem specified in Gemfile
 
 ## DESCRIPTION
 
-Removes a set of specified gems from the Gemfile or if needed from the bundle itself.
+Removes a set of specified gems from the Gemfile or if needed runs `bundle install` and removes them from bundle as well.
 If any gem specified to be removed does not exist the in Gemfile, Bundler prints error message.
-If gem could not be removed due to any reason Bundler warns the user.
+If the gem could not be removed due to any reason, Bundler warns the user.
 
 ## OPTIONS
 
 * `--install`:
-  Runs 'bundle install' after removing the gems from the gemfile.
+  Runs 'bundle install' after removing the gems from the gemfile. This option sync the lockfile.
 
 Example:
 

--- a/man/bundle-remove.ronn
+++ b/man/bundle-remove.ronn
@@ -3,14 +3,23 @@ bundle-remove(1) -- Removes gem specified in Gemfile
 
 ## SYNOPSIS
 
-`bundle remove [GEMS]`
+`bundle remove [GEMS] [--install]`
 
 ## DESCRIPTION
 
-Removes a set of specified gems.
+Removes a set of specified gems from Gemfile or if needed from the bundle itself.
+If any gem specified to be removed does not exist the in Gemfile, Bundler prints error message.
+If gem could not be removed due to any reason Bundler warns the user.
+
+## OPTIONS
+
+* `--install`:
+  Remove gems from bundle.
 
 Example:
 
 bundle remove rails
 
 bundle remove rails rack
+
+bundle remove rails rack --install

--- a/man/bundle-remove.ronn
+++ b/man/bundle-remove.ronn
@@ -7,7 +7,7 @@ bundle-remove(1) -- Removes gem specified in Gemfile
 
 ## DESCRIPTION
 
-Removes a set of specified gems from Gemfile or if needed from the bundle itself.
+Removes a set of specified gems from the Gemfile or if needed from the bundle itself.
 If any gem specified to be removed does not exist the in Gemfile, Bundler prints error message.
 If gem could not be removed due to any reason Bundler warns the user.
 

--- a/man/bundle-remove.ronn
+++ b/man/bundle-remove.ronn
@@ -1,20 +1,18 @@
-bundle-remove(1) -- Removes gem specified in Gemfile
+bundle-remove(1) -- Removes gems from the Gemfile
 ===========================================================================
 
 ## SYNOPSIS
 
-`bundle remove [GEMS] [--install]`
+`bundle remove [GEM [GEM ...]] [--install]`
 
 ## DESCRIPTION
 
-Removes a set of specified gems from the Gemfile or if needed runs `bundle install` and removes them from bundle as well.
-If any gem specified to be removed does not exist the in Gemfile, Bundler prints error message.
-If the gem could not be removed due to any reason, Bundler warns the user.
+Removes the given gems from the Gemfile while ensuring that the resulting Gemfile is still valid. If a gem cannot be removed, a warning is printed. If a gem is already absent from the Gemfile, and error is raised.
 
 ## OPTIONS
 
 * `--install`:
-  Runs 'bundle install' after removing the gems from the gemfile. This option sync the lockfile.
+  Runs `bundle install` after the given gems have been removed from the Gemfile, which ensures that both the lockfile and the installed gems on disk are also updated to remove the given gem(s).
 
 Example:
 

--- a/spec/commands/remove_spec.rb
+++ b/spec/commands/remove_spec.rb
@@ -1,38 +1,57 @@
 # frozen_string_literal: true
 
-RSpec.describe "bundle remove", :focus do
-  context "remove a specific gem from gemfile when gem is present in gemfile" do
-    before do
-      install_gemfile <<-G
+RSpec.describe "bundle remove" do
+  context "remove a single gem from gemfile" do
+    it "when gem is present in gemfile" do
+      gemfile <<-G
         source "file://#{gem_repo1}"
-        gem "rails"
+
         gem "rack"
       G
-    end
 
-    it "removes successfully" do
       bundle "remove rack"
+
+      expect(gemfile).to_not match(/gem "rack"/)
       expect(out).to include("rack(>= 0) was removed.")
     end
 
-    it "displays warning that gemfile is empty when removing last gem" do
-      bundle "remove rails"
+    it "when gem is not present in gemfile" do
+      gemfile <<-G
+        source "file://#{gem_repo1}"
+      G
+
       bundle "remove rack"
-      expect(out).to include("rack(>= 0) was removed.")
-      expect(out).to include("The Gemfile specifies no dependencies")
+
+      expect(out).to include("You cannot remove a gem which not specified in Gemfile.")
+      expect(out).to include("rack is not specified in Gemfile so not removed.")
     end
   end
 
-  context "remove a specific gem from gemfile when gem is not present in gemfile" do
-    before do
-      install_gemfile <<-G
+  context "remove mutiple gems from gemfile" do
+    it "when all gems are present in gemfile" do
+      gemfile <<-G
         source "file://#{gem_repo1}"
+
+        gem "rack"
         gem "rails"
       G
+
+      bundle "remove rack rails"
+
+      expect(gemfile).to_not match(/gem "rack"/)
+      expect(gemfile).to_not match(/gem "rails"/)
+      expect(out).to include("rack(>= 0) was removed.")
+      expect(out).to include("rails(>= 0) was removed.")
     end
 
-    it "throws error" do
-      bundle "remove rack"
+    it "when a gem is not present in gemfile" do
+      gemfile <<-G
+        source "file://#{gem_repo1}"
+
+        gem "rails"
+      G
+
+      bundle "remove rack rails"
       expect(out).to include("You cannot remove a gem which not specified in Gemfile.")
       expect(out).to include("rack is not specified in Gemfile so not removed.")
     end

--- a/spec/commands/remove_spec.rb
+++ b/spec/commands/remove_spec.rb
@@ -262,7 +262,7 @@ RSpec.describe "bundle remove" do
 
   describe "arbitrary gemfile" do
     context "when mutiple gems are present in same line" do
-      it "does not removes the gem" do
+      it "shows warning for gems not removed" do
         install_gemfile <<-G
           source "file://#{gem_repo1}"
           gem "rack"; gem "rails"
@@ -270,10 +270,33 @@ RSpec.describe "bundle remove" do
 
         bundle "remove rails"
 
-        expect(out).to include("The specified gem could not be removed.")
+        expect(out).to include("rails could not be removed.")
         gemfile_should_be <<-G
           source "file://#{gem_repo1}"
           gem "rack"; gem "rails"
+        G
+      end
+    end
+
+    context "when some gems could not be removed" do
+      it "shows warning for gems not removed and success for those removed" do
+        install_gemfile <<-G
+          source "file://#{gem_repo1}"
+          gem"rack"
+          gem"rspec"
+          gem "rails"
+          gem "minitest"
+        G
+
+        bundle "remove rails rack rspec minitest"
+
+        expect(out).to include("rails was removed.")
+        expect(out).to include("minitest was removed.")
+        expect(out).to include("rack, rspec could not be removed.")
+        gemfile_should_be <<-G
+          source "file://#{gem_repo1}"
+          gem"rack"
+          gem"rspec"
         G
       end
     end

--- a/spec/commands/remove_spec.rb
+++ b/spec/commands/remove_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe "bundle remove" do
           gem "rack"
         G
 
-        expected_gemfile = "source \"file://#{gem_repo1}\"\n"
-
         bundle! "remove rack"
 
-        expect(gemfile).to eq(expected_gemfile)
-        expect(out).to include("rack(>= 0) was removed.")
+        expect(out).to include("rack was removed.")
+        gemfile_should_be <<-G
+          source "file://#{gem_repo1}"
+        G
       end
 
       it "when gem is not present in gemfile" do
@@ -39,13 +39,13 @@ RSpec.describe "bundle remove" do
           gem "rails"
         G
 
-        expected_gemfile = "source \"file://#{gem_repo1}\"\n"
-
         bundle! "remove rack rails"
 
-        expect(gemfile).to eq(expected_gemfile)
-        expect(out).to include("rack(>= 0) was removed.")
-        expect(out).to include("rails(>= 0) was removed.")
+        expect(out).to include("rack was removed.")
+        expect(out).to include("rails was removed.")
+        gemfile_should_be <<-G
+          source "file://#{gem_repo1}"
+        G
       end
 
       it "when a gem is not present in gemfile" do
@@ -71,12 +71,12 @@ RSpec.describe "bundle remove" do
           gem "rack", :group => [:dev]
         G
 
-        expected_gemfile = "source \"file://#{gem_repo1}\"\n"
-
         bundle! "remove rack"
 
-        expect(gemfile).to eq(expected_gemfile)
-        expect(out).to include("rack(>= 0) was removed.")
+        expect(out).to include("rack was removed.")
+        gemfile_should_be <<-G
+          source "file://#{gem_repo1}"
+        G
       end
     end
 
@@ -90,12 +90,12 @@ RSpec.describe "bundle remove" do
           end
         G
 
-        expected_gemfile = "source \"file://#{gem_repo1}\"\n"
-
         bundle! "remove rspec"
 
-        expect(gemfile).to eq(expected_gemfile)
-        expect(out).to include("rspec(>= 0) was removed.")
+        expect(out).to include("rspec was removed.")
+        gemfile_should_be <<-G
+          source "file://#{gem_repo1}"
+        G
       end
 
       it "when any other empty block is also present" do
@@ -110,12 +110,12 @@ RSpec.describe "bundle remove" do
           end
         G
 
-        expected_gemfile = "source \"file://#{gem_repo1}\"\n"
-
         bundle! "remove rspec"
 
-        expect(gemfile).to eq(expected_gemfile)
-        expect(out).to include("rspec(>= 0) was removed.")
+        expect(out).to include("rspec was removed.")
+        gemfile_should_be <<-G
+          source "file://#{gem_repo1}"
+        G
       end
     end
 
@@ -129,12 +129,12 @@ RSpec.describe "bundle remove" do
           end
         G
 
-        expected_gemfile = "source \"file://#{gem_repo1}\"\n"
-
         bundle! "remove rspec"
 
-        expect(gemfile).to eq(expected_gemfile)
-        expect(out).to include("rspec(>= 0) was removed.")
+        expect(out).to include("rspec was removed.")
+        gemfile_should_be <<-G
+          source "file://#{gem_repo1}"
+        G
       end
 
       it "gem is present in mutiple groups" do
@@ -150,12 +150,12 @@ RSpec.describe "bundle remove" do
           end
         G
 
-        expected_gemfile = "source \"file://#{gem_repo1}\"\n"
-
         bundle! "remove rspec"
 
-        expect(gemfile).to eq(expected_gemfile)
-        expect(out).to include("rspec(>= 0) was removed.")
+        expect(out).to include("rspec was removed.")
+        gemfile_should_be <<-G
+          source "file://#{gem_repo1}"
+        G
       end
     end
 
@@ -171,12 +171,12 @@ RSpec.describe "bundle remove" do
           end
         G
 
-        expected_gemfile = "source \"file://#{gem_repo1}\"\n"
-
         bundle! "remove rspec"
 
-        expect(gemfile).to eq(expected_gemfile)
-        expect(out).to include("rspec(>= 0) was removed.")
+        expect(out).to include("rspec was removed.")
+        gemfile_should_be <<-G
+          source "file://#{gem_repo1}"
+        G
       end
 
       it "when outer group will not be empty after removal" do
@@ -192,15 +192,17 @@ RSpec.describe "bundle remove" do
           end
         G
 
-        expected_gemfile = "source \"file://#{gem_repo1}\"\n\n" \
-                        "group :test do\n" \
-                        "  gem \"rack-test\"\n\n" \
-                        "end\n"
-
         bundle! "remove rspec"
 
-        expect(gemfile).to eq(expected_gemfile)
-        expect(out).to include("rspec(>= 0) was removed.")
+        expect(out).to include("rspec was removed.")
+        gemfile_should_be <<-G
+          source "file://#{gem_repo1}"
+
+          group :test do
+            gem "rack-test"
+
+          end
+        G
       end
 
       it "when inner group will not be empty after removal" do
@@ -215,17 +217,18 @@ RSpec.describe "bundle remove" do
           end
         G
 
-        expected_gemfile = "source \"file://#{gem_repo1}\"\n\n" \
-                        "group :test do\n" \
-                        "  group :serioustest do\n" \
-                        "    gem \"rack-test\"\n" \
-                        "  end\n" \
-                        "end\n"
-
         bundle! "remove rspec"
 
-        expect(gemfile).to eq(expected_gemfile)
-        expect(out).to include("rspec(>= 0) was removed.")
+        expect(out).to include("rspec was removed.")
+        gemfile_should_be <<-G
+          source "file://#{gem_repo1}"
+
+          group :test do
+            group :serioustest do
+              gem "rack-test"
+            end
+          end
+        G
       end
     end
   end
@@ -238,13 +241,13 @@ RSpec.describe "bundle remove" do
           gem "rack"; gem "rails"
         G
 
-        expected_gemfile = "source \"file://#{gem_repo1}\"\n\n" \
-                        "gem \"rack\"; gem \"rails\"\n"
-
         bundle "remove rails"
 
-        expect(gemfile).to eq(expected_gemfile)
         expect(out).to include("The specified gem could not be removed.")
+        gemfile_should_be <<-G
+          source "file://#{gem_repo1}"
+          gem "rack"; gem "rails"
+        G
       end
     end
   end
@@ -269,13 +272,14 @@ RSpec.describe "bundle remove" do
 
       bundle! "install"
 
-      expected_gemfile = "source \"file://#{gem_repo1}\"\n\n" \
-                      "gem \"rack\"\n"
-
       bundle! "remove rspec"
 
-      expect(gemfile).to eq(expected_gemfile)
-      expect(out).to include("rspec(>= 0) was removed.")
+      expect(out).to include("rspec was removed.")
+      gemfile_should_be <<-G
+        source "file://#{gem_repo1}"
+
+        gem "rack"
+      G
     end
   end
 
@@ -294,7 +298,7 @@ RSpec.describe "bundle remove" do
       bundle! "remove rack"
 
       expect(bundled_app("Gemfile-other").read).to_not include("gem \"rack\"")
-      expect(out).to include("rack(>= 0) was removed.")
+      expect(out).to include("rack was removed.")
     end
   end
 
@@ -308,12 +312,12 @@ RSpec.describe "bundle remove" do
         end
       G
 
-      expected_gemfile = "source \"file://#{gem_repo1}\"\n"
-
       bundle! "remove rack"
 
-      expect(gemfile).to eq(expected_gemfile)
-      expect(out).to include("rack(>= 0) was removed.")
+      expect(out).to include("rack was removed.")
+      gemfile_should_be <<-G
+        source "file://#{gem_repo1}"
+      G
     end
   end
 
@@ -327,12 +331,12 @@ RSpec.describe "bundle remove" do
         end
       G
 
-      expected_gemfile = "source \"file://#{gem_repo1}\"\n"
-
       bundle! "remove rack"
 
-      expect(gemfile).to eq(expected_gemfile)
-      expect(out).to include("rack(>= 0) was removed.")
+      expect(out).to include("rack was removed.")
+      gemfile_should_be <<-G
+        source "file://#{gem_repo1}"
+      G
     end
   end
 end

--- a/spec/commands/remove_spec.rb
+++ b/spec/commands/remove_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.describe "bundle remove", :focus do
+  context "remove a specific gem from gemfile when gem is present in gemfile" do
+    before do
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem "rails"
+        gem "rack"
+      G
+    end
+
+    it "removes successfully" do
+      bundle "remove rack"
+      expect(out).to include("rack(>= 0) was removed.")
+    end
+
+    it "displays warning that gemfile is empty when removing last gem" do
+      bundle "remove rails"
+      bundle "remove rack"
+      expect(out).to include("rack(>= 0) was removed.")
+      expect(out).to include("The Gemfile specifies no dependencies")
+    end
+  end
+
+  context "remove a specific gem from gemfile when gem is not present in gemfile" do
+    before do
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem "rails"
+      G
+    end
+
+    it "throws error" do
+      bundle "remove rack"
+      expect(out).to include("You cannot remove a gem which not specified in Gemfile.")
+      expect(out).to include("rack is not specified in Gemfile so not removed.")
+    end
+  end
+end

--- a/spec/commands/remove_spec.rb
+++ b/spec/commands/remove_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "bundle remove", :focus do
+RSpec.describe "bundle remove" do
   context "when no gems are specified" do
     it "throws error" do
       gemfile <<-G

--- a/spec/commands/remove_spec.rb
+++ b/spec/commands/remove_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "bundle remove" do
 
       bundle! "remove rack --install"
 
-      expect(out).to include("rack (>= 0) was removed.")
+      expect(out).to include("rack was removed.")
       expect(the_bundle).to_not include_gems "rack"
     end
   end
@@ -39,7 +39,7 @@ RSpec.describe "bundle remove" do
 
         bundle! "remove rack"
 
-        expect(out).to include("rack (>= 0) was removed.")
+        expect(out).to include("rack was removed.")
         gemfile_should_be <<-G
           source "file://#{gem_repo1}"
         G
@@ -54,7 +54,7 @@ RSpec.describe "bundle remove" do
 
         bundle "remove rack"
 
-        expect(out).to include("`rack` is not specified in Gemfile so could not be removed.")
+        expect(out).to include("`rack` is not specified in #{bundled_app("Gemfile")} so it could not be removed.")
       end
     end
   end
@@ -71,8 +71,8 @@ RSpec.describe "bundle remove" do
 
         bundle! "remove rack rails"
 
-        expect(out).to include("rack (>= 0) was removed.")
-        expect(out).to include("rails (>= 0) was removed.")
+        expect(out).to include("rack was removed.")
+        expect(out).to include("rails was removed.")
         gemfile_should_be <<-G
         source "file://#{gem_repo1}"
         G
@@ -91,7 +91,7 @@ RSpec.describe "bundle remove" do
 
         bundle "remove rails rack minitest"
 
-        expect(out).to include("`rack` is not specified in Gemfile so could not be removed.")
+        expect(out).to include("`rack` is not specified in #{bundled_app("Gemfile")} so it could not be removed.")
         gemfile_should_be <<-G
           source "file://#{gem_repo1}"
 
@@ -113,7 +113,7 @@ RSpec.describe "bundle remove" do
 
       bundle! "remove rack"
 
-      expect(out).to include("rack (>= 0) was removed.")
+      expect(out).to include("rack was removed.")
       gemfile_should_be <<-G
         source "file://#{gem_repo1}"
       G
@@ -133,7 +133,7 @@ RSpec.describe "bundle remove" do
 
         bundle! "remove rspec"
 
-        expect(out).to include("rspec (>= 0) was removed.")
+        expect(out).to include("rspec was removed.")
         gemfile_should_be <<-G
           source "file://#{gem_repo1}"
         G
@@ -155,7 +155,7 @@ RSpec.describe "bundle remove" do
 
         bundle! "remove rspec"
 
-        expect(out).to include("rspec (>= 0) was removed.")
+        expect(out).to include("rspec was removed.")
         gemfile_should_be <<-G
           source "file://#{gem_repo1}"
         G
@@ -174,7 +174,7 @@ RSpec.describe "bundle remove" do
 
         bundle! "remove rspec"
 
-        expect(out).to include("rspec (>= 0) was removed.")
+        expect(out).to include("rspec was removed.")
         gemfile_should_be <<-G
           source "file://#{gem_repo1}"
         G
@@ -197,7 +197,7 @@ RSpec.describe "bundle remove" do
 
         bundle! "remove rspec"
 
-        expect(out).to include("rspec (>= 0) was removed.")
+        expect(out).to include("rspec was removed.")
         gemfile_should_be <<-G
           source "file://#{gem_repo1}"
         G
@@ -220,7 +220,7 @@ RSpec.describe "bundle remove" do
 
         bundle! "remove rspec"
 
-        expect(out).to include("rspec (>= 0) was removed.")
+        expect(out).to include("rspec was removed.")
         gemfile_should_be <<-G
           source "file://#{gem_repo1}"
         G
@@ -243,7 +243,7 @@ RSpec.describe "bundle remove" do
 
         bundle! "remove rspec"
 
-        expect(out).to include("rspec (>= 0) was removed.")
+        expect(out).to include("rspec was removed.")
         gemfile_should_be <<-G
           source "file://#{gem_repo1}"
 
@@ -270,7 +270,7 @@ RSpec.describe "bundle remove" do
 
         bundle! "remove rspec"
 
-        expect(out).to include("rspec (>= 0) was removed.")
+        expect(out).to include("rspec was removed.")
         gemfile_should_be <<-G
           source "file://#{gem_repo1}"
 
@@ -294,7 +294,7 @@ RSpec.describe "bundle remove" do
 
         bundle "remove rails"
 
-        expect(out).to include("Gems could not be removed.")
+        expect(out).to include("Gems could not be removed. rack (>= 0) would also have been removed.")
         gemfile_should_be <<-G
           source "file://#{gem_repo1}"
           gem "rack"; gem "rails"
@@ -314,8 +314,8 @@ RSpec.describe "bundle remove" do
 
         bundle! "remove rails rack rspec minitest"
 
-        expect(out).to include("rails (>= 0) was removed.")
-        expect(out).to include("minitest (>= 0) was removed.")
+        expect(out).to include("rails was removed.")
+        expect(out).to include("minitest was removed.")
         expect(out).to include("rack, rspec could not be removed.")
         gemfile_should_be <<-G
           source "file://#{gem_repo1}"
@@ -348,7 +348,7 @@ RSpec.describe "bundle remove" do
 
       bundle! "remove rspec"
 
-      expect(out).to include("rspec (>= 0) was removed.")
+      expect(out).to include("rspec was removed.")
       gemfile_should_be <<-G
         source "file://#{gem_repo1}"
 
@@ -374,7 +374,7 @@ RSpec.describe "bundle remove" do
 
         bundle! "remove rack"
 
-        expect(out).to include("rack (>= 0) was removed.")
+        expect(out).to include("rack was removed.")
       end
     end
 
@@ -393,7 +393,7 @@ RSpec.describe "bundle remove" do
         bundle! "remove rack"
 
         expect(bundled_app("Gemfile-other").read).to_not include("gem \"rack\"")
-        expect(out).to include("rack (>= 0) was removed.")
+        expect(out).to include("rack was removed.")
       end
     end
 
@@ -412,7 +412,7 @@ RSpec.describe "bundle remove" do
 
         bundle "remove rack"
 
-        expect(out).to include("`rack` is not specified in Gemfile so could not be removed.")
+        expect(out).to include("`rack` is not specified in #{bundled_app("Gemfile")} so it could not be removed.")
       end
     end
 
@@ -431,8 +431,8 @@ RSpec.describe "bundle remove" do
 
         bundle "remove rack"
 
-        expect(out).to include("rack (>= 0) was removed.")
-        expect(out).to include("`rack` is not specified in Gemfile so could not be removed.")
+        expect(out).to include("rack was removed.")
+        expect(out).to include("`rack` is not specified in #{bundled_app("Gemfile-other")} so it could not be removed.")
         gemfile_should_be <<-G
           source "file://#{gem_repo1}"
 
@@ -456,8 +456,8 @@ RSpec.describe "bundle remove" do
 
         bundle "remove rack"
 
-        expect(out).to include("rack could not be removed.")
-        expect(out).to include("Gems could not be removed")
+        expect(out).to include("rack was removed.")
+        expect(out).to include("Gems could not be removed. rails (>= 0) would also have been removed.")
         gemfile_should_be <<-G
           source "file://#{gem_repo1}"
 
@@ -481,7 +481,7 @@ RSpec.describe "bundle remove" do
 
         bundle "remove rack"
 
-        expect(out).to include("Gems could not be removed.")
+        expect(out).to include("Gems could not be removed. rails (>= 0) would also have been removed.")
         expect(bundled_app("Gemfile-other").read).to include("gem \"rack\"")
         gemfile_should_be <<-G
           source "file://#{gem_repo1}"
@@ -507,7 +507,7 @@ RSpec.describe "bundle remove" do
 
         bundle! "remove rack"
 
-        expect(out).to include("rack could not be removed.")
+        expect(out).to include("rack was removed.")
         expect(bundled_app("Gemfile-other").read).to_not include("gem \"rack\"")
       end
     end
@@ -525,7 +525,7 @@ RSpec.describe "bundle remove" do
 
       bundle! "remove rack"
 
-      expect(out).to include("rack (>= 0) was removed.")
+      expect(out).to include("rack was removed.")
       gemfile_should_be <<-G
         source "file://#{gem_repo1}"
       G
@@ -544,7 +544,7 @@ RSpec.describe "bundle remove" do
 
       bundle! "remove rack"
 
-      expect(out).to include("rack (>= 0) was removed.")
+      expect(out).to include("rack was removed.")
       gemfile_should_be <<-G
         source "file://#{gem_repo1}"
       G

--- a/spec/commands/remove_spec.rb
+++ b/spec/commands/remove_spec.rb
@@ -268,7 +268,7 @@ RSpec.describe "bundle remove" do
           gem "rack"; gem "rails"
         G
 
-        bundle "remove rails"
+        bundle! "remove rails"
 
         expect(out).to include("rails could not be removed.")
         gemfile_should_be <<-G
@@ -288,7 +288,7 @@ RSpec.describe "bundle remove" do
           gem "minitest"
         G
 
-        bundle "remove rails rack rspec minitest"
+        bundle! "remove rails rack rspec minitest"
 
         expect(out).to include("rails was removed.")
         expect(out).to include("minitest was removed.")

--- a/spec/commands/remove_spec.rb
+++ b/spec/commands/remove_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "bundle remove" do
           gem "rack"
         G
 
-      bundle "remove rack --install"
+      bundle! "remove rack --install"
 
       expect(out).to include("rack was removed.")
       expect(the_bundle).to_not include_gems "rack"
@@ -391,12 +391,20 @@ RSpec.describe "bundle remove" do
   end
 
   context "with gemspec" do
-    it "" do
-      install_gemfile <<-G
+    it "should not remove the gem" do
+      build_lib("foo", :path => tmp.join("foo")) do |s|
+        s.write("foo.gemspec", "")
+        s.add_dependency "rack"
+      end
+
+      install_gemfile(<<-G)
         source "file://#{gem_repo1}"
-
-
+        gemspec :path => '#{tmp.join("foo")}', :name => 'foo'
       G
+
+      bundle! "remove foo"
+
+      expect(out).to include("foo could not be removed.")
     end
   end
 end

--- a/spec/commands/remove_spec.rb
+++ b/spec/commands/remove_spec.rb
@@ -268,9 +268,9 @@ RSpec.describe "bundle remove" do
           gem "rack"; gem "rails"
         G
 
-        bundle! "remove rails"
+        bundle "remove rails"
 
-        expect(out).to include("rails could not be removed.")
+        expect(out).to include("Gems could not be removed.")
         gemfile_should_be <<-G
           source "file://#{gem_repo1}"
           gem "rack"; gem "rails"

--- a/spec/commands/remove_spec.rb
+++ b/spec/commands/remove_spec.rb
@@ -56,4 +56,22 @@ RSpec.describe "bundle remove" do
       expect(out).to include("rack is not specified in Gemfile so not removed.")
     end
   end
+
+  context "removes empty block on removal of all gems from it" do
+    it "when a gem is present in gemfile" do
+      gemfile <<-G
+        source "file://#{gem_repo1}"
+
+        group :test do
+          gem "minitest"
+        end
+      G
+
+      bundle "remove minitest"
+
+      expect(gemfile).to_not match(/group :test do/)
+      expect(gemfile).to_not match(/gem "minitest"/)
+      expect(out).to include("minitest(>= 0) was removed.")
+    end
+  end
 end

--- a/spec/commands/remove_spec.rb
+++ b/spec/commands/remove_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "bundle remove" do
   end
 
   context "removes empty block on removal of all gems from it" do
-    it "when a gem is present in gemfile" do
+    it "when single block with gem is present" do
       gemfile <<-G
         source "file://#{gem_repo1}"
 
@@ -71,6 +71,27 @@ RSpec.describe "bundle remove" do
 
       expect(gemfile).to_not match(/group :test do/)
       expect(gemfile).to_not match(/gem "minitest"/)
+      expect(out).to include("minitest(>= 0) was removed.")
+    end
+
+    it "when any other empty block is also present" do
+      gemfile <<-G
+        source "file://#{gem_repo1}"
+
+        group :test do
+          gem "minitest"
+        end
+
+        group :dev do
+
+        end
+      G
+
+      bundle "remove minitest"
+
+      expect(gemfile).to_not match(/group :test do/)
+      expect(gemfile).to_not match(/gem "minitest"/)
+      expect(gemfile).to_not match(/group :dev do/)
       expect(out).to include("minitest(>= 0) was removed.")
     end
   end

--- a/spec/commands/remove_spec.rb
+++ b/spec/commands/remove_spec.rb
@@ -1,6 +1,33 @@
 # frozen_string_literal: true
 
 RSpec.describe "bundle remove" do
+  context "when no gems are specified" do
+    it "throws error" do
+      gemfile <<-G
+          source "file://#{gem_repo1}"
+        G
+
+      bundle "remove"
+
+      expect(out).to include("Please specify gems to remove.")
+    end
+  end
+
+  context "when --install flag is specified" do
+    it "removes gems from .bundle" do
+      gemfile <<-G
+          source "file://#{gem_repo1}"
+
+          gem "rack"
+        G
+
+      bundle "remove rack --install"
+
+      expect(out).to include("rack was removed.")
+      expect(the_bundle).to_not include_gems "rack"
+    end
+  end
+
   describe "basic gemfile" do
     context "remove single gem from gemfile" do
       it "when gem is present in gemfile" do
@@ -336,6 +363,16 @@ RSpec.describe "bundle remove" do
       expect(out).to include("rack was removed.")
       gemfile_should_be <<-G
         source "file://#{gem_repo1}"
+      G
+    end
+  end
+
+  context "with gemspec" do
+    it "" do
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+
+
       G
     end
   end

--- a/spec/commands/remove_spec.rb
+++ b/spec/commands/remove_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-RSpec.describe "bundle remove" do
+RSpec.describe "bundle remove", :focus do
   context "when no gems are specified" do
     it "throws error" do
       gemfile <<-G
-          source "file://#{gem_repo1}"
-        G
+        source "file://#{gem_repo1}"
+      G
 
       bundle "remove"
 
@@ -16,10 +16,10 @@ RSpec.describe "bundle remove" do
   context "when --install flag is specified" do
     it "removes gems from .bundle" do
       gemfile <<-G
-          source "file://#{gem_repo1}"
+        source "file://#{gem_repo1}"
 
-          gem "rack"
-        G
+        gem "rack"
+      G
 
       bundle! "remove rack --install"
 
@@ -28,9 +28,9 @@ RSpec.describe "bundle remove" do
     end
   end
 
-  describe "basic gemfile" do
-    context "remove single gem from gemfile" do
-      it "when gem is present in gemfile" do
+  describe "remove single gem from gemfile" do
+    context "when gem is present in gemfile" do
+      it "shows success for removed gem" do
         gemfile <<-G
           source "file://#{gem_repo1}"
 
@@ -44,8 +44,10 @@ RSpec.describe "bundle remove" do
           source "file://#{gem_repo1}"
         G
       end
+    end
 
-      it "when gem is not present in gemfile" do
+    context "when gem is not present in gemfile" do
+      it "shows warning for gem that could not be removed" do
         gemfile <<-G
           source "file://#{gem_repo1}"
         G
@@ -53,11 +55,14 @@ RSpec.describe "bundle remove" do
         bundle! "remove rack"
 
         expect(out).to include("`rack` is not specified in Gemfile so not removed.")
+        expect(out).to include("No gems were removed from the gemfile")
       end
     end
+  end
 
-    context "remove mutiple gems from gemfile" do
-      it "when all gems are present in gemfile" do
+  describe "remove mutiple gems from gemfile" do
+    context "when all gems are present in gemfile" do
+      it "shows success fir all removed gems" do
         gemfile <<-G
           source "file://#{gem_repo1}"
 
@@ -70,43 +75,54 @@ RSpec.describe "bundle remove" do
         expect(out).to include("rack (>= 0) was removed.")
         expect(out).to include("rails (>= 0) was removed.")
         gemfile_should_be <<-G
-          source "file://#{gem_repo1}"
+        source "file://#{gem_repo1}"
         G
       end
+    end
 
-      it "when a gem is not present in gemfile" do
+    context "when some gems are not present in the gemfile" do
+      it "shows warning for those not present and success for those that can be removed" do
         gemfile <<-G
           source "file://#{gem_repo1}"
 
           gem "rails"
+          gem "minitest"
+          gem "rspec"
         G
 
-        bundle! "remove rack rails"
+        bundle! "remove rails rack minitest"
+        expect(out).to include("rails (>= 0) was removed.")
+        expect(out).to include("minitest (>= 0) was removed.")
         expect(out).to include("`rack` is not specified in Gemfile so not removed.")
+        gemfile_should_be <<-G
+          source "file://#{gem_repo1}"
+
+          gem "rspec"
+        G
       end
     end
   end
 
-  describe "with groups" do
-    context "with inline groups" do
-      it "removes the gem" do
-        gemfile <<-G
-          source "file://#{gem_repo1}"
+  context "with inline groups" do
+    it "removes the specified gem" do
+      gemfile <<-G
+        source "file://#{gem_repo1}"
 
-          gem "rack", :group => [:dev]
-        G
+        gem "rack", :group => [:dev]
+      G
 
-        bundle! "remove rack"
+      bundle! "remove rack"
 
-        expect(out).to include("rack (>= 0) was removed.")
-        gemfile_should_be <<-G
-          source "file://#{gem_repo1}"
-        G
-      end
+      expect(out).to include("rack (>= 0) was removed.")
+      gemfile_should_be <<-G
+        source "file://#{gem_repo1}"
+      G
     end
+  end
 
-    context "removes empty block on removal of all gems from it" do
-      it "when single group block with gem is present" do
+  describe "with group blocks" do
+    context "when single group block with gem to be removed is present" do
+      it "removes the group block" do
         gemfile <<-G
           source "file://#{gem_repo1}"
 
@@ -122,8 +138,10 @@ RSpec.describe "bundle remove" do
           source "file://#{gem_repo1}"
         G
       end
+    end
 
-      it "when any other empty block is also present" do
+    context "when an empty block is also present" do
+      it "removes all empty blocks" do
         gemfile <<-G
           source "file://#{gem_repo1}"
 
@@ -144,8 +162,8 @@ RSpec.describe "bundle remove" do
       end
     end
 
-    context "when gem belongs to mutiple groups" do
-      it "when gems assigned to multiple groups" do
+    context "when the gem belongs to mutiple groups" do
+      it "removes the groups" do
         gemfile <<-G
           source "file://#{gem_repo1}"
 
@@ -161,8 +179,10 @@ RSpec.describe "bundle remove" do
           source "file://#{gem_repo1}"
         G
       end
+    end
 
-      it "gem is present in mutiple groups" do
+    context "when the gem is present in mutiple groups" do
+      it "removes all empty blocks" do
         gemfile <<-G
           source "file://#{gem_repo1}"
 
@@ -183,9 +203,11 @@ RSpec.describe "bundle remove" do
         G
       end
     end
+  end
 
-    context "nested group blocks" do
-      it "when all the groups will be empty after removal" do
+  describe "nested group blocks" do
+    context "when all the groups will be empty after removal" do
+      it "removes the empty nested blocks" do
         gemfile <<-G
           source "file://#{gem_repo1}"
 
@@ -203,8 +225,10 @@ RSpec.describe "bundle remove" do
           source "file://#{gem_repo1}"
         G
       end
+    end
 
-      it "when outer group will not be empty after removal" do
+    context "when outer group will not be empty after removal" do
+      it "removes only empty blocks" do
         install_gemfile <<-G
           source "file://#{gem_repo1}"
 
@@ -229,8 +253,10 @@ RSpec.describe "bundle remove" do
           end
         G
       end
+    end
 
-      it "when inner group will not be empty after removal" do
+    context "when inner group will not be empty after removal" do
+      it "removes only empty blocks" do
         install_gemfile <<-G
           source "file://#{gem_repo1}"
 
@@ -332,8 +358,28 @@ RSpec.describe "bundle remove" do
   end
 
   describe "with eval_gemfile" do
-    context "when gems are present in gemfile" do
-      it "removes gems" do
+    context "when gems are present in both gemfiles" do
+      it "removes the gems" do
+        create_file "Gemfile-other", <<-G
+          gem "rack"
+        G
+
+        install_gemfile <<-G
+          source "file://#{gem_repo1}"
+
+          eval_gemfile "Gemfile-other"
+
+          gem "rack"
+        G
+
+        bundle! "remove rack"
+
+        expect(out).to include("rack (>= 0) was removed.")
+      end
+    end
+
+    context "when gems are present in other gemfile" do
+      it "removes the gems" do
         create_file "Gemfile-other", <<-G
           gem "rack"
         G
@@ -351,8 +397,8 @@ RSpec.describe "bundle remove" do
       end
     end
 
-    context "when gem to be removed is not specified in the gemfile" do
-      it "throws error for gems not present" do
+    context "when gems to be removed are not specified in any of the gemfiles" do
+      it "throws error for the gems not present" do
         # an empty gemfile
         # indicating the gem is not present in the gemfile
         create_file "Gemfile-other", <<-G
@@ -371,7 +417,7 @@ RSpec.describe "bundle remove" do
     end
 
     context "when the gem is present in parent file but not in gemfile specified by eval_gemfile" do
-      it "removes gem" do
+      it "removes the gem" do
         create_file "Gemfile-other", <<-G
           gem "rails"
         G
@@ -411,6 +457,7 @@ RSpec.describe "bundle remove" do
         bundle "remove rack"
 
         expect(out).to include("rack could not be removed.")
+        expect(out).to include("Gems could not be removed")
         gemfile_should_be <<-G
           source "file://#{gem_repo1}"
 
@@ -435,7 +482,7 @@ RSpec.describe "bundle remove" do
         bundle "remove rack"
 
         expect(out).to include("Gems could not be removed.")
-        expect(bundled_app("Gemfile-other").read).to include("rack")
+        expect(bundled_app("Gemfile-other").read).to include("gem \"rack\"")
         gemfile_should_be <<-G
           source "file://#{gem_repo1}"
 
@@ -467,7 +514,7 @@ RSpec.describe "bundle remove" do
   end
 
   context "with install_if" do
-    it "should remove gems inside blocks and empty blocks" do
+    it "removes gems inside blocks and empty blocks" do
       install_gemfile <<-G
         source "file://#{gem_repo1}"
 
@@ -486,7 +533,7 @@ RSpec.describe "bundle remove" do
   end
 
   context "with env" do
-    it "should remove gems inside blocks and empty blocks" do
+    it "removes gems inside blocks and empty blocks" do
       install_gemfile <<-G
         source "file://#{gem_repo1}"
 

--- a/spec/commands/remove_spec.rb
+++ b/spec/commands/remove_spec.rb
@@ -52,10 +52,9 @@ RSpec.describe "bundle remove" do
           source "file://#{gem_repo1}"
         G
 
-        bundle! "remove rack"
+        bundle "remove rack"
 
-        expect(out).to include("`rack` is not specified in Gemfile so not removed.")
-        expect(out).to include("No gems were removed from the gemfile")
+        expect(out).to include("`rack` is not specified in Gemfile so could not be removed.")
       end
     end
   end
@@ -90,13 +89,14 @@ RSpec.describe "bundle remove" do
           gem "rspec"
         G
 
-        bundle! "remove rails rack minitest"
-        expect(out).to include("rails (>= 0) was removed.")
-        expect(out).to include("minitest (>= 0) was removed.")
-        expect(out).to include("`rack` is not specified in Gemfile so not removed.")
+        bundle "remove rails rack minitest"
+
+        expect(out).to include("`rack` is not specified in Gemfile so could not be removed.")
         gemfile_should_be <<-G
           source "file://#{gem_repo1}"
 
+          gem "rails"
+          gem "minitest"
           gem "rspec"
         G
       end
@@ -410,9 +410,9 @@ RSpec.describe "bundle remove" do
           eval_gemfile "Gemfile-other"
         G
 
-        bundle! "remove rack"
+        bundle "remove rack"
 
-        expect(out).to include("`rack` is not specified in Gemfile so not removed.")
+        expect(out).to include("`rack` is not specified in Gemfile so could not be removed.")
       end
     end
 
@@ -429,10 +429,10 @@ RSpec.describe "bundle remove" do
           gem "rack"
         G
 
-        bundle! "remove rack"
+        bundle "remove rack"
 
         expect(out).to include("rack (>= 0) was removed.")
-        expect(out).to include("`rack` is not specified in Gemfile so not removed.")
+        expect(out).to include("`rack` is not specified in Gemfile so could not be removed.")
         gemfile_should_be <<-G
           source "file://#{gem_repo1}"
 

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -238,5 +238,9 @@ module Spec
     def lockfile_should_be(expected)
       expect(bundled_app("Gemfile.lock")).to read_as(normalize_uri_file(strip_whitespace(expected)))
     end
+
+    def gemfile_should_be(expected)
+      expect(bundled_app("Gemfile")).to read_as(strip_whitespace(expected))
+    end
   end
 end


### PR DESCRIPTION
Features of the command implemented:
- Multiple gems support
```bash
$ bundle remove rack rails
```
- Remove any empty block that might occur after removing the gem or otherwise present

Things yet to implement:
- Add `rm` alias. _Optional_
- [x] Add `--install` flag to remove gems from `.bundle`.
- [x] Handling multiple gems on the same line.
- [x] Handle gem spec
- [x] Handle eval_gemfile cases ([one](https://github.com/bundler/bundler/pull/6513#discussion_r195632603) case left)

Closes #6506 