### PR TITLE
Fix singular groups on injecting gem

### DIFF
--- a/lib/bundler/injector.rb
+++ b/lib/bundler/injector.rb
@@ -107,7 +107,7 @@ module Bundler
         end
 
         if d.groups != Array(:default)
-          group = d.groups.size == 1 ? ", :group => #{d.groups.inspect}" : ", :groups => #{d.groups.inspect}"
+          group = d.groups.size == 1 ? ", :group => #{d.groups.first.inspect}" : ", :groups => #{d.groups.inspect}"
         end
 
         source = ", :source => \"#{d.source}\"" unless d.source.nil?

--- a/spec/commands/add_spec.rb
+++ b/spec/commands/add_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "bundle add" do
   describe "with --group" do
     it "adds dependency for the specified group" do
       bundle "add 'foo' --group='development'"
-      expect(bundled_app("Gemfile").read).to match(/gem "foo", "~> 2.0", :group => \[:development\]/)
+      expect(bundled_app("Gemfile").read).to match(/gem "foo", "~> 2.0", :group => :development/)
       expect(the_bundle).to include_gems "foo 2.0"
     end
 
@@ -100,7 +100,7 @@ RSpec.describe "bundle add" do
 
   it "using combination of short form options works like long form" do
     bundle "add 'foo' -s='file://#{gem_repo2}' -g='development' -v='~>1.0'"
-    expect(bundled_app("Gemfile").read).to include %(gem "foo", "~> 1.0", :group => [:development], :source => "file://#{gem_repo2}")
+    expect(bundled_app("Gemfile").read).to include %(gem "foo", "~> 1.0", :group => :development, :source => "file://#{gem_repo2}")
     expect(the_bundle).to include_gems "foo 1.1"
   end
 

--- a/spec/commands/inject_spec.rb
+++ b/spec/commands/inject_spec.rb
@@ -64,7 +64,7 @@ Usage: "bundle inject GEM VERSION"
     it "add gem with group option in gemfile" do
       bundle "inject 'rack-obama' '>0' --group=development"
       gemfile = bundled_app("Gemfile").read
-      str = "gem \"rack-obama\", \"> 0\", :group => [:development]"
+      str = "gem \"rack-obama\", \"> 0\", :group => :development"
       expect(gemfile).to include str
     end
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that on adding a gem to a group via
```bash
bundle add rack --group=dev
```
It gets added as 
```ruby
gem "rack", :group => [:dev]
```
It should rather be 
```ruby
gem "rack", :group => :dev
```

### What was your diagnosis of the problem?

My diagnosis was to not add single groups in the array.

### What is your fix for the problem, implemented in this PR?

My fix was to pick the element from the array of groups and append using
```ruby
":group => :#{d.groups.first}"
```

### Why did you choose this fix out of the possible options?

I chose this fix because it seemed to most appropriate.
