### PR TITLE
Add registered plugin events for before-all, before, and after gem install

### DIFF
--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -23,6 +23,7 @@ module Bundler
       installer = new(root, definition)
       Plugin.hook(Plugin::Events::GEM_BEFORE_INSTALL_ALL, definition.dependencies)
       installer.run(options)
+      Plugin.hook(Plugin::Events::GEM_AFTER_INSTALL_ALL, definition.dependencies)
       installer
     end
 

--- a/lib/bundler/installer/parallel_installer.rb
+++ b/lib/bundler/installer/parallel_installer.rb
@@ -156,6 +156,7 @@ module Bundler
     end
 
     def do_install(spec_install, worker_num)
+      Plugin.hook(Plugin::Events::GEM_BEFORE_INSTALL, spec_install)
       gem_installer = Bundler::GemInstaller.new(
         spec_install.spec, @installer, @standalone, worker_num, @force
       )
@@ -171,6 +172,7 @@ module Bundler
         spec_install.state = :failed
         spec_install.error = "#{message}\n\n#{require_tree_for_spec(spec_install.spec)}"
       end
+      Plugin.hook(Plugin::Events::GEM_AFTER_INSTALL, spec_install)
       spec_install
     end
 

--- a/lib/bundler/plugin/events.rb
+++ b/lib/bundler/plugin/events.rb
@@ -31,9 +31,31 @@ module Bundler
       end
 
       # @!parse
-      #   # A hook called before any gems install
+      #   A hook called before each individual gem is installed
+      #   Includes a Bundler::ParallelInstaller::SpecInstallation.
+      #   No state, error, post_install_message will be present as nothing has installed yet
+      #   GEM_BEFORE_INSTALL = "before-install"
+      define :GEM_BEFORE_INSTALL, "before-install"
+
+      # @!parse
+      #   A hook called after each individual gem is installed
+      #   Includes a Bundler::ParallelInstaller::SpecInstallation.
+      #     - If state is failed, an error will be present.
+      #     - If state is success, a post_install_message may be present.
+      #   GEM_AFTER_INSTALL = "after-install"
+      define :GEM_AFTER_INSTALL,  "after-install"
+
+      # @!parse
+      #   A hook called before any gems install
+      #   Includes an Array of Bundler::Dependency objects
       #   GEM_BEFORE_INSTALL_ALL = "before-install-all"
       define :GEM_BEFORE_INSTALL_ALL, "before-install-all"
+
+      # @!parse
+      #   A hook called after any gems install
+      #   Includes an Array of Bundler::Dependency objects
+      #   GEM_AFTER_INSTALL_ALL = "after-install-all"
+      define :GEM_AFTER_INSTALL_ALL,  "after-install-all"
     end
   end
 end

--- a/spec/plugins/hook_spec.rb
+++ b/spec/plugins/hook_spec.rb
@@ -1,27 +1,109 @@
 # frozen_string_literal: true
 
 RSpec.describe "hook plugins" do
-  before do
-    build_repo2 do
-      build_plugin "before-install-plugin" do |s|
-        s.write "plugins.rb", <<-RUBY
-          Bundler::Plugin::API.hook "before-install-all" do |deps|
-            puts "gems to be installed \#{deps.map(&:name).join(", ")}"
-          end
-        RUBY
+  context "before-install-all hook" do
+    before do
+      build_repo2 do
+        build_plugin "before-install-all-plugin" do |s|
+          s.write "plugins.rb", <<-RUBY
+            Bundler::Plugin::API.hook Bundler::Plugin::Events::GEM_BEFORE_INSTALL_ALL do |deps|
+              puts "gems to be installed \#{deps.map(&:name).join(", ")}"
+            end
+          RUBY
+        end
       end
+
+      bundle "plugin install before-install-all-plugin --source file://#{gem_repo2}"
     end
 
-    bundle "plugin install before-install-plugin --source file://#{gem_repo2}"
+    it "runs before all rubygems are installed" do
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem "rake"
+        gem "rack"
+      G
+
+      expect(out).to include "gems to be installed rake, rack"
+    end
   end
 
-  it "runs after a rubygem is installed" do
-    install_gemfile <<-G
-      source "file://#{gem_repo1}"
-      gem "rake"
-      gem "rack"
-    G
+  context "before-install hook" do
+    before do
+      build_repo2 do
+        build_plugin "before-install-plugin" do |s|
+          s.write "plugins.rb", <<-RUBY
+            Bundler::Plugin::API.hook Bundler::Plugin::Events::GEM_BEFORE_INSTALL do |spec_install|
+              puts "installing gem \#{spec_install.name}"
+            end
+          RUBY
+        end
+      end
 
-    expect(out).to include "gems to be installed rake, rack"
+      bundle "plugin install before-install-plugin --source file://#{gem_repo2}"
+    end
+
+    it "runs before each rubygem is installed" do
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem "rake"
+        gem "rack"
+      G
+
+      expect(out).to include "installing gem rake"
+      expect(out).to include "installing gem rack"
+    end
+  end
+
+  context "after-install-all hook" do
+    before do
+      build_repo2 do
+        build_plugin "after-install-all-plugin" do |s|
+          s.write "plugins.rb", <<-RUBY
+            Bundler::Plugin::API.hook Bundler::Plugin::Events::GEM_AFTER_INSTALL_ALL do |deps|
+              puts "installed gems \#{deps.map(&:name).join(", ")}"
+            end
+          RUBY
+        end
+      end
+
+      bundle "plugin install after-install-all-plugin --source file://#{gem_repo2}"
+    end
+
+    it "runs after each rubygem is installed" do
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem "rake"
+        gem "rack"
+      G
+
+      expect(out).to include "installed gems rake, rack"
+    end
+  end
+
+  context "after-install hook" do
+    before do
+      build_repo2 do
+        build_plugin "after-install-plugin" do |s|
+          s.write "plugins.rb", <<-RUBY
+            Bundler::Plugin::API.hook Bundler::Plugin::Events::GEM_AFTER_INSTALL do |spec_install|
+              puts "installed gem \#{spec_install.name} : \#{spec_install.state}"
+            end
+          RUBY
+        end
+      end
+
+      bundle "plugin install after-install-plugin --source file://#{gem_repo2}"
+    end
+
+    it "runs after each rubygem is installed" do
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem "rake"
+        gem "rack"
+      G
+
+      expect(out).to include "installed gem rake : installed"
+      expect(out).to include "installed gem rack : installed"
+    end
   end
 end


### PR DESCRIPTION
Depends on #6548

### What was the end-user problem that led to this PR?

We only had one plugin hook, which limited the plugin's capabilities a lot.
This adds more

### What was your diagnosis of the problem?

We need more plugin hooks for gem stuff

### What is your fix for the problem, implemented in this PR?

Add more hooks in after-all (including dependencies) and before/after (including install spec)

### Why did you choose this fix out of the possible options?

These seemed like the obvious spots to put the hooks, but I could be wrong. The passed objects also seem to include all the info we need to action on the installations (errors, etc)
