### PR TITLE
Bump rake version

### DIFF
--- a/bundler.gemspec
+++ b/bundler.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "automatiek", "~> 0.1.0"
   s.add_development_dependency "mustache",   "0.99.6"
-  s.add_development_dependency "rake",       "~> 10.0"
+  s.add_development_dependency "rake",       "~> 11.1"
   s.add_development_dependency "rdiscount",  "~> 2.2"
   s.add_development_dependency "ronn",       "~> 0.7.3"
   s.add_development_dependency "rspec",      "~> 3.6"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

We are working to [effectively deprecate `rubyforge_project` in RubyGems](https://github.com/rubygems/rubygems/pull/2436) and remove other extraneous references to the attribute. This caused tests tied to bundler to fail.

### What was your diagnosis of the problem?

Ultimately the failure can be found here: https://travis-ci.org/rubygems/rubygems/jobs/442597902

Due to a reference in the `rake` gem to `rubyforge_project`, and the spec treating a deprecation notice as an error and a failure.

### What is your fix for the problem, implemented in this PR?

The `rake` gem removed the last of its references to `rubyforge_project` by [December 2016](https://github.com/ruby/rake/search?q=rubyforge&type=Commits), so this update points the development dependency to the nearest minor upgrade to `rake` after those changes.

### Why did you choose this fix out of the possible options?

I am not absolutely certain that this is the exact final wrinkle needed to fix this bug and pass this test, but it made the most sense to me. In the stacktrace the `10.x` rake version was referenced, which matched with the development dependency, which would cause this failure. Look forward to thoughts and feedback. :) 