### PR TITLE
Check if 'search' is initialized.

### DIFF
--- a/lib/bundler/lazy_specification.rb
+++ b/lib/bundler/lazy_specification.rb
@@ -80,7 +80,7 @@ module Bundler
             "To use the platform-specific version of the gem, run `bundle config specific_platform true` and install again."
           search = source.specs.search(self).last
         end
-        search.dependencies = dependencies if search.is_a?(RemoteSpecification) || search.is_a?(EndpointSpecification)
+        search.dependencies = dependencies if search && (search.is_a?(RemoteSpecification) || search.is_a?(EndpointSpecification))
         search
       end
     end


### PR DESCRIPTION
The search was checked previously, so maybe it should be checked also at this place.

This issue was identified by Coverity scanner:

~~~
Error: FORWARD_NULL (CWE-476):
rubygem-bundler-1.16.1/usr/share/gems/gems/bundler-1.16.1/lib/bundler/lazy_specification.rb:77: null_check: Comparing "search" to a null-like value implies that "search" might be null-like.
rubygem-bundler-1.16.1/usr/share/gems/gems/bundler-1.16.1/lib/bundler/lazy_specification.rb:83: property_access: Accessing a property of null-like value "search".
#   81|             search = source.specs.search(self).last
#   82|           end
#   83|->         search.dependencies = dependencies if search.is_a?(RemoteSpecification) || search.is_a?(EndpointSpecification)
#   84|           search
#   85|         end
~~~