### PR TITLE
Support URI::File of Ruby 2.6

### DIFF
--- a/lib/bundler/source/rubygems.rb
+++ b/lib/bundler/source/rubygems.rb
@@ -344,7 +344,11 @@ module Bundler
       end
 
       def remove_auth(remote)
-        remote.dup.tap {|uri| uri.user = uri.password = nil }.to_s
+        if remote.user || remote.password
+          remote.dup.tap {|uri| uri.user = uri.password = nil }.to_s
+        else
+          remote.to_s
+        end
       end
 
       def installed_specs

--- a/lib/bundler/source/rubygems/remote.rb
+++ b/lib/bundler/source/rubygems/remote.rb
@@ -25,7 +25,14 @@ module Bundler
 
             cache_uri = original_uri || uri
 
-            uri_parts = [cache_uri.host, cache_uri.user, cache_uri.port, cache_uri.path]
+            # URI::File of Ruby 2.6 returns empty string when given "file://".
+            if defined?(URI::File) && cache_uri.is_a?(URI::File)
+              host = nil
+            else
+              host = cache_uri.host
+            end
+
+            uri_parts = [host, cache_uri.user, cache_uri.port, cache_uri.path]
             uri_digest = SharedHelpers.digest(:MD5).hexdigest(uri_parts.compact.join("."))
 
             uri_parts[-1] = uri_digest

--- a/lib/bundler/source/rubygems/remote.rb
+++ b/lib/bundler/source/rubygems/remote.rb
@@ -26,11 +26,7 @@ module Bundler
             cache_uri = original_uri || uri
 
             # URI::File of Ruby 2.6 returns empty string when given "file://".
-            if defined?(URI::File) && cache_uri.is_a?(URI::File)
-              host = nil
-            else
-              host = cache_uri.host
-            end
+            host = defined?(URI::File) && cache_uri.is_a?(URI::File) ? nil : cache_uri.host
 
             uri_parts = [host, cache_uri.user, cache_uri.port, cache_uri.path]
             uri_digest = SharedHelpers.digest(:MD5).hexdigest(uri_parts.compact.join("."))

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -789,6 +789,8 @@ __FILE__: #{path.to_s.inspect}
       end
 
       it "overrides disable_shared_gems so bundler can be found" do
+        skip "bundler 1.16.x is not support with Ruby 2.6 on Travis CI" if RUBY_VERSION >= "2.6"
+
         file = bundled_app("file_that_bundle_execs.rb")
         create_file(file, <<-RB)
           #!#{Gem.ruby}

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -354,8 +354,10 @@ RSpec.describe "bundle install with gem sources" do
       G
 
       expect(last_command.stdboth).not_to match(/Error Report/i)
+      msg = "Make sure that `gem install ajp-rails -v '0.0.0' --source 'file://localhost#{gem_repo2}/'` succeeds before bundling."
+      msg = msg.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
       expect(last_command.bundler_err).to include("An error occurred while installing ajp-rails (0.0.0), and Bundler cannot continue.").
-        and include("Make sure that `gem install ajp-rails -v '0.0.0' --source 'file://localhost#{gem_repo2}/'` succeeds before bundling.")
+        and include(msg)
     end
 
     it "doesn't blow up when the local .bundle/config is empty" do

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -354,10 +354,8 @@ RSpec.describe "bundle install with gem sources" do
       G
 
       expect(last_command.stdboth).not_to match(/Error Report/i)
-      msg = "Make sure that `gem install ajp-rails -v '0.0.0' --source 'file://localhost#{gem_repo2}/'` succeeds before bundling."
-      msg = msg.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
       expect(last_command.bundler_err).to include("An error occurred while installing ajp-rails (0.0.0), and Bundler cannot continue.").
-        and include(msg)
+        and include(normalize_uri_file("Make sure that `gem install ajp-rails -v '0.0.0' --source 'file://localhost#{gem_repo2}/'` succeeds before bundling."))
     end
 
     it "doesn't blow up when the local .bundle/config is empty" do

