### PR TITLE
http:// URLs in the gemspec

### DIFF
--- a/bundler.gemspec
+++ b/bundler.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
     "Yehuda Katz"
   ]
   s.email       = ["team@bundler.io"]
-  s.homepage    = "http://bundler.io"
+  s.homepage    = "https://bundler.io"
   s.summary     = "The best way to manage your application's dependencies"
   s.description = "Bundler manages an application's dependencies through its entire life, across many machines, systematically and repeatably"
 

--- a/bundler.gemspec
+++ b/bundler.gemspec
@@ -21,10 +21,10 @@ Gem::Specification.new do |s|
 
   if s.respond_to?(:metadata=)
     s.metadata = {
-      "bug_tracker_uri" => "http://github.com/bundler/bundler/issues",
+      "bug_tracker_uri" => "https://github.com/bundler/bundler/issues",
       "changelog_uri" => "https://github.com/bundler/bundler/blob/master/CHANGELOG.md",
       "homepage_uri" => "https://bundler.io/",
-      "source_code_uri" => "http://github.com/bundler/bundler/",
+      "source_code_uri" => "https://github.com/bundler/bundler/",
     }
   end
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

When the users visit https://rubygems.org/gems/bundler and click the links, or access the gem metadata from scripts e.g. gem-src, we're seeing unneeded redirection from http://... to https://... because both github.com and bundler.io redirects http requests to https.

### What is your fix for the problem, implemented in this PR?

Rewrote all http:// URLs in the gemspec to https://.