### PR TITLE
when running from source, find submodule shas too

### DIFF
--- a/lib/bundler/build_metadata.rb
+++ b/lib/bundler/build_metadata.rb
@@ -36,7 +36,7 @@ module Bundler
       git_sub_dir = File.join(File.expand_path("../../../..", __FILE__), ".git")
       if File.directory?(git_sub_dir)
         return @git_commit_sha = Dir.chdir(git_sub_dir) do
-          `git ls-tree --abbrev=8 HEAD bundler | awk '{ print $3 }'`.strip.freeze
+          `git ls-tree --abbrev=8 HEAD bundler`.split(/\s/).fetch(2, "").strip.freeze
         end
       end
 

--- a/lib/bundler/build_metadata.rb
+++ b/lib/bundler/build_metadata.rb
@@ -29,13 +29,13 @@ module Bundler
       # commit instance variable then we can't determine its commits SHA.
       git_dir = File.join(File.expand_path("../../..", __FILE__), ".git")
       if File.directory?(git_dir)
-        @git_commit_sha = Dir.chdir(git_dir) { `git rev-parse --short HEAD`.strip.freeze }
+        return @git_commit_sha = Dir.chdir(git_dir) { `git rev-parse --short HEAD`.strip.freeze }
       end
 
       # If Bundler is a submodule in RubyGems, get the submodule commit
       git_sub_dir = File.join(File.expand_path("../../../..", __FILE__), ".git")
       if File.directory?(git_sub_dir)
-        @git_commit_sha = Dir.chdir(git_sub_dir) do
+        return @git_commit_sha = Dir.chdir(git_sub_dir) do
           `git ls-tree --abbrev=8 HEAD bundler | awk '{ print $3 }'`.strip.freeze
         end
       end


### PR DESCRIPTION
We recently merged #6664 to prevent Bundler from (wrongly) claiming the
git commit of any parent directory when it is run from source. However,
Bundler is also run from source as a submodule in RubyGems, and in that
case it does not have its own git directory.

This commit resolves the failure in version_spec.rb that only appears
when the Bundler tests are run from a submodule, by explicitly checking
for that submodule, and using `git ls-tree` to get the sha if so.

Arguably, this is a bugfix compared to the previous behavior, which
would blindly print the current sha from the _RubyGems_ repo, while
claiming that it was the sha of Bundler.