--- a/spec/commands/lock_spec.rb
+++ b/spec/commands/lock_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "bundle lock" do
       gem "foo"
     G
 
-    @lockfile = strip_lockfile <<-L
+    @lockfile = strip_lockfile(normalize_uri_file(<<-L))
       GEM
         remote: file://localhost#{repo}/
         specs:
@@ -53,7 +53,6 @@ RSpec.describe "bundle lock" do
       BUNDLED WITH
          #{Bundler::VERSION}
     L
-    @lockfile = @lockfile.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
   end
 
   it "prints a lockfile when there is no existing lockfile with --print" do
@@ -258,7 +257,7 @@ RSpec.describe "bundle lock" do
 
     simulate_platform(mingw) { bundle! :lock }
 
-    lockfile_should_be(<<-G, the_bundle.lockfile)
+    expect(the_bundle.lockfile).to read_as(normalize_uri_file(strip_whitespace(<<-G)))
       GEM
         remote: file://localhost#{gem_repo4}/
         specs:
@@ -283,7 +282,7 @@ RSpec.describe "bundle lock" do
 
     simulate_platform(rb) { bundle! :lock }
 
-    lockfile_should_be(<<-G, the_bundle.lockfile)
+    expect(the_bundle.lockfile).to read_as(normalize_uri_file(strip_whitespace(<<-G)))
       GEM
         remote: file://localhost#{gem_repo4}/
         specs:

--- a/spec/commands/lock_spec.rb
+++ b/spec/commands/lock_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe "bundle lock" do
       BUNDLED WITH
          #{Bundler::VERSION}
     L
+    @lockfile = @lockfile.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
   end
 
   it "prints a lockfile when there is no existing lockfile with --print" do
@@ -257,7 +258,7 @@ RSpec.describe "bundle lock" do
 
     simulate_platform(mingw) { bundle! :lock }
 
-    expect(the_bundle.lockfile).to read_as(strip_whitespace(<<-G))
+    lockfile_should_be(<<-G, the_bundle.lockfile)
       GEM
         remote: file://localhost#{gem_repo4}/
         specs:
@@ -282,7 +283,7 @@ RSpec.describe "bundle lock" do
 
     simulate_platform(rb) { bundle! :lock }
 
-    expect(the_bundle.lockfile).to read_as(strip_whitespace(<<-G))
+    lockfile_should_be(<<-G, the_bundle.lockfile)
       GEM
         remote: file://localhost#{gem_repo4}/
         specs:

--- a/spec/install/failure_spec.rb
+++ b/spec/install/failure_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "bundle install" do
         source "file:\/\/localhost#{gem_repo2}"
         gem "rails"
       G
-      expect(last_command.bundler_err).to end_with(<<-M.strip)
+      msg = <<-M.strip
 An error occurred while installing activesupport (2.3.2), and Bundler cannot continue.
 Make sure that `gem install activesupport -v '2.3.2' --source 'file://localhost#{gem_repo2}/'` succeeds before bundling.
 
@@ -27,6 +27,8 @@ In Gemfile:
     actionmailer was resolved to 2.3.2, which depends on
       activesupport
                      M
+      msg = msg.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
+      expect(last_command.bundler_err).to end_with(msg)
     end
 
     context "when installing a git gem" do
@@ -111,7 +113,7 @@ In Gemfile:
           gem "rails"
         end
       G
-      expect(last_command.bundler_err).to end_with(<<-M.strip)
+      msg = <<-M.strip
 An error occurred while installing activesupport (2.3.2), and Bundler cannot continue.
 Make sure that `gem install activesupport -v '2.3.2' --source 'file://localhost#{gem_repo2}/'` succeeds before bundling.
 
@@ -120,6 +122,8 @@ In Gemfile:
     actionmailer was resolved to 2.3.2, which depends on
       activesupport
                      M
+      msg = msg.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
+      expect(last_command.bundler_err).to end_with(msg)
     end
 
     context "because the downloaded .gem was invalid" do

--- a/spec/install/failure_spec.rb
+++ b/spec/install/failure_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "bundle install" do
         source "file:\/\/localhost#{gem_repo2}"
         gem "rails"
       G
