### PR TITLE
Make config location relative to the current working directory

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -286,7 +286,13 @@ module Bundler
         end
       end
 
-      current_config_root.join(app_config || ".bundle")
+      config_root = if Bundler.feature_flag.config_relative_to_cwd?
+        current_config_root
+      else
+        app_config_root
+      end
+
+      config_root.join(app_config || ".bundle")
     end
 
     def app_cache(custom_path = nil)

--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -288,13 +288,11 @@ module Bundler
         app_config_pathname = Pathname.new(app_config)
 
         if app_config_pathname.absolute?
-          app_config_pathname
-        else
-          root.join(app_config_pathname)
+          return app_config_pathname
         end
-      else
-        root.join(".bundle")
       end
+
+      root.join(app_config || ".bundle")
     end
 
     def app_cache(custom_path = nil)

--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -274,13 +274,7 @@ module Bundler
     end
 
     def root
-      @root ||= begin
-                  SharedHelpers.root
-                rescue GemfileNotFound
-                  bundle_dir = default_bundle_dir
-                  raise GemfileNotFound, "Could not locate Gemfile or .bundle/ directory" unless bundle_dir
-                  bundle_dir.parent
-                end
+      @root ||= SharedHelpers.root
     end
 
     def app_config_path

--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -279,7 +279,7 @@ module Bundler
                 rescue GemfileNotFound
                   bundle_dir = default_bundle_dir
                   raise GemfileNotFound, "Could not locate Gemfile or .bundle/ directory" unless bundle_dir
-                  Pathname.new(File.expand_path("..", bundle_dir))
+                  bundle_dir.parent
                 end
     end
 

--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -290,7 +290,7 @@ module Bundler
         if app_config_pathname.absolute?
           app_config_pathname
         else
-          app_config_pathname.expand_path(root)
+          root.join(app_config_pathname)
         end
       else
         root.join(".bundle")

--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -286,7 +286,7 @@ module Bundler
         end
       end
 
-      app_config_root.join(app_config || ".bundle")
+      current_config_root.join(app_config || ".bundle")
     end
 
     def app_cache(custom_path = nil)
@@ -684,6 +684,10 @@ EOF
       root
     rescue GemfileNotFound
       Pathname.new(".").expand_path
+    end
+
+    def current_config_root
+      SharedHelpers.config_root
     end
   end
 end

--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -292,7 +292,7 @@ module Bundler
         end
       end
 
-      root.join(app_config || ".bundle")
+      app_config_root.join(app_config || ".bundle")
     end
 
     def app_cache(custom_path = nil)
@@ -319,8 +319,6 @@ EOF
 
     def settings
       @settings ||= Settings.new(app_config_path)
-    rescue GemfileNotFound
-      @settings = Settings.new(Pathname.new(".bundle").expand_path)
     end
 
     # @return [Hash] Environment present before Bundler was activated
@@ -686,6 +684,12 @@ EOF
       yield
     ensure
       ENV.replace(backup)
+    end
+
+    def app_config_root
+      root
+    rescue GemfileNotFound
+      Pathname.new(".").expand_path
     end
   end
 end

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -54,10 +54,14 @@ module Bundler
     def initialize(*args)
       super
 
-      custom_gemfile = options[:gemfile] || Bundler.settings[:gemfile]
-      if custom_gemfile && !custom_gemfile.empty?
-        Bundler::SharedHelpers.set_env "BUNDLE_GEMFILE", File.expand_path(custom_gemfile)
-        Bundler.reset_paths!
+      if Bundler.feature_flag.config_relative_to_cwd?
+        Bundler.settings.set_command_option_if_given :gemfile, options[:gemfile]
+      else
+        custom_gemfile = options[:gemfile] || Bundler.settings[:gemfile]
+        if custom_gemfile && !custom_gemfile.empty?
+          Bundler::SharedHelpers.set_env "BUNDLE_GEMFILE", File.expand_path(custom_gemfile)
+          Bundler.reset_paths!
+        end
       end
 
       Bundler.settings.set_command_option_if_given :retry, options[:retry]

