### PR TITLE
Remove Travis condition making test fail locally

### DIFF
--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -561,7 +561,7 @@ RSpec.describe "bundle exec" do
         ex << "raise SignalException, 'SIGTERM'\n"
         ex
       end
-      let(:expected_err) { ENV["TRAVIS"] ? "Terminated" : "" }
+      let(:expected_err) { "Terminated" }
       let(:exit_code) do
         # signal mask 128 + plus signal 15 -> TERM
         # this is specified by C99


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

I tried running the specs locally and I got two failures.

### What was your diagnosis of the problem?
 My diagnosis was that the tests were artificially only doing the right thing on Travis.

### What is your fix for the problem, implemented in this PR?

My fix was to remove the condition to check whether we're in Travis or not, so that the correct assertion is made.

### Why did you choose this fix out of the possible options?

I chose this fix because it works for me and it simplifies the test.