### PR TITLE
Check if source responds to `#remotes` before printing gem install error message

### DIFF
--- a/lib/bundler/installer/gem_installer.rb
+++ b/lib/bundler/installer/gem_installer.rb
@@ -44,9 +44,11 @@ module Bundler
     end
 
     def gem_install_message
-      remotes = spec.source.remotes
-      if remotes.size == 1
-        "Make sure that `gem install #{spec.name} -v '#{spec.version}' --source '#{remotes.first}'` succeeds before bundling."
+      source = spec.source
+      return unless source.respond_to?(:remotes)
+
+      if source.remotes.size == 1
+        "Make sure that `gem install #{spec.name} -v '#{spec.version}' --source '#{source.remotes.first}'` succeeds before bundling."
       else
         "Make sure that `gem install #{spec.name} -v '#{spec.version}'` succeeds before bundling."
       end

--- a/spec/install/failure_spec.rb
+++ b/spec/install/failure_spec.rb
@@ -29,6 +29,66 @@ In Gemfile:
                      M
     end
 
+    context "when installing a git gem" do
+      it "does not tell the user to run 'gem install'" do
+        build_git "activesupport", "2.3.2", :path => lib_path("activesupport") do |s|
+          s.extensions << "Rakefile"
+          s.write "Rakefile", <<-RUBY
+            task :default do
+              abort "make installing activesupport-2.3.2 fail"
+            end
+          RUBY
+        end
+
+        install_gemfile <<-G
+          source "file:\/\/localhost#{gem_repo1}"
+          gem "rails"
+          gem "activesupport", :git => "#{lib_path("activesupport")}"
+        G
+
+        expect(last_command.bundler_err).to end_with(<<-M.strip)
+An error occurred while installing activesupport (2.3.2), and Bundler cannot continue.
+
+In Gemfile:
+  rails was resolved to 2.3.2, which depends on
+    actionmailer was resolved to 2.3.2, which depends on
+      activesupport
+                     M
+      end
+    end
+
+    context "when installing a gem using a git block" do
+      it "does not tell the user to run 'gem install'" do
+        build_git "activesupport", "2.3.2", :path => lib_path("activesupport") do |s|
+          s.extensions << "Rakefile"
+          s.write "Rakefile", <<-RUBY
+            task :default do
+              abort "make installing activesupport-2.3.2 fail"
+            end
+          RUBY
+        end
+
+        install_gemfile <<-G
+          source "file:\/\/localhost#{gem_repo1}"
+          gem "rails"
+
+          git "#{lib_path("activesupport")}" do
+            gem "activesupport"
+          end
+        G
+
+        expect(last_command.bundler_err).to end_with(<<-M.strip)
+An error occurred while installing activesupport (2.3.2), and Bundler cannot continue.
+
+
+In Gemfile:
+  rails was resolved to 2.3.2, which depends on
+    actionmailer was resolved to 2.3.2, which depends on
+      activesupport
+                     M
+      end
+    end
+
     it "prints out the hint for the remote source when available" do
       build_repo2 do
         build_gem "activesupport", "2.3.2" do |s|


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

There is a bug that was introduced in #6211 that prints an error message during `bundle install` if a gem failed to be installed. The error message attempts to call the `#remotes` method on `Bundler::Source::Git` which it does not implement.

### What was your diagnosis of the problem?

See #6563

### What is your fix for the problem, implemented in this PR?

Check if the `source` responds to `#remotes` before and return early

### Why did you choose this fix out of the possible options?

This seems to be the most simplest fix without having to refactor a lot of code.