--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -25,6 +25,15 @@ module Bundler
     end
     private_class_method :settings_method
 
+    def self.env_flag(name, &default)
+      define_method(:"#{name}?") do
+        value = ENV["BUNDLE_#{name.to_s.upcase}"]
+        value = instance_eval(&default) if value.nil?
+        value
+      end
+    end
+    private_class_method :env_flag
+
     (1..10).each {|v| define_method("bundler_#{v}_mode?") { major_version >= v } }
 
     settings_flag(:allow_bundler_dependency_conflicts) { bundler_3_mode? }
@@ -50,6 +59,8 @@ module Bundler
     settings_flag(:use_gem_version_promoter_for_major_updates) { bundler_3_mode? }
 
     settings_option(:default_cli_command) { bundler_3_mode? ? :cli_help : :install }
+
+    env_flag(:config_relative_to_cwd) { bundler_3_mode? }
 
     def initialize(bundler_version)
       @bundler_version = Gem::Version.create(bundler_version)

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -108,6 +108,8 @@ module Bundler
     end
 
     def set_local(key, value)
+      local_config_file || raise(GemfileNotFound, "Could not locate Gemfile")
+
       set_key(key, value, @local_config, local_config_file)
     end
 
@@ -384,7 +386,7 @@ module Bundler
     end
 
     def local_config_file
-      @root.join("config")
+      @root.join("config") if @root
     end
 
     def load_config(config_file)

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -108,8 +108,6 @@ module Bundler
     end
 
     def set_local(key, value)
-      local_config_file || raise(GemfileNotFound, "Could not locate Gemfile")
-
       set_key(key, value, @local_config, local_config_file)
     end
 
@@ -386,7 +384,7 @@ module Bundler
     end
 
     def local_config_file
-      Pathname.new(@root).join("config") if @root
+      Pathname.new(@root).join("config")
     end
 
     def load_config(config_file)

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -384,7 +384,7 @@ module Bundler
     end
 
     def local_config_file
-      Pathname.new(@root).join("config")
+      @root.join("config")
     end
 
     def load_config(config_file)

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -12,8 +12,12 @@ module Bundler
   module SharedHelpers
     def root
       gemfile = find_gemfile
-      raise GemfileNotFound, "Could not locate Gemfile" unless gemfile
-      Pathname.new(gemfile).tap{|x| x.untaint if RUBY_VERSION < "2.7" }.expand_path.parent
+      return Pathname.new(gemfile).tap{|x| x.untaint if RUBY_VERSION < "2.7" }.expand_path.parent if gemfile
+
+      bundle_dir = default_bundle_dir
+      raise GemfileNotFound, "Could not locate Gemfile or .bundle/ directory" unless bundle_dir
+
+      bundle_dir.parent
     end
 
     def default_gemfile

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -238,7 +238,11 @@ module Bundler
 
     def find_gemfile
       require_relative "../bundler"
-      given = Bundler.settings[:gemfile]
+      given = if Bundler.feature_flag.config_relative_to_cwd?
+        Bundler.settings[:gemfile]
+      else
+        ENV["BUNDLE_GEMFILE"]
+      end
       return given if given && !given.empty?
       find_file(*gemfile_names)
     end

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -237,7 +237,8 @@ module Bundler
     end
 
     def find_gemfile
-      given = ENV["BUNDLE_GEMFILE"]
+      require_relative "../bundler"
+      given = Bundler.settings[:gemfile]
       return given if given && !given.empty?
       find_file(*gemfile_names)
     end

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -20,6 +20,12 @@ module Bundler
       bundle_dir.parent
     end
 
+    def config_root
+      bundle_dir = default_bundle_dir
+
+      bundle_dir ? bundle_dir.parent : Pathname.pwd
+    end
+
     def default_gemfile
       gemfile = find_gemfile
       raise GemfileNotFound, "Could not locate Gemfile" unless gemfile

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -23,7 +23,7 @@ module Bundler
     def config_root
       bundle_dir = default_bundle_dir
 