-      msg = <<-M.strip
+      expect(last_command.bundler_err).to end_with(normalize_uri_file(<<-M.strip))
 An error occurred while installing activesupport (2.3.2), and Bundler cannot continue.
 Make sure that `gem install activesupport -v '2.3.2' --source 'file://localhost#{gem_repo2}/'` succeeds before bundling.
 
@@ -27,8 +27,6 @@ In Gemfile:
     actionmailer was resolved to 2.3.2, which depends on
       activesupport
                      M
-      msg = msg.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
-      expect(last_command.bundler_err).to end_with(msg)
     end
 
     context "when installing a git gem" do
@@ -113,7 +111,7 @@ In Gemfile:
           gem "rails"
         end
       G
-      msg = <<-M.strip
+      expect(last_command.bundler_err).to end_with(normalize_uri_file(<<-M.strip))
 An error occurred while installing activesupport (2.3.2), and Bundler cannot continue.
 Make sure that `gem install activesupport -v '2.3.2' --source 'file://localhost#{gem_repo2}/'` succeeds before bundling.
 
@@ -122,8 +120,6 @@ In Gemfile:
     actionmailer was resolved to 2.3.2, which depends on
       activesupport
                      M
-      msg = msg.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
-      expect(last_command.bundler_err).to end_with(msg)
     end
 
     context "because the downloaded .gem was invalid" do

--- a/spec/install/gemfile/gemspec_spec.rb
+++ b/spec/install/gemfile/gemspec_spec.rb
@@ -565,6 +565,7 @@ RSpec.describe "bundle install from an existing gemspec" do
               PLATFORMS
                 java
                 ruby
+
               DEPENDENCIES
                 foo!
 

--- a/spec/install/gemfile/gemspec_spec.rb
+++ b/spec/install/gemfile/gemspec_spec.rb
@@ -442,7 +442,7 @@ RSpec.describe "bundle install from an existing gemspec" do
         context "as a runtime dependency" do
           it "keeps java dependencies in the lockfile" do
             expect(the_bundle).to include_gems "foo 1.0", "platform_specific 1.0 RUBY"
-            expect(lockfile).to eq strip_whitespace(<<-L)
+            expected = strip_whitespace(<<-L)
               PATH
                 remote: .
                 specs:
@@ -465,6 +465,8 @@ RSpec.describe "bundle install from an existing gemspec" do
               BUNDLED WITH
                  #{Bundler::VERSION}
             L
+            expected = expected.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
+            expect(lockfile).to eq expected
           end
         end
 
@@ -473,7 +475,7 @@ RSpec.describe "bundle install from an existing gemspec" do
 
           it "keeps java dependencies in the lockfile" do
             expect(the_bundle).to include_gems "foo 1.0", "platform_specific 1.0 RUBY"
-            expect(lockfile).to eq strip_whitespace(<<-L)
+            expected = strip_whitespace(<<-L)
               PATH
                 remote: .
                 specs:
@@ -496,6 +498,8 @@ RSpec.describe "bundle install from an existing gemspec" do
               BUNDLED WITH
                  #{Bundler::VERSION}
             L
+            expected = expected.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
+            expect(lockfile).to eq expected
           end
         end
 
@@ -505,7 +509,7 @@ RSpec.describe "bundle install from an existing gemspec" do
 
           it "keeps java dependencies in the lockfile" do
             expect(the_bundle).to include_gems "foo 1.0", "indirect_platform_specific 1.0", "platform_specific 1.0 RUBY"
-            expect(lockfile).to eq strip_whitespace(<<-L)
+            expected = strip_whitespace(<<-L)
               PATH
                 remote: .
                 specs:
@@ -530,6 +534,8 @@ RSpec.describe "bundle install from an existing gemspec" do
               BUNDLED WITH
                  #{Bundler::VERSION}
             L
+            expected = expected.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
+            expect(lockfile).to eq expected
           end
         end
       end
