### PR TITLE
Add flag to generate generic binstubs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
   TargetRubyVersion: 1.9
   Exclude:
     - tmp/**/*
+    - lib/bundler/templates/Executable
     - lib/bundler/vendor/**/*
   DisplayCopNames: true
 
@@ -20,10 +21,6 @@ Lint/EndAlignment:
 
 Lint/UnusedMethodArgument:
   Enabled: false
-
-Lint/ScriptPermission:
-  Exclude:
-    - 'lib/bundler/templates/Executable'
 
 # Layout
 

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -317,6 +317,8 @@ module Bundler
       "Binstub destination directory (default bin)"
     method_option "shebang", :type => :string, :banner =>
       "Specify a different shebang executable name than the default (usually 'ruby')"
+    method_option "locked", :type => :boolean, :default => Bundler.bundler_major_version >= 2, :banner =>
+      "Make binstubs that are locked to a specific application"
     method_option "standalone", :type => :boolean, :banner =>
       "Make binstubs that can work without the Bundler runtime"
     method_option "all", :type => :boolean, :banner =>

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -317,7 +317,7 @@ module Bundler
       "Binstub destination directory (default bin)"
     method_option "shebang", :type => :string, :banner =>
       "Specify a different shebang executable name than the default (usually 'ruby')"
-    method_option "locked", :type => :boolean, :default => Bundler.bundler_major_version >= 2, :banner =>
+    method_option "locked", :type => :boolean, :default => Bundler.feature_flag.application_locked?, :banner =>
       "Make binstubs that are locked to a specific application"
     method_option "standalone", :type => :boolean, :banner =>
       "Make binstubs that can work without the Bundler runtime"

--- a/lib/bundler/cli/binstubs.rb
+++ b/lib/bundler/cli/binstubs.rb
@@ -16,7 +16,7 @@ module Bundler
       Bundler.settings.set_command_option_if_given :shebang, options["shebang"]
       installer = Installer.new(Bundler.root, Bundler.definition)
 
-      installer_opts = { :force => options[:force], :binstubs_cmd => true }
+      installer_opts = { :force => options[:force], :binstubs_cmd => true, :locked => options[:locked] }
 
       if options[:all]
         raise InvalidOption, "Cannot specify --all with specific gems" unless gems.empty?
@@ -40,6 +40,8 @@ module Bundler
           Bundler.settings.temporary(:path => (Bundler.settings[:path] || Bundler.root)) do
             installer.generate_standalone_bundler_executable_stubs(spec)
           end
+        elsif gem_name == "bundler" && options[:locked] == false
+          next Bundler.ui.warn("Sorry, Bundler can only be run via RubyGems.")
         else
           installer.generate_bundler_executable_stubs(spec, installer_opts)
         end

--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -29,6 +29,7 @@ module Bundler
 
     settings_flag(:allow_bundler_dependency_conflicts) { bundler_2_mode? }
     settings_flag(:allow_offline_install) { bundler_2_mode? }
+    settings_flag(:application_locked) { bundler_2_mode? }
     settings_flag(:auto_clean_without_path) { bundler_2_mode? }
     settings_flag(:auto_config_jobs) { bundler_2_mode? }
     settings_flag(:cache_all) { bundler_2_mode? }

--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -119,6 +119,8 @@ module Bundler
       relative_gemfile_path = relative_gemfile_path
       ruby_command = Thor::Util.ruby_command
       ruby_command = ruby_command
+      application_locked = options[:locked] || Bundler.settings[:application_locked]
+      application_locked = application_locked
       template_path = File.expand_path("../templates/Executable", __FILE__)
       if spec.name == "bundler"
         template_path += ".bundler"
@@ -128,6 +130,8 @@ module Bundler
 
       exists = []
       spec.executables.each do |executable|
+        next if executable == "bundle" && application_locked == false
+
         binstub_path = "#{bin_path}/#{executable}"
         if File.exist?(binstub_path) && !options[:force]
           exists << executable

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -12,6 +12,7 @@ module Bundler
       allow_bundler_dependency_conflicts
       allow_deployment_source_credential_changes
       allow_offline_install
+      application_locked
       auto_clean_without_path
       auto_install
       auto_config_jobs

--- a/lib/bundler/templates/Executable
+++ b/lib/bundler/templates/Executable
@@ -11,7 +11,7 @@
 require "pathname"
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../<%= relative_gemfile_path %>",
   Pathname.new(__FILE__).realpath)
-
+<% if application_locked %>
 bundle_binstub = File.expand_path("../bundle", __FILE__)
 
 if File.file?(bundle_binstub)
