### PR TITLE
More flexible stub

### DIFF
--- a/spec/support/builders.rb
+++ b/spec/support/builders.rb
@@ -601,7 +601,7 @@ module Spec
           @spec.rubygems_version = options[:rubygems_version]
           def @spec.mark_version; end
 
-          def @spec.validate; end
+          def @spec.validate(*); end
         end
 
         case options[:gemspec]


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

My problem is that I can't get https://github.com/rubygems/rubygems/pull/2332 CI passing.

### What was your diagnosis of the problem?

My diagnosis was that current bundler test don't support my changes in that PR, because previously the `validate` method in `rubygems` would be called without arguments, and now it's called with two arguments.

### What is your fix for the problem, implemented in this PR?

My fix is to make the specification stub more flexible so it supports any number of arguments.

### Why did you choose this fix out of the possible options?

I chose this fix because it supports my changes and doesn't break the previous version either.
