### PR TITLE
[Definition] Dont pin path deps to newer versions

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -977,7 +977,9 @@ module Bundler
       dependencies_by_name = dependencies.inject({}) {|memo, dep| memo.update(dep.name => dep) }
       @locked_gems.specs.reduce({}) do |requirements, locked_spec|
         name = locked_spec.name
-        next requirements if @locked_gems.dependencies[name] != dependencies_by_name[name]
+        dependency = dependencies_by_name[name]
+        next requirements if @locked_gems.dependencies[name] != dependency
+        next requirements if dependency && dependency.source.is_a?(Source::Path)
         dep = Gem::Dependency.new(name, ">= #{locked_spec.version}")
         requirements[name] = DepProxy.new(dep, locked_spec.platform)
         requirements

--- a/spec/install/gemfile/gemspec_spec.rb
+++ b/spec/install/gemfile/gemspec_spec.rb
@@ -263,6 +263,20 @@ RSpec.describe "bundle install from an existing gemspec" do
     expect(out).to eq("WIN")
   end
 
+  it "works with only_update_to_newer_versions" do
+    build_lib "omg", "2.0", :path => lib_path("omg")
+
+    install_gemfile <<-G
+      gemspec :path => "#{lib_path("omg")}"
+    G
+
+    build_lib "omg", "1.0", :path => lib_path("omg")
+
+    bundle! :install, :env => { "BUNDLE_BUNDLE_ONLY_UPDATE_TO_NEWER_VERSIONS" => "true" }
+
+    expect(the_bundle).to include_gems "omg 1.0"
+  end
+
   context "in deployment mode" do
     context "when the lockfile was not updated after a change to the gemspec's dependencies" do
       it "reports that installation failed" do

--- a/spec/install/gemfile/path_spec.rb
+++ b/spec/install/gemfile/path_spec.rb
@@ -132,6 +132,20 @@ RSpec.describe "bundle install with explicit source paths" do
     expect(the_bundle).to include_gems "foo 1.0"
   end
 
+  it "works with only_update_to_newer_versions" do
+    build_lib "omg", "2.0", :path => lib_path("omg")
+
+    install_gemfile <<-G
+      gem "omg", :path => "#{lib_path("omg")}"
+    G
+
+    build_lib "omg", "1.0", :path => lib_path("omg")
+
+    bundle! :install, :env => { "BUNDLE_BUNDLE_ONLY_UPDATE_TO_NEWER_VERSIONS" => "true" }
+
+    expect(the_bundle).to include_gems "omg 1.0"
+  end
+
   it "prefers gemspecs closer to the path root" do
     build_lib "premailer", "1.0.0", :path => lib_path("premailer") do |s|
       s.write "gemfiles/ruby187.gemspec", <<-G


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was setting `only_update_to_newer_versions` would break using path gems.

Closes #6750

### What was your diagnosis of the problem?

My diagnosis was path gems should _always_ get their version used, since there's 0 alternative versions from a path source.

### What is your fix for the problem, implemented in this PR?

My fix should circuits the list of additional requirements when the dependency's source is a path source.

### Why did you choose this fix out of the possible options?

I chose this fix because it solves the problem in the same place that has the feature flag conditional