### PR TITLE
Remove if branch that always evaluate to false

### DIFF
--- a/lib/bundler/source/metadata.rb
+++ b/lib/bundler/source/metadata.rb
@@ -21,9 +21,7 @@ module Bundler
             # can't point to the actual gemspec or else the require paths will be wrong
             s.loaded_from = File.expand_path("..", __FILE__)
           end
-          if loaded_spec = nil && Bundler.rubygems.loaded_specs("bundler")
-            idx << loaded_spec # this has to come after the fake gemspec, to override it
-          elsif local_spec = Bundler.rubygems.find_name("bundler").find {|s| s.version.to_s == VERSION }
+          if local_spec = Bundler.rubygems.find_name("bundler").find {|s| s.version.to_s == VERSION }
             idx << local_spec
           end
 


### PR DESCRIPTION
`loaded_spec = nil` always evaluate to false, so the code in this if is never executed.
 
I'm not sure if this is a bug or if the branch is not necessary. Since I don't know the codebase well enough, I'm opening the pull request to at least bring the attention to a possible problem.