### PR TITLE
Avoid fetching an rebuilding git gems when it's not necessary

### DIFF
--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -260,7 +260,11 @@ module Bundler
       end
 
       def requires_checkout?
-        allow_git_ops? && !local?
+        !cached_revision_checked_out? && allow_git_ops? && !local?
+      end
+
+      def cached_revision_checked_out?
+        cached_revision && cached_revision == revision && install_path.exist?
       end
 
       def base_name

--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -260,7 +260,7 @@ module Bundler
       end
 
       def requires_checkout?
-        !cached_revision_checked_out? && allow_git_ops? && !local?
+        allow_git_ops? && !local? && !cached_revision_checked_out?
       end
 
       def cached_revision_checked_out?

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -1211,6 +1211,47 @@ In Gemfile:
 
       install_gemfile <<-G
         source "file://#{gem_repo1}"
+        gem "foo", :git => "#{lib_path("foo-1.0")}"
+      G
+
+      run! <<-R
+        require 'foo'
+        puts FOO
+      R
+
+      installed_time = out
+      expect(installed_time).to match(/\A\d+\.\d+\z/)
+
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem "foo", :git => "#{lib_path("foo-1.0")}"
+      G
+
+      run! <<-R
+        require 'foo'
+        puts FOO
+      R
+      expect(out).to eq(installed_time)
+    end
+
+    it "does not reinstall the extension when changing another gem", :rubygems => ">= 2.3.0" do
+      build_git "foo" do |s|
+        s.add_dependency "rake"
+        s.extensions << "Rakefile"
+        s.write "Rakefile", <<-RUBY
+          task :default do
+            path = File.expand_path("../lib", __FILE__)
+            FileUtils.mkdir_p(path)
+            cur_time = Time.now.to_f.to_s
+            File.open("\#{path}/foo.rb", "w") do |f|
+              f.puts "FOO = \#{cur_time}"
+            end
+          end
+        RUBY
+      end
+
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
         gem "rack", "0.9.1"
         gem "foo", :git => "#{lib_path("foo-1.0")}"
       G
@@ -1234,6 +1275,60 @@ In Gemfile:
         puts FOO
       R
       expect(out).to eq(installed_time)
+    end
+
+    it "does reinstall the extension when changing refs", :rubygems => ">= 2.3.0" do
+      build_git "foo" do |s|
+        s.add_dependency "rake"
+        s.extensions << "Rakefile"
+        s.write "Rakefile", <<-RUBY
+          task :default do
+            path = File.expand_path("../lib", __FILE__)
+            FileUtils.mkdir_p(path)
+            cur_time = Time.now.to_f.to_s
+            File.open("\#{path}/foo.rb", "w") do |f|
+              f.puts "FOO = \#{cur_time}"
+            end
+          end
+        RUBY
+      end
+
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem "foo", :git => "#{lib_path("foo-1.0")}"
+      G
+
+      run! <<-R
+        require 'foo'
+        puts FOO
+      R
+
+      update_git("foo", :branch => "branch2")
+
+      installed_time = out
+      expect(installed_time).to match(/\A\d+\.\d+\z/)
+
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem "foo", :git => "#{lib_path("foo-1.0")}", :branch => "branch2"
+      G
+
+      run! <<-R
+        require 'foo'
+        puts FOO
+      R
+      expect(out).not_to eq(installed_time)
+
+      installed_time = out
+
+      update_git("foo")
+      bundle! "update foo"
+
+      run! <<-R
+        require 'foo'
+        puts FOO
+      R
+      expect(out).not_to eq(installed_time)
     end
   end
 

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -1211,6 +1211,7 @@ In Gemfile:
 
       install_gemfile <<-G
         source "file://#{gem_repo1}"
+        gem "rack", "0.9.1"
         gem "foo", :git => "#{lib_path("foo-1.0")}"
       G
 
@@ -1224,6 +1225,7 @@ In Gemfile:
 
       install_gemfile <<-G
         source "file://#{gem_repo1}"
+        gem "rack", "1.0.0"
         gem "foo", :git => "#{lib_path("foo-1.0")}"
       G
 


### PR DESCRIPTION
Kind of a followup to https://github.com/bundler/bundler/pull/4272

### The issue

As demonstrated by the updated test case, whenever a gem is changed (even a non-git one), bundler re-fetch all git gems, and recompile their extensions (if any).

You can repro that issue by running the modified `git_spec.rb` against master.

### The proposed fix

In that patch I simply make `Source::Git` skip the `fetch` step if the `cached_revision` matches the install path.

Since `install_path` uses only the first 10 characters of the full revision, there is a very very small chance of a collision happening, but It's so small that I think it can be ignored.

However my understanding of the codebase is too limited to be 100% sure the git gem would be properly updated if it's definition (`branch` / `ref` / `etc`) is updated. I tried to write a test case for this but couldn't figure out how to create a repo with multiple revisions. I'll keep digging, but I figured I might as well ask for feedback at this stage.


@segiddins any thoughts on this ? (since you fixed #4272), any pointers on how to better test this?

cc @rafaelfranca @jules2689 