### PR TITLE
Fix man page links

### DIFF
--- a/man/bundle-binstubs.ronn
+++ b/man/bundle-binstubs.ronn
@@ -40,4 +40,4 @@ Calling binstubs with [GEM [GEM]] will create binstubs for all given gems.
 ## BUNDLE INSTALL --BINSTUBS
 
 To create binstubs for all the gems in the bundle you can use the `--binstubs`
-flag in [bundle install(1)][bundle-install(1)].
+flag in [bundle install(1)](bundle-install.1.html).

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -285,7 +285,7 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
    A `:`-separated list of groups whose gems bundler should not install.
 
 In general, you should set these settings per-application by using the applicable
-flag to the [bundle install(1)](bundle-install(1)] or [bundle package(1)][bundle-package.1.html) command.
+flag to the [bundle install(1)](bundle-install.1.html) or [bundle package(1)](bundle-package.1.html) command.
 
 You can set them globally either via environment variables or `bundle config`,
 whichever is preferable for your setup. If you use both, environment variables

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -102,11 +102,11 @@ After running this command, every time bundler needs to install the
 Configuration keys in bundler have two forms: the canonical form and the
 environment variable form.
 
-For instance, passing the `--without` flag to [bundle install(1)][bundle-install(1)]
+For instance, passing the `--without` flag to [bundle install(1)](bundle-install.1.html)
 prevents Bundler from installing certain groups specified in the Gemfile(5). Bundler
 persists this value in `app/.bundle/config` so that calls to `Bundler.setup`
 do not try to find gems from the `Gemfile` that you didn't install. Additionally,
-subsequent calls to [bundle install(1)][bundle-install(1)] remember this setting
+subsequent calls to [bundle install(1)](bundle-install.1.html) remember this setting
 and skip those groups.
 
 The canonical form of this configuration is `"without"`. To convert the canonical
@@ -120,7 +120,7 @@ the environment variable `BUNDLE_LOCAL__RACK`.
 ## LIST OF AVAILABLE KEYS
 
 The following is a list of all configuration keys and their purpose. You can
-learn more about their operation in [bundle install(1)][bundle-install(1)].
+learn more about their operation in [bundle install(1)](bundle-install.1.html).
 
 * `allow_bundler_dependency_conflicts` (`BUNDLE_ALLOW_BUNDLER_DEPENDENCY_CONFLICTS`):
    Allow resolving to specifications that have dependencies on `bundler` that
@@ -285,7 +285,7 @@ learn more about their operation in [bundle install(1)][bundle-install(1)].
    A `:`-separated list of groups whose gems bundler should not install.
 
 In general, you should set these settings per-application by using the applicable
-flag to the [bundle install(1)][bundle-install(1)] or [bundle package(1)][bundle-package(1)] command.
+flag to the [bundle install(1)](bundle-install(1)] or [bundle package(1)][bundle-package.1.html) command.
 
 You can set them globally either via environment variables or `bundle config`,
 whichever is preferable for your setup. If you use both, environment variables

--- a/man/bundle-exec.ronn
+++ b/man/bundle-exec.ronn
@@ -12,7 +12,7 @@ This command executes the command, making all gems specified in the
 
 Essentially, if you would normally have run something like
 `rspec spec/my_spec.rb`, and you want to use the gems specified
-in the [`Gemfile(5)`][Gemfile(5)] and installed via [bundle install(1)][bundle-install(1)], you
+in the [`Gemfile(5)`][Gemfile(5)] and installed via [bundle install(1)](bundle-install.1.html), you
 should run `bundle exec rspec spec/my_spec.rb`.
 
 Note that `bundle exec` does not require that an executable is
@@ -27,7 +27,7 @@ available on your shell's `$PATH`.
 
 ## BUNDLE INSTALL --BINSTUBS
 
-If you use the `--binstubs` flag in [bundle install(1)][bundle-install(1)], Bundler will
+If you use the `--binstubs` flag in [bundle install(1)](bundle-install.1.html), Bundler will
 automatically create a directory (which defaults to `app_root/bin`)
 containing all of the executables available from gems in the bundle.
 

--- a/man/bundle-gem.ronn
+++ b/man/bundle-gem.ronn
@@ -75,4 +75,4 @@ configuration file using the following names:
 
 ## SEE ALSO
 
-* [bundle config(1)][bundle-config(1)]
+* [bundle config(1)](bundle-config.1.html)