-      bundle_dir ? bundle_dir.parent : Pathname.pwd
+      bundle_dir ? bundle_dir.parent : pwd
     end
 
     def default_gemfile

--- a/spec/bundler/definition_spec.rb
+++ b/spec/bundler/definition_spec.rb
@@ -5,7 +5,6 @@ require "bundler/definition"
 RSpec.describe Bundler::Definition do
   describe "#lock" do
     before do
-      allow(Bundler).to receive(:settings) { Bundler::Settings.new(".") }
       allow(Bundler::SharedHelpers).to receive(:find_gemfile) { Pathname.new("Gemfile") }
       allow(Bundler).to receive(:ui) { double("UI", :info => "", :debug => "") }
     end

--- a/spec/bundler/plugin/index_spec.rb
+++ b/spec/bundler/plugin/index_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Bundler::Plugin::Index do
   Index = Bundler::Plugin::Index
 
   before do
-    allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
+    allow(Bundler::SharedHelpers).to receive(:pwd).and_return(bundled_app)
     gemfile ""
     path = lib_path(plugin_name)
     index.register_plugin("new-plugin", path.to_s, [path.join("lib").to_s], commands, sources, hooks)

--- a/spec/bundler/plugin_spec.rb
+++ b/spec/bundler/plugin_spec.rb
@@ -237,7 +237,8 @@ RSpec.describe Bundler::Plugin do
   describe "#root" do
     context "in app dir" do
       before do
-        allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
+        allow(Bundler::SharedHelpers).to receive(:pwd).and_return(bundled_app)
+        FileUtils.touch(bundled_app.join("Gemfile"))
       end
 
       it "returns plugin dir in app .bundle path" do
@@ -247,7 +248,7 @@ RSpec.describe Bundler::Plugin do
 
     context "outside app dir" do
       before do
-        allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(nil)
+        allow(Bundler::SharedHelpers).to receive(:pwd).and_return(root)
       end
 
       it "returns plugin dir in global bundle path" do

--- a/spec/commands/config_spec.rb
+++ b/spec/commands/config_spec.rb
@@ -53,7 +53,19 @@ RSpec.describe ".bundle/config" do
       expect(the_bundle).to include_gems "rack 1.0.0"
     end
 
-    it "can provide a relative path with the environment variable" do
+    it "can provide a relative path with the environment variable, and generates config relative to the Gemfile", :bundler => "< 3" do
+      FileUtils.mkdir_p bundled_app("omg")
+
+      ENV["BUNDLE_APP_CONFIG"] = "../foo"
+      bundle "config set --local path vendor/bundle", :dir => bundled_app("omg")
+      bundle "install", :dir => bundled_app("omg")
+
+      expect(bundled_app(".bundle")).not_to exist
+      expect(bundled_app("../foo/config")).to exist
+      expect(the_bundle).to include_gems "rack 1.0.0"
+    end
+
+    it "can provide a relative path with the environment variable, and generates config relative to the cwd", :bundler => "3" do
       FileUtils.mkdir_p bundled_app("omg")
 
       ENV["BUNDLE_APP_CONFIG"] = "../foo"
@@ -65,7 +77,7 @@ RSpec.describe ".bundle/config" do
       expect(the_bundle).to include_gems "rack 1.0.0", :dir => bundled_app("omg")
     end
 
-    it "is relative to the pwd and not to the gemfile" do
+    it "is relative to the pwd and not to the gemfile", :bundler => "3" do
       FileUtils.mkdir_p bundled_app("omg/gmo")
 
       gemfile bundled_app("omg/gmo/AnotherGemfile"), <<-G
@@ -78,7 +90,7 @@ RSpec.describe ".bundle/config" do
       expect(bundled_app("omg/.bundle")).to exist
     end
 
