### PR TITLE
[StubSpecification] Fix up the stubs to_spec whenever it is referenced

### DIFF
--- a/lib/bundler/rubygems_gem_installer.rb
+++ b/lib/bundler/rubygems_gem_installer.rb
@@ -4,12 +4,6 @@ require "rubygems/installer"
 
 module Bundler
   class RubyGemsGemInstaller < Gem::Installer
-    unless respond_to?(:at)
-      def self.at(*args)
-        new(*args)
-      end
-    end
-
     def check_executable_overwrite(filename)
       # Bundler needs to install gems regardless of binstub overwriting
     end

--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -223,11 +223,6 @@ module Bundler
       Gem.bin_path(gem, bin, ver)
     end
 
-    def preserve_paths
-      # this is a no-op outside of RubyGems 1.8
-      yield
-    end
-
     def loaded_gem_paths
       loaded_gem_paths = Gem.loaded_specs.map {|_, s| s.full_require_paths }
       loaded_gem_paths.flatten

--- a/lib/bundler/source/rubygems.rb
+++ b/lib/bundler/source/rubygems.rb
@@ -145,20 +145,17 @@ module Bundler
 
           Bundler.mkdir_p bin_path, :no_sudo => true unless spec.executables.empty? || Bundler.rubygems.provides?(">= 2.7.5")
 
-          installed_spec = nil
-          Bundler.rubygems.preserve_paths do
-            installed_spec = Bundler::RubyGemsGemInstaller.at(
-              path,
-              :install_dir         => install_path.to_s,
-              :bin_dir             => bin_path.to_s,
-              :ignore_dependencies => true,
-              :wrappers            => true,
-              :env_shebang         => true,
-              :build_args          => opts[:build_args],
-              :bundler_expected_checksum => spec.respond_to?(:checksum) && spec.checksum,
-              :bundler_extension_cache_path => extension_cache_path(spec)
-            ).install
-          end
+          installed_spec = Bundler::RubyGemsGemInstaller.at(
+            path,
+            :install_dir         => install_path.to_s,
+            :bin_dir             => bin_path.to_s,
+            :ignore_dependencies => true,
+            :wrappers            => true,
+            :env_shebang         => true,
+            :build_args          => opts[:build_args],
+            :bundler_expected_checksum => spec.respond_to?(:checksum) && spec.checksum,
+            :bundler_extension_cache_path => extension_cache_path(spec)
+          ).install
           spec.full_gem_path = installed_spec.full_gem_path
 
           # SUDO HAX

--- a/lib/bundler/stub_specification.rb
+++ b/lib/bundler/stub_specification.rb
@@ -36,7 +36,7 @@ module Bundler
 
     # This is defined directly to avoid having to load every installed spec
     def missing_extensions?
-      stub.missing_extensions?
+      stub(true).missing_extensions?
     end
 
     def activated
@@ -82,8 +82,8 @@ module Bundler
     #   from `Gem.loaded_specs`, which can end up being self.
     #   #_remote_specification has logic to handle this case, so delegate to that in that situation,
     #   because otherwise we can end up with a stack overflow when calling #missing_extensions?
-    def stub
-      if @_remote_specification.nil? && @stub.instance_variable_get(:@data) && Gem.loaded_specs[name].equal?(self)
+    def stub(check = false)
+      if check && @_remote_specification.nil? && @stub.instance_variable_get(:@data) && Gem.loaded_specs[name].equal?(self)
         _remote_specification
       end
       @stub
@@ -95,7 +95,7 @@ module Bundler
       @_remote_specification ||= begin
         rs = @stub.to_spec
         if rs.equal?(self) # happens when to_spec gets the spec from Gem.loaded_specs
-          rs = Gem::Specification.load(@stub.loaded_from)
+          rs = Bundler.load_gemspec(@stub.loaded_from)
           Bundler.rubygems.stub_set_spec(@stub, rs)
         end
 

--- a/lib/bundler/stub_specification.rb
+++ b/lib/bundler/stub_specification.rb
@@ -77,8 +77,13 @@ module Bundler
       stub.raw_require_paths
     end
 
+    # @note
+    #   Cannot be an attr_reader that returns @stub, because the stub can pull it's `to_spec`
+    #   from `Gem.loaded_specs`, which can end up being self.
+    #   #_remote_specification has logic to handle this case, so delegate to that in that situation,
+    #   because otherwise we can end up with a stack overflow when calling #missing_extensions?
     def stub
-      if !@_remote_specification && @stub.instance_variable_get(:@data) && Gem.loaded_specs[name].equal?(self)
+      if @_remote_specification.nil? && @stub.instance_variable_get(:@data) && Gem.loaded_specs[name].equal?(self)
         _remote_specification
       end
       @stub

--- a/lib/bundler/stub_specification.rb
+++ b/lib/bundler/stub_specification.rb
@@ -83,7 +83,7 @@ module Bundler
     #   #_remote_specification has logic to handle this case, so delegate to that in that situation,
     #   because otherwise we can end up with a stack overflow when calling #missing_extensions?
     def stub(check = false)
