### PR TITLE
Removed win32-open3 workaround.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,17 +34,6 @@ end
 
 require "bundler"
 
-# Require the correct version of popen for the current platform
-if RbConfig::CONFIG["host_os"] =~ /mingw|mswin/
-  begin
-    require "win32/open3"
-  rescue LoadError
-    abort "Run `gem install win32-open3` to be able to run specs"
-  end
-else
-  require "open3"
-end
-
 Dir["#{File.expand_path("../support", __FILE__)}/*.rb"].each do |file|
   file = file.gsub(%r{\A#{Regexp.escape File.expand_path("..", __FILE__)}/}, "")
   require file unless file.end_with?("hax.rb")

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "open3"
+
 module Spec
   module Helpers
     def reset!


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

`win32-open3` gem was required Ruby 1.8 with Windows environment. Because RubyInstaller2 only provides the version of Ruby 2.1+.

### What is your fix for the problem, implemented in this PR?

Removed needless workaround.

