### PR TITLE
Don't mutate original error trees when determining version_conflict_message

### DIFF
--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -317,7 +317,7 @@ module Bundler
         :possibility_type => possibility_type,
         :reduce_trees => lambda do |trees|
           # called first, because we want to reduce the amount of work required to find maximal empty sets
-          trees.uniq! {|t| t.flatten.map {|dep| [dep.name, dep.requirement] } }
+          trees = trees.uniq {|t| t.flatten.map {|dep| [dep.name, dep.requirement] } }
 
           # bail out if tree size is too big for Array#combination to make any sense
           return trees if trees.size > 15


### PR DESCRIPTION
*I know I'm messing with private APIs here, so have no right to expect this PR merged!*

Currently, when Bundler generates its error message for a version conflict, it mutates the `requirement_trees` array on the underlying `Molinillo::VersionConflict` error.

I would really like it if it didn't. Dependabot taps into that error to understand what went wrong with resolution and unlock any dependencies that are blocking resolution. The code where we do so is [here](https://github.com/dependabot/dependabot-core/blob/9abcb85ba69b408b11b56572dd13ab89d0c55b8c/lib/dependabot/file_updaters/ruby/bundler/lockfile_updater.rb#L142-L167).

I don't think that there's any downside to not mutating here. Resolution has finished (and failed) at this stage, so trying to reduce memory usage doesn't really matter.

🙏 