### PR TITLE
Fix SystemStackError (stack level too deep) in GemHelper#sh_with_code

### DIFF
--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -188,7 +188,7 @@ module Bundler
     end
 
     def sh_with_code(cmd, &block)
-      outbuf, status = sh_with_code(cmd, &block)
+      outbuf, status = sh_with_status(cmd, &block)
       [outbuf, (status && status.exitstatus) || -1]
     end
 

--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -187,11 +187,6 @@ module Bundler
       out
     end
 
-    def sh_with_code(cmd, &block)
-      outbuf, status = sh_with_status(cmd, &block)
-      [outbuf, (status && status.exitstatus) || -1]
-    end
-
     if RUBY_VERSION >= "1.9"
       def sh_with_status(cmd, &block)
         Bundler.ui.debug(cmd)


### PR DESCRIPTION
Hello. I found a method which raises SystemStackError by chance.

### What was the end-user problem that led to this PR?

The method always calls itself recursively like as follows:

```
irb(main):006:0> require './lib/bundler/gem_helper'
=> true
irb(main):007:0> Bundler::GemHelper.new.send(:sh_with_code, 'ls')
Traceback (most recent call last):
       16: from /home/hibariya/src/github.com/bundler/bundler/lib/bundler/gem_helper.rb:191:in `sh_with_code'
       15: from /home/hibariya/src/github.com/bundler/bundler/lib/bundler/gem_helper.rb:191:in `sh_with_code'
       14: from /home/hibariya/src/github.com/bundler/bundler/lib/bundler/gem_helper.rb:191:in `sh_with_code'
       13: from /home/hibariya/src/github.com/bundler/bundler/lib/bundler/gem_helper.rb:191:in `sh_with_code'
       12: from /home/hibariya/src/github.com/bundler/bundler/lib/bundler/gem_helper.rb:191:in `sh_with_code'
       11: from /home/hibariya/src/github.com/bundler/bundler/lib/bundler/gem_helper.rb:191:in `sh_with_code'
       10: from /home/hibariya/src/github.com/bundler/bundler/lib/bundler/gem_helper.rb:191:in `sh_with_code'
        9: from /home/hibariya/src/github.com/bundler/bundler/lib/bundler/gem_helper.rb:191:in `sh_with_code'
        8: from /home/hibariya/src/github.com/bundler/bundler/lib/bundler/gem_helper.rb:191:in `sh_with_code'
        7: from /home/hibariya/src/github.com/bundler/bundler/lib/bundler/gem_helper.rb:191:in `sh_with_code'
        6: from /home/hibariya/src/github.com/bundler/bundler/lib/bundler/gem_helper.rb:191:in `sh_with_code'
        5: from /home/hibariya/src/github.com/bundler/bundler/lib/bundler/gem_helper.rb:191:in `sh_with_code'
        4: from /home/hibariya/src/github.com/bundler/bundler/lib/bundler/gem_helper.rb:191:in `sh_with_code'
        3: from /home/hibariya/src/github.com/bundler/bundler/lib/bundler/gem_helper.rb:191:in `sh_with_code'
        2: from /home/hibariya/src/github.com/bundler/bundler/lib/bundler/gem_helper.rb:191:in `sh_with_code'
        1: from /home/hibariya/src/github.com/bundler/bundler/lib/bundler/gem_helper.rb:191:in `sh_with_code'
SystemStackError (stack level too deep)
```

### What was your diagnosis of the problem?

I think that it can be supposed that `sh_with_status` should be called rather than `sh_with_code` because Process::Status#exitstatus is called later on. 
(related to #6036)

After this changes, the result of calling the method is as follows:

```
irb(main):011:0> load './lib/bundler/gem_helper.rb'
=> true
irb(main):012:0>
irb(main):013:0> Bundler::GemHelper.new.send(:sh_with_code, 'ls')
=> ["bin\nbundler.gemspec\nCHANGELOG.md\nCODE_OF_CONDUCT.md\ndoc\nexe\nGemfile\nGemfile.lock\nlib\nLICENSE.md\nman\nRakefile\nREADME.md\nspec\ntask\n", 0]
```

I am not sure if I could remove the method since I cannot have confidence that the method is not used anymore. So I simply fixed it.