### PR TITLE
[bundle list] add `--without-group` and `--only-group`

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -287,8 +287,8 @@ module Bundler
     if Bundler.feature_flag.list_command?
       desc "list", "List all gems in the bundle"
       method_option "name-only", :type => :boolean, :banner => "print only the gem names"
-      method_option "only", :type => :string, :banner => "print gems from a particular group"
-      method_option "without", :type => :string, :banner => "print all gems expect from a group"
+      method_option "only-group", :type => :string, :banner => "print gems from a particular group"
+      method_option "without-group", :type => :string, :banner => "print all gems expect from a group"
       method_option "paths", :type => :boolean, :banner => "print the path to each gem in the bundle"
       def list
         require "bundler/cli/list"

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -287,6 +287,8 @@ module Bundler
     if Bundler.feature_flag.list_command?
       desc "list", "List all gems in the bundle"
       method_option "name-only", :type => :boolean, :banner => "print only the gem names"
+      method_option "only", :type => :string, :banner => "print only the gem names"
+      method_option "without", :type => :string, :banner => "print only the gem names"
       method_option "paths", :type => :boolean, :banner => "print the path to each gem in the bundle"
       def list
         require "bundler/cli/list"

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -287,8 +287,8 @@ module Bundler
     if Bundler.feature_flag.list_command?
       desc "list", "List all gems in the bundle"
       method_option "name-only", :type => :boolean, :banner => "print only the gem names"
-      method_option "only", :type => :string, :banner => "print only the gem names"
-      method_option "without", :type => :string, :banner => "print only the gem names"
+      method_option "only", :type => :string, :banner => "print gems from a particular group"
+      method_option "without", :type => :string, :banner => "print all gems expect from a group"
       method_option "paths", :type => :boolean, :banner => "print the path to each gem in the bundle"
       def list
         require "bundler/cli/list"

--- a/lib/bundler/cli/list.rb
+++ b/lib/bundler/cli/list.rb
@@ -7,19 +7,60 @@ module Bundler
     end
 
     def run
-      specs = Bundler.load.specs.reject {|s| s.name == "bundler" }.sort_by(&:name)
+      raise InvalidOption, "The `--only` and `--without` options cannot be used together" if @options[:only] && @options[:without]
 
       raise InvalidOption, "The `--name-only` and `--paths` options cannot be used together" if @options["name-only"] && @options["paths"]
+
+      builder = Dsl.new
+      builder.eval_gemfile(Bundler.default_gemfile)
+
+      @definition = builder.to_definition(Bundler.default_lockfile, {})
+
+      verify_group_exists
+
+      @definition.resolve_remotely!
+
+      # get gems that are to be shown from upper and then filter them from specs
+
+      p @definition.specs
+      return
+
+      specs = filter_groups.map(&:to_spec).sort_by(&:name)
+
+      return Bundler.ui.info "No gems in the Gemfile" if specs.empty?
+
       return specs.each {|s| Bundler.ui.info s.name } if @options["name-only"]
       return specs.each {|s| Bundler.ui.info s.full_gem_path } if @options["paths"]
 
-      return Bundler.ui.info "No gems in the Gemfile" if specs.empty?
       Bundler.ui.info "Gems included by the bundle:"
-      specs.each do |s|
-        Bundler.ui.info "  * #{s.name} (#{s.version}#{s.git_version})"
-      end
+
+      specs.each {|s| Bundler.ui.info "  * #{s.name} (#{s.version}#{s.git_version})" }
 
       Bundler.ui.info "Use `bundle info` to print more detailed information about a gem"
+    end
+
+  private
+
+    def verify_group_exists
+      if @options[:without] && !@definition.groups.include?(@options[:without].to_sym)
+        raise InvalidOption, "`#{@options[:without]}` group could not be found"
+      end
+
+      if @options[:only] && !@definition.groups.include?(@options[:only].to_sym)
+        raise InvalidOption, "`#{@options[:only]}` group could not be found"
+      end
+    end
+
+    def filter_groups
+      deps = @definition.dependencies.reject {|d| d.name == "bundler" }
+
+      if @options[:without]
+        deps.reject {|d| d.groups.include?(@options[:without].to_sym) }
+      elsif @options[:only]
+        deps.select {|d| d.groups.include?(@options[:only].to_sym) }
+      else
+        deps
+      end
     end
   end
 end

