### PR TITLE
Enable gemfile flag for bundle lock

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -618,6 +618,8 @@ module Bundler
       "do not attempt to fetch remote gemspecs and use the local gem cache only"
     method_option "print", :type => :boolean, :default => false, :banner =>
       "print the lockfile to STDOUT instead of writing to the file system"
+    method_option "gemfile", :type => :string, :banner =>
+      "Use the specified gemfile instead of Gemfile"
     method_option "lockfile", :type => :string, :default => nil, :banner =>
       "the path the lockfile should be written to"
     method_option "full-index", :type => :boolean, :default => false, :banner =>

--- a/spec/commands/lock_spec.rb
+++ b/spec/commands/lock_spec.rb
@@ -89,6 +89,33 @@ RSpec.describe "bundle lock" do
     expect(out).to match(/sources listed in your Gemfile|installed locally/)
   end
 
+  it "works with --gemfile flag" do
+    create_file "CustomGemfile", <<-G
+      source "file://localhost#{repo}"
+      gem "foo"
+    G
+    lockfile = strip_lockfile(normalize_uri_file(<<-L))
+      GEM
+        remote: file://localhost#{repo}/
+        specs:
+          foo (1.0)
+
+      PLATFORMS
+        #{lockfile_platforms}
+
+      DEPENDENCIES
+        foo
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+    bundle "lock --gemfile CustomGemfile"
+
+    expect(out).to match(/Writing lockfile to.+CustomGemfile\.lock/)
+    expect(read_lockfile("CustomGemfile.lock")).to eq(lockfile)
+    expect { read_lockfile }.to raise_error(Errno::ENOENT)
+  end
+
   it "writes to a custom location using --lockfile" do
     bundle "lock --lockfile=lock"
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

`bundle lock` does not accept the `--gemfile` flag that allows to define a custom Gemfile.

### What was your diagnosis of the problem?

The option is not defined as available.

### What is your fix for the problem, implemented in this PR?

Adds the option to the list available options for `lock` command. 

I wasn't sure though, in which order to display this the new option. I just added it where it felt the most natural to me, but please let me know if there is a better order.

Also do you think it would make sense to add this flag to the other commands as well? 
For example: `add`, `remove`, `console`, `outdated`, `clean`?
For now it is available for: `check`, `exec`, `install`, `update`, `package`, `doctor`. 

### Why did you choose this fix out of the possible options?

I don't think there are any other options to implement this.

Closes #6735
