### PR TITLE
Removed jobs with old ruby versions from Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,13 +43,20 @@ env:
 
 matrix:
   include:
-    - rvm: 2.4.1
-      env: RGV=v2.6.8 BUNDLER_SPEC_SUB_VERSION=2.0.0
-    # Ruby 2.4, Rubygems 2.6.8 and up
-    # Ruby 2.3, Rubygems 2.5.1 and up
+    # Ruby 2.4, Rubygems 2.6 and up
+    - rvm: 2.4.2
+      env: RGV=v2.6.14
+    # Ruby 2.3, Rubygems 2.5 and up
+    - rvm: 2.3.7
+      env: RGV=v2.5.2
+    - rvm: 2.3.7
+      env: RGV=v2.6.14
     # Ruby-head (we want to know how we're doing, but not fail the build)
     - rvm: ruby-head
       env: RGV=master
+    # 1.x mode (we want to keep stuff passing in 1.x mode for now)
+    - rvm: 2.5.1
+      env: RGV=v2.7.7 BUNDLER_SPEC_SUB_VERSION=1.98
 
   allow_failures:
     - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ rvm:
   - 2.5.1
   - 2.4.3
   - 2.3.6
-  - 2.2.7
 
 # Rubygems versions MUST be available as rake tasks
 # see Rakefile:125 for the list of possible RGV values
@@ -48,11 +47,6 @@ matrix:
       env: RGV=v2.6.8 BUNDLER_SPEC_SUB_VERSION=2.0.0
     # Ruby 2.4, Rubygems 2.6.8 and up
     # Ruby 2.3, Rubygems 2.5.1 and up
-    - rvm: 2.2.6
-      env: RGV=v2.5.2
-    # Ruby 2.2, Rubygems 2.4.5 and up
-    - rvm: 2.2.6
-      env: RGV=v2.4.8
     # Ruby-head (we want to know how we're doing, but not fail the build)
     - rvm: ruby-head
       env: RGV=master

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,9 @@ addons:
       secure: "TrzIv116JLGUxm6PAUskCYrv8KTDguncKROVwbnjVPKTGDAgoDderd8JUdDEXrKoZ9qGLD2TPYKExt9/QDl71E+qHdWnVqWv4HKCUk2P9z/VLKzHuggOUBkCXiJUhjywUieCJhI3N92bfq2EjSBbu2/OFHqWOjLQ+QCooTEBjv8="
 
 rvm:
-  - 2.5.1
-  - 2.4.3
-  - 2.3.6
+  - 2.5.3
+  - 2.4.5
+  - 2.3.8
 
 # Rubygems versions MUST be available as rake tasks
 # see Rakefile:125 for the list of possible RGV values

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,6 @@ rvm:
   - 2.4.3
   - 2.3.6
   - 2.2.7
-  - 2.1.10
-  - 2.0.0
 
 # Rubygems versions MUST be available as rake tasks
 # see Rakefile:125 for the list of possible RGV values
@@ -55,77 +53,10 @@ matrix:
     # Ruby 2.2, Rubygems 2.4.5 and up
     - rvm: 2.2.6
       env: RGV=v2.4.8
-    # Ruby 2.1, Rubygems 2.2.2 and up
-    - rvm: 2.1.10
-      env: RGV=v2.2.5
-    # Ruby 2.0.0, Rubygems 2.0.0 and up
-    - rvm: 2.0.0
-      env: RGV=v2.2.5
-    - rvm: 2.0.0
-      env: RGV=v2.1.11
-    - rvm: 2.0.0
-      env: RGV=v2.0.14
-    # Ruby 1.9.3, Rubygems 1.5.3 and up
-    - rvm: 1.9.3
-      env: RGV=v2.7.7
-    - rvm: 1.9.3
-      env: RGV=v2.2.5
-    - rvm: 1.9.3
-      env: RGV=v2.1.11
-    - rvm: 1.9.3
-      env: RGV=v2.0.14
-    - rvm: 1.9.3
-      env: RGV=v1.8.29
-    - rvm: 1.9.3
-      env: RGV=v1.7.2
-    - rvm: 1.9.3
-      env: RGV=v1.6.2
-    - rvm: 1.9.3
-      env: RGV=v1.5.3
-
-    - rvm: 1.8.7
-      env: RGV=v2.6.8
-    # Ruby 1.8.7, Rubygems 1.3.6 and up
-    - rvm: 1.8.7
-      env: RGV=v2.2.5
-    # ALLOWED FAILURES
-    # since the great Travis image outage, frequent random segfaults :'(
-    - rvm: 1.8.7
-      env: RGV=v2.0.14
-    - rvm: 1.8.7
-      env: RGV=v1.8.29
-    - rvm: 1.8.7
-      env: RGV=v1.7.2
-    - rvm: 1.8.7
-      env: RGV=v1.6.2
-    - rvm: 1.8.7
-      env: RGV=v1.5.3
-    - rvm: 1.8.7
-      env: RGV=v1.4.2
-    - rvm: 1.8.7
-      env: RGV=v1.3.7
-    - rvm: 1.8.7
-      env: RGV=v1.3.6
     # Ruby-head (we want to know how we're doing, but not fail the build)
     - rvm: ruby-head
       env: RGV=master
 
   allow_failures:
-    - rvm: 1.8.7
-      env: RGV=v2.0.14
-    - rvm: 1.8.7
-      env: RGV=v1.8.29
-    - rvm: 1.8.7
-      env: RGV=v1.7.2
-    - rvm: 1.8.7
-      env: RGV=v1.6.2
-    - rvm: 1.8.7
-      env: RGV=v1.5.3
-    - rvm: 1.8.7
-      env: RGV=v1.4.2
-    - rvm: 1.8.7
-      env: RGV=v1.3.7
-    - rvm: 1.8.7
-      env: RGV=v1.3.6
     - rvm: ruby-head
       env: RGV=master


### PR DESCRIPTION
I removed the ruby versions under the Ruby 2.2. We need to fix gemspec and other parameters of .travis.yml. But this is the first step of Bundler-2.0.0 reboot.