--- a/lib/bundler/cli/list.rb
+++ b/lib/bundler/cli/list.rb
@@ -7,11 +7,11 @@ module Bundler
     end
 
     def run
-      raise InvalidOption, "The `--only` and `--without` options cannot be used together" if @options[:only] && @options[:without]
+      raise InvalidOption, "The `--only-group` and `--without-group` options cannot be used together" if @options["only-group"] && @options["without-group"]
 
       raise InvalidOption, "The `--name-only` and `--paths` options cannot be used together" if @options["name-only"] && @options[:paths]
 
-      specs = if @options[:only] || @options[:without]
+      specs = if @options["only-group"] || @options["without-group"]
         filtered_specs_by_groups
       else
         Bundler.load.specs
@@ -32,9 +32,9 @@ module Bundler
   private
 
     def verify_group_exists(groups)
-      raise InvalidOption, "`#{@options[:without]}` group could not be found." if @options[:without] && !groups.include?(@options[:without].to_sym)
+      raise InvalidOption, "`#{@options["without-group"]}` group could not be found." if @options["without-group"] && !groups.include?(@options["without-group"].to_sym)
 
-      raise InvalidOption, "`#{@options[:only]}` group could not be found." if @options[:only] && !groups.include?(@options[:only].to_sym)
+      raise InvalidOption, "`#{@options["only-group"]}` group could not be found." if @options["only-group"] && !groups.include?(@options["only-group"].to_sym)
     end
 
     def filtered_specs_by_groups
@@ -44,10 +44,10 @@ module Bundler
       verify_group_exists(groups)
 
       show_groups =
-        if @options[:without]
-          groups.reject {|g| g == @options[:without].to_sym }
-        elsif @options[:only]
-          groups.select {|g| g == @options[:only].to_sym }
+        if @options["without-group"]
+          groups.reject {|g| g == @options["without-group"].to_sym }
+        elsif @options["only-group"]
+          groups.select {|g| g == @options["only-group"].to_sym }
         else
           groups
         end.map(&:to_sym)

--- a/man/bundle-list.ronn
+++ b/man/bundle-list.ronn
@@ -3,7 +3,7 @@ bundle-list(1) -- List all the gems in the bundle
 
 ## SYNOPSIS
 
-`bundle list` [--name-only] [--paths] [--without=GROUP] [--only=GROUP]
+`bundle list` [--name-only] [--paths] [--without-group=GROUP] [--only-group=GROUP]
 
 ## DESCRIPTION
 
@@ -15,11 +15,11 @@ bundle list --name-only
 
 bundle list --paths
 
-bundle list --without test
+bundle list --without-group test
 
-bundle list --only dev
+bundle list --only-group dev
 
-bundle list --only dev --paths
+bundle list --only-group dev --paths
 
 ## OPTIONS
 
@@ -27,7 +27,7 @@ bundle list --only dev --paths
   Print only the name of each gem.
 * `--paths`:
   Print the path to each gem in the bundle.
-* `--without`:
+* `--without-group`:
   Print all gems expect from a group.
-* `--only`:
+* `--only-group`:
   Print gems from a particular group.

--- a/man/bundle-list.ronn
+++ b/man/bundle-list.ronn
@@ -3,11 +3,23 @@ bundle-list(1) -- List all the gems in the bundle
 
 ## SYNOPSIS
 
-`bundle list` [--name-only]
+`bundle list` [--name-only] [--paths] [--without=GROUP] [--only=GROUP]
 
 ## DESCRIPTION
 
 Prints a list of all the gems in the bundle including their version.
+
+Example:
+
+bundle list --name-only
+
+bundle list --paths
+
+bundle list --without test
+
+bundle list --only dev
+
+bundle list --only dev --paths
 
 ## OPTIONS
 
@@ -15,3 +27,7 @@ Prints a list of all the gems in the bundle including their version.
   Print only the name of each gem.
 * `--paths`:
   Print the path to each gem in the bundle.
