### PR TITLE
update ruby to the latest versions in travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,9 @@ addons:
       secure: "TrzIv116JLGUxm6PAUskCYrv8KTDguncKROVwbnjVPKTGDAgoDderd8JUdDEXrKoZ9qGLD2TPYKExt9/QDl71E+qHdWnVqWv4HKCUk2P9z/VLKzHuggOUBkCXiJUhjywUieCJhI3N92bfq2EjSBbu2/OFHqWOjLQ+QCooTEBjv8="
 
 rvm:
-  - 2.5.1
-  - 2.4.3
-  - 2.3.7
+  - 2.5.2
+  - 2.4.5
+  - 2.3.8
 
 # Rubygems versions MUST be available as rake tasks
 # see Rakefile:125 for the list of possible RGV values


### PR DESCRIPTION
### Overview

New versions of all the currently supported versions of Ruby we're released today. This PR is just updating .travis.yml to use these new versions of Ruby.