### PR TITLE
No need to setup BUNDLE_BIN in using DynamicCommand with --path

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -30,6 +30,17 @@ module Bundler
       end
     end
 
+    def self.dynamic_command_class
+      CustomSubCommand
+    end
+
+    class CustomSubCommand < DynamicCommand
+      def run(*)
+        SharedHelpers.set_bundle_environment
+        super
+      end
+    end
+
     def initialize(*args)
       super
 

--- a/spec/bundler/cli_spec.rb
+++ b/spec/bundler/cli_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "bundle executable" do
   end
 
   it "looks for a binary and executes it if it's named bundler-<task>" do
+    Dir.mkdir ".bundle"
     File.open(tmp("bundler-testtasks"), "w", 0o755) do |f|
       f.puts "#!/usr/bin/env ruby\nputs 'Hello, world'\n"
     end
@@ -88,6 +89,7 @@ RSpec.describe "bundle executable" do
   describe "printing the outdated warning" do
     shared_examples_for "no warning" do
       it "prints no warning" do
+        Dir.mkdir ".bundle"
         bundle "fail"
         expect(last_command.stdboth).to eq("Could not find command \"fail\".")
       end

--- a/spec/plugins/command_spec.rb
+++ b/spec/plugins/command_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe "command plugins" do
   it "executes without arguments" do
     expect(out).to include("Installed plugin command-mah")
 
+    Dir.mkdir ".bundle"
     bundle "mahcommand"
     expect(out).to eq("MahHello")
   end
@@ -46,6 +47,7 @@ RSpec.describe "command plugins" do
       end
     end
 
+    Dir.mkdir ".bundle"
     bundle "plugin install the-echoer --source file://#{gem_repo2}"
     expect(out).to include("Installed plugin the-echoer")
 

--- a/spec/plugins/install_spec.rb
+++ b/spec/plugins/install_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe "bundler plugin install" do
     end
     bundle "plugin install testing --source file://#{gem_repo2}"
 
+    Dir.mkdir ".bundle"
     bundle "check2", "no-color" => false
     expect(out).to eq("mate")
   end
@@ -248,6 +249,7 @@ RSpec.describe "bundler plugin install" do
 
       it "outside the app global plugin is used" do
         Dir.chdir tmp
+        Dir.mkdir ".bundle"
 
         bundle "shout"
         expect(out).to eq("global_one")


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

When we use a bundler's custom sub command provided by gem with `--path` option, we must use BUNDLE_BIN or bundle config bin to add it to PATH.

### What was your diagnosis of the problem?

We can use BUNDLE_BIN as workaround, but I think it's easy for user to use the custom sub command with no option like as normal command installed by gem just after `bundle install`.

### What is your fix for the problem, implemented in this PR?

I've changed to use a new `CustomSubCommand` class rather than Thor's `DynamicCommand` class directly in custom sub command.

### Why did you choose this fix out of the possible options?

It is the responsibility of Bundler to setup for its environment.
