### PR TITLE
Fix local spec failure

### DIFF
--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -884,7 +884,11 @@ end
     it "should successfully require 'bundler/setup'" do
       install_gemfile ""
 
-      ruby <<-R, :env => { "GEM_PATH" => symlinked_gem_home }, :no_lib => true
+      ruby <<-'R', :env => { "GEM_PATH" => symlinked_gem_home }, :no_lib => true
+        # Remove any bundler that's not the current bundler from $LOAD_PATH
+        $LOAD_PATH.each do |path|
+          $LOAD_PATH.delete(path) if File.exist?("#{path}/bundler.rb")
+        end
         puts (require 'bundler/setup')
       R
 

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -886,14 +886,7 @@ end
 
       ENV["GEM_PATH"] = symlinked_gem_home.path
 
-      ruby <<-R
-        if $LOAD_PATH.include?("#{bundler_lib}")
-          # We should use bundler from GEM_PATH for this test, so we should
-          # remove path to the bundler source tree
-          $LOAD_PATH.delete("#{bundler_lib}")
-        else
-          raise "We don't have #{bundler_lib} in $LOAD_PATH"
-        end
+      ruby <<-R, :no_lib => true
         puts (require 'bundler/setup')
       R
 

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -859,12 +859,12 @@ end
 
   context "with bundler is located in symlinked GEM_HOME" do
     let(:gem_home) { Dir.mktmpdir }
-    let(:symlinked_gem_home) { Tempfile.new("gem_home") }
+    let(:symlinked_gem_home) { Tempfile.new("gem_home").path }
     let(:bundler_dir) { File.expand_path("../../..", __FILE__) }
     let(:bundler_lib) { File.join(bundler_dir, "lib") }
 
     before do
-      FileUtils.ln_sf(gem_home, symlinked_gem_home.path)
+      FileUtils.ln_sf(gem_home, symlinked_gem_home)
       gems_dir = File.join(gem_home, "gems")
       specifications_dir = File.join(gem_home, "specifications")
       Dir.mkdir(gems_dir)
@@ -884,7 +884,7 @@ end
     it "should successfully require 'bundler/setup'" do
       install_gemfile ""
 
-      ruby <<-R, :env => { "GEM_PATH" => symlinked_gem_home.path }, :no_lib => true
+      ruby <<-R, :env => { "GEM_PATH" => symlinked_gem_home }, :no_lib => true
         puts (require 'bundler/setup')
       R
 

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -884,9 +884,7 @@ end
     it "should successfully require 'bundler/setup'" do
       install_gemfile ""
 
-      ENV["GEM_PATH"] = symlinked_gem_home.path
-
-      ruby <<-R, :no_lib => true
+      ruby <<-R, :env => { "GEM_PATH" => symlinked_gem_home.path }, :no_lib => true
         puts (require 'bundler/setup')
       R
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,18 +28,6 @@ require "bundler/vendored_fileutils"
 require "uri"
 require "digest"
 
-# Delete the default copy of Bundler that RVM installs for us when running in CI
-require "fileutils"
-if ENV.select {|k, _v| k =~ /TRAVIS/ }.any? && Gem::Version.new(Gem::VERSION) > Gem::Version.new("2.0")
-  Dir.glob(File.join(Gem::Specification.default_specifications_dir, "bundler*.gemspec")).each do |file|
-    FileUtils.rm_rf(file)
-  end
-
-  Dir.glob(File.join(RbConfig::CONFIG["sitelibdir"], "bundler*")).each do |file|
-    FileUtils.rm_rf(file)
-  end
-end
-
 if File.expand_path(__FILE__) =~ %r{([^\w/\.-])}
   abort "The bundler specs cannot be run from a path that contains special characters (particularly #{$1.inspect})"
 end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that bundler specs won't pass on my system. One of the two failures I was getting is the spec added by #6502.

### What was your diagnosis of the problem?

My diagnosis was that my system has a similar setup as TravisCI (Linux with a ruby version manager on top), but I don't set the `TRAVIS` environment variable to run the tests. This means some trickery used in the specs to get them green on TravisCI is not applied to my local run, so specs failed.

### What is your fix for the problem, implemented in this PR?

My fix is to make this spec green independently from whether it's run on TravisCI or not. My changes also make this spec not delete any files from the rubygems installation where the specs are running. In https://github.com/bundler/bundler/pull/6502#issuecomment-403713916 @indirect said that the files being deleted here are put in there by `RVM`. However, I don't think that's accurate, it's `gem update --system` putting these files in there. So if these files should not be there, we should not put them there in the first place instead of deleting them during bundler's specs.

### Why did you choose this fix out of the possible options?

I chose this fix because the alternative would be to set the `TRAVIS` environment variable before running the specs locally, but that would mean that `bundler`'s specs would delete files from my global `rubygems` installation, which seems... no good.