### PR TITLE
Use helper method instead of hard-code path.

### DIFF
--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -327,7 +327,7 @@ RSpec.describe "bundle gem" do
       end
 
       Dir.chdir(bundled_app(gem_name)) do
-        sys_exec("rake")
+        sys_exec(rake)
         expect(out).to include("SUCCESS")
       end
     end
@@ -612,7 +612,7 @@ RSpec.describe "bundle gem" do
       end
 
       Dir.chdir(bundled_app(gem_name)) do
-        sys_exec("rake")
+        sys_exec(rake)
         expect(out).to include("SUCCESS")
       end
     end

--- a/spec/runtime/gem_tasks_spec.rb
+++ b/spec/runtime/gem_tasks_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "require 'bundler/gem_tasks'" do
 
   it "includes the relevant tasks" do
     with_gem_path_as(Spec::Path.base_system_gems.to_s) do
-      sys_exec "ruby -S rake -T"
+      sys_exec "#{rake} -T"
     end
 
     expect(err).to eq("")
@@ -37,7 +37,7 @@ RSpec.describe "require 'bundler/gem_tasks'" do
 
   it "adds 'pkg' to rake/clean's CLOBBER" do
     with_gem_path_as(Spec::Path.base_system_gems.to_s) do
-      sys_exec! %('#{Gem.ruby}' -S rake -e 'load "Rakefile"; puts CLOBBER.inspect')
+      sys_exec! %(#{rake} -e 'load "Rakefile"; puts CLOBBER.inspect')
     end
     expect(last_command.stdout).to eq '["pkg"]'
   end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -214,6 +214,10 @@ module Spec
     end
     bang :gem_command
 
+    def rake
+      "#{Gem.ruby} -S rake"
+    end
+
     def sys_exec(cmd)
       command_execution = CommandExecution.new(cmd.to_s, Dir.pwd)
 

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -215,7 +215,7 @@ module Spec
     bang :gem_command
 
     def rake
-      "#{Gem.ruby} -S #{ENV['GEM_PATH']}/bin/rake"
+      "#{Gem.ruby} -S #{ENV["GEM_PATH"]}/bin/rake"
     end
 
     def sys_exec(cmd)

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -215,7 +215,7 @@ module Spec
     bang :gem_command
 
     def rake
-      "#{Gem.ruby} -S rake"
+      "#{Gem.ruby} -S #{ENV['GEM_PATH']}/bin/rake"
     end
 
     def sys_exec(cmd)

--- a/spec/support/rubygems_ext.rb
+++ b/spec/support/rubygems_ext.rb
@@ -33,7 +33,7 @@ module Spec
 
       ENV["BUNDLE_PATH"] = nil
       ENV["GEM_HOME"] = ENV["GEM_PATH"] = Path.base_system_gems.to_s
-      ENV["PATH"] = ["#{Path.root}/exe", "#{Path.system_gem_path}/bin", ENV["PATH"]].join(File::PATH_SEPARATOR)
+      ENV["PATH"] = [Path.bindir, "#{Path.system_gem_path}/bin", ENV["PATH"]].join(File::PATH_SEPARATOR)
 
       manifest = DEPS.to_a.sort_by(&:first).map {|k, v| "#{k} => #{v}\n" }
       manifest_path = "#{Path.base_system_gems}/manifest.txt"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

In ruby core repository, We need to replace executable file like `ruby`, `rake`, `gem`. 

### What is your fix for the problem, implemented in this PR?

This pull request makes hard-coded executable file to the helper methods.