@@ -543,7 +549,7 @@ RSpec.describe "bundle install from an existing gemspec" do
         context "as a runtime dependency" do
           it "keeps java dependencies in the lockfile" do
             expect(the_bundle).to include_gems "foo 1.0", "platform_specific 1.0 RUBY"
-            expect(lockfile).to eq strip_whitespace(<<-L)
+            expected = strip_whitespace(<<-L)
               GEM
                 remote: file://localhost#{gem_repo2}/
                 specs:
@@ -559,13 +565,14 @@ RSpec.describe "bundle install from an existing gemspec" do
               PLATFORMS
                 java
                 ruby
-
               DEPENDENCIES
                 foo!
 
               BUNDLED WITH
                  #{Bundler::VERSION}
             L
+            expected = expected.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
+            expect(lockfile).to eq expected
           end
         end
 
@@ -574,7 +581,7 @@ RSpec.describe "bundle install from an existing gemspec" do
 
           it "keeps java dependencies in the lockfile" do
             expect(the_bundle).to include_gems "foo 1.0", "platform_specific 1.0 RUBY"
-            expect(lockfile).to eq strip_whitespace(<<-L)
+            expected = strip_whitespace(<<-L)
               GEM
                 remote: file://localhost#{gem_repo2}/
                 specs:
@@ -597,6 +604,8 @@ RSpec.describe "bundle install from an existing gemspec" do
               BUNDLED WITH
                  #{Bundler::VERSION}
             L
+            expected = expected.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
+            expect(lockfile).to eq expected
           end
         end
 
@@ -606,7 +615,7 @@ RSpec.describe "bundle install from an existing gemspec" do
 
           it "keeps java dependencies in the lockfile" do
             expect(the_bundle).to include_gems "foo 1.0", "indirect_platform_specific 1.0", "platform_specific 1.0 RUBY"
-            expect(lockfile).to eq strip_whitespace(<<-L)
+            expected = strip_whitespace(<<-L)
               GEM
                 remote: file://localhost#{gem_repo2}/
                 specs:
@@ -631,6 +640,8 @@ RSpec.describe "bundle install from an existing gemspec" do
               BUNDLED WITH
                  #{Bundler::VERSION}
             L
+            expected = expected.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
+            expect(lockfile).to eq expected
           end
         end
       end

--- a/spec/install/gemfile/gemspec_spec.rb
+++ b/spec/install/gemfile/gemspec_spec.rb
@@ -442,7 +442,7 @@ RSpec.describe "bundle install from an existing gemspec" do
         context "as a runtime dependency" do
           it "keeps java dependencies in the lockfile" do
             expect(the_bundle).to include_gems "foo 1.0", "platform_specific 1.0 RUBY"
-            expected = strip_whitespace(<<-L)
+            expect(lockfile).to eq normalize_uri_file(strip_whitespace(<<-L))
               PATH
                 remote: .
                 specs:
@@ -465,8 +465,6 @@ RSpec.describe "bundle install from an existing gemspec" do
               BUNDLED WITH
                  #{Bundler::VERSION}
             L
-            expected = expected.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
-            expect(lockfile).to eq expected
           end
         end
 
@@ -475,7 +473,7 @@ RSpec.describe "bundle install from an existing gemspec" do
 
           it "keeps java dependencies in the lockfile" do
             expect(the_bundle).to include_gems "foo 1.0", "platform_specific 1.0 RUBY"
-            expected = strip_whitespace(<<-L)
+            expect(lockfile).to eq normalize_uri_file(strip_whitespace(<<-L))
               PATH
                 remote: .
                 specs:
@@ -498,8 +496,6 @@ RSpec.describe "bundle install from an existing gemspec" do
               BUNDLED WITH
                  #{Bundler::VERSION}
             L
-            expected = expected.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
-            expect(lockfile).to eq expected
           end
         end
 
@@ -509,7 +505,7 @@ RSpec.describe "bundle install from an existing gemspec" do
 
           it "keeps java dependencies in the lockfile" do
             expect(the_bundle).to include_gems "foo 1.0", "indirect_platform_specific 1.0", "platform_specific 1.0 RUBY"
