### PR TITLE
Enable bundler caching for generated travis config

### DIFF
--- a/lib/bundler/templates/newgem/travis.yml.tt
+++ b/lib/bundler/templates/newgem/travis.yml.tt
@@ -1,5 +1,7 @@
+---
 sudo: false
 language: ruby
+cache: bundler
 rvm:
   - <%= RUBY_VERSION %>
 before_install: gem install bundler -v <%= Bundler::VERSION %>


### PR DESCRIPTION
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

Whenever I create a gem using `bundle gem`, I always have to manually specify that I would like travis to cache bundler.

### What is your fix for the problem, implemented in this PR?

Specify `cache: bundler` in the generated .travis.yml.