### PR TITLE
Fix BUNDLE_PATH_RELATIVE_TO_CWD env variable name

### DIFF
--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -227,7 +227,7 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
    is used, defaults to vendor/bundle.
 * `path.system` (`BUNDLE_PATH__SYSTEM`):
    Whether Bundler will install gems into the default system path (`Gem.dir`).
-* `path_relative_to_cwd` (`PATH_RELATIVE_TO_CWD`)
+* `path_relative_to_cwd` (`BUNDLE_PATH_RELATIVE_TO_CWD`)
    Makes `--path` relative to the CWD instead of the `Gemfile`.
 * `plugins` (`BUNDLE_PLUGINS`):
    Enable Bundler's experimental plugin system.


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that an environment variable in the docs does not work.

### What was your diagnosis of the problem?

My diagnosis was that its name is incorrect.

### What is your fix for the problem, implemented in this PR?

My fix is to fix the typo.

### Why did you choose this fix out of the possible options?

I chose this fix because it's the only non absurd fix.