-            expected = strip_whitespace(<<-L)
+            expect(lockfile).to eq normalize_uri_file(strip_whitespace(<<-L))
               PATH
                 remote: .
                 specs:
@@ -534,8 +530,6 @@ RSpec.describe "bundle install from an existing gemspec" do
               BUNDLED WITH
                  #{Bundler::VERSION}
             L
-            expected = expected.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
-            expect(lockfile).to eq expected
           end
         end
       end
@@ -549,7 +543,7 @@ RSpec.describe "bundle install from an existing gemspec" do
         context "as a runtime dependency" do
           it "keeps java dependencies in the lockfile" do
             expect(the_bundle).to include_gems "foo 1.0", "platform_specific 1.0 RUBY"
-            expected = strip_whitespace(<<-L)
+            expect(lockfile).to eq nomalize_uri_file(strip_whitespace(<<-L))
               GEM
                 remote: file://localhost#{gem_repo2}/
                 specs:
@@ -572,8 +566,6 @@ RSpec.describe "bundle install from an existing gemspec" do
               BUNDLED WITH
                  #{Bundler::VERSION}
             L
-            expected = expected.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
-            expect(lockfile).to eq expected
           end
         end
 
@@ -582,7 +574,7 @@ RSpec.describe "bundle install from an existing gemspec" do
 
           it "keeps java dependencies in the lockfile" do
             expect(the_bundle).to include_gems "foo 1.0", "platform_specific 1.0 RUBY"
-            expected = strip_whitespace(<<-L)
+            expect(lockfile).to eq normalize_uri_file(strip_whitespace(<<-L))
               GEM
                 remote: file://localhost#{gem_repo2}/
                 specs:
@@ -605,8 +597,6 @@ RSpec.describe "bundle install from an existing gemspec" do
               BUNDLED WITH
                  #{Bundler::VERSION}
             L
-            expected = expected.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
-            expect(lockfile).to eq expected
           end
         end
 
@@ -616,7 +606,7 @@ RSpec.describe "bundle install from an existing gemspec" do
 
           it "keeps java dependencies in the lockfile" do
             expect(the_bundle).to include_gems "foo 1.0", "indirect_platform_specific 1.0", "platform_specific 1.0 RUBY"
-            expected = strip_whitespace(<<-L)
+            expect(lockfile).to eq normalize_uri_file(strip_whitespace(<<-L))
               GEM
                 remote: file://localhost#{gem_repo2}/
                 specs:
@@ -641,8 +631,6 @@ RSpec.describe "bundle install from an existing gemspec" do
               BUNDLED WITH
                  #{Bundler::VERSION}
             L
-            expected = expected.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
-            expect(lockfile).to eq expected
           end
         end
       end

--- a/spec/install/gemfile/gemspec_spec.rb
+++ b/spec/install/gemfile/gemspec_spec.rb
@@ -543,7 +543,7 @@ RSpec.describe "bundle install from an existing gemspec" do
         context "as a runtime dependency" do
           it "keeps java dependencies in the lockfile" do
             expect(the_bundle).to include_gems "foo 1.0", "platform_specific 1.0 RUBY"
-            expect(lockfile).to eq nomalize_uri_file(strip_whitespace(<<-L))
+            expect(lockfile).to eq normalize_uri_file(strip_whitespace(<<-L))
               GEM
                 remote: file://localhost#{gem_repo2}/
                 specs:

--- a/spec/install/gemfile/sources_spec.rb
+++ b/spec/install/gemfile/sources_spec.rb
@@ -33,9 +33,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
         expect(out).to have_major_deprecation a_string_including("Your Gemfile contains multiple primary sources.")
         expect(out).to include("Warning: the gem 'rack' was found in multiple sources.")
-        msg = "Installed from: file://localhost#{gem_repo1}"
-        msg = msg.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
-        expect(out).to include(msg)
+        expect(out).to include(normalize_uri_file("Installed from: file://localhost#{gem_repo1}"))
         expect(the_bundle).to include_gems("rack-obama 1.0.0", "rack 1.0.0", :source => "remote1")
       end
 
