### PR TITLE
Support Windows platform with ruby core repository.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,7 +28,7 @@ require "bundler/vendored_fileutils"
 require "uri"
 require "digest"
 
-if File.expand_path(__FILE__) =~ %r{([^\w/\.-])}
+if File.expand_path(__FILE__) =~ %r{([^\w/\.:\-])}
   abort "The bundler specs cannot be run from a path that contains special characters (particularly #{$1.inspect})"
 end
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

In Windows environment, ':' is always contained path variable.

See our original commit and its message 

https://github.com/ruby/ruby/commit/f35fb6d36c3218988b17dbeb4412922c23745f0e

