### PR TITLE
Fix typos detected by github.com/client9/misspell

### DIFF
--- a/doc/development/RELEASING.md
+++ b/doc/development/RELEASING.md
@@ -55,7 +55,7 @@ The `rake release:patch` command will automatically handle cherry-picking, and i
 Bundler maintains a list of changes present in each version in the `CHANGELOG.md` file.
 Entries should not be added in pull requests, but are rather written by the Bundler
 maintainers in the [bundler-changelog repo](https://github.com/bundler/bundler-changelog).
-That reposity tracks changes by pull requests, with each entry having an associated version,
+That repository tracks changes by pull requests, with each entry having an associated version,
 PR, section, author(s), issue(s) closed, and message.
 
 Ensure that repo has been updated with all new PRs before releasing a new version,

--- a/lib/bundler/vendor/thor/lib/thor/base.rb
+++ b/lib/bundler/vendor/thor/lib/thor/base.rb
@@ -113,7 +113,7 @@ class Bundler::Thor
       end
 
       # Whenever a class inherits from Bundler::Thor or Bundler::Thor::Group, we should track the
-      # class and the file on Bundler::Thor::Base. This is the method responsable for it.
+      # class and the file on Bundler::Thor::Base. This is the method responsible for it.
       #
       def register_klass_file(klass) #:nodoc:
         file = caller[1].match(/(.*):\d+/)[1]

--- a/lib/bundler/vendor/thor/lib/thor/util.rb
+++ b/lib/bundler/vendor/thor/lib/thor/util.rb
@@ -27,7 +27,7 @@ class Bundler::Thor
       end
 
       # Receives a constant and converts it to a Bundler::Thor namespace. Since Bundler::Thor
-      # commands can be added to a sandbox, this method is also responsable for
+      # commands can be added to a sandbox, this method is also responsible for
       # removing the sandbox namespace.
       #
       # This method should not be used in general because it's used to deal with

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -881,7 +881,7 @@ end
       end
     end
 
-    it "should succesfully require 'bundler/setup'" do
+    it "should successfully require 'bundler/setup'" do
       install_gemfile ""
 
       ENV["GEM_PATH"] = symlinked_gem_home.path


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Fixing typos is sometimes very hard. It's not so easy to visually review them. Recently, I discovered a very useful tool for it, [misspell](https://github.com/client9/misspell). 

This pull request fixes minor typos detected by [misspell](https://github.com/client9/misspell). 

I've ignored the past changelogs and false positives. If you would like me to work on other files as well, let me know. 

#### before

```
$ misspell .
bundler.gemspec:38:32: "automatiek" is a misspelling of "automate"
Rakefile:324:11: "automatiek" is a misspelling of "automate"
Rakefile:326:2: "Automatiek" is a misspelling of "Automate"
Rakefile:333:2: "Automatiek" is a misspelling of "Automate"
Rakefile:340:2: "Automatiek" is a misspelling of "Automate"
Rakefile:347:2: "Automatiek" is a misspelling of "Automate"
Rakefile:365:42: "automatiek" is a misspelling of "automate"
Rakefile:366:42: "automatiek" is a misspelling of "automate"
Rakefile:367:37: "automatiek" is a misspelling of "automate"
Rakefile:368:53: "automatiek" is a misspelling of "automate"
doc/development/RELEASING.md:58:5: "reposity" is a misspelling of "repository"
lib/bundler/vendor/thor/lib/thor/base.rb:116:70: "responsable" is a misspelling of "responsible"
lib/bundler/vendor/thor/lib/thor/util.rb:30:64: "responsable" is a misspelling of "responsible"
spec/runtime/setup_spec.rb:884:15: "succesfully" is a misspelling of "successfully"
spec/support/artifice/vcr_cassettes/realworld/api.rubygems.org/gems/bundler-1.12.3.gem/GET/response:193:467: "nkwo" is a misspelling of "know"
spec/support/artifice/vcr_cassettes/realworld/rubygems.org/gems/bundler-1.12.3.gem/GET/response:193:467: "nkwo" is a misspelling of "know"
spec/support/artifice/vcr_cassettes/realworld/rubygems.org/gems/diff-lcs-1.3.gem/GET/response:132:127: "Tje" is a misspelling of "The"
spec/support/artifice/vcr_cassettes/realworld/rubygems.org/gems/rack-2.0.1.gem/GET/response:572:234: "adn" is a misspelling of "and"
spec/support/artifice/vcr_cassettes/realworld/rubygems.org/gems/rack-2.0.1.gem/GET/response:831:39: "NTO" is a misspelling of "NOT"
spec/support/artifice/vcr_cassettes/realworld/api.rubygems.org/specs.4.8.gz/GET/response:4371:940: "ADN" is a misspelling of "AND"
spec/support/artifice/vcr_cassettes/realworld/api.rubygems.org/specs.4.8.gz/GET/response:6338:370: "WIH" is a misspelling of "WITH"
spec/support/artifice/vcr_cassettes/realworld/rubygems.org/specs.4.8.gz/GET/response:1790:150: "WIH" is a misspelling of "WITH"
spec/support/artifice/vcr_cassettes/realworld/rubygems.org/specs.4.8.gz/GET/response:2017:85: "TJE" is a misspelling of "THE"
```

#### after

```
$ misspell .
Rakefile:324:11: "automatiek" is a misspelling of "automate"
Rakefile:326:2: "Automatiek" is a misspelling of "Automate"
Rakefile:333:2: "Automatiek" is a misspelling of "Automate"
Rakefile:340:2: "Automatiek" is a misspelling of "Automate"
Rakefile:347:2: "Automatiek" is a misspelling of "Automate"
Rakefile:365:42: "automatiek" is a misspelling of "automate"
Rakefile:366:42: "automatiek" is a misspelling of "automate"
Rakefile:367:37: "automatiek" is a misspelling of "automate"
Rakefile:368:53: "automatiek" is a misspelling of "automate"
bundler.gemspec:38:32: "automatiek" is a misspelling of "automate"
spec/support/artifice/vcr_cassettes/realworld/api.rubygems.org/gems/bundler-1.12.3.gem/GET/response:193:467: "nkwo" is a misspelling of "know"
spec/support/artifice/vcr_cassettes/realworld/rubygems.org/gems/diff-lcs-1.3.gem/GET/response:132:127: "Tje" is a misspelling of "The"
spec/support/artifice/vcr_cassettes/realworld/rubygems.org/gems/bundler-1.12.3.gem/GET/response:193:467: "nkwo" is a misspelling of "know"
spec/support/artifice/vcr_cassettes/realworld/api.rubygems.org/specs.4.8.gz/GET/response:4371:940: "ADN" is a misspelling of "AND"
spec/support/artifice/vcr_cassettes/realworld/api.rubygems.org/specs.4.8.gz/GET/response:6338:370: "WIH" is a misspelling of "WITH"
spec/support/artifice/vcr_cassettes/realworld/rubygems.org/gems/rack-2.0.1.gem/GET/response:572:234: "adn" is a misspelling of "and"
spec/support/artifice/vcr_cassettes/realworld/rubygems.org/gems/rack-2.0.1.gem/GET/response:831:39: "NTO" is a misspelling of "NOT"
spec/support/artifice/vcr_cassettes/realworld/rubygems.org/specs.4.8.gz/GET/response:1790:150: "WIH" is a misspelling of "WITH"
spec/support/artifice/vcr_cassettes/realworld/rubygems.org/specs.4.8.gz/GET/response:2017:85: "TJE" is a misspelling of "THE"
spec/support/artifice/vcr_cassettes/realworld/index.rubygems.org/versions/GET/response:10887:60: "ect" is a misspelling of "etc"
```

### What was your diagnosis of the problem?
### What is your fix for the problem, implemented in this PR?
### Why did you choose this fix out of the possible options?

Read the first part.