### PR TITLE
Fix encoding spec from #6661 to also work 1.9.3

### DIFF
--- a/spec/install/gemfile_spec.rb
+++ b/spec/install/gemfile_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe "bundle install" do
       # NOTE: This works thanks to #eval interpreting the magic encoding comment
       install_gemfile <<-G
         # encoding: iso-8859-1
-        str = "Il #{"\xE9".b}tait une fois ..."
+        str = "Il #{"\xE9".dup.force_encoding("binary")}tait une fois ..."
         puts "The source encoding is: " + str.encoding.name
       G
 


### PR DESCRIPTION
* String#b is Ruby 2.0+.

### What was the problem that led to this PR?

The CI is failing on the `1-16-stable` branch.

### What was your diagnosis of the problem?

The CI on master doesn't run against MRI 1.9.3, so this failure slipped in in #6661.
Probably testing against MRI 1.9.3 should be done on `master` too?

### What is your fix for the problem, implemented in this PR?

Make the spec work on 1.9.3.

cc @hsbt 
