### PR TITLE
Fix DepProxy == method

### DIFF
--- a/lib/bundler/dep_proxy.rb
+++ b/lib/bundler/dep_proxy.rb
@@ -10,7 +10,7 @@ module Bundler
     end
 
     def hash
-      @hash ||= dep.hash
+      @hash ||= [dep, __platform].hash
     end
 
     def ==(other)

--- a/lib/bundler/dep_proxy.rb
+++ b/lib/bundler/dep_proxy.rb
@@ -14,7 +14,7 @@ module Bundler
     end
 
     def ==(other)
-      return if other.nil?
+      return false if other.class != self.class
       dep == other.dep && __platform == other.__platform
     end
 

--- a/spec/bundler/dep_proxy_spec.rb
+++ b/spec/bundler/dep_proxy_spec.rb
@@ -14,4 +14,9 @@ RSpec.describe Bundler::DepProxy do
     it { expect(subject.eql?(nil)).to be false }
     it { expect(subject.eql?("foobar")).to be false }
   end
+
+  describe "#hash" do
+    it { expect(subject.hash).to eq(same.hash) }
+    it { expect(subject.hash).to eq(other.hash) }
+  end
 end

--- a/spec/bundler/dep_proxy_spec.rb
+++ b/spec/bundler/dep_proxy_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.describe Bundler::DepProxy do
+  let(:dep) { Bundler::Dependency.new("rake", ">= 0") }
+  subject { described_class.new(dep, Gem::Platform::RUBY) }
+  let(:same) { subject }
+  let(:other) { subject.dup }
+  let(:different) { described_class.new(dep, Gem::Platform::JAVA) }
+
+  describe "#eql?" do
+    it { expect(subject.eql?(same)).to be true }
+    it { expect(subject.eql?(other)).to be true }
+    it { expect(subject.eql?(different)).to be false }
+    it { expect(subject.eql?(nil)).to be false }
+    it { expect(subject.eql?("foobar")).to be false }
+  end
+end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?
After implementing a new hash table strategy in JRuby, bundle is broken for JRuby. The problem is caused that the ``==`` method in bundler does not check the class of the ``other`` object. This causes problems now when calling ``==`` on object other than DepProxy or nil.

 jruby/jruby#5280 travis-ci/travis-ci#9994

### What was your diagnosis of the problem?
The code crashes for anything other than DepProxy class or nil.

### What is your fix for the problem, implemented in this PR?
Checking now also that other class is the same as self.
