### PR TITLE
Remove extra new lines from `bundle env` output

### DIFF
--- a/lib/bundler/env.rb
+++ b/lib/bundler/env.rb
@@ -88,7 +88,7 @@ module Bundler
 
     def self.version_of(script)
       return "not installed" unless Bundler.which(script)
-      `#{script} --version`
+      `#{script} --version`.chomp
     end
 
     def self.chruby_version

--- a/spec/bundler/env_spec.rb
+++ b/spec/bundler/env_spec.rb
@@ -139,9 +139,13 @@ RSpec.describe Bundler::Env do
         expect(described_class.report).to include("Git         1.2.3 (Apple Git-BS)")
       end
     end
+  end
 
-    it "properly parses version of tools when shelling out to them" do
-      expect(described_class.send(:version_of, "ruby")).to_not include("\n")
+  describe ".version_of" do
+    let(:parsed_version) { described_class.send(:version_of, "ruby") }
+
+    it "strips version of new line characters" do
+      expect(parsed_version).to_not include("\n")
     end
   end
 end

--- a/spec/bundler/env_spec.rb
+++ b/spec/bundler/env_spec.rb
@@ -139,5 +139,9 @@ RSpec.describe Bundler::Env do
         expect(described_class.report).to include("Git         1.2.3 (Apple Git-BS)")
       end
     end
+
+    it "properly parses version of tools when shelling out to them" do
+      expect(described_class.send(:version_of, "ruby")).to_not include("\n")
+    end
   end
 end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

When reporting my `bundle env` for https://github.com/bundler/bundler/issues/6677, I noticed an extra blank line between the `rbenv` and the `chruby` lines. Not really a big problem, other than people like me getting distracted by those little inconsistencies.

### What was your diagnosis of the problem?

My diagnosis was that the formatting method was somewhere unintentionally printing an extra new line. After checking it out, it looks like any versions that are grabbed by shelling out to `#{tool} --version` will have this problem, since the new line from the subprocess output is included in the `bundle env` output, together with its own line returns.

### What is your fix for the problem, implemented in this PR?

My fix is to prune any trailing new lines from the output of those subprocesses. 

### Why did you choose this fix out of the possible options?

I chose this fix because it seemed like the simplest way to fix the issue.