@@ -65,9 +63,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
         expect(out).to have_major_deprecation a_string_including("Your Gemfile contains multiple primary sources.")
         expect(out).to include("Warning: the gem 'rack' was found in multiple sources.")
-        msg = "Installed from: file://localhost#{gem_repo1}"
-        msg = msg.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
-        expect(out).to include(msg)
+        expect(out).to include(normalize_uri_file("Installed from: file://localhost#{gem_repo1}"))
         expect(the_bundle).to include_gems("rack-obama 1.0.0", "rack 1.0.0", :source => "remote1")
       end
     end
@@ -257,9 +253,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
             bundle :install
             expect(out).to have_major_deprecation a_string_including("Your Gemfile contains multiple primary sources.")
             expect(out).to include("Warning: the gem 'rack' was found in multiple sources.")
-            msg = "Installed from: file://localhost#{gem_repo2}"
-            msg = msg.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
-            expect(out).to include(msg)
+            expect(out).to include(normalize_uri_file("Installed from: file://localhost#{gem_repo2}"))
             expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0")
           end
         end
@@ -640,14 +634,12 @@ RSpec.describe "bundle install with gems on multiple sources" do
         gem "depends_on_rack"
       G
       expect(last_command).to be_failure
-      msg = strip_whitespace(<<-EOS).strip
+      expect(last_command.stderr).to eq normalize_uri_file(strip_whitespace(<<-EOS).strip)
         The gem 'rack' was found in multiple relevant sources.
           * rubygems repository file://localhost#{gem_repo1}/ or installed locally
           * rubygems repository file://localhost#{gem_repo4}/ or installed locally
         You must add this gem to the source block for the source you wish it to be installed from.
       EOS
-      msg = msg.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
-      expect(last_command.stderr).to eq msg
       expect(the_bundle).not_to be_locked
     end
   end

--- a/spec/install/gemfile/sources_spec.rb
+++ b/spec/install/gemfile/sources_spec.rb
@@ -33,7 +33,9 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
         expect(out).to have_major_deprecation a_string_including("Your Gemfile contains multiple primary sources.")
         expect(out).to include("Warning: the gem 'rack' was found in multiple sources.")
-        expect(out).to include("Installed from: file://localhost#{gem_repo1}")
+        msg = "Installed from: file://localhost#{gem_repo1}"
+        msg = msg.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
+        expect(out).to include(msg)
         expect(the_bundle).to include_gems("rack-obama 1.0.0", "rack 1.0.0", :source => "remote1")
       end
 
@@ -63,7 +65,9 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
         expect(out).to have_major_deprecation a_string_including("Your Gemfile contains multiple primary sources.")
         expect(out).to include("Warning: the gem 'rack' was found in multiple sources.")
-        expect(out).to include("Installed from: file://localhost#{gem_repo1}")
+        msg = "Installed from: file://localhost#{gem_repo1}"
+        msg = msg.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
+        expect(out).to include(msg)
         expect(the_bundle).to include_gems("rack-obama 1.0.0", "rack 1.0.0", :source => "remote1")
       end
     end
@@ -253,7 +257,9 @@ RSpec.describe "bundle install with gems on multiple sources" do
             bundle :install
             expect(out).to have_major_deprecation a_string_including("Your Gemfile contains multiple primary sources.")
             expect(out).to include("Warning: the gem 'rack' was found in multiple sources.")
-            expect(out).to include("Installed from: file://localhost#{gem_repo2}")
+            msg = "Installed from: file://localhost#{gem_repo2}"
+            msg = msg.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
+            expect(out).to include(msg)
             expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0")
           end
         end
@@ -634,12 +640,14 @@ RSpec.describe "bundle install with gems on multiple sources" do
         gem "depends_on_rack"
       G
       expect(last_command).to be_failure
-      expect(last_command.stderr).to eq strip_whitespace(<<-EOS).strip
+      msg = strip_whitespace(<<-EOS).strip
         The gem 'rack' was found in multiple relevant sources.
           * rubygems repository file://localhost#{gem_repo1}/ or installed locally
           * rubygems repository file://localhost#{gem_repo4}/ or installed locally
         You must add this gem to the source block for the source you wish it to be installed from.
       EOS
