### PR TITLE
Add support for TruffleRuby

### DIFF
--- a/lib/bundler/cli/exec.rb
+++ b/lib/bundler/cli/exec.rb
@@ -89,6 +89,7 @@ module Bundler
       possibilities = [
         "#!/usr/bin/env ruby\n",
         "#!/usr/bin/env jruby\n",
+        "#!/usr/bin/env truffleruby\n",
         "#!#{Gem.ruby}\n",
       ]
 

--- a/lib/bundler/current_ruby.rb
+++ b/lib/bundler/current_ruby.rb
@@ -32,11 +32,13 @@ module Bundler
       mswin64
       rbx
       ruby
+      truffleruby
       x64_mingw
     ].freeze
 
     def ruby?
-      !mswin? && (!defined?(RUBY_ENGINE) || RUBY_ENGINE == "ruby" || RUBY_ENGINE == "rbx" || RUBY_ENGINE == "maglev")
+      !mswin? && (!defined?(RUBY_ENGINE) || RUBY_ENGINE == "ruby" ||
+          RUBY_ENGINE == "rbx" || RUBY_ENGINE == "maglev" || RUBY_ENGINE == "truffleruby")
     end
 
     def mri?
@@ -53,6 +55,10 @@ module Bundler
 
     def maglev?
       defined?(RUBY_ENGINE) && RUBY_ENGINE == "maglev"
+    end
+
+    def truffleruby?
+      defined?(RUBY_ENGINE) && RUBY_ENGINE == "truffleruby"
     end
 
     def mswin?

--- a/lib/bundler/dependency.rb
+++ b/lib/bundler/dependency.rb
@@ -29,6 +29,7 @@ module Bundler
       :mri_24   => Gem::Platform::RUBY,
       :mri_25   => Gem::Platform::RUBY,
       :rbx      => Gem::Platform::RUBY,
+      :truffleruby => Gem::Platform::RUBY,
       :jruby    => Gem::Platform::JAVA,
       :jruby_18 => Gem::Platform::JAVA,
       :jruby_19 => Gem::Platform::JAVA,

--- a/lib/bundler/ruby_version.rb
+++ b/lib/bundler/ruby_version.rb
@@ -118,8 +118,8 @@ module Bundler
                             when "jruby"
                               JRUBY_VERSION.dup
                             else
-                              raise BundlerError, "RUBY_ENGINE value #{RUBY_ENGINE} is not recognized"
-      end
+                              RUBY_ENGINE_VERSION.dup
+                            end
       patchlevel = RUBY_PATCHLEVEL.to_s
 
       @ruby_version ||= RubyVersion.new(ruby_version, patchlevel, ruby_engine, ruby_engine_version)

--- a/lib/bundler/ruby_version.rb
+++ b/lib/bundler/ruby_version.rb
@@ -119,7 +119,7 @@ module Bundler
                               JRUBY_VERSION.dup
                             else
                               RUBY_ENGINE_VERSION.dup
-                            end
+      end
       patchlevel = RUBY_PATCHLEVEL.to_s
 
       @ruby_version ||= RubyVersion.new(ruby_version, patchlevel, ruby_engine, ruby_engine_version)

--- a/man/gemfile.5.ronn
+++ b/man/gemfile.5.ronn
@@ -59,8 +59,8 @@ All parameters are `OPTIONAL` unless otherwise specified.
 ### VERSION (required)
 
 The version of Ruby that your application requires. If your application
-requires an alternate Ruby engine, such as JRuby or Rubinius, this should be
-the Ruby version that the engine is compatible with.
+requires an alternate Ruby engine, such as JRuby, Rubinius or TruffleRuby, this
+should be the Ruby version that the engine is compatible with.
 
     ruby "1.9.3"
 
@@ -188,22 +188,24 @@ platforms.
 There are a number of `Gemfile` platforms:
 
   * `ruby`:
-    C Ruby (MRI) or Rubinius, but `NOT` Windows
+    C Ruby (MRI), Rubinius or TruffleRuby, but `NOT` Windows
   * `mri`:
-    Same as _ruby_, but not Rubinius
+    Same as _ruby_, but only C Ruby (MRI)
   * `mingw`:
     Windows 32 bit 'mingw32' platform (aka RubyInstaller)
   * `x64_mingw`:
     Windows 64 bit 'mingw32' platform (aka RubyInstaller x64)
   * `rbx`:
-    Same as _ruby_, but only Rubinius (not MRI)
+    Rubinius
   * `jruby`:
     JRuby
+  * `truffleruby`:
+    TruffleRuby
   * `mswin`:
     Windows
 
 You can restrict further by platform and version for all platforms *except* for
