### PR TITLE
select a pre-release if it's specified in the Gemfile

### DIFF
--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -183,10 +183,6 @@ module Bundler
 
     def requirement_satisfied_by?(requirement, activated, spec)
       return false unless requirement.matches_spec?(spec) || spec.source.is_a?(Source::Gemspec)
-      if spec.version.prerelease? && !requirement.prerelease? && search_for(requirement).any? {|sg| !sg.version.prerelease? }
-        vertex = activated.vertex_named(spec.name)
-        return false if vertex.requirements.none?(&:prerelease?)
-      end
       spec.activate_platform!(requirement.__platform) if !@platforms || @platforms.include?(requirement.__platform)
       true
     end

--- a/spec/resolver/basic_spec.rb
+++ b/spec/resolver/basic_spec.rb
@@ -80,6 +80,13 @@ RSpec.describe "Resolving" do
     should_resolve_as %w[need-pre-1.0.0 activesupport-3.0.0.beta1]
   end
 
+  it "selects a pre-release if it's specified in the Gemfile" do
+    dep "activesupport", "= 3.0.0.beta"
+    dep "actionpack"
+
+    should_resolve_as %w[activesupport-3.0.0.beta actionpack-3.0.0.beta rack-1.1 rack-mount-0.6]
+  end
+
   it "raises an exception if a child dependency is not resolved" do
     @index = a_unresovable_child_index
     dep "chef_app_error"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was #6449

Closes #6449 

### What was your diagnosis of the problem?

My diagnosis was that Bundler didn't select a pre-release even if one of the dependencies of a gem was specified with a pre-release version in the Gemfile.

### What is your fix for the problem, implemented in this PR?

My fix is to change `Bundler::Resolver#requirement_satisfied_by?` so that it does not reject a pre-release if at least one of the dependencies is pre-released.

### Why did you choose this fix out of the possible options?
