### PR TITLE
fix error with path objects in array

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -371,7 +371,7 @@ EOF
         unwritable_files = files.reject {|f| File.writable?(f) }
         sudo_needed = !unwritable_files.empty?
         if sudo_needed
-          Bundler.ui.warn "Following files may not be writable, so sudo is needed:\n  #{unwritable_files.sort.map(&:to_s).join("\n  ")}"
+          Bundler.ui.warn "Following files may not be writable, so sudo is needed:\n  #{unwritable_files.map(&:to_s).sort.join("\n  ")}"
         end
       end
 


### PR DESCRIPTION
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was that `Pathname` instances in an array can not be sorted when there are string instances in the array also. Because of this, calling `.sort` before `.to_s` resulted in the error

```
[!] There was an error parsing `Gemfile`: comparison of Pathname with String failed. Bundler cannot continue.
```

you can easily see this issue doing
```
> require 'rails'
=> true
> [Pathname.new("/tmp/bundle")]
=> [#<Pathname:/tmp/bundle>]
> [Pathname.new("/tmp/bundle"), "test"]
=> [#<Pathname:/tmp/bundle>, "test"]
> [Pathname.new("/tmp/bundle"), "test"].sort
ArgumentError: comparison of Pathname with String failed
```

### What was your diagnosis of the problem?

`sort` was called before `map` in the warn message. 

### What is your fix for the problem, implemented in this PR?

We should call `map(&:to_s)` before calling sort, and add a test case for this scenario. 

### Why did you choose this fix out of the possible options?

Because it broke our production deploys. 