### PR TITLE
Prefer to use `--no-document` option in spec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -56,7 +56,7 @@ namespace :spec do
         sh %(#{Gem.ruby} -S gem #{gem_install_command})
       end
     else
-      gem_install_command = "install --no-ri --no-rdoc --conservative " + deps.sort_by {|name, _| name }.map do |name, version|
+      gem_install_command = "install --no-document --conservative " + deps.sort_by {|name, _| name }.map do |name, version|
         "'#{name}:#{version}'"
       end.join(" ")
       sh %(#{Gem.ruby} -S gem #{gem_install_command})

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -319,7 +319,11 @@ module Spec
 
         raise "OMG `#{path}` does not exist!" unless File.exist?(path)
 
-        gem_command! :install, "--no-rdoc --no-ri --ignore-dependencies '#{path}'"
+        if Gem::VERSION < "2.0.0"
+          gem_command! :install, "--no-rdoc --no-ri --ignore-dependencies '#{path}'"
+        else
+          gem_command! :install, "--no-document --ignore-dependencies '#{path}'"
+        end
         bundler_path && bundler_path.rmtree
       end
     end

--- a/spec/support/rubygems_ext.rb
+++ b/spec/support/rubygems_ext.rb
@@ -59,10 +59,10 @@ module Spec
       no_reqs.map!(&:first)
       reqs.map! {|name, req| "'#{name}:#{req}'" }
       deps = reqs.concat(no_reqs).join(" ")
-      if Gem::VERSION < "2.0.0"
-        cmd = "gem install #{deps} --no-rdoc --no-ri --conservative"
+      cmd = if Gem::VERSION < "2.0.0"
+        "gem install #{deps} --no-rdoc --no-ri --conservative"
       else
-        cmd = "gem install #{deps} --no-document --conservative"
+        "gem install #{deps} --no-document --conservative"
       end
       puts cmd
       system(cmd) || raise("Installing gems #{deps} for the tests to use failed!")

--- a/spec/support/rubygems_ext.rb
+++ b/spec/support/rubygems_ext.rb
@@ -59,7 +59,11 @@ module Spec
       no_reqs.map!(&:first)
       reqs.map! {|name, req| "'#{name}:#{req}'" }
       deps = reqs.concat(no_reqs).join(" ")
-      cmd = "gem install #{deps} --no-rdoc --no-ri --conservative"
+      if Gem::VERSION < "2.0.0"
+        cmd = "gem install #{deps} --no-rdoc --no-ri --conservative"
+      else
+        cmd = "gem install #{deps} --no-document --conservative"
+      end
       puts cmd
       system(cmd) || raise("Installing gems #{deps} for the tests to use failed!")
     end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

RubyGems will remove `--no-ri` and `--no-rdoc` options at RubyGems 3.0. But bundler spec is also broken when removing them.

* https://github.com/rubygems/rubygems/pull/2354
* https://travis-ci.org/rubygems/rubygems/jobs/402911887

### What is your fix for the problem, implemented in this PR?

To use --no-document option after RubyGems 2.0. 
