### PR TITLE
Fix indentation of bundler executable

### DIFF
--- a/lib/bundler/templates/Executable.bundler
+++ b/lib/bundler/templates/Executable.bundler
@@ -11,7 +11,7 @@
 require "rubygems"
 
 m = Module.new do
-    module_function
+  module_function
 
   def invoked_as_script?
     File.expand_path($0) == File.expand_path(__FILE__)


### PR DESCRIPTION
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

`bundle binstubs bundler` generates the file like followings.

```ruby
require "rubygems"

m = Module.new do
    module_function

  def invoked_as_script?
    File.expand_path($0) == File.expand_path(__FILE__)
  end
(snip)
end
```

### What was your diagnosis of the problem?

My diagnosis was...

the template's `module_function` line is not match to other lines.

### What is your fix for the problem, implemented in this PR?

I fix the template.

### Why did you choose this fix out of the possible options?

no other options.