### PR TITLE
handle Errno::ENOTSUP in the Bundler process lock

### DIFF
--- a/lib/bundler/process_lock.rb
+++ b/lib/bundler/process_lock.rb
@@ -12,7 +12,7 @@ module Bundler
         yield
         f.flock(File::LOCK_UN)
       end
-    rescue Errno::EACCES, Errno::ENOLCK
+    rescue Errno::EACCES, Errno::ENOLCK, *[SharedHelpers.const_get_safely(:ENOTSUP, Errno)].compact
       # In the case the user does not have access to
       # create the lock file or is using NFS where
       # locks are not available we skip locking.

--- a/spec/install/process_lock_spec.rb
+++ b/spec/install/process_lock_spec.rb
@@ -20,5 +20,16 @@ RSpec.describe "process lock spec" do
       thread.join
       expect(the_bundle).to include_gems "rack 1.0"
     end
+
+    context "when creating a lock raises Errno::ENOTSUP", :ruby => ">= 1.9" do
+      before { allow(File).to receive(:open).and_raise(Errno::ENOTSUP) }
+
+      it "skips creating the lock file and yields" do
+        processed = false
+        Bundler::ProcessLock.lock(default_bundle_path) { processed = true }
+
+        expect(processed).to eq true
+      end
+    end
   end
 end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Bundler is trying to perform an operation on an NFS that is raising an exception (Errno::ENOTSUP)

### What was your diagnosis of the problem?

See #6566 

### What is your fix for the problem, implemented in this PR?

Catch the exception and allow Bundler to continue

### Why did you choose this fix out of the possible options?

This conforms with the existing pattern in regards to handling these types of errors in the Bundler process lock logic.
