### PR TITLE
[CLI::GEM] bundle gem will generate homepage_uri and code and changelog section …

### DIFF
--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -25,6 +25,10 @@ Gem::Specification.new do |spec|
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)
     spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
+
+    spec.metadata["homepage_uri"] = spec.homepage
+    spec.metadata["source_code_uri"] = "TODO: Put your gem's public repo URL here."
+    spec.metadata["changelog_uri"] = "TODO: Put your gem's CHANGELOG.md URL here."
   else
     raise "RubyGems 2.0 or newer is required to protect against " \
       "public gem pushes."

--- a/spec/bundler/gem_helper_spec.rb
+++ b/spec/bundler/gem_helper_spec.rb
@@ -77,6 +77,7 @@ RSpec.describe Bundler::GemHelper do
     before(:each) do
       content = app_gemspec_content.gsub("TODO: ", "")
       content.sub!(/homepage\s+= ".*"/, 'homepage = ""')
+      content.gsub!(/spec\.metadata.+\n/, "")
       File.open(app_gemspec_path, "w") {|file| file << content }
     end
 

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe "bundle gem" do
     process_file(bundled_app("newgem", "newgem.gemspec")) do |line|
       # Simulate replacing TODOs with real values
       case line
-      when /spec\.metadata\['allowed_push_host'\]/, /spec\.homepage/
+      when /spec\.metadata\["(?:allowed_push_host|homepage_uri|source_code_uri|changelog_uri)"\]/, /spec\.homepage/
         line.gsub(/\=.*$/, "= 'http://example.org'")
       when /spec\.summary/
         line.gsub(/\=.*$/, "= %q{A short summary of my new gem.}")


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was I always have to remember how to add CHANGELOG.md  when I set up a new gem.

### What was your diagnosis of the problem?

My diagnosis was that CHANGELOG.md has become enough of a community standard that it makes sense to offer it in bundle gem.

### What is your fix for the problem, implemented in this PR?

My fix is only added metadata[:changelog_uri] to generated gemspec file.
Changelog.md file is not generated by default.

### Why did you choose this fix out of the possible options?

I chose this fix because Changelog.md file format is different by projects.
