### PR TITLE
Remove the duplicate gems from suggestions

### DIFF
--- a/lib/bundler/cli/common.rb
+++ b/lib/bundler/cli/common.rb
@@ -72,7 +72,7 @@ module Bundler
     end
 
     def self.ensure_all_gems_in_lockfile!(names, locked_gems = Bundler.locked_gems)
-      locked_names = locked_gems.specs.map(&:name)
+      locked_names = locked_gems.specs.map(&:name).uniq
       names.-(locked_names).each do |g|
         raise GemNotFound, gem_not_found_message(g, locked_names)
       end

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "bundle update" do
       source "file://#{gem_repo2}"
       gem "activesupport"
       gem "rack-obama"
+      gem "platform_specific"
     G
   end
 
@@ -116,8 +117,8 @@ RSpec.describe "bundle update" do
       expect(out).to include "Could not find gem 'halting-problem-solver'"
     end
     it "should suggest alternatives" do
-      bundle "update active-support"
-      expect(out).to include "Did you mean activesupport?"
+      bundle "update platformspecific"
+      expect(out).to include "Did you mean platform_specific?"
     end
   end
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

If the lock file has the same gems for different platforms, the
suggestion includes all those gems.

For example, using the [Rails's lock file](https://github.com/rails/rails/blob/4a51cbba58435bbba65ca50670bd6ae4887942bd/Gemfile.lock),
it shows like this:

```
$ bundle update mai
Could not find gem 'mai'.
Did you mean ffi, ffi, ffi, ffi, mail, ast, jwt, que or wdm?
```

### What was your diagnosis of the problem?

Missing consideration when lock file contains the same gem.

### What is your fix for the problem, implemented in this PR?

I removed the same name using `uniq`.

