### PR TITLE
[SharedHelpers] Only hard-error on major deprecations in the following version

### DIFF
--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -140,12 +140,13 @@ module Bundler
     end
 
     def major_deprecation(major_version, message)
-      if Bundler.bundler_major_version >= major_version
+      bundler_major_version = Bundler.bundler_major_version
+      if bundler_major_version > major_version
         require "bundler/errors"
-        raise DeprecatedError, "[REMOVED FROM #{major_version}.0] #{message}"
+        raise DeprecatedError, "[REMOVED FROM #{major_version.succ}.0] #{message}"
       end
 
-      return unless prints_major_deprecations?
+      return unless bundler_major_version >= major_version || prints_major_deprecations?
       @major_deprecation_ui ||= Bundler::UI::Shell.new("no-color" => true)
       ui = Bundler.ui.is_a?(@major_deprecation_ui.class) ? Bundler.ui : @major_deprecation_ui
       ui.warn("[DEPRECATED FOR #{major_version}.0] #{message}")


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was, actually I'm not sure. @indirect ?

Addresses the first bullet point in https://github.com/bundler/bundler/issues/6582.

### What was your diagnosis of the problem?

My diagnosis was we should only hard error on deprecations in the major version _after_ we stop supporting them.