### PR TITLE
Don't call File.realpath in a loop, single call does what we want

### DIFF
--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -351,13 +351,9 @@ module Bundler
 
     def resolve_path(path)
       expanded = File.expand_path(path)
-      return expanded unless File.respond_to?(:realpath)
+      return expanded unless File.respond_to?(:realpath) && File.exist?(expanded)
 
-      while File.exist?(expanded) && File.realpath(expanded) != expanded
-        expanded = File.realpath(expanded)
-      end
-
-      expanded
+      File.realpath(expanded)
     end
 
     def prints_major_deprecations?


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

We're calling `File.realpath` in a loop

### What was your diagnosis of the problem?

Single call already resolves symlinks recursively

### What is your fix for the problem, implemented in this PR?

Drop call in a loop