### PR TITLE
Document that `bundle show [--paths]` sorts results

### DIFF
--- a/man/bundle-show.ronn
+++ b/man/bundle-show.ronn
@@ -9,7 +9,7 @@ bundle-show(1) -- Shows all the gems in your bundle, or the path to a gem
 ## DESCRIPTION
 
 Without the [GEM] option, `show` will print a list of the names and versions of
-all gems that are required by your [`Gemfile(5)`][Gemfile(5)].
+all gems that are required by your [`Gemfile(5)`][Gemfile(5)], sorted by name.
 
 Calling show with [GEM] will list the exact location of that gem on your
 machine.
@@ -17,4 +17,5 @@ machine.
 ## OPTIONS
 
 * `--paths`:
-  List the paths of all gems that are required by your [`Gemfile(5)`][Gemfile(5)].
+  List the paths of all gems that are required by your [`Gemfile(5)`][Gemfile(5)],
+  sorted by gem name.


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that I could not tell from the manpage or documentation website whether `bundle show` and `bundle show --paths` would list gems and gem paths in the same order.

I am using `bundle show` and `bundle show --paths` to inventory gems that projects depend upon.

### What was your diagnosis of the problem?

My diagnosis was that the implementation of `bundle show` _does_ sort results by name, but that the manpage for the subcommand doesn't mention this.

### What is your fix for the problem, implemented in this PR?

My fix involved slightly editing the existing manpage for `bundle show`.

### Why did you choose this fix out of the possible options?

I chose this fix because the `.ronn` file text matched the current text I was seeing via the documentation website.