-      if check && @_remote_specification.nil? && @stub.instance_variable_get(:@data) && Gem.loaded_specs[name].equal?(self)
+      if check && @_remote_specification.nil? && Gem.loaded_specs[name].equal?(self)
         _remote_specification
       end
       @stub

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -926,5 +926,25 @@ __FILE__: #{path.to_s.inspect}
         expect(err).to include("custom openssl should not be loaded")
       end
     end
+
+    context "with a git gem that includes extensions" do
+      before do
+        system_gems :bundler, :keep_path => true
+        build_git "simple_git_binary", &:add_c_extension
+        bundle! "config set path .bundle"
+        install_gemfile! <<-G, :system_bundler => true
+          gem "simple_git_binary", :git => '#{lib_path("simple_git_binary-1.0")}'
+        G
+      end
+
+      it "allows calling bundle install" do
+        bundle! "exec bundle install", :system_bundler => true
+      end
+
+      it "allows calling bundle install after removing gem.build_complete" do
+        FileUtils.rm_rf Dir[bundled_app(".bundle/**/gem.build_complete")]
+        bundle! "exec #{Gem.ruby} -S bundle install", :system_bundler => true
+      end
+    end
   end
 end

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -929,7 +929,7 @@ __FILE__: #{path.to_s.inspect}
 
     context "with a git gem that includes extensions" do
       before do
-        system_gems :bundler, :keep_path => true
+        system_gems :bundler
         build_git "simple_git_binary", &:add_c_extension
         bundle! "config set path .bundle"
         install_gemfile! <<-G, :system_bundler => true

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -931,7 +931,7 @@ __FILE__: #{path.to_s.inspect}
       before do
         system_gems :bundler
         build_git "simple_git_binary", &:add_c_extension
-        bundle! "config set path .bundle"
+        bundle! "config set --local path .bundle"
         install_gemfile! <<-G, :system_bundler => true
           gem "simple_git_binary", :git => '#{lib_path("simple_git_binary-1.0")}'
         G

--- a/spec/install/binstubs_spec.rb
+++ b/spec/install/binstubs_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "bundle install" do
         gem "rack"
       G
 
+      FileUtils.mkdir_p system_gem_path
       config "BUNDLE_SYSTEM_BINDIR" => system_gem_path("altbin").to_s
       bundle :install
       expect(the_bundle).to include_gems "rack 1.0.0"

--- a/spec/install/gemfile/gemspec_spec.rb
+++ b/spec/install/gemfile/gemspec_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe "bundle install from an existing gemspec" do
       s.add_dependency "platform_specific"
     end
 
-    system_gems "platform_specific-1.0-java", :path => :bundle_path, :keep_path => true
+    system_gems "platform_specific-1.0-java", :path => :bundle_path
 
     install_gemfile! <<-G
       gemspec :path => '#{tmp.join("foo")}'

--- a/spec/support/builders.rb
+++ b/spec/support/builders.rb
@@ -763,9 +763,9 @@ module Spec
 
         gem_path = File.expand_path("#{@spec.full_name}.gem", lib_path)
         if opts[:to_system]
-          @context.system_gems gem_path, :keep_path => true
+          @context.system_gems gem_path
         elsif opts[:to_bundle]
-          @context.system_gems gem_path, :path => :bundle_path, :keep_path => true
+          @context.system_gems gem_path, :path => :bundle_path
         else
           FileUtils.mv(gem_path, destination)
         end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -91,7 +91,7 @@ module Spec
       end
 
       env = options.delete(:env) || {}
-      env["PATH"].gsub!("#{Path.root}/exe", "") if env["PATH"] && system_bundler
+      env["PATH"] = ENV["PATH"].gsub("#{Path.root}/exe", "") if system_bundler
 
       requires = options.delete(:requires) || []
       requires << "support/hax"

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -374,11 +374,6 @@ module Spec
       end
       gems = gems.flatten
 
-      unless opts[:keep_path]
-        FileUtils.rm_rf(path)
-        FileUtils.mkdir_p(path)
-      end
-
       Gem.clear_paths
 
       env_backup = ENV.to_hash


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was testing whether a git gem was missing extensions could cause a stack overflow.

Closes https://github.com/bundler/bundler/issues/6533.

### What was your diagnosis of the problem?

My diagnosis was we were calling a method that would call `stub.to_spec`, returning the `Bundler::StubSpecification` instead of a non-delegating `Gem::Specification`

### What is your fix for the problem, implemented in this PR?

My fix will always go through the codepath that fixes up the stub's `to_spec` method _before_ using the stub, instead of waiting until we need to materialize the full spec.

### Why did you choose this fix out of the possible options?

I chose this fix because we know this situation causes a problem, so it seems to make sense to eagerly make the stub object safe to use.

cc @nelhage-stripe