### PR TITLE
Add option to filter gem-dependencies from output of 'bundle outdated'

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -368,6 +368,8 @@ module Bundler
     method_option "filter-patch", :type => :boolean, :banner => "Only list patch newer versions"
     method_option "parseable", :aliases => "--porcelain", :type => :boolean, :banner =>
       "Use minimal formatting for more parseable output"
+    method_option "filter-dependencies", :type => :boolean, :banner =>
+      "Only list gems specified in your Gemfile, not their dependencies"
     def outdated(*gems)
       require "bundler/cli/outdated"
       Outdated.new(options, gems).run

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -368,7 +368,7 @@ module Bundler
     method_option "filter-patch", :type => :boolean, :banner => "Only list patch newer versions"
     method_option "parseable", :aliases => "--porcelain", :type => :boolean, :banner =>
       "Use minimal formatting for more parseable output"
-    method_option "filter-dependencies", :type => :boolean, :banner =>
+    method_option "only-explicit", :type => :boolean, :banner =>
       "Only list gems specified in your Gemfile, not their dependencies"
     def outdated(*gems)
       require "bundler/cli/outdated"

--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -66,7 +66,13 @@ module Bundler
         current_dependencies.key? spec.name
       end
 
-      (gemfile_specs + dependency_specs).sort_by(&:name).each do |current_spec|
+      specs = if options["filter-dependencies"]
+        gemfile_specs
+      else
+        gemfile_specs + dependency_specs
+      end
+
+      specs.sort_by(&:name).each do |current_spec|
         next if !gems.empty? && !gems.include?(current_spec.name)
 
         dependency = current_dependencies[current_spec.name]

--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -66,7 +66,7 @@ module Bundler
         current_dependencies.key? spec.name
       end
 
-      specs = if options["filter-dependencies"]
+      specs = if options["only-explicit"]
         gemfile_specs
       else
         gemfile_specs + dependency_specs

--- a/man/bundle-outdated.ronn
+++ b/man/bundle-outdated.ronn
@@ -15,7 +15,7 @@ bundle-outdated(1) -- List installed gems with newer versions available
                         [--filter-major]
                         [--filter-minor]
                         [--filter-patch]
-                        [--filter-dependencies]
+                        [--only-explicit]
 
 ## DESCRIPTION
 
@@ -68,7 +68,7 @@ are up to date, Bundler will exit with a status of 0. Otherwise, it will exit 1.
 * `--filter-patch`:
   Only list patch newer versions.
 
-* `--filter-dependencies`:
+* `--only-explicit`:
   Only list gems specified in your Gemfile, not their dependencies.
 
 ## PATCH LEVEL OPTIONS

--- a/man/bundle-outdated.ronn
+++ b/man/bundle-outdated.ronn
@@ -15,6 +15,7 @@ bundle-outdated(1) -- List installed gems with newer versions available
                         [--filter-major]
                         [--filter-minor]
                         [--filter-patch]
+                        [--filter-dependencies]
 
 ## DESCRIPTION
 
@@ -66,6 +67,9 @@ are up to date, Bundler will exit with a status of 0. Otherwise, it will exit 1.
 
 * `--filter-patch`:
   Only list patch newer versions.
+
+* `--filter-dependencies`:
+  Only list gems specified in your Gemfile, not their dependencies.
 
 ## PATCH LEVEL OPTIONS
 

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -764,4 +764,31 @@ RSpec.describe "bundle outdated" do
       end
     end
   end
+
+  describe "with --filter-dependencies" do
+    it "does not report outdated dependent gems" do
+      build_repo4 do
+        build_gem "weakling", %w[0.2 0.3] do |s|
+          s.add_dependency "bar", "~> 2.1"
+        end
+        build_gem "bar", %w[2.1 2.2]
+      end
+
+      install_gemfile <<-G
+        source "file://#{gem_repo4}"
+        gem 'weakling', '0.2'
+        gem 'bar', '2.1'
+      G
+
+      gemfile  <<-G
+        source "file://#{gem_repo4}"
+        gem 'weakling'
+      G
+
+      bundle "outdated --filter-dependencies"
+
+      expect(out).to include("weakling (newest 0.3")
+      expect(out).not_to include("bar (newest 2.2")
+    end
+  end
 end

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -765,7 +765,7 @@ RSpec.describe "bundle outdated" do
     end
   end
 
-  describe "with --filter-dependencies" do
+  describe "with --only-explicit" do
     it "does not report outdated dependent gems" do
       build_repo4 do
         build_gem "weakling", %w[0.2 0.3] do |s|
@@ -785,7 +785,7 @@ RSpec.describe "bundle outdated" do
         gem 'weakling'
       G
 
-      bundle "outdated --filter-dependencies"
+      bundle "outdated --only-explicit"
 
       expect(out).to include("weakling (newest 0.3")
       expect(out).not_to include("bar (newest 2.2")


### PR DESCRIPTION
Resolves #5366 by adding a new option '--filter-dependencies' to `bundle outdated`. When present, `outdated` will only check the `gemfile_specs` and skip the `dependency_specs`.