+      msg = msg.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
+      expect(last_command.stderr).to eq msg
       expect(the_bundle).not_to be_locked
     end
   end

--- a/spec/install/gems/mirror_spec.rb
+++ b/spec/install/gems/mirror_spec.rb
@@ -13,9 +13,7 @@ RSpec.describe "bundle install with a mirror configured" do
 
     it "installs from the normal location" do
       bundle :install
-      msg = "Fetching source index from file://localhost#{gem_repo1}"
-      msg = msg.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
-      expect(out).to include(msg)
+      expect(out).to include(normalize_uri_file("Fetching source index from file://localhost#{gem_repo1}"))
       expect(the_bundle).to include_gems "rack 1.0"
     end
   end
@@ -33,12 +31,8 @@ RSpec.describe "bundle install with a mirror configured" do
 
     it "installs the gem from the mirror" do
       bundle :install
-      msg = "Fetching source index from file://localhost#{gem_repo1}"
-      msg = msg.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
-      expect(out).to include(msg)
-      msg = "Fetching source index from file://localhost#{gem_repo2}"
-      msg = msg.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
-      expect(out).not_to include(msg)
+      expect(out).to include(normalize_uri_file("Fetching source index from file://localhost#{gem_repo1}"))
+      expect(out).not_to include(normalize_uri_file("Fetching source index from file://localhost#{gem_repo2}"))
       expect(the_bundle).to include_gems "rack 1.0"
     end
   end

--- a/spec/install/gems/mirror_spec.rb
+++ b/spec/install/gems/mirror_spec.rb
@@ -13,7 +13,9 @@ RSpec.describe "bundle install with a mirror configured" do
 
     it "installs from the normal location" do
       bundle :install
-      expect(out).to include("Fetching source index from file://localhost#{gem_repo1}")
+      msg = "Fetching source index from file://localhost#{gem_repo1}"
+      msg = msg.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
+      expect(out).to include(msg)
       expect(the_bundle).to include_gems "rack 1.0"
     end
   end
@@ -31,8 +33,12 @@ RSpec.describe "bundle install with a mirror configured" do
 
     it "installs the gem from the mirror" do
       bundle :install
-      expect(out).to include("Fetching source index from file://localhost#{gem_repo1}")
-      expect(out).not_to include("Fetching source index from file://localhost#{gem_repo2}")
+      msg = "Fetching source index from file://localhost#{gem_repo1}"
+      msg = msg.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
+      expect(out).to include(msg)
+      msg = "Fetching source index from file://localhost#{gem_repo2}"
+      msg = msg.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
+      expect(out).not_to include(msg)
       expect(the_bundle).to include_gems "rack 1.0"
     end
   end

--- a/spec/install/post_bundle_message_spec.rb
+++ b/spec/install/post_bundle_message_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe "post bundle message" do
           gem "rack"
           gem "not-a-gem", :group => :development
         G
-        expect(out).to include normalize_uri_fil(<<-EOS.strip)
+        expect(out).to include normalize_uri_file(<<-EOS.strip)
 Could not find gem 'not-a-gem' in rubygems repository file://localhost#{gem_repo1}/ or installed locally.
 The source does not contain any versions of 'not-a-gem'
         EOS

--- a/spec/install/post_bundle_message_spec.rb
+++ b/spec/install/post_bundle_message_spec.rb
@@ -116,10 +116,12 @@ RSpec.describe "post bundle message" do
           gem "rack"
           gem "not-a-gem", :group => :development
         G
-        expect(out).to include <<-EOS.strip
+        msg = <<-EOS.strip
 Could not find gem 'not-a-gem' in rubygems repository file://localhost#{gem_repo1}/ or installed locally.
 The source does not contain any versions of 'not-a-gem'
         EOS
+        msg = msg.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
+        expect(out).to include msg
       end
 
       it "should report a helpful error message with reference to cache if available" do