--- a/man/bundle-install.ronn
+++ b/man/bundle-install.ronn
@@ -375,7 +375,7 @@ which other gems in the Gemfile(5) still depend on, run
 `Summary`: In general, after making a change to the Gemfile(5) , you
 should first try to run `bundle install`, which will guarantee that no
 other gem in the Gemfile(5) is impacted by the change. If that
-does not work, run [bundle update(1)][bundle-update(1)].
+does not work, run [bundle update(1)](bundle-update.1.html).
 
 ## SEE ALSO
 

--- a/man/bundle-lock.ronn
+++ b/man/bundle-lock.ronn
@@ -91,4 +91,4 @@ For a full explanation of gem platforms, see `gem help platform`.
 
 ## PATCH LEVEL OPTIONS
 
-See [bundle update(1)][bundle-update(1)] for details.
+See [bundle update(1)](bundle-update.1.html) for details.

--- a/man/bundle-outdated.ronn
+++ b/man/bundle-outdated.ronn
@@ -69,7 +69,7 @@ are up to date, Bundler will exit with a status of 0. Otherwise, it will exit 1.
 
 ## PATCH LEVEL OPTIONS
 
-See [bundle update(1)][bundle-update(1)] for details.
+See [bundle update(1)](bundle-update.1.html) for details.
 
 One difference between the patch level options in `bundle update` and here is the `--strict` option.
 `--strict` was already an option on outdated before the patch level options were added. `--strict`

--- a/man/bundle-package.ronn
+++ b/man/bundle-package.ronn
@@ -27,8 +27,8 @@ in your local bundler configuration.
 
 ## REMOTE FETCHING
 
-By default, if you run `bundle install(1)`][bundle-install(1)] after running
-[bundle package(1)][bundle-package(1)], bundler will still connect to `rubygems.org`
+By default, if you run `bundle install(1)`](bundle-install.1.html) after running
+[bundle package(1)](bundle-package.1.html), bundler will still connect to `rubygems.org`
 to check whether a platform-specific gem exists for any of the gems
 in `vendor/cache`.
 
@@ -66,7 +66,7 @@ machine and check in the gems. For instance, you can run
 staging process, and check in the `vendor/cache` before
 deploying to production.
 
-By default, [bundle package(1)][bundle-package(1)] fetches and also
+By default, [bundle package(1)](bundle-package.1.html) fetches and also
 installs the gems to the default location. To package the
 dependencies to `vendor/cache` without installing them to the
 local install location, you can run `bundle package --no-install`.

--- a/man/bundle-update.ronn
+++ b/man/bundle-update.ronn
@@ -21,7 +21,7 @@ bundle-update(1) -- Update your gems to the latest available versions
 
 Update the gems specified (all gems, if `--all` flag is used), ignoring
 the previously installed gems specified in the `Gemfile.lock`. In
-general, you should use [bundle install(1)][bundle-install(1)] to install the same exact
+general, you should use [bundle install(1)](bundle-install.1.html) to install the same exact
 gems and versions across machines.
 
 You would use `bundle update` to explicitly update the version of a
@@ -95,7 +95,7 @@ Consider the following Gemfile(5):
     gem "rails", "3.0.0.rc"
     gem "nokogiri"
 
-When you run [bundle install(1)][bundle-install(1)] the first time, bundler will resolve
+When you run [bundle install(1)](bundle-install.1.html) the first time, bundler will resolve
 all of the dependencies, all the way down, and install what you need:
 
     Fetching gem metadata from https://rubygems.org/.........
@@ -132,11 +132,11 @@ all of the dependencies, all the way down, and install what you need:
 
 As you can see, even though you have two gems in the Gemfile(5), your application
 needs 26 different gems in order to run. Bundler remembers the exact versions
-it installed in `Gemfile.lock`. The next time you run [bundle install(1)][bundle-install(1)], bundler skips
+it installed in `Gemfile.lock`. The next time you run [bundle install(1)](bundle-install.1.html), bundler skips
 the dependency resolution and installs the same gems as it installed last time.
 
 After checking in the `Gemfile.lock` into version control and cloning it on another
-machine, running [bundle install(1)][bundle-install(1)] will _still_ install the gems that you installed
+machine, running [bundle install(1)](bundle-install.1.html) will _still_ install the gems that you installed
 last time. You don't need to worry that a new release of `erubis` or `mail` changes
 the gems you use.
 
