### PR TITLE
Run more assertions in more cases 

### DIFF
--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -843,10 +843,7 @@ __FILE__: #{path.to_s.inspect}
           expect(bundle!("exec #{file}", :artifice => nil)).to eq(expected)
           expect(bundle!("exec bundle exec #{file}", :artifice => nil)).to eq(expected)
           expect(bundle!("exec ruby #{file}", :artifice => nil)).to eq(expected)
-          # Ignore expectation for default bundler gem conflict.
-          unless ENV["BUNDLER_SPEC_SUB_VERSION"]
-            expect(run!(file.read, :artifice => nil)).to eq(expected)
-          end
+          expect(run!(file.read, :artifice => nil)).to eq(expected)
         end
 
         # sanity check that we get the newer, custom version without bundler

--- a/spec/install/redownload_spec.rb
+++ b/spec/install/redownload_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "bundle install", :bundler => "2" do
+RSpec.describe "bundle install" do
   before :each do
     gemfile <<-G
       source "file://#{gem_repo1}"
@@ -61,14 +61,24 @@ RSpec.describe "bundle install", :bundler => "2" do
       let(:flag) { "force" }
     end
 
-    it "shows a deprecation when single flag passed" do
+    it "shows a deprecation when single flag passed", :bundler => 2 do
       bundle! "install --force"
       expect(out).to include "[DEPRECATED FOR 2.0] The `--force` option has been renamed to `--redownload`"
     end
 
-    it "shows a deprecation when multiple flags passed" do
+    it "shows a deprecation when multiple flags passed", :bundler => 2 do
       bundle! "install --no-color --force"
       expect(out).to include "[DEPRECATED FOR 2.0] The `--force` option has been renamed to `--redownload`"
+    end
+
+    it "does not show a deprecation when single flag passed", :bundler => "< 2" do
+      bundle! "install --force"
+      expect(out).not_to include "[DEPRECATED FOR 2.0] The `--force` option has been renamed to `--redownload`"
+    end
+
+    it "does not show a deprecation when multiple flags passed", :bundler => "< 2" do
+      bundle! "install --no-color --force"
+      expect(out).not_to include "[DEPRECATED FOR 2.0] The `--force` option has been renamed to `--redownload`"
     end
   end
 

--- a/spec/update/redownload_spec.rb
+++ b/spec/update/redownload_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "bundle update", :bundler => "2" do
+RSpec.describe "bundle update" do
   before :each do
     install_gemfile <<-G
       source "file://#{gem_repo1}"
@@ -9,14 +9,24 @@ RSpec.describe "bundle update", :bundler => "2" do
   end
 
   describe "with --force" do
-    it "shows a deprecation when single flag passed" do
+    it "shows a deprecation when single flag passed", :bundler => 2 do
       bundle! "update rack --force"
       expect(out).to include "[DEPRECATED FOR 2.0] The `--force` option has been renamed to `--redownload`"
     end
 
-    it "shows a deprecation when multiple flags passed" do
+    it "shows a deprecation when multiple flags passed", :bundler => 2 do
       bundle! "update rack --no-color --force"
       expect(out).to include "[DEPRECATED FOR 2.0] The `--force` option has been renamed to `--redownload`"
+    end
+
+    it "does not show a deprecation when single flag passed", :bundler => "< 2" do
+      bundle! "update rack --force"
+      expect(out).not_to include "[DEPRECATED FOR 2.0] The `--force` option has been renamed to `--redownload`"
+    end
+
+    it "does not show a deprecation when multiple flags passed", :bundler => "< 2" do
+      bundle! "update rack --no-color --force"
+      expect(out).not_to include "[DEPRECATED FOR 2.0] The `--force` option has been renamed to `--redownload`"
     end
   end
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

I noticed a couple of places where assertions were being excluded and they shouldn't:

* One was introduced by me in #6702, where the specs added (and some already present) started being tested only on bundler 2.x.
* The other one was introduced in f7414bcb17fe1bd67246021251b5f0527bd6afd1, where one assertion would be run only if a certain env variable was not set. I think it was because of a TravisCI environmental issue that now seems fixed.

### What was your diagnosis of the problem?

My diagnosis was that none of these exclusions are necessary.

### What is your fix for the problem, implemented in this PR?

My fix is to restore the excluded assertions to all environments and branches.

### Why did you choose this fix out of the possible options?

I chose this fix because it seems best to avoid future problems.