### PR TITLE
Correct `bundle show` deprecation

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -292,18 +292,16 @@ module Bundler
     def show(gem_name = nil)
       if ARGV[0] == "show"
         rest = ARGV[1..-1]
-        alternative = rest.find {|arg| !arg.start_with?("--") } ? "info" : "list"
 
-        new_argv = [alternative, *rest]
+        new_command = rest.find {|arg| !arg.start_with?("--") } ? "info" : "list"
 
-        if alternative == "list" && rest.include?("--paths")
-          new_argv.delete("--paths")
-        else
-          new_argv = new_argv.map {|arg| arg == "--paths" ? "--path" : arg }
+        new_arguments = rest.map do |arg|
+          next arg if arg != "--paths"
+          next "--path" if new_command == "info"
         end
 
         old_argv = ARGV.join(" ")
-        new_argv = new_argv.join(" ")
+        new_argv = [new_command, *new_arguments.compact].join(" ")
 
         Bundler::SharedHelpers.major_deprecation(2, "use `bundle #{new_argv}` instead of `bundle #{old_argv}`")
       end

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -290,7 +290,15 @@ module Bundler
     method_option "outdated", :type => :boolean,
                               :banner => "Show verbose output including whether gems are outdated."
     def show(gem_name = nil)
-      Bundler::SharedHelpers.major_deprecation(2, "use `bundle list` instead of `bundle show`") if ARGV[0] == "show"
+      if ARGV[0] == "show"
+        rest = ARGV[1..-1]
+        alternative = rest.find {|arg| !arg.start_with?("--") } ? "info" : "list"
+
+        old_argv = ARGV.join(" ")
+        new_argv = [alternative, *rest].join(" ")
+
+        Bundler::SharedHelpers.major_deprecation(2, "use `bundle #{new_argv}` instead of `bundle #{old_argv}`")
+      end
       require "bundler/cli/show"
       Show.new(options, gem_name).run
     end

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -294,8 +294,16 @@ module Bundler
         rest = ARGV[1..-1]
         alternative = rest.find {|arg| !arg.start_with?("--") } ? "info" : "list"
 
+        new_argv = [alternative, *rest]
+
+        if alternative == "list" && rest.include?("--paths")
+          new_argv.delete("--paths")
+        else
+          new_argv = new_argv.map {|arg| arg == "--paths" ? "--path" : arg }
+        end
+
         old_argv = ARGV.join(" ")
-        new_argv = [alternative, *rest].join(" ")
+        new_argv = new_argv.join(" ")
 
         Bundler::SharedHelpers.major_deprecation(2, "use `bundle #{new_argv}` instead of `bundle #{old_argv}`")
       end

--- a/spec/bundler/cli_spec.rb
+++ b/spec/bundler/cli_spec.rb
@@ -71,17 +71,17 @@ RSpec.describe "bundle executable" do
     it "prints the running command" do
       gemfile ""
       bundle! "info bundler", :verbose => true
-      expect(last_command.stdout).to start_with("Running `bundle info bundler --no-color --verbose` with bundler #{Bundler::VERSION}")
+      expect(last_command.stdout).to start_with("Running `bundle info bundler --verbose` with bundler #{Bundler::VERSION}")
     end
 
     it "doesn't print defaults" do
       install_gemfile! "", :verbose => true
-      expect(last_command.stdout).to start_with("Running `bundle install --no-color --retry 0 --verbose` with bundler #{Bundler::VERSION}")
+      expect(last_command.stdout).to start_with("Running `bundle install --retry 0 --verbose` with bundler #{Bundler::VERSION}")
     end
 
     it "doesn't print defaults" do
       install_gemfile! "", :verbose => true
-      expect(last_command.stdout).to start_with("Running `bundle install --no-color --retry 0 --verbose` with bundler #{Bundler::VERSION}")
+      expect(last_command.stdout).to start_with("Running `bundle install --retry 0 --verbose` with bundler #{Bundler::VERSION}")
     end
   end
 

--- a/spec/commands/show_spec.rb
+++ b/spec/commands/show_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "bundle show", :bundler => "< 2" do
+RSpec.describe "bundle show" do
   context "with a standard Gemfile" do
     before :each do
       install_gemfile <<-G
@@ -25,9 +25,17 @@ RSpec.describe "bundle show", :bundler => "< 2" do
       expect(bundled_app("Gemfile.lock")).to exist
     end
 
-    it "prints path if gem exists in bundle" do
+    it "prints path if gem exists in bundle", :bundler => "< 2" do
       bundle "show rails"
       expect(out).to eq(default_bundle_path("gems", "rails-2.3.2").to_s)
+    end
+
+    it "prints path if gem exists in bundle", :bundler => "2" do
+      bundle "show rails"
+      expect(out).to eq(
+        "[DEPRECATED FOR 2.0] use `bundle info rails` instead of `bundle show rails`\n" +
+        default_bundle_path("gems", "rails-2.3.2").to_s
+      )
     end
 
     it "warns if path no longer exists on disk" do
@@ -39,9 +47,17 @@ RSpec.describe "bundle show", :bundler => "< 2" do
         and include(default_bundle_path("gems", "rails-2.3.2").to_s)
     end
 
-    it "prints the path to the running bundler" do
+    it "prints the path to the running bundler", :bundler => "< 2" do
       bundle "show bundler"
       expect(out).to eq(root.to_s)