@@ -22,7 +22,7 @@ if File.file?(bundle_binstub)
 Replace `bin/bundle` by running `bundle binstubs bundler --force`, then run this command again.")
   end
 end
-
+<% end %>
 require "rubygems"
 require "bundler/setup"
 

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -130,6 +130,10 @@ learn more about their operation in [bundle install(1)][bundle-install(1)].
    Ex: `https://some.host.com/gems/path/` -> `https://user_name:password@some.host.com/gems/path`
 * `allow_offline_install` (`BUNDLE_ALLOW_OFFLINE_INSTALL`):
    Allow Bundler to use cached data when installing without network access.
+* `application_locked` (`BUNDLE_APPLICATION_LOCKED`):
+   Allow Bundler to create application-locked binstubs. Application-locked
+   binstubs should not be added to your PATH unless you explicitly want to be
+   locked into that application's bundle.
 * `auto_clean_without_path` (`BUNDLE_AUTO_CLEAN_WITHOUT_PATH`):
    Automatically run `bundle clean` after installing when an explicit `path`
    has not been set and Bundler is not installing into the system gems.

--- a/spec/commands/binstubs_spec.rb
+++ b/spec/commands/binstubs_spec.rb
@@ -39,6 +39,49 @@ RSpec.describe "bundle binstubs <gem>" do
       expect(bundled_app("bin/rails")).to exist
     end
 
+    it "installs application-locked binstubs" do
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem "rack"
+        gem "rails"
+      G
+
+      bundle "binstubs rack rails --locked"
+
+      expect(bundled_app("bin/rackup")).to exist
+      expect(File.read("bin/rackup")).to include("bundle_binstub")
+
+      expect(bundled_app("bin/rails")).to exist
+      expect(File.read("bin/rails")).to include("bundle_binstub")
+    end
+
+    it "allows installing generic binstubs" do
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem "rack"
+        gem "rails"
+      G
+
+      bundle "binstubs rack rails --locked=false"
+
+      expect(bundled_app("bin/rackup")).to exist
+      expect(File.read("bin/rackup")).to_not include("bundle_binstub")
+
+      expect(bundled_app("bin/rails")).to exist
+      expect(File.read("bin/rails")).to_not include("bundle_binstub")
+    end
+
+    it "does not create a generic bundle binstub" do
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem "rack"
+      G
+
+      bundle "binstubs bundler rack --locked=false"
+
+      expect(out).to include("Bundler can only be run via RubyGems")
+    end
+
     it "allows installing all binstubs" do
       install_gemfile! <<-G
         source "file://#{gem_repo1}"
@@ -80,7 +123,7 @@ RSpec.describe "bundle binstubs <gem>" do
           gem "rack"
         G
 
-        bundle "binstubs rack"
+        bundle "binstubs rack --locked"
 
         File.open("bin/bundle", "wb") do |file|
           file.print "OMG"
@@ -121,7 +164,7 @@ RSpec.describe "bundle binstubs <gem>" do
           gem "rack"
           gem "prints_loaded_gems"
         G
-        bundle! "binstubs bundler rack prints_loaded_gems"
+        bundle! "binstubs bundler rack prints_loaded_gems --locked"
       end
 
       let(:system_bundler_version) { Bundler::VERSION }


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Issues #6154 and #6162, in which Bundler v1.16.1 appeared to be looking for the wrong Gemfile when using Docker. Further investigation showed that this issue was not just limited to the use of Docker (see non-Docker repro of 6154).

### What was your diagnosis of the problem?

The diagnosis was that as of 1.16 Bundler started generating a `bin/bundle` and calling it from other binstubs. This change led to two problems (taken from conversation in #6469):

> 1. Docker (and other users) used to be able to treat bundler binstubs as if they were rubygems binstubs, not tied to any application, and usable on any ruby where that gem was installed. This change made that no longer true, and tied each binstub a to a specific application and Gemfile.
> 2. Previously, `bundle exec CMD` would find the Gemfile based on the CWD, and even if Bundler exec’ed a binstub from the PATH that was tied to a different application, that was fine, because binstubs were fully generic. It sounds like the `bin/bundle` binstub no longer does that, and instead when you run `bin/bundle exec rspec`, you get `bin/rspec`, which is tied to a specific application and Gemfile.

### What is your fix for the problem, implemented in this PR?

My fix was to add a flag to the `binstubs` command to generate application-locked binstubs and to make that flag the default for Bundler >= 2.

### Why did you choose this fix out of the possible options?

I chose this fix because of the conversation from #6469.
