### PR TITLE
Use filesystem_access when reading a Gemfile

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -421,7 +421,9 @@ EOF
     end
 
     def read_file(file)
-      File.open(file, "rb", &:read)
+      SharedHelpers.filesystem_access(file, :read) do
+        File.open(file, "rb", &:read)
+      end
     end
 
     def load_marshal(data)


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was users would see an issue template when their `Gemfile` did not have read permissions

Fixes https://github.com/bundler/bundler/issues/6541

### What is your fix for the problem, implemented in this PR?

My fix is to use `SharedHelpers.filesystem_access` when reading the Gemfile