### PR TITLE
[bundle add] Add version prefix flexibility

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -335,6 +335,8 @@ module Bundler
     method_option "source", :aliases => "-s", :type => :string
     method_option "skip-install", :type => :boolean, :banner =>
       "Adds gem to the Gemfile but does not install it"
+    method_option "optimistic", :type => :boolean
+    method_option "strict", :type => :boolean
     def add(gem_name)
       require "bundler/cli/add"
       Add.new(options.dup, gem_name).run

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -335,8 +335,8 @@ module Bundler
     method_option "source", :aliases => "-s", :type => :string
     method_option "skip-install", :type => :boolean, :banner =>
       "Adds gem to the Gemfile but does not install it"
-    method_option "optimistic", :type => :boolean
-    method_option "strict", :type => :boolean
+    method_option "optimistic", :type => :boolean, :banner => "Adds optimistic declaration of version to gem"
+    method_option "strict", :type => :boolean, :banner => "Adds strict declaration of version to gem"
     def add(gem_name)
       require "bundler/cli/add"
       Add.new(options.dup, gem_name).run

--- a/lib/bundler/cli/add.rb
+++ b/lib/bundler/cli/add.rb
@@ -9,6 +9,8 @@ module Bundler
     end
 
     def run
+      raise InvalidOption, "You can not specify `--strict` and `--optimistic` at the same time." if @options[:strict] && @options[:optimistic]
+
       version = @options[:version].nil? ? nil : @options[:version].split(",").map(&:strip)
 
       unless version.nil?

--- a/lib/bundler/cli/add.rb
+++ b/lib/bundler/cli/add.rb
@@ -18,7 +18,10 @@ module Bundler
       end
       dependency = Bundler::Dependency.new(@gem_name, version, @options)
 
-      Injector.inject([dependency], :conservative_versioning => @options[:version].nil?) # Perform conservative versioning only when version is not specified
+      Injector.inject([dependency],
+        :conservative_versioning => @options[:version].nil?, # Perform conservative versioning only when version is not specified
+        :optimistic => @options[:optimistic],
+        :strict => @options[:strict])
       Installer.install(Bundler.root, Bundler.definition) unless @options["skip-install"]
     end
   end

--- a/lib/bundler/injector.rb
+++ b/lib/bundler/injector.rb
@@ -61,7 +61,17 @@ module Bundler
       seg_end_index = version >= Gem::Version.new("1.0") ? 1 : 2
 
       prerelease_suffix = version.to_s.gsub(version.release.to_s, "") if version.prerelease?
-      "~> #{segments[0..seg_end_index].join(".")}#{prerelease_suffix}"
+      "#{version_prefix}#{segments[0..seg_end_index].join(".")}#{prerelease_suffix}"
+    end
+
+    def version_prefix
+      if @options[:strict]
+        "= "
+      elsif @options[:optimistic]
+        ">= "
+      else
+        "~> "
+      end
     end
 
     def build_gem_lines(conservative_versioning)

--- a/man/bundle-add.ronn
+++ b/man/bundle-add.ronn
@@ -3,7 +3,7 @@ bundle-add(1) -- Add gem to the Gemfile and run bundle install
 
 ## SYNOPSIS
 
-`bundle add` <GEM_NAME> [--group=GROUP] [--version=VERSION] [--source=SOURCE] [--skip-install]
+`bundle add` <GEM_NAME> [--group=GROUP] [--version=VERSION] [--source=SOURCE] [--skip-install] [--strict] [--optimistic]
 
 ## DESCRIPTION
 Adds the named gem to the Gemfile and run `bundle install`. `bundle install` can be avoided by using the flag `--skip-install`.
@@ -32,3 +32,9 @@ bundle add rails --group "development, test"
 
 * `--skip-install`:
   Adds the gem to the Gemfile but does not install it.
+
+* `--optimistic`:
+  Adds optimistic declaration of version
+
+* `--strict`:
+  Adds strict declaration of version

--- a/spec/commands/add_spec.rb
+++ b/spec/commands/add_spec.rb
@@ -116,4 +116,28 @@ RSpec.describe "bundle add" do
     bundle "add 'baz' --source='file://does/not/exist'"
     expect(out).to include("Could not fetch specs from file://does/not/exist/")
   end
+
+  describe "with --optimistic" do
+    it "adds optimistic version" do
+      bundle! "add 'foo' --optimistic"
+      expect(bundled_app("Gemfile").read).to include %(gem "foo", ">= 2.0")
+      expect(the_bundle).to include_gems "foo 2.0"
+    end
+  end
+
+  describe "with --strict option" do
+    it "adds strict version" do
+      bundle! "add 'foo' --strict"
+      expect(bundled_app("Gemfile").read).to include %(gem "foo", "= 2.0")
+      expect(the_bundle).to include_gems "foo 2.0"
+    end
+  end
+
+  describe "with no option" do
+    it "adds pessimistic version" do
+      bundle! "add 'foo'"
+      expect(bundled_app("Gemfile").read).to include %(gem "foo", "~> 2.0")
+      expect(the_bundle).to include_gems "foo 2.0"
+    end
+  end
 end

--- a/spec/commands/add_spec.rb
+++ b/spec/commands/add_spec.rb
@@ -140,4 +140,12 @@ RSpec.describe "bundle add" do
       expect(the_bundle).to include_gems "foo 2.0"
     end
   end
+
+  describe "with --optimistic and --strict" do
+    it "throws error" do
+      bundle "add 'foo' --strict --optimistic"
+
+      expect(out).to include("You can not specify `--strict` and `--optimistic` at the same time")
+    end
+  end
 end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

By default, on `bundle add` we use "pessimistic" way (~>) of versions. According to this [comment](https://github.com/bundler/bundler/issues/6553#issue-326023952) some users face problems.

### What was your diagnosis of the problem?

Adding flags to provide flexibility to change this declaration namely `optimistic` and `strict`

### What is your fix for the problem, implemented in this PR?

Adding flags to opt for other declarations.

### Why did you choose this fix out of the possible options?

Currently, its an experiment and I have added it to only `bundle add` but still the version locked in lockfile are "pessimistic". Need suggestions on this and on how to proceed.

Addresses #6553 