### PR TITLE
Respect --conservative flag when updating a dependency group

### DIFF
--- a/lib/bundler/cli/update.rb
+++ b/lib/bundler/cli/update.rb
@@ -38,8 +38,8 @@ module Bundler
         Bundler::CLI::Common.ensure_all_gems_in_lockfile!(gems)
 
         if groups.any?
-          specs = Bundler.definition.specs_for groups
-          gems.concat(specs.map(&:name))
+          deps = Bundler.definition.dependencies.select {|d| (d.groups & groups).any? }
+          gems.concat(deps.map(&:name))
         end
 
         Bundler.definition(:gems => gems, :sources => sources, :ruby => options[:ruby],

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -189,6 +189,23 @@ RSpec.describe "bundle update" do
       expect(the_bundle).not_to include_gems "rack 1.2"
     end
 
+    context "when conservatively updating a group with non-group sub-deps" do
+      it "should update only specified group gems" do
+        install_gemfile <<-G
+          source "file://#{gem_repo2}"
+          gem "activemerchant", :group => :development
+          gem "activesupport"
+        G
+        update_repo2 do
+          build_gem "activemerchant", "2.0"
+          build_gem "activesupport", "3.0"
+        end
+        bundle "update --conservative --group development"
+        expect(the_bundle).to include_gems "activemerchant 2.0"
+        expect(the_bundle).not_to include_gems "activesupport 3.0"
+      end
+    end
+
     context "when there is a source with the same name as a gem in a group" do
       before :each do
         build_git "foo", :path => lib_path("activesupport")


### PR DESCRIPTION
Previously, we were using `Bundler.definition.specs_for groups` to get the list of dependencies to unlock when updating a specific group. That method returns all sub-dependencies for the dependencies in the group, too, which were therefore being unlocked and --conservative was being ignored.

This PR ensures `--conservative` is respected for group updates by selecting the dependencies for the group directly from the definition instead. It adds a test to ensure we don't accidentally regress.

Fixes https://github.com/bundler/bundler/issues/6560.