### PR TITLE
Don't fallback to tempdir when required directories exist.

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -159,12 +159,13 @@ module Bundler
     def user_home
       @user_home ||= begin
         home = Bundler.rubygems.user_home
+        bundle_home = home ? File.join(home, ".bundle") : nil
 
         warning = if home.nil?
           "Your home directory is not set."
         elsif !File.directory?(home)
           "`#{home}` is not a directory."
-        elsif !File.writable?(home)
+        elsif !File.writable?(home) && (!File.directory?(bundle_home) || !File.writable?(bundle_home))
           "`#{home}` is not writable."
         end
 

--- a/spec/bundler/bundler_spec.rb
+++ b/spec/bundler/bundler_spec.rb
@@ -199,6 +199,57 @@ EOF
         allow(File).to receive(:writable?).with(path).and_return true
         expect(Bundler.user_home).to eq(Pathname(path))
       end
+
+      context "is not a directory" do
+        it "should issue a warning and return a temporary user home" do
+          path = "/home/oggy"
+          allow(Bundler.rubygems).to receive(:user_home).and_return(path)
+          allow(File).to receive(:directory?).with(path).and_return false
+          allow(Etc).to receive(:getlogin).and_return("USER")
+          allow(Dir).to receive(:tmpdir).and_return("/TMP")
+          allow(FileTest).to receive(:exist?).with("/TMP/bundler/home").and_return(true)
+          expect(FileUtils).to receive(:mkpath).with("/TMP/bundler/home/USER")
+          message = <<EOF
+`/home/oggy` is not a directory.
+Bundler will use `/TMP/bundler/home/USER' as your home directory temporarily.
+EOF
+          expect(Bundler.ui).to receive(:warn).with(message)
+          expect(Bundler.user_home).to eq(Pathname("/TMP/bundler/home/USER"))
+        end
+      end
+
+      context "is not writable" do
+        let(:path) { "/home/oggy" }
+        let(:dotbundle) { "/home/oggy/.bundle" }
+
+        it "should issue a warning and return a temporary user home" do
+          allow(Bundler.rubygems).to receive(:user_home).and_return(path)
+          allow(File).to receive(:directory?).with(path).and_return true
+          allow(File).to receive(:writable?).with(path).and_return false
+          allow(File).to receive(:directory?).with(dotbundle).and_return false
+          allow(Etc).to receive(:getlogin).and_return("USER")
+          allow(Dir).to receive(:tmpdir).and_return("/TMP")
+          allow(FileTest).to receive(:exist?).with("/TMP/bundler/home").and_return(true)
+          expect(FileUtils).to receive(:mkpath).with("/TMP/bundler/home/USER")
+          message = <<EOF
+`/home/oggy` is not writable.
+Bundler will use `/TMP/bundler/home/USER' as your home directory temporarily.
+EOF
+          expect(Bundler.ui).to receive(:warn).with(message)
+          expect(Bundler.user_home).to eq(Pathname("/TMP/bundler/home/USER"))
+        end
+
+        context ".bundle exists and have correct permissions" do
+          it "should return the user home" do
+            allow(Bundler.rubygems).to receive(:user_home).and_return(path)
+            allow(File).to receive(:directory?).with(path).and_return true
+            allow(File).to receive(:writable?).with(path).and_return false
+            allow(File).to receive(:directory?).with(dotbundle).and_return true
+            allow(File).to receive(:writable?).with(dotbundle).and_return true
+            expect(Bundler.user_home).to eq(Pathname(path))
+          end
+        end
+      end
     end
 
     context "home directory is not set" do


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

When running Omnibus packaged software with updated bundler, a warning is displayed because the home folder is not owned by the user:

```
`/var/opt/gitlab` is not writable.
Bundler will use `/tmp/bundler/home/root' as your home directory temporarily.
```

There are valid reasons why this is desired, and I don't have control over it. What I can do is create the required folders used by bundler and provide them with the right permissions.

See https://github.com/bundler/bundler/issues/6546

### What was your diagnosis of the problem?

In practice instead of asking for permission on a higher level, if required folders are present and they have the right permissions, we shouldn't fallback to warning + temp directory, we should just use what is provided.

### What is your fix for the problem, implemented in this PR?

When home directory is not writable, but the required .gem and .bundle
are, we should use them instead of falling back to use tempdirs.

This creates a workaround for more restrictive setups using Omnibus
Docker or any hardened setup, to overcome the annoyances introduced by #4951.

### Why did you choose this fix out of the possible options?

This allows for distributions, package maintainers, etc to provide an alternative while keeping their hardenings requirements.

When provided the required folders with the required ownership/permission, we should not bother by not having any write permissions on the `$HOME` directory.