### PR TITLE
Added RFC to contributing guidelines

### DIFF
--- a/doc/contributing/README.md
+++ b/doc/contributing/README.md
@@ -8,20 +8,21 @@ Before submitting a contribution, read through the following guidelines:
 * [Issue Reporting Guidelines](https://github.com/bundler/bundler/blob/master/doc/contributing/ISSUES.md)
 * [Pull Request Guidelines](https://github.com/bundler/bundler/blob/master/doc/development/PULL_REQUESTS.md)
 
-And be sure to set up your development environment:
+And be sure to [set up your development environment](https://github.com/bundler/bundler/blob/master/doc/development/SETUP.md).
 
-Once you've reviewed the above guidelines, be sure to [set up your development environment](https://github.com/bundler/bundler/blob/master/doc/development/SETUP.md).
+## Feature Requests
+
+To request substantial changes to Bundler and/or Bundler documentation, please refer to the [README](https://github.com/bundler/rfcs/blob/master/README.md) in the [RFC repository](https://github.com/bundler/rfcs) for instructions.
 
 ## Contributing to Bundler
 
 Here are the different ways you can start contributing to the Bundler project:
 
 * [First contribution suggestions](https://github.com/bundler/bundler/blob/master/doc/contributing/HOW_YOU_CAN_HELP.md)
-* [Adding new features](https://github.com/bundler/bundler/blob/master/doc/development/NEW_FEATURES.md)
+* [Adding new features](https://github.com/bundler/bundler/blob/master/doc/development/NEW_FEATURES.md).
 * [Triaging bugs](https://github.com/bundler/bundler/blob/master/doc/contributing/BUG_TRIAGE.md)
 * [Writing documentation](https://github.com/bundler/bundler/blob/master/doc/documentation/WRITING.md)
 * [Community engagement](https://github.com/bundler/bundler/blob/master/doc/contributing/COMMUNITY.md)
-
 
 ## Supporting Bundler
 

--- a/doc/contributing/README.md
+++ b/doc/contributing/README.md
@@ -19,7 +19,7 @@ To request substantial changes to Bundler and/or Bundler documentation, please r
 Here are the different ways you can start contributing to the Bundler project:
 
 * [First contribution suggestions](https://github.com/bundler/bundler/blob/master/doc/contributing/HOW_YOU_CAN_HELP.md)
-* [Adding new features](https://github.com/bundler/bundler/blob/master/doc/development/NEW_FEATURES.md).
+* [Adding new features](https://github.com/bundler/bundler/blob/master/doc/development/NEW_FEATURES.md)
 * [Triaging bugs](https://github.com/bundler/bundler/blob/master/doc/contributing/BUG_TRIAGE.md)
 * [Writing documentation](https://github.com/bundler/bundler/blob/master/doc/documentation/WRITING.md)
 * [Community engagement](https://github.com/bundler/bundler/blob/master/doc/contributing/COMMUNITY.md)


### PR DESCRIPTION
We're trying to publicize the new RFC process more, and one of the ways to do this is to make it prominent in the Bundler contributing guidelines.