### PR TITLE
Add space inside block braces

### DIFF
--- a/lib/bundler/templates/Gemfile
+++ b/lib/bundler/templates/Gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # gem "rails"


### PR DESCRIPTION
With default settings, rubocop detects this as an offense of Layout/SpaceInsideBlockBraces. It is quite common to leave a space between `{` and `|`.

Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was that with default settings, Rubocop detects this as an offense. I think it is common to leave a space between `{` and `|`.

### What was your diagnosis of the problem?

N/A

### What is your fix for the problem, implemented in this PR?

Add a space between `{` and `|`.

### Why did you choose this fix out of the possible options?

I chose this fix because I think that disabling this particular cop makes less sense.
