### PR TITLE
Respect encodings when reading gemspecs

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -444,7 +444,7 @@ EOF
 
     def load_gemspec_uncached(file, validate = false)
       path = Pathname.new(file)
-      contents = path.read(:encoding => Encoding::UTF_8)
+      contents = File.open(file, "r:UTF-8", &:read)
       spec = if contents.start_with?("---") # YAML header
         eval_yaml_gemspec(path, contents)
       else

--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -444,7 +444,7 @@ EOF
 
     def load_gemspec_uncached(file, validate = false)
       path = Pathname.new(file)
-      contents = read_file(file)
+      contents = path.read(:encoding => Encoding::UTF_8)
       spec = if contents.start_with?("---") # YAML header
         eval_yaml_gemspec(path, contents)
       else

--- a/spec/install/gemspecs_spec.rb
+++ b/spec/install/gemspecs_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "bundle install" do
   end
 
   it "reads gemspecs respecting their encoding" do
-    skip "Too cool for 1.8" if RUBY_VERSION < "1.9"
+    skip "unicode constants are most likely not supported on 1.8" if RUBY_VERSION < "1.9"
 
     create_file("version.rb", <<-RUBY)
       module Persistent💎

--- a/spec/install/gemspecs_spec.rb
+++ b/spec/install/gemspecs_spec.rb
@@ -64,6 +64,8 @@ RSpec.describe "bundle install" do
   end
 
   it "reads gemspecs respecting their encoding" do
+    skip "Too cool for 1.8" if RUBY_VERSION < "1.9"
+
     create_file("version.rb", <<-RUBY)
       module Persistent💎
         VERSION = "0.0.1"

--- a/spec/install/gemspecs_spec.rb
+++ b/spec/install/gemspecs_spec.rb
@@ -63,6 +63,31 @@ RSpec.describe "bundle install" do
     expect(out).to include("Bundle complete!")
   end
 
+  it "reads gemspecs respecting their encoding" do
+    create_file("version.rb", <<-RUBY)
+      module Persistent💎
+        VERSION = "0.0.1"
+      end
+    RUBY
+
+    create_file("persistent-dmnd.gemspec", <<-G)
+      require_relative "version"
+
+      Gem::Specification.new do |gem|
+        gem.name = "persistent-dmnd"
+        gem.version = Persistent💎::VERSION
+        gem.author = "Ivo Anjo"
+        gem.summary = "Unscratchable stuff"
+      end
+    G
+
+    install_gemfile <<-G
+      gemspec
+    G
+
+    expect(out).to include("Bundle complete!")
+  end
+
   context "when ruby version is specified in gemspec and gemfile" do
     it "installs when patch level is not specified and the version matches" do
       build_lib("foo", :path => bundled_app) do |s|


### PR DESCRIPTION
This PR fixes #6598. Thanks @eregon for the help and the explanation that helped me understand the issue :)!

### What was the end-user problem that led to this PR?

On gems using UTF-8 symbols defined in other files in their gemspecs, `bundle install` would crash.

### What was your diagnosis of the problem?

The problem was that since #6279 gemspecs are read binarily. However, files required from them as read as text. That means that the constants defined on those files and used in the gemspec are interpreted different and thus don't match.

### What is your fix for the problem, implemented in this PR?

My fix is to go back to reading gemspec as text again. Explictly passing the encoding when reading them still fixes the problem that the PR introducing the regression was meant to fix. 

### Why did you choose this fix out of the possible options?

I chose this fix because it fixes the problem, and keeps the situation that the PR introducing the regression fixed also working.
