### PR TITLE
require `etc` in Bundler#user_home

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -170,6 +170,7 @@ module Bundler
         end
 
         if warning
+          Kernel.send(:require, "etc")
           user_home = tmp_home_path(Etc.getlogin, warning)
           Bundler.ui.warn "#{warning}\nBundler will use `#{user_home}' as your home directory temporarily.\n"
           user_home


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

In some cases, we are sending messages to the`Etc` library which may not be loaded.

### What was your diagnosis of the problem?

See #6640 

### What is your fix for the problem, implemented in this PR?

Require the `etc` library before we use it

Fixes #6640 
