### PR TITLE
Add adding a team member to bundlerbot

### DIFF
--- a/doc/playbooks/TEAM_CHANGES.md
+++ b/doc/playbooks/TEAM_CHANGES.md
@@ -16,6 +16,7 @@ Interested in adding someone to the team? Here's the process.
     - Add them to the [Team page][team] on bundler.io, in the [maintainers list][maintainers]
     - Add them to the [list of team members][list] in `contributors.rake`
     - Add them to the authors list in `bundler.gemspec`
+    - Add them to the reviewer list in bundlerbot
     - Add them to the owners list on RubyGems.org by running
       ```
       $ gem owner -a EMAIL bundler


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The "adding a team member" was missing adding the person to bundlerbot
