### PR TITLE
[Plugin::Index] Only register each plugin once for a given hook

### DIFF
--- a/lib/bundler/plugin/index.rb
+++ b/lib/bundler/plugin/index.rb
@@ -58,7 +58,10 @@ module Bundler
         raise SourceConflict.new(name, common) unless common.empty?
         sources.each {|k| @sources[k] = name }
 
-        hooks.each {|e| (@hooks[e] ||= []) << name }
+        hooks.each do |event|
+          event_hooks = (@hooks[event] ||= []) << name
+          event_hooks.uniq!
+        end
 
         @plugin_paths[name] = path
         @load_paths[name] = load_paths

--- a/spec/bundler/plugin/index_spec.rb
+++ b/spec/bundler/plugin/index_spec.rb
@@ -88,7 +88,12 @@ RSpec.describe Bundler::Plugin::Index do
 
     it "only registers a gem once for an event" do
       path = lib_path(plugin_name)
-      index.register_plugin(plugin_name, path.to_s, [path.join("lib").to_s], commands, sources, hooks)
+      index.register_plugin(plugin_name,
+                            path.to_s,
+                            [path.join("lib").to_s],
+                            commands,
+                            sources,
+                            hooks + hooks)
       expect(index.hook_plugins("after-bar")).to eq([plugin_name])
     end
 

--- a/spec/bundler/plugin/index_spec.rb
+++ b/spec/bundler/plugin/index_spec.rb
@@ -89,11 +89,11 @@ RSpec.describe Bundler::Plugin::Index do
     it "only registers a gem once for an event" do
       path = lib_path(plugin_name)
       index.register_plugin(plugin_name,
-                            path.to_s,
-                            [path.join("lib").to_s],
-                            commands,
-                            sources,
-                            hooks + hooks)
+        path.to_s,
+        [path.join("lib").to_s],
+        commands,
+        sources,
+        hooks + hooks)
       expect(index.hook_plugins("after-bar")).to eq([plugin_name])
     end
 

--- a/spec/bundler/plugin/index_spec.rb
+++ b/spec/bundler/plugin/index_spec.rb
@@ -86,6 +86,12 @@ RSpec.describe Bundler::Plugin::Index do
       expect(new_index.hook_plugins("after-bar")).to eq([plugin_name])
     end
 
+    it "only registers a gem once for an event" do
+      path = lib_path(plugin_name)
+      index.register_plugin(plugin_name, path.to_s, [path.join("lib").to_s], commands, sources, hooks)
+      expect(index.hook_plugins("after-bar")).to eq([plugin_name])
+    end
+
     context "that are not registered", :focused do
       let(:file) { double("index-file") }
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was running `plugin install` twice for a plugin withs hooks would cause that hook to be registered twice.

Closes #6771.

### What was your diagnosis of the problem?

My diagnosis was a plugin's hooks should only be run once per event.

### What is your fix for the problem, implemented in this PR?

My fix is to `uniq` the list of plugins registered for each event.