### PR TITLE
Check that Bundler::Deprecate is not an autoload constant

### DIFF
--- a/lib/bundler/deprecate.rb
+++ b/lib/bundler/deprecate.rb
@@ -8,7 +8,8 @@ rescue LoadError
 end
 
 module Bundler
-  if defined? Bundler::Deprecate
+  # If Bundler::Deprecate is an autoload constant, we need to define it
+  if defined?(Bundler::Deprecate) && !autoload?(:Deprecate)
     # nothing to do!
   elsif defined? ::Deprecate
     Deprecate = ::Deprecate


### PR DESCRIPTION
* Otherwise, it should be defined by this file.
* The issue is bundler/deprecate.rb checks `defined? Bundler::Deprecate`
  and this would normally return true since an autoload is defined for
  that constant. But since the autoload file is #require-d explicitly
  (by bundler/psyched_yaml and bundler/shared_helpers), MRI makes it
  undefined to save this pattern. This however requires a complex
  autoload implementation and is confusing to debug, so let's simplify.
* Related to https://github.com/bundler/bundler/issues/6163 and https://github.com/rubinius/rubinius/issues/3769.


### What was the end-user problem that led to this PR?

Bundler fails in TruffleRuby without this change.
We plan to fix this case in TruffleRuby, but since at least 2 Ruby implementations did not expect such a corner case, we should make the code simpler since it's easy enough in this case.

### What was your diagnosis of the problem?

See above.

### Why did you choose this fix out of the possible options?

It's simple and does not break if an extra `require "bundler/deprecate"` is later added in the codebase.