### PR TITLE
Update vendored molinillo to 0.6.5

### DIFF
--- a/lib/bundler/vendor/molinillo/lib/molinillo/dependency_graph/vertex.rb
+++ b/lib/bundler/vendor/molinillo/lib/molinillo/dependency_graph/vertex.rb
@@ -50,14 +50,25 @@ module Bundler::Molinillo
         incoming_edges.map(&:origin)
       end
 
-      # @return [Array<Vertex>] the vertices of {#graph} where `self` is a
+      # @return [Set<Vertex>] the vertices of {#graph} where `self` is a
       #   {#descendent?}
       def recursive_predecessors
-        vertices = predecessors
-        vertices += Compatibility.flat_map(vertices, &:recursive_predecessors)
-        vertices.uniq!
+        _recursive_predecessors
+      end
+
+      # @param [Set<Vertex>] vertices the set to add the predecessors to
+      # @return [Set<Vertex>] the vertices of {#graph} where `self` is a
+      #   {#descendent?}
+      def _recursive_predecessors(vertices = Set.new)
+        incoming_edges.each do |edge|
+          vertex = edge.origin
+          next unless vertices.add?(vertex)
+          vertex._recursive_predecessors(vertices)
+        end
+
         vertices
       end
+      protected :_recursive_predecessors
 
       # @return [Array<Vertex>] the vertices of {#graph} that have an edge with
       #   `self` as their {Edge#origin}
@@ -65,14 +76,25 @@ module Bundler::Molinillo
         outgoing_edges.map(&:destination)
       end
 
-      # @return [Array<Vertex>] the vertices of {#graph} where `self` is an
+      # @return [Set<Vertex>] the vertices of {#graph} where `self` is an
       #   {#ancestor?}
       def recursive_successors
-        vertices = successors
-        vertices += Compatibility.flat_map(vertices, &:recursive_successors)
-        vertices.uniq!
+        _recursive_successors
+      end
+
+      # @param [Set<Vertex>] vertices the set to add the successors to
+      # @return [Set<Vertex>] the vertices of {#graph} where `self` is an
+      #   {#ancestor?}
+      def _recursive_successors(vertices = Set.new)
+        outgoing_edges.each do |edge|
+          vertex = edge.destination
+          next unless vertices.add?(vertex)
+          vertex._recursive_successors(vertices)
+        end
+
         vertices
       end
+      protected :_recursive_successors
 
       # @return [String] a string suitable for debugging
       def inspect

--- a/lib/bundler/vendor/molinillo/lib/molinillo/gem_metadata.rb
+++ b/lib/bundler/vendor/molinillo/lib/molinillo/gem_metadata.rb
@@ -2,5 +2,5 @@
 
 module Bundler::Molinillo
   # The version of Bundler::Molinillo.
-  VERSION = '0.6.4'.freeze
+  VERSION = '0.6.5'.freeze
 end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was bundler was using an outdated version of Molinillo.

### What is your fix for the problem, implemented in this PR?

My fix was to bump the version.

### Why did you choose this fix out of the possible options?

I chose this fix because it includes resolver performance improvements when using `recursive_predecessors` / `recursive_successors`