### PR TITLE
explicitly call the system bundler executable in bundler specs rather than depending on $PATH

### DIFF
--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -105,7 +105,7 @@ module Spec
       bundle_bin = options.delete("bundle_bin") || bindir.join("bundle")
 
       if system_bundler = options.delete(:system_bundler)
-        bundle_bin = "-S bundle"
+        bundle_bin = system_gem_path("bin", "bundle")
       end
 
       env = options.delete(:env) || {}


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

A spec in the [pristine command](https://github.com/bundler/bundler/blob/1-16-stable/spec/commands/pristine_spec.rb#L48) was failing in older versions of Ruby because the version of Bundler inside RubyGems was being loaded and executed instead of the current development version.

See: https://travis-ci.org/bundler/bundler/jobs/368955082

### What was your diagnosis of the problem?

The `$PATH` variable when running `bundle -v` in [this test](https://github.com/bundler/bundler/blob/1-16-stable/spec/commands/pristine_spec.rb#L48) had `/path/to/bundler/exe` listed as the first directory to search. This was causing `/path/to/bundler/exe/bundle` to be called which was loading Bundler in RubyGems to be loaded.

### What is your fix for the problem, implemented in this PR?

Instead of relying on `$PATH` to call the stubbed system Bundler gem, call it explicitly.

### Why did you choose this fix out of the possible options?

This seems like a simple solution and will prevent issues with making sure the `$PATH` is set correctly 