+* `--without`:
+  Print all gems expect from a group.
+* `--only`:
+  Print gems from a particular group.

--- a/spec/commands/list_spec.rb
+++ b/spec/commands/list_spec.rb
@@ -4,21 +4,72 @@ RSpec.describe "bundle list", :bundler => "2" do
   before do
     install_gemfile <<-G
       source "file://#{gem_repo1}"
+
       gem "rack"
+      gem "rspec", :group => [:test]
     G
   end
 
   context "with name-only and paths option" do
     it "raises an error" do
       bundle "list --name-only --paths"
+
       expect(out).to eq "The `--name-only` and `--paths` options cannot be used together"
+    end
+  end
+
+  context "with without and only option" do
+    it "raises an error" do
+      bundle "list --without dev --only test"
+
+      expect(out).to eq "The `--only` and `--without` options cannot be used together"
+    end
+  end
+
+  describe "with without option" do
+    context "when group is present" do
+      it "prints the gems not in the specified group" do
+        bundle! "list --without test"
+
+        expect(out).to include("  * rack (1.0.0)")
+        expect(out).not_to include("  * rspec (1.2.7)")
+      end
+    end
+
+    context "when group is not found" do
+      it "raises an error" do
+        bundle "list --without random"
+
+        expect(out).to eq "`random` group could not be found."
+      end
+    end
+  end
+
+  describe "with only option" do
+    context "when group is present" do
+      it "prints the gems in the specified group" do
+        bundle! "list --only default"
+
+        expect(out).to include("  * rack (1.0.0)")
+        expect(out).not_to include("  * rspec (1.2.7)")
+      end
+    end
+
+    context "when group is not found" do
+      it "raises an error" do
+        bundle "list --only random"
+
+        expect(out).to eq "`random` group could not be found."
+      end
     end
   end
 
   context "with name-only option" do
     it "prints only the name of the gems in the bundle" do
       bundle "list --name-only"
-      expect(out).to eq "rack"
+
+      expect(out).to include("rack")
+      expect(out).to include("rspec")
     end
   end
 

--- a/spec/commands/list_spec.rb
+++ b/spec/commands/list_spec.rb
@@ -18,18 +18,18 @@ RSpec.describe "bundle list", :bundler => "2" do
     end
   end
 
-  context "with without and only option" do
+  context "with without-group and only-group option" do
     it "raises an error" do
-      bundle "list --without dev --only test"
+      bundle "list --without-group dev --only-group test"
 
-      expect(out).to eq "The `--only` and `--without` options cannot be used together"
+      expect(out).to eq "The `--only-group` and `--without-group` options cannot be used together"
     end
   end
 
-  describe "with without option" do
+  describe "with without-group option" do
     context "when group is present" do
       it "prints the gems not in the specified group" do
-        bundle! "list --without test"
+        bundle! "list --without-group test"
 
         expect(out).to include("  * rack (1.0.0)")
         expect(out).not_to include("  * rspec (1.2.7)")
@@ -38,17 +38,17 @@ RSpec.describe "bundle list", :bundler => "2" do
 
     context "when group is not found" do
       it "raises an error" do
-        bundle "list --without random"
+        bundle "list --without-group random"
 
         expect(out).to eq "`random` group could not be found."
       end
     end
   end
 
-  describe "with only option" do
+  describe "with only-group option" do
     context "when group is present" do
       it "prints the gems in the specified group" do
-        bundle! "list --only default"
+        bundle! "list --only-group default"
 
         expect(out).to include("  * rack (1.0.0)")
         expect(out).not_to include("  * rspec (1.2.7)")
@@ -57,7 +57,7 @@ RSpec.describe "bundle list", :bundler => "2" do
 
     context "when group is not found" do
       it "raises an error" do
-        bundle "list --only random"
+        bundle "list --only-group random"
 
         expect(out).to eq "`random` group could not be found."
       end


### PR DESCRIPTION
Listing gems according to groups, either excluding a particular or from a specific group.

Usage:
```bash
bundle list --without-group dev
```

```bash
bundle list --only-group dev
```

Addresses #6564 