### PR TITLE
Add mutiple gems by names

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -337,9 +337,9 @@ module Bundler
       "Adds gem to the Gemfile but does not install it"
     method_option "optimistic", :type => :boolean, :banner => "Adds optimistic declaration of version to gem"
     method_option "strict", :type => :boolean, :banner => "Adds strict declaration of version to gem"
-    def add(gem_name)
+    def add(*gems)
       require "bundler/cli/add"
-      Add.new(options.dup, gem_name).run
+      Add.new(options.dup, gems).run
     end
 
     desc "outdated GEM [OPTIONS]", "List installed gems with newer versions available"

--- a/lib/bundler/cli/add.rb
+++ b/lib/bundler/cli/add.rb
@@ -11,6 +11,9 @@ module Bundler
     def run
       raise InvalidOption, "You can not specify `--strict` and `--optimistic` at the same time." if @options[:strict] && @options[:optimistic]
 
+      # raise error when no gems are specified
+      raise InvalidOption, "Please specify gems to add." if @gems.empty?
+
       version = @options[:version].nil? ? nil : @options[:version].split(",").map(&:strip)
 
       unless version.nil?

--- a/lib/bundler/cli/add.rb
+++ b/lib/bundler/cli/add.rb
@@ -14,10 +14,6 @@ module Bundler
       # raise error when no gems are specified
       raise InvalidOption, "Please specify gems to add." if @gems.empty?
 
-      # show warning when options are used with mutiple gems
-      # for time being they will be applied to the all gems
-      Bundler.ui.warn "All the options will be applied to all gems`."
-
       version = @options[:version].nil? ? nil : @options[:version].split(",").map(&:strip)
 
       unless version.nil?
@@ -28,7 +24,10 @@ module Bundler
 
       dependencies = @gems.map {|g| Bundler::Dependency.new(g, version, @options) }
 
-      Injector.inject(dependencies, :conservative_versioning => @options[:version].nil?) # Perform conservative versioning only when version is not specified
+      Injector.inject(dependencies,
+        :conservative_versioning => @options[:version].nil?, # Perform conservative versioning only when version is not specified
+        :optimistic => @options[:optimistic],
+        :strict => @options[:strict])
 
       Installer.install(Bundler.root, Bundler.definition) unless @options["skip-install"]
     end

--- a/lib/bundler/cli/add.rb
+++ b/lib/bundler/cli/add.rb
@@ -15,7 +15,7 @@ module Bundler
       raise InvalidOption, "Please specify gems to add." if @gems.empty?
 
       # show warning when options are used with mutiple gems
-      # for time being they will be applied to the last gem
+      # for time being they will be applied to the all gems
       Bundler.ui.warn "All the options will be applied to all gems`."
 
       version = @options[:version].nil? ? nil : @options[:version].split(",").map(&:strip)
@@ -26,14 +26,8 @@ module Bundler
         end
       end
 
-      # to store dependencies formed from gem names
-      dependencies = []
+      dependencies = @gems.map {|g| Bundler::Dependency.new(g, version, @options) }
 
-      # create a dependency from gem name and
-      # push to dependencies
-      @gems.each {|g| dependencies << Bundler::Dependency.new(g, version, @options) }
-
-      # inject the dependencies
       Injector.inject(dependencies, :conservative_versioning => @options[:version].nil?) # Perform conservative versioning only when version is not specified
 
       Installer.install(Bundler.root, Bundler.definition) unless @options["skip-install"]

--- a/lib/bundler/cli/add.rb
+++ b/lib/bundler/cli/add.rb
@@ -14,6 +14,10 @@ module Bundler
       # raise error when no gems are specified
       raise InvalidOption, "Please specify gems to add." if @gems.empty?
 
+      # show warning when options are used with mutiple gems
+      # for time being they will be applied to the last gem
+      Bundler.ui.warn "All the options will be applied to all gems`."
+
       version = @options[:version].nil? ? nil : @options[:version].split(",").map(&:strip)
 
       unless version.nil?

--- a/lib/bundler/injector.rb
+++ b/lib/bundler/injector.rb
@@ -31,7 +31,8 @@ module Bundler
         @new_deps -= builder.dependencies
 
         # add new deps to the end of the in-memory Gemfile
-        # Set conservative versioning to false because we want to let the resolver resolve the version first
+        # Set conservative versioning to false because
+        # we want to let the resolver resolve the version first
         builder.eval_gemfile("injected gems", build_gem_lines(false)) if @new_deps.any?
 
         # resolve to see if the new deps broke anything

--- a/spec/commands/add_spec.rb
+++ b/spec/commands/add_spec.rb
@@ -17,6 +17,14 @@ RSpec.describe "bundle add" do
     G
   end
 
+  context "when no gems are specified" do
+    it "shows error" do
+      bundle "add"
+
+      expect(out).to include("Please specify gems to add")
+    end
+  end
+
   describe "without version specified" do
     it "version requirement becomes ~> major.minor.patch when resolved version is < 1.0" do
       bundle "add 'bar'"

--- a/spec/commands/add_spec.rb
+++ b/spec/commands/add_spec.rb
@@ -148,4 +148,20 @@ RSpec.describe "bundle add" do
       expect(out).to include("You can not specify `--strict` and `--optimistic` at the same time")
     end
   end
+
+  context "multiple gems" do
+    it "adds multiple gems to gemfile" do
+      bundle! "add bar baz"
+
+      expect(bundled_app("Gemfile").read).to match(/gem "bar", "~> 0.12.3"/)
+      expect(bundled_app("Gemfile").read).to match(/gem "baz", "~> 1.2"/)
+    end
+
+    it "throws error if any of the specified gems are present in the gemfile with different version" do
+      bundle "add weakling bar"
+
+      expect(out).to include("You cannot specify the same gem twice with different version requirements")
+      expect(out).to include("You specified: weakling (~> 0.0.1) and weakling (>= 0).")
+    end
+  end
 end

--- a/spec/commands/add_spec.rb
+++ b/spec/commands/add_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "bundle add" do
     it "shows error" do
       bundle "add"
 
-      expect(out).to include("Please specify gems to add")
+      expect(last_command.bundler_err).to include("Please specify gems to add")
     end
   end
 


### PR DESCRIPTION
Add support for mutiple gems by names only

```bash
bundle add rack rails
```
Concerns:
- All the options/switches used would be applied to the all gems specified and a warning is displayed for the time being.

Closes #6543 