-    it "uses the first existing local config from the pwd and not from the gemfile" do
+    it "uses the first existing local config from the pwd and not from the gemfile", :bundler => "3" do
       bundle "install"
 
       FileUtils.mkdir_p bundled_app("omg/gmo")
@@ -534,7 +546,7 @@ RSpec.describe "setting gemfile via config" do
       expect(out).to include("NotGemfile")
     end
 
-    it "gets used when requiring bundler/setup" do
+    it "gets used when requiring bundler/setup", :bundler => "3" do
       bundle :install
       code = "puts $LOAD_PATH.count {|path| path =~ /rack/} == 1"
 

--- a/spec/commands/config_spec.rb
+++ b/spec/commands/config_spec.rb
@@ -518,17 +518,33 @@ end
 
 RSpec.describe "setting gemfile via config" do
   context "when only the non-default Gemfile exists" do
-    it "persists the gemfile location to .bundle/config" do
+    before do
       gemfile bundled_app("NotGemfile"), <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem 'rack'
       G
 
       bundle "config set --local gemfile #{bundled_app("NotGemfile")}"
+    end
+
+    it "persists the gemfile location to .bundle/config" do
       expect(File.exist?(bundled_app(".bundle/config"))).to eq(true)
 
       bundle "config list"
       expect(out).to include("NotGemfile")
+    end
+
+    it "gets used when requiring bundler/setup" do
+      bundle :install
+      code = "puts $LOAD_PATH.count {|path| path =~ /rack/} == 1"
+
+      gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+      G
+
+      ruby! code, :env => { "RUBYOPT" => "-r#{lib_dir}/bundler/setup" }, :no_lib => true
+
+      expect(out).to eq("true")
     end
   end
 end

--- a/spec/commands/config_spec.rb
+++ b/spec/commands/config_spec.rb
@@ -45,7 +45,8 @@ RSpec.describe ".bundle/config" do
 
     it "can be moved with an environment variable" do
       ENV["BUNDLE_APP_CONFIG"] = tmp("foo/bar").to_s
-      bundle "install", forgotten_command_line_options(:path => "vendor/bundle")
+      bundle "config set --local path vendor/bundle"
+      bundle "install"
 
       expect(bundled_app(".bundle")).not_to exist
       expect(tmp("foo/bar/config")).to exist
@@ -56,7 +57,8 @@ RSpec.describe ".bundle/config" do
       FileUtils.mkdir_p bundled_app("omg")
 
       ENV["BUNDLE_APP_CONFIG"] = "../foo"
-      bundle "install", forgotten_command_line_options(:path => "vendor/bundle").merge(:dir => bundled_app("omg"))
+      bundle "config set --local path vendor/bundle", :dir => bundled_app("omg")
+      bundle "install", :dir => bundled_app("omg")
 
       expect(bundled_app(".bundle")).not_to exist
       expect(bundled_app("../foo/config")).to exist

--- a/spec/plugins/install_spec.rb
+++ b/spec/plugins/install_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe "bundler plugin install" do
 
   context "Gemfile eval" do
     before do
-      allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
+      allow(Bundler::SharedHelpers).to receive(:pwd).and_return(bundled_app)
     end
 
     it "installs plugins listed in gemfile" do
@@ -249,7 +249,7 @@ RSpec.describe "bundler plugin install" do
 
   describe "local plugin" do
     it "is installed when inside an app" do
-      allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
+      allow(Bundler::SharedHelpers).to receive(:pwd).and_return(bundled_app)
       gemfile ""
       bundle "plugin install foo --source #{file_uri_for(gem_repo2)}"
 

--- a/spec/plugins/source_spec.rb
+++ b/spec/plugins/source_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "bundler source plugin" do
         end
       G
 
-      allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
+      allow(Bundler::SharedHelpers).to receive(:pwd).and_return(bundled_app)
       plugin_should_be_installed("bundler-source-psource")
     end
 
@@ -76,7 +76,7 @@ RSpec.describe "bundler source plugin" do
         end
 
         it "installs the explicit one" do