-`rbx`, `jruby`, and `mswin`.
+`rbx`, `jruby`, `truffleruby` and `mswin`.
 
 To specify a version in addition to a platform, append the version number without
 the delimiter to the platform. For example, to specify that a gem should only be

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Bundler::Dsl do
 
   describe "#gem" do
     [:ruby, :ruby_18, :ruby_19, :ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24, :ruby_25, :mri, :mri_18, :mri_19,
-     :mri_20, :mri_21, :mri_22, :mri_23, :mri_24, :mri_25, :jruby, :rbx].each do |platform|
+     :mri_20, :mri_21, :mri_22, :mri_23, :mri_24, :mri_25, :jruby, :rbx, :truffleruby].each do |platform|
       it "allows #{platform} as a valid platform" do
         subject.gem("foo", :platform => platform)
       end

--- a/spec/bundler/ruby_version_spec.rb
+++ b/spec/bundler/ruby_version_spec.rb
@@ -443,7 +443,7 @@ RSpec.describe "Bundler::RubyVersion and its subclasses" do
         context "engine is ruby" do
           before do
             stub_const("RUBY_VERSION", "2.2.4")
-            allow(Bundler).to receive(:ruby_engine).and_return("ruby")
+            stub_const("RUBY_ENGINE", "ruby")
           end
 
           it "should return a copy of the value of RUBY_VERSION" do
@@ -479,11 +479,11 @@ RSpec.describe "Bundler::RubyVersion and its subclasses" do
         context "engine is some other ruby engine" do
           before do
             stub_const("RUBY_ENGINE", "not_supported_ruby_engine")
-            allow(Bundler).to receive(:ruby_engine).and_return("not_supported_ruby_engine")
+            stub_const("RUBY_ENGINE_VERSION", "1.2.3")
           end
 
-          it "should raise a BundlerError with a 'not recognized' message" do
-            expect { bundler_system_ruby_version.engine_versions }.to raise_error(Bundler::BundlerError, "RUBY_ENGINE value not_supported_ruby_engine is not recognized")
+          it "returns RUBY_ENGINE_VERSION" do
+            expect(bundler_system_ruby_version.engine_versions).to eq(["1.2.3"])
           end
         end
       end

--- a/spec/other/bundle_ruby_spec.rb
+++ b/spec/other/bundle_ruby_spec.rb
@@ -54,6 +54,19 @@ RSpec.describe "bundle_ruby", :bundler => "< 2" do
       expect(out).to include("ruby 1.8.7 (rbx 1.2.4)")
     end
 
+    it "handles truffleruby" do
+      gemfile <<-G
+        source "file://#{gem_repo1}"
+        ruby "2.5.1", :engine => 'truffleruby', :engine_version => '1.0.0-rc6'
+
+        gem "foo"
+      G
+
+      bundle_ruby
+
+      expect(out).to include("ruby 2.5.1 (truffleruby 1.0.0-rc6)")
+    end
+
     it "raises an error if engine is used but engine version is not" do
       gemfile <<-G
         source "file://#{gem_repo1}"

--- a/spec/other/platform_spec.rb
+++ b/spec/other/platform_spec.rb
@@ -149,6 +149,19 @@ G
       expect(out).to eq("ruby 1.8.7 (rbx 1.2.4)")
     end
 
+    it "handles truffleruby" do
+      gemfile <<-G
+        source "file://#{gem_repo1}"
+        ruby "2.5.1", :engine => 'truffleruby', :engine_version => '1.0.0-rc6'
+
+        gem "foo"
+      G
+
+      bundle "platform --ruby"
+
+      expect(out).to eq("ruby 2.5.1 (truffleruby 1.0.0-rc6)")
+    end
+
     it "raises an error if engine is used but engine version is not" do
       gemfile <<-G
         source "file://#{gem_repo1}"

--- a/spec/support/platforms.rb
+++ b/spec/support/platforms.rb
@@ -79,7 +79,7 @@ module Spec
       when "jruby"
         JRUBY_VERSION
       else
-        raise BundlerError, "That RUBY_ENGINE is not recognized"
+        RUBY_ENGINE_VERSION
       end
     end
 


### PR DESCRIPTION
Hello,
This PR adds support for TruffleRuby in Bundler.

I searched for `rbx` and `jruby` (case-insensitive) through the codebase to find all places which need changes and where tests use specific Ruby implementations. So hopefully this PR is complete, but please tell me if I missed something.

I'd also like to test TruffleRuby in Bundler's CI, but will do this as a separate PR, as we first need the next release of TruffleRuby so that it includes the fix for https://github.com/oracle/truffleruby/issues/1413.