### PR TITLE
Make RakeTask spec:deps OS agnostic

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,8 @@ $:.unshift File.expand_path("../lib", __FILE__)
 require "shellwords"
 require "benchmark"
 
-RUBYGEMS_REPO = if `cd .. && git remote --verbose 2>/dev/null` =~ /rubygems/i
+NULL_DEVICE = (Gem.win_platform? ? "NUL" : "/dev/null")
+RUBYGEMS_REPO = if `git -C "#{File.expand_path("..")}" remote --verbose 2> #{NULL_DEVICE}` =~ /rubygems/i
   File.expand_path("..")
 else
   File.expand_path("tmp/rubygems")

--- a/spec/support/path.rb
+++ b/spec/support/path.rb
@@ -9,15 +9,15 @@ module Spec
     end
 
     def gemspec
-      @gemspec ||= Pathname.new(File.expand_path(root.join("bundler.gemspec"), __FILE__))
+      @gemspec ||= root.join("bundler.gemspec")
     end
 
     def bindir
-      @bindir ||= Pathname.new(File.expand_path(root.join("exe"), __FILE__))
+      @bindir ||= root.join("exe")
     end
 
     def spec_dir
-      @spec_dir ||= Pathname.new(File.expand_path(root.join("spec"), __FILE__))
+      @spec_dir ||= root.join("spec")
     end
 
     def tmp(*path)
@@ -95,7 +95,7 @@ module Spec
     end
 
     def bundler_path
-      Pathname.new(File.expand_path(root.join("lib"), __FILE__))
+      root.join("lib")
     end
 
     def global_plugin_gem(*args)


### PR DESCRIPTION
@segiddins encouraged contributions towards support for Windows
https://github.com/bundler/bundler/issues/5992#issuecomment-326809543

As a first step towards this goal this commit introduces safe and
OS agnostic directory traversal in the first pieces of Ruby code
called when setting up a test environment.

### What was the end-user problem that led to this PR?

See #5992.

### What was your diagnosis of the problem?

File path concatenation explicitly used UNIX style file system separators.

### What is your fix for the problem, implemented in this PR?

Use `File.join` and `Pathname.join` instead. Define null device explicitly since Ruby 1.8.7 does not know `File::NULL`.