-          allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
+          allow(Bundler::SharedHelpers).to receive(:pwd).and_return(bundled_app)
           plugin_should_be_installed("another-psource")
         end
 
@@ -102,7 +102,7 @@ RSpec.describe "bundler source plugin" do
         end
 
         it "installs the default one" do
-          allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
+          allow(Bundler::SharedHelpers).to receive(:pwd).and_return(bundled_app)
           plugin_should_be_installed("bundler-source-psource")
         end
       end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -302,7 +302,12 @@ module Spec
       bundler_path = tmp + "bundler-#{Bundler::VERSION}.gem"
 
       with_root_gemspec do |gemspec|
-        gem_command! "build #{gemspec} --output #{bundler_path}", :dir => root
+        if Gem::VERSION >= "3.0.0"
+          gem_command! "build #{gemspec} --output #{bundler_path}", :dir => root
+        else
+          gem_command! "build #{gemspec}", :dir => root
+          FileUtils.mv root + File.basename(bundler_path), bundler_path
+        end
       end
 
       begin

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -299,11 +299,11 @@ module Spec
     end
 
     def with_built_bundler
-      with_root_gemspec do |gemspec|
-        gem_command! "build #{gemspec}", :dir => root
-      end
+      bundler_path = tmp + "bundler-#{Bundler::VERSION}.gem"
 
-      bundler_path = root + "bundler-#{Bundler::VERSION}.gem"
+      with_root_gemspec do |gemspec|
+        gem_command! "build #{gemspec} --output #{bundler_path}", :dir => root
+      end
 
       begin
         yield(bundler_path)


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

There are two related end-user problems.

* When a custom `Gemfile` is configured via `BUNDLE_GEMFILE` and we run `bundle config`, the local config is not generated in the current working directory. The reason is in the diagnosis section, but the end user problem is that it is very counterintuitive. On bundler 1 this is aggravated because of "sticky options". See https://github.com/bundler/bundler/issues/2048#issuecomment-7615264 for an example.

* When configuring a custom gemfile via settings, it is not respected when requiring `bundler/setup`. See #6589.

### What was your diagnosis of the problem?

My diagnosis was that the config location is currently resolved from the current `Gemfile` location, and that leads to configuration being created on counterintuitive locations. For example, you have `BUNDLE_GEMFILE` set to a particular non-root location, and run `bundle config` on the root folder, but no local config is apparently generated... until you figure out it's being generated in the same folder `BUNDLE_GEMFILE` is pointing to.

Also, since the config location depends on the location of the current `Gemfile`, we can't consistently resolve the `Gemfile` from configuration, because of a chicken-and-egg problem. We need the `Gemfile` to figure out where the config is, but we need the config to figure out where the `Gemfile` is. This is why #6589 can't currently work.

### What is your fix for the problem, implemented in this PR?

My fix was to change how we resolve the configuration root, and instead look up in the directory hierarchy for an existing local config, and otherwise default to the current working directory. With that in place, fixing #6589 is easy. My changes led to a single spec failure. Even if it's just one, it is backwards incompatible if backwards compatibility is defined by our current set of specs. Since I'd like to be able to opt-in to the new behavior right now on bundler 1, I made a feature flag for this change. This feature flag needed to be different from the other feature flags we currently have, because it can't be config-based (chicken-and-egg problem again). So I introduced "env-based feature flags".

Once we have the new configuration root resolution in place, the fix for #6589 is to add knowledge to the `find_gemfile` method to read from settings (and not just from env).

### Why did you choose this fix out of the possible options?

I chose this fix because changing the way we resolve configuration seemed like the only way to resolve the problems that I wanted to fix here.

Fixes #6589.
Fixes #2048 (the remaining part of it, https://github.com/bundler/bundler/issues/2048#issuecomment-7615264 and https://github.com/bundler/bundler/issues/2048#issuecomment-47390038).
Fixes #7445.