### PR TITLE
Check for file or folder when checking for git hash in build metadata

### DIFF
--- a/lib/bundler/build_metadata.rb
+++ b/lib/bundler/build_metadata.rb
@@ -28,7 +28,9 @@ module Bundler
       # If Bundler has been installed without its .git directory and without a
       # commit instance variable then we can't determine its commits SHA.
       git_dir = File.join(File.expand_path("../../..", __FILE__), ".git")
-      return "unknown" unless File.directory?(git_dir)
+      # Check for both a file or folder because RubyGems runs Bundler's test suite in a submodule
+      # which does not have a .git folder
+      return "unknown" unless File.exist?(git_dir)
 
       # Otherwise shell out to git.
       @git_commit_sha = Dir.chdir(File.expand_path("..", __FILE__)) do


### PR DESCRIPTION
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

A change that was introduced in #6664 is breaking RubyGem's specs because the Build Metadata is not being generated correctly.

This is breaking because the change is checking for the `.git` to determine if the git hash should be fetched for the version string. This folder does not exist in the submodule in RubyGems' repo

### What was your diagnosis of the problem?

See https://travis-ci.org/rubygems/rubygems/jobs/437576972

### What is your fix for the problem, implemented in this PR?

Check if `.git` exists either as a file or folder