--- a/spec/install/post_bundle_message_spec.rb
+++ b/spec/install/post_bundle_message_spec.rb
@@ -116,12 +116,10 @@ RSpec.describe "post bundle message" do
           gem "rack"
           gem "not-a-gem", :group => :development
         G
-        msg = <<-EOS.strip
+        expect(out).to include normalize_uri_fil(<<-EOS.strip)
 Could not find gem 'not-a-gem' in rubygems repository file://localhost#{gem_repo1}/ or installed locally.
 The source does not contain any versions of 'not-a-gem'
         EOS
-        msg = msg.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
-        expect(out).to include msg
       end
 
       it "should report a helpful error message with reference to cache if available" do

--- a/spec/lock/lockfile_bundler_1_spec.rb
+++ b/spec/lock/lockfile_bundler_1_spec.rb
@@ -1240,7 +1240,7 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
     expect(the_bundle).to include_gems "omg 1.0"
 
     # Confirm that duplicate specs do not appear
-    expect(File.read(bundled_app("Gemfile.lock"))).to eq(strip_whitespace(<<-L))
+    lockfile_should_be(<<-L)
       GIT
         remote: #{lib_path("omg")}
         revision: #{revision}

--- a/spec/lock/lockfile_spec.rb
+++ b/spec/lock/lockfile_spec.rb
@@ -1279,7 +1279,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
     expect(the_bundle).to include_gems "omg 1.0"
 
     # Confirm that duplicate specs do not appear
-    expect(File.read(bundled_app("Gemfile.lock"))).to eq(strip_whitespace(<<-L))
+    lockfile_should_be(<<-L)
       GEM
         remote: file://localhost#{gem_repo1}/
         specs:

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -1166,8 +1166,7 @@ end
            #{Bundler::VERSION}
       L
 
-      lock = lock.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
-      lock
+      normalize_uri_file(lock)
     end
 
     before do

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -1166,6 +1166,7 @@ end
            #{Bundler::VERSION}
       L
 
+      lock = lock.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
       lock
     end
 

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -280,6 +280,15 @@ module Spec
       str.gsub(/^#{spaces}/, "")
     end
 
+    def normalize_uri_file(str)
+      # URI::File of Ruby 2.6 normalize localhost variable with file protocol.
+      if defined?(URI::File)
+        str.gsub(%r{file:\/\/localhost}, "file://")
+      else
+        str
+      end
+    end
+
     def install_gemfile(*args)
       gemfile(*args)
       opts = args.last.is_a?(Hash) ? args.last : {}

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -235,8 +235,9 @@ module Spec
       end
     end
 
-    def lockfile_should_be(expected)
-      expect(bundled_app("Gemfile.lock")).to read_as(strip_whitespace(expected))
+    def lockfile_should_be(expected, actual = bundled_app("Gemfile.lock"))
+      expected = expected.dup.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
+      expect(actual).to read_as(strip_whitespace(expected))
     end
   end
 end

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -236,7 +236,7 @@ module Spec
     end
 
     def lockfile_should_be(expected)
-      expect(bundled_app("Gemfile.lock")).to read_as(nomalize_uri_file(strip_whitespace(expected)))
+      expect(bundled_app("Gemfile.lock")).to read_as(normalize_uri_file(strip_whitespace(expected)))
     end
   end
 end

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -235,9 +235,8 @@ module Spec
       end
     end
 
-    def lockfile_should_be(expected, actual = bundled_app("Gemfile.lock"))
-      expected = expected.dup.gsub(%r{file:\/\/localhost}, "file://") if defined?(URI::File)
-      expect(actual).to read_as(strip_whitespace(expected))
+    def lockfile_should_be(expected)
+      expect(bundled_app("Gemfile.lock")).to read_as(nomalize_uri_file(strip_whitespace(expected)))
     end
   end
 end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

When users use file protocol with bundler, URI of Ruby 2.6 will raise auth info assignment and normalize host parameter given localhost variable with its case.

### Why did you choose this fix out of the possible options?

URI behavior of Ruby 2.6 is reasonable for me. Because I will fix this problem on bundler side.
