### PR TITLE
Remove unnecessary stuff from specs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -51,17 +51,10 @@ namespace :spec do
       deps.delete("rdiscount")
     end
 
-    if Gem::VERSION < "2.0.0"
-      deps.sort_by {|name, _| name }.map do |name, version|
-        gem_install_command = "install --no-ri --no-rdoc --conservative #{name} -v '#{version}'"
-        sh %(#{Gem.ruby} -S gem #{gem_install_command})
-      end
-    else
-      gem_install_command = "install --no-document --conservative " + deps.sort_by {|name, _| name }.map do |name, version|
-        "'#{name}:#{version}'"
-      end.join(" ")
-      sh %(#{Gem.ruby} -S gem #{gem_install_command})
-    end
+    gem_install_command = "install --no-document --conservative " + deps.sort_by {|name, _| name }.map do |name, version|
+      "'#{name}:#{version}'"
+    end.join(" ")
+    sh %(#{Gem.ruby} -S gem #{gem_install_command})
 
     # Download and install gems used inside tests
     $LOAD_PATH.unshift("./spec")

--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -21,18 +21,11 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 <%- end -%>
 
-  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
-  # to allow pushing to a single host or delete this section to allow pushing to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
+  spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
 
-    spec.metadata["homepage_uri"] = spec.homepage
-    spec.metadata["source_code_uri"] = "TODO: Put your gem's public repo URL here."
-    spec.metadata["changelog_uri"] = "TODO: Put your gem's CHANGELOG.md URL here."
-  else
-    raise "RubyGems 2.0 or newer is required to protect against " \
-      "public gem pushes."
-  end
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = "TODO: Put your gem's public repo URL here."
+  spec.metadata["changelog_uri"] = "TODO: Put your gem's CHANGELOG.md URL here."
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/spec/bundler/gem_helper_spec.rb
+++ b/spec/bundler/gem_helper_spec.rb
@@ -29,15 +29,6 @@ RSpec.describe Bundler::GemHelper do
     end
 
     context "interpolates the name" do
-      before do
-        # Remove exception that prevents public pushes on older RubyGems versions
-        if Gem::Version.new(Gem::VERSION) < Gem::Version.new("2.0")
-          content = File.read(app_gemspec_path)
-          content.sub!(/raise "RubyGems 2\.0 or newer.*/, "")
-          File.open(app_gemspec_path, "w") {|f| f.write(content) }
-        end
-      end
-
       it "when there is only one gemspec" do
         expect(subject.gemspec.name).to eq(app_name)
       end
@@ -72,21 +63,13 @@ RSpec.describe Bundler::GemHelper do
     let(:app_version) { "0.1.0" }
     let(:app_gem_dir) { app_path.join("pkg") }
     let(:app_gem_path) { app_gem_dir.join("#{app_name}-#{app_version}.gem") }
-    let(:app_gemspec_content) { remove_push_guard(File.read(app_gemspec_path)) }
+    let(:app_gemspec_content) { File.read(app_gemspec_path) }
 
     before(:each) do
       content = app_gemspec_content.gsub("TODO: ", "")
       content.sub!(/homepage\s+= ".*"/, 'homepage = ""')
       content.gsub!(/spec\.metadata.+\n/, "")
       File.open(app_gemspec_path, "w") {|file| file << content }
-    end
-
-    def remove_push_guard(gemspec_content)
-      # Remove exception that prevents public pushes on older RubyGems versions
-      if Gem::Version.new(Gem::VERSION) < Gem::Version.new("2.0")
-        gemspec_content.sub!(/raise "RubyGems 2\.0 or newer.*/, "")
-      end
-      gemspec_content
     end
 
     it "uses a shell UI for output" do

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -191,8 +191,6 @@ RSpec.describe "bundle gem" do
         line.gsub(/\=.*$/, "= %q{A short summary of my new gem.}")
       when /spec\.description/
         line.gsub(/\=.*$/, "= %q{A longer description of my new gem.}")
-      # Remove exception that prevents public pushes on older RubyGems versions
-      when /raise "RubyGems 2.0 or newer/
       else
         line
       end

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -6,18 +6,8 @@ RSpec.describe "bundle gem" do
     global_config "BUNDLE_GEM__MIT" => "false", "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__COC" => "false"
   end
 
-  def remove_push_guard(gem_name)
-    # Remove exception that prevents public pushes on older RubyGems versions
-    if Gem::Version.new(Gem::VERSION) < Gem::Version.new("2.0")
-      path = "#{gem_name}/#{gem_name}.gemspec"
-      content = File.read(path).sub(/raise "RubyGems 2\.0 or newer.*/, "")
-      File.open(path, "w") {|f| f.write(content) }
-    end
-  end
-
-  def execute_bundle_gem(gem_name, flag = "", to_remove_push_guard = true)
+  def execute_bundle_gem(gem_name, flag = "")
     bundle! "gem #{gem_name} #{flag}"
-    remove_push_guard(gem_name) if to_remove_push_guard
     # reset gemspec cache for each test because of commit 3d4163a
     Bundler.clear_gemspec_cache
   end
@@ -96,7 +86,7 @@ RSpec.describe "bundle gem" do
 
   shared_examples_for "--coc flag" do
     before do
-      execute_bundle_gem(gem_name, "--coc", false)
+      execute_bundle_gem(gem_name, "--coc")
     end
     it "generates a gem skeleton with MIT license" do
       gem_skeleton_assertions(gem_name)
@@ -113,7 +103,7 @@ RSpec.describe "bundle gem" do
 
   shared_examples_for "--no-coc flag" do
     before do
-      execute_bundle_gem(gem_name, "--no-coc", false)
+      execute_bundle_gem(gem_name, "--no-coc")
     end
     it "generates a gem skeleton without Code of Conduct" do
       gem_skeleton_assertions(gem_name)
@@ -149,7 +139,6 @@ RSpec.describe "bundle gem" do
         reset!
         in_app_root
         bundle "gem #{gem_name}"
-        remove_push_guard(gem_name)
       end
 
       it "contribute URL set to [USERNAME]" do
@@ -204,7 +193,6 @@ RSpec.describe "bundle gem" do
         line.gsub(/\=.*$/, "= %q{A longer description of my new gem.}")
       # Remove exception that prevents public pushes on older RubyGems versions
       when /raise "RubyGems 2.0 or newer/
-        line.gsub(/.*/, "") if Gem::Version.new(Gem::VERSION) < Gem::Version.new("2.0")
       else
         line
       end
@@ -295,7 +283,6 @@ RSpec.describe "bundle gem" do
         reset!
         in_app_root
         bundle "gem #{gem_name}"
-        remove_push_guard(gem_name)
       end
 
       it_should_behave_like "git config is absent"
@@ -394,7 +381,6 @@ RSpec.describe "bundle gem" do
       end
 
       it "depends on a specific version of rspec", :rubygems => ">= 1.8.1" do
-        remove_push_guard(gem_name)
         rspec_dep = generated_gem.gemspec.development_dependencies.find {|d| d.name == "rspec" }
         expect(rspec_dep).to be_specific
       end
@@ -445,7 +431,6 @@ RSpec.describe "bundle gem" do
       end
 
       it "depends on a specific version of minitest", :rubygems => ">= 1.8.1" do
-        remove_push_guard(gem_name)
         rspec_dep = generated_gem.gemspec.development_dependencies.find {|d| d.name == "minitest" }
         expect(rspec_dep).to be_specific
       end
@@ -589,7 +574,6 @@ RSpec.describe "bundle gem" do
         reset!
         in_app_root
         bundle "gem #{gem_name}"
-        remove_push_guard(gem_name)
       end
 
       it_should_behave_like "git config is absent"

--- a/spec/commands/pristine_spec.rb
+++ b/spec/commands/pristine_spec.rb
@@ -48,9 +48,7 @@ RSpec.describe "bundle pristine" do
       bundle! "install"
       bundle! "pristine", :system_bundler => true
       bundle! "-v", :system_bundler => true
-      # An old rubygems couldn't handle a correct version of vendoered bundler.
-      bundler_version = Gem::VERSION < "2.1" ? "1.16.0" : Bundler::VERSION
-      expect(out).to end_with(bundler_version)
+      expect(out).to end_with(Bundler::VERSION)
     end
   end
 

--- a/spec/support/builders.rb
+++ b/spec/support/builders.rb
@@ -210,12 +210,7 @@ module Spec
         # The yard gem iterates over Gem.source_index looking for plugins
         build_gem "yard" do |s|
           s.write "lib/yard.rb", <<-Y
-            if Gem::Version.new(Gem::VERSION) >= Gem::Version.new("1.8.10")
-              specs = Gem::Specification
-            else
-              specs = Gem.source_index.find_name('')
-            end
-            specs.sort_by(&:name).each do |gem|
+            Gem::Specification.sort_by(&:name).each do |gem|
               puts gem.full_name
             end
           Y

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -322,11 +322,8 @@ module Spec
 
         raise "OMG `#{path}` does not exist!" unless File.exist?(path)
 
-        if Gem::VERSION < "2.0.0"
-          gem_command! :install, "--no-rdoc --no-ri --ignore-dependencies '#{path}'"
-        else
-          gem_command! :install, "--no-document --ignore-dependencies '#{path}'"
-        end
+        gem_command! :install, "--no-document --ignore-dependencies '#{path}'"
+
         bundler_path && bundler_path.rmtree
       end
     end

--- a/spec/support/rubygems_ext.rb
+++ b/spec/support/rubygems_ext.rb
@@ -59,11 +59,7 @@ module Spec
       no_reqs.map!(&:first)
       reqs.map! {|name, req| "'#{name}:#{req}'" }
       deps = reqs.concat(no_reqs).join(" ")
-      cmd = if Gem::VERSION < "2.0.0"
-        "#{Gem.ruby} -S gem install #{deps} --no-rdoc --no-ri --conservative"
-      else
-        "#{Gem.ruby} -S gem install #{deps} --no-document --conservative"
-      end
+      cmd = "#{Gem.ruby} -S gem install #{deps} --no-document --conservative"
       puts cmd
       system(cmd) || raise("Installing gems #{deps} for the tests to use failed!")
     end


### PR DESCRIPTION
I wrote this patch a while ago but I didn't propose it because I didn't think it would be accepted. Now I think we're ready.

### What was the end-user problem that led to this PR?

The problem was that the specs have a lot of conditional behavior on `Gem::VERSION`.

### What was your diagnosis of the problem?

My diagnosis was that this was necessary because of testing against a big range of rubygems versions on the latest stable branch.

### What is your fix for the problem, implemented in this PR?

My fix is to remove all the conditionals since we'll no longer test against rubygems versions that old on the latest stable, once #6763 lands.

### Why did you choose this fix out of the possible options?

I chose this fix because it makes test code simpler.
