### PR TITLE
add option to Bundler#mkdir_p to force Bundler to not use sudo

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -373,8 +373,8 @@ EOF
       @requires_sudo = settings.allow_sudo? && sudo_present && sudo_needed
     end
 
-    def mkdir_p(path)
-      if requires_sudo?
+    def mkdir_p(path, options = {})
+      if requires_sudo? && !options[:no_sudo]
         sudo "mkdir -p '#{path}'" unless File.exist?(path)
       else
         SharedHelpers.filesystem_access(path, :write) do |p|

--- a/lib/bundler/source/rubygems.rb
+++ b/lib/bundler/source/rubygems.rb
@@ -144,7 +144,7 @@ module Bundler
             bin_path     = Bundler.system_bindir
           end
 
-          Bundler.mkdir_p bin_path unless spec.executables.empty? || Bundler.rubygems.provides?(">= 2.7.5")
+          Bundler.mkdir_p bin_path, :no_sudo => true unless spec.executables.empty? || Bundler.rubygems.provides?(">= 2.7.5")
 
           installed_spec = nil
           Bundler.rubygems.preserve_paths do

--- a/spec/bundler/bundler_spec.rb
+++ b/spec/bundler/bundler_spec.rb
@@ -190,6 +190,34 @@ EOF
     end
   end
 
+  describe "#mkdir_p" do
+    it "creates a folder at the given path" do
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem "rack"
+      G
+
+      Bundler.mkdir_p(bundled_app.join("foo", "bar"))
+      expect(bundled_app.join("foo", "bar")).to exist
+    end
+
+    context "when mkdir_p requires sudo" do
+      it "creates a new folder using sudo" do
+        expect(Bundler).to receive(:requires_sudo?).and_return(true)
+        expect(Bundler).to receive(:sudo).and_return true
+        Bundler.mkdir_p(bundled_app.join("foo"))
+      end
+    end
+
+    context "with :no_sudo option" do
+      it "forces mkdir_p to not use sudo" do
+        expect(Bundler).to receive(:requires_sudo?).and_return(true)
+        expect(Bundler).to_not receive(:sudo)
+        Bundler.mkdir_p(bundled_app.join("foo"), :no_sudo => true)
+      end
+    end
+  end
+
   describe "#user_home" do
     context "home directory is set" do
       it "should return the user home" do


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

There is a bug for functionality that was added in #6258.  In certain scenarios, Bundler will create a folder for a temporary gem install with `root:root` permissions. This is happening because [Bundler#mkdir_p](https://github.com/bundler/bundler/blob/master/lib/bundler.rb#L377) checks for `requires_sudo?` which is creating a folder owned by `root:root` when it should be creating the folder with the current user.

### What was your diagnosis of the problem?

See #6535

I can see that Bundler is creating the `bin` folder with `root:root` permissions

```
[vagrant@localhost ~]$ ls -la /tmp/bundler20180519-24861-1y67io7rake-12.3.1/
total 4
drwx------. 3 vagrant vagrant   17 May 19 07:36 .
drwxrwxrwt. 9 root    root    4096 May 19 07:36 ..
drwxr-xr-x. 2 root    root       6 May 19 07:36 bin
```

### What is your fix for the problem, implemented in this PR?

Add an option for `Bundler#mkdir_p` to prevent it from using `sudo` even though `requires_sudo?` is true.

Fixes #6535 