### PR TITLE
Support rubocop-0.57.2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_from:
   - .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 1.9
+  TargetRubyVersion: 2.2
   Exclude:
     - tmp/**/*
     - lib/bundler/vendor/**/*
@@ -74,7 +74,10 @@ Style/StringLiteralsInInterpolation:
 
 # Having these make it easier to *not* forget to add one when adding a new
 # value and you can simply copy the previous line.
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
 
 Style/TrailingUnderscoreVariable:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,10 +14,6 @@ AllCops:
 Lint/AssignmentInCondition:
   Enabled: false
 
-Lint/EndAlignment:
-  EnforcedStyleAlignWith: variable
-  AutoCorrect: true
-
 Lint/UnusedMethodArgument:
   Enabled: false
 
@@ -32,6 +28,10 @@ Layout/AccessModifierIndentation:
 
 Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation
+
+Layout/EndAlignment:
+  EnforcedStyleAlignWith: variable
+  AutoCorrect: true
 
 Layout/MultilineOperationIndentation:
   EnforcedStyle: indented

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -87,7 +87,7 @@ Lint/RescueException:
     - 'lib/bundler/worker.rb'
 
 # Offense count: 29
-Lint/RescueWithoutErrorClass:
+Lint/RescueStandardError:
   Enabled: false
 
 # Offense count: 2
@@ -145,20 +145,6 @@ Performance/Caller:
   Exclude:
     - 'lib/bundler/rubygems_integration.rb'
     - 'spec/support/builders.rb'
-
-# Offense count: 9
-# Cop supports --auto-correct.
-# Configuration parameters: AutoCorrect.
-Performance/HashEachMethods:
-  Exclude:
-    - 'lib/bundler/definition.rb'
-    - 'lib/bundler/dependency.rb'
-    - 'lib/bundler/dsl.rb'
-    - 'lib/bundler/index.rb'
-    - 'lib/bundler/plugin.rb'
-    - 'spec/install/gems/standalone_spec.rb'
-    - 'spec/support/builders.rb'
-    - 'spec/support/helpers.rb'
 
 # Offense count: 7
 # Cop supports --auto-correct.
@@ -297,7 +283,7 @@ Style/InverseMethods:
     - 'lib/bundler/resolver/spec_group.rb'
 
 # Offense count: 6
-Style/MethodMissing:
+Style/MethodMissingSuper:
   Exclude:
     - 'lib/bundler/dep_proxy.rb'
     - 'lib/bundler/dsl.rb'
@@ -362,7 +348,17 @@ Style/RaiseArgs:
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyleForMultiline, SupportedStylesForMultiline.
 # SupportedStylesForMultiline: comma, consistent_comma, no_comma
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  Exclude:
+    - 'lib/bundler/cli/gem.rb'
+    - 'lib/bundler/fetcher.rb'
+    - 'lib/bundler/gem_helpers.rb'
+    - 'lib/bundler/graph.rb'
+    - 'lib/bundler/ruby_version.rb'
+    - 'lib/bundler/similarity_detector.rb'
+    - 'spec/support/artifice/endpoint.rb'
+
+Style/TrailingCommaInHashLiteral:
   Exclude:
     - 'lib/bundler/cli/gem.rb'
     - 'lib/bundler/fetcher.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -86,10 +86,6 @@ Lint/RescueException:
     - 'lib/bundler/rubygems_integration.rb'
     - 'lib/bundler/worker.rb'
 
-# Offense count: 29
-Lint/RescueStandardError:
-  Enabled: false
-
 # Offense count: 2
 Lint/ShadowedException:
   Exclude:
@@ -281,6 +277,10 @@ Style/InverseMethods:
     - 'lib/bundler/index.rb'
     - 'lib/bundler/resolver.rb'
     - 'lib/bundler/resolver/spec_group.rb'
+
+# Offense count: 29
+Style/RescueStandardError:
+  Enabled: false
 
 # Offense count: 6
 Style/MethodMissingSuper:


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

When users use rubocop-0.57.2, They faced following errors.

```
.rubocop.yml: Lint/EndAlignment has the wrong namespace - should be Layout
Error: The `Style/TrailingCommaInLiteral` cop no longer exists. Please use `Style/TrailingCommaInArrayLiteral` and/or `Style/TrailingCommaInHashLiteral` instead.
(obsolete configuration found in .rubocop_todo.yml, please update it)
The `Lint/RescueWithoutErrorClass` cop has been replaced by `Style/RescueStandardError`.
(obsolete configuration found in .rubocop_todo.yml, please update it)
The `Performance/HashEachMethods` cop has been removed since it no longer provides performance benefits in modern rubies.
(obsolete configuration found in .rubocop_todo.yml, please update it)
The `Style/MethodMissing` cop has been split into `Style/MethodMissingSuper` and `Style/MissingRespondToMissing`.
(obsolete configuration found in .rubocop_todo.yml, please update it)
```

### What was your diagnosis of the problem?

.rubocop.yml and .rubocop_todo.yml still uses old configuration.

### What is your fix for the problem, implemented in this PR?

I fixed style declarations to modern style.