@@ -196,12 +196,12 @@ update all dependencies of that gem, including those that are also dependencies
 of another gem.
 
 To prevent updating shared dependencies, prior to version 1.14 the only option
-was the `CONSERVATIVE UPDATING` behavior in [bundle install(1)][bundle-install(1)]:
+was the `CONSERVATIVE UPDATING` behavior in [bundle install(1)](bundle-install.1.html):
 
 In this scenario, updating the `thin` version manually in the Gemfile(5),
-and then running [bundle install(1)][bundle-install(1)] will only update `daemons` and `eventmachine`,
+and then running [bundle install(1)](bundle-install.1.html) will only update `daemons` and `eventmachine`,
 but not `rack`. For more information, see the `CONSERVATIVE UPDATING` section
-of [bundle install(1)][bundle-install(1)].
+of [bundle install(1)](bundle-install.1.html).
 
 Starting with 1.14, specifying the `--conservative` option will also prevent shared
 dependencies from being updated.
@@ -339,7 +339,7 @@ use the following workflow:
 
     $ git add Gemfile.lock
 
-* If [bundle install(1)][bundle-install(1)] reports a conflict, manually update the specific
+* If [bundle install(1)](bundle-install.1.html) reports a conflict, manually update the specific
   gems that you changed in the Gemfile(5)
 
     $ bundle update rails thin

--- a/man/bundle-viz.ronn
+++ b/man/bundle-viz.ronn
@@ -14,7 +14,7 @@ bundle-viz(1) -- Generates a visual dependency graph for your Gemfile
 `viz` generates a PNG file of the current `Gemfile(5)` as a dependency graph.
 `viz` requires the ruby-graphviz gem (and its dependencies).
 
-The associated gems must also be installed via [`bundle install(1)`][bundle-install(1)].
+The associated gems must also be installed via [`bundle install(1)`](bundle-install.1.html).
 
 ## OPTIONS
 

--- a/man/bundle.ronn
+++ b/man/bundle.ronn
@@ -30,20 +30,20 @@ We divide `bundle` subcommands into primary commands and utilities:
 
 ## PRIMARY COMMANDS
 
-* [`bundle install(1)`][bundle-install(1)]:
+* [`bundle install(1)`](bundle-install.1.html):
   Install the gems specified by the `Gemfile` or `Gemfile.lock`
 
-* [`bundle update(1)`][bundle-update(1)]:
+* [`bundle update(1)`](bundle-update.1.html):
   Update dependencies to their latest versions
 
-* [`bundle package(1)`][bundle-package(1)]:
+* [`bundle package(1)`](bundle-package.1.html):
   Package the .gem files required by your application into the
   `vendor/cache` directory
 
-* [`bundle exec(1)`][bundle-exec(1)]:
+* [`bundle exec(1)`](bundle-exec.1.html):
   Execute a script in the current bundle
 
-* [`bundle config(1)`][bundle-config(1)]:
+* [`bundle config(1)`](bundle-config.1.html):
   Specify and read configuration options for Bundler
 
 * `bundle help(1)`:
@@ -51,44 +51,44 @@ We divide `bundle` subcommands into primary commands and utilities:
 
 ## UTILITIES
 
-* [`bundle add(1)`][bundle-add(1)]:
+* [`bundle add(1)`](bundle-add.1.html):
   Add the named gem to the Gemfile and run `bundle install`
 
-* [`bundle binstubs(1)`][bundle-binstubs(1)]:
+* [`bundle binstubs(1)`](bundle-binstubs.1.html):
   Generate binstubs for executables in a gem
 
-* [`bundle check(1)`][bundle-check(1)]:
+* [`bundle check(1)`](bundle-check.1.html):
   Determine whether the requirements for your application are installed
   and available to Bundler
 
-* [`bundle show(1)`][bundle-show(1)]:
+* [`bundle show(1)`](bundle-show.1.html):
   Show the source location of a particular gem in the bundle
 
-* [`bundle outdated(1)`][bundle-outdated(1)]:
+* [`bundle outdated(1)`](bundle-outdated.1.html):
   Show all of the outdated gems in the current bundle
 
 * `bundle console(1)`:
   Start an IRB session in the current bundle
 
-* [`bundle open(1)`][bundle-open(1)]:
+* [`bundle open(1)`](bundle-open.1.html):
   Open an installed gem in the editor
 
 * [`bundle lock(1)`][bundle-lock]:
   Generate a lockfile for your dependencies
 
