### PR TITLE
Avoid printing git error when checking version on badly packaged version

### DIFF
--- a/lib/bundler/build_metadata.rb
+++ b/lib/bundler/build_metadata.rb
@@ -23,7 +23,15 @@ module Bundler
 
     # The SHA for the git commit the bundler gem was built from.
     def self.git_commit_sha
-      @git_commit_sha ||= Dir.chdir(File.expand_path("..", __FILE__)) do
+      return @git_commit_sha if @git_commit_sha
+
+      # If Bundler has been installed without its .git directory and without a
+      # commit instance variable then we can't determine its commits SHA.
+      git_dir = File.join(File.expand_path("../../..", __FILE__), ".git")
+      return "unknown" unless File.directory?(git_dir)
+
+      # Otherwise shell out to git.
+      @git_commit_sha = Dir.chdir(File.expand_path("..", __FILE__)) do
         `git rev-parse --short HEAD`.strip.freeze
       end
     end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was https://github.com/bundler/bundler/issues/6453.

### What was your diagnosis of the problem?

A use had a version of Bundler packaged with Ruby 2.5.0 in RVM, but this version didn't include Bundler's git repo or any of the ivars which should have been set. As a result, Bundler was shelling out to git even though it wasn't in a git repo.

### What is your fix for the problem, implemented in this PR?

My fix is to show a nicer result in this case (just say that the SHA is unknown)

### Why did you choose this fix out of the possible options?

I chose this fix because ensuring Bundler is always packaged correctly by others isn't possible (although it seems weird and unlikely that a version without instance variables set would be used). Falling back to a cleaner error message is marginally nicer than what we currently have, and not much work.

Fixes #6453.