+    end
+
+    it "prints the path to the running bundler", :bundler => "2" do
+      bundle "show bundler"
+      expect(out).to eq(
+        "[DEPRECATED FOR 2.0] use `bundle info bundler` instead of `bundle show bundler`\n" +
+        root.to_s
+      )
     end
 
     it "complains if gem not in bundle" do
@@ -49,7 +65,7 @@ RSpec.describe "bundle show", :bundler => "< 2" do
       expect(out).to match(/could not find gem 'missing'/i)
     end
 
-    it "prints path of all gems in bundle sorted by name" do
+    it "prints path of all gems in bundle sorted by name", :bundler => "< 2" do
       bundle "show --paths"
 
       expect(out).to include(default_bundle_path("gems", "rake-10.0.2").to_s)
@@ -57,6 +73,20 @@ RSpec.describe "bundle show", :bundler => "< 2" do
 
       # Gem names are the last component of their path.
       gem_list = out.split.map {|p| p.split("/").last }
+      expect(gem_list).to eq(gem_list.sort)
+    end
+
+    it "prints path of all gems in bundle sorted by name", :bundler => "2" do
+      bundle "show --paths"
+
+      expect(out).to include(default_bundle_path("gems", "rake-10.0.2").to_s)
+      expect(out).to include(default_bundle_path("gems", "rails-2.3.2").to_s)
+
+      out_lines = out.split("\n")
+      expect(out_lines[0]).to eq("[DEPRECATED FOR 2.0] use `bundle list --paths` instead of `bundle show --paths`")
+
+      # Gem names are the last component of their path.
+      gem_list = out_lines[1..-1].map {|p| p.split("/").last }
       expect(gem_list).to eq(gem_list.sort)
     end
 

--- a/spec/commands/show_spec.rb
+++ b/spec/commands/show_spec.rb
@@ -38,6 +38,19 @@ RSpec.describe "bundle show" do
       )
     end
 
+    it "prints path if gem exists in bundle (with --paths option)", :bundler => "< 2" do
+      bundle "show rails --paths"
+      expect(out).to eq(default_bundle_path("gems", "rails-2.3.2").to_s)
+    end
+
+    it "prints path if gem exists in bundle (with --paths option)", :bundler => "2" do
+      bundle "show rails --paths"
+      expect(out).to eq(
+        "[DEPRECATED FOR 2.0] use `bundle info rails --path` instead of `bundle show rails --paths`\n" +
+        default_bundle_path("gems", "rails-2.3.2").to_s
+      )
+    end
+
     it "warns if path no longer exists on disk" do
       FileUtils.rm_rf(default_bundle_path("gems", "rails-2.3.2"))
 
@@ -83,7 +96,7 @@ RSpec.describe "bundle show" do
       expect(out).to include(default_bundle_path("gems", "rails-2.3.2").to_s)
 
       out_lines = out.split("\n")
-      expect(out_lines[0]).to eq("[DEPRECATED FOR 2.0] use `bundle list --paths` instead of `bundle show --paths`")
+      expect(out_lines[0]).to eq("[DEPRECATED FOR 2.0] use `bundle list` instead of `bundle show --paths`")
 
       # Gem names are the last component of their path.
       gem_list = out_lines[1..-1].map {|p| p.split("/").last }

--- a/spec/other/cli_dispatch_spec.rb
+++ b/spec/other/cli_dispatch_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "bundle command names" do
 
     it "dispatches `bundle cache` to the package command" do
       bundle "cache --verbose"
-      expect(last_command.stdout).to start_with "Running `bundle package --no-color --verbose`"
+      expect(last_command.stdout).to start_with "Running `bundle package --verbose`"
     end
   end
 end

--- a/spec/plugins/command_spec.rb
+++ b/spec/plugins/command_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "command plugins" do
     bundle "plugin install the-echoer --source file://#{gem_repo2}"
     expect(out).to include("Installed plugin the-echoer")
 
-    bundle "echo tacos tofu lasange", "no-color" => false
+    bundle "echo tacos tofu lasange"
     expect(out).to eq("You gave me tacos, tofu, lasange")
   end
 

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -99,9 +99,6 @@ module Spec
       with_sudo = options.delete(:sudo)
       sudo = with_sudo == :preserve_env ? "sudo -E" : "sudo" if with_sudo
 
-      no_color = options.delete("no-color") { cmd.to_s !~ /\A(e|ex|exe|exec|conf|confi|config)(\s|\z)/ }
-      options["no-color"] = true if no_color
-
       bundle_bin = options.delete("bundle_bin") || bindir.join("bundle")
 
       if system_bundler = options.delete(:system_bundler)


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was `bundle show` deprecation messages are incorrect:

```
$ bundle show yard
[DEPRECATED FOR 2.0] use `bundle list` instead of `bundle show`
Resolving dependencies...
/home/deivid/Code/activeadmin/.bundle/ruby/2.5.0/gems/yard-0.9.16
$ bundle list yard
ERROR: "bundle list" was called with arguments ["yard"]
Usage: "bundle list"
```

### What was your diagnosis of the problem?

My diagnosis was that deprecation messages only mention `bundle list`, but in some cases, the replacement is `bundle info`.

### What is your fix for the problem, implemented in this PR?

My fix is to replace "show" in the original command with the appropriate alternative in each case.

### Why did you choose this fix out of the possible options?

I chose this fix because it was the most user friendly message, since it prints the exact command the user needs to type to get rid of the warning.