-* [`bundle viz(1)`][bundle-viz(1)]:
+* [`bundle viz(1)`](bundle-viz.1.html):
   Generate a visual representation of your dependencies
 
-* [`bundle init(1)`][bundle-init(1)]:
+* [`bundle init(1)`](bundle-init.1.html):
   Generate a simple `Gemfile`, placed in the current directory
 
-* [`bundle gem(1)`][bundle-gem(1)]:
+* [`bundle gem(1)`](bundle-gem.1.html):
   Create a simple gem, suitable for development with Bundler
 
-* [`bundle platform(1)`][bundle-platform(1)]:
+* [`bundle platform(1)`](bundle-platform.1.html):
   Display platform compatibility information
 
-* [`bundle clean(1)`][bundle-clean(1)]:
+* [`bundle clean(1)`](bundle-clean.1.html):
   Clean up unused gems in your Bundler directory
 
 * `bundle doctor(1)`:

--- a/man/bundle.ronn
+++ b/man/bundle.ronn
@@ -73,7 +73,7 @@ We divide `bundle` subcommands into primary commands and utilities:
 * [`bundle open(1)`](bundle-open.1.html):
   Open an installed gem in the editor
 
-* [`bundle lock(1)`][bundle-lock]:
+* [`bundle lock(1)`](bundle-lock.1.hmtl):
   Generate a lockfile for your dependencies
 
 * [`bundle viz(1)`](bundle-viz.1.html):
@@ -91,7 +91,7 @@ We divide `bundle` subcommands into primary commands and utilities:
 * [`bundle clean(1)`](bundle-clean.1.html):
   Clean up unused gems in your Bundler directory
 
-* `bundle doctor(1)`:
+* [`bundle doctor(1)`](bundle-doctor.1.html):
   Display warnings about common problems
 
 ## PLUGINS

--- a/man/gemfile.5.ronn
+++ b/man/gemfile.5.ronn
@@ -35,7 +35,7 @@ this warning, by using the [`:source` option](#SOURCE) or a
 
 ### CREDENTIALS
 
-Some gem sources require a username and password. Use [bundle config(1)][bundle-config(1)] to set
+Some gem sources require a username and password. Use [bundle config(1)](bundle-config.1.html) to set
 the username and password for any of the sources that need it. The command must
 be run once on each computer that will install the Gemfile, but this keeps the
 credentials from being stored in plain text in version control.
@@ -228,7 +228,7 @@ As with groups, you can specify one or more platforms:
     gem "ruby-debug", :platforms => :mri_18
     gem "nokogiri",   :platforms => [:mri_18, :jruby]
 
-All operations involving groups ([`bundle install`][bundle-install(1)], `Bundler.setup`,
+All operations involving groups ([`bundle install`](bundle-install.1.html), `Bundler.setup`,
 `Bundler.require`) behave exactly the same as if any groups not
 matching the current platform were explicitly excluded.
 


### PR DESCRIPTION
With a markup

    [`bundle platform(1)`][bundle-platform(1)]

ronn creates this HTML fragment

    <a href="bundle-platform.html"><code>bundle platform(1)</code></a>

At the same time, it generates HTML file `bundle-platform.1.html` based on the
man page section, and this results in certain inter-man-page links 404.

We resolve this inconsistency by spelling out the href attributes.

-----

Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

404's on https://bundler.io.

For example, https://bundler.io/v1.16/man/bundle.1.html has the link to `bundle platform(1)`:


<img width="1061" alt="bundler__bundle" src="https://user-images.githubusercontent.com/25666/40212893-7fc73196-5a20-11e8-8964-5ca5ed9abfa2.png">

This points to https://bundler.io/v1.16/man/bundle-platform.html, but it is 404. The correct link is https://bundler.io/v1.16/man/bundle-platform.1.html.

### What was your diagnosis of the problem?

My diagnosis was... 

that the document source was wrong.

### What is your fix for the problem, implemented in this PR?

My fix...

is this PR.

### Why did you choose this fix out of the possible options?

I chose this fix because...

`ronn -5 man/*.ronn` appears to generate `<a>` tags with the correct `href` attributes.

I tried serving the generated files with `bundler-site`, but I could not convince it to do so; `bundler-site`'s Rake tasks assumes the document source *always* comes from the remote `bundler/bundler`, and coming up with a way to test it seemed rather involved.