### PR TITLE
Fix multiple source warning messages from `error` to `warn`

### DIFF
--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -202,15 +202,16 @@ module Bundler
     end
 
     def warn_ambiguous_gems
+      # TODO: remove this when we drop Bundler 1.x support
       Installer.ambiguous_gems.to_a.each do |name, installed_from_uri, *also_found_in_uris|
-        Bundler.ui.error "Warning: the gem '#{name}' was found in multiple sources."
-        Bundler.ui.error "Installed from: #{installed_from_uri}"
-        Bundler.ui.error "Also found in:"
-        also_found_in_uris.each {|uri| Bundler.ui.error "  * #{uri}" }
-        Bundler.ui.error "You should add a source requirement to restrict this gem to your preferred source."
-        Bundler.ui.error "For example:"
-        Bundler.ui.error "    gem '#{name}', :source => '#{installed_from_uri}'"
-        Bundler.ui.error "Then uninstall the gem '#{name}' (or delete all bundled gems) and then install again."
+        Bundler.ui.warn "Warning: the gem '#{name}' was found in multiple sources."
+        Bundler.ui.warn "Installed from: #{installed_from_uri}"
+        Bundler.ui.warn "Also found in:"
+        also_found_in_uris.each {|uri| Bundler.ui.warn "  * #{uri}" }
+        Bundler.ui.warn "You should add a source requirement to restrict this gem to your preferred source."
+        Bundler.ui.warn "For example:"
+        Bundler.ui.warn "    gem '#{name}', :source => '#{installed_from_uri}'"
+        Bundler.ui.warn "Then uninstall the gem '#{name}' (or delete all bundled gems) and then install again."
       end
     end
   end

--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -414,7 +414,7 @@ module Bundler
         msg = msg.join("\n")
 
         raise SecurityError, msg if multisource_disabled
-        Bundler.ui.error "Warning: #{msg}"
+        Bundler.ui.warn "Warning: #{msg}"
       end
     end
   end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

I've been working on a few repos for most of this year that use a privately-hosted gem with the same name (but completely different purpose) as a gem hosted at rubygems.org - whenever I start with a clean copy and `bundle install` for the first time, I am presented with a warning in red that the gem was found in multiple sources. The red text makes me think that something went wrong, even though bundler did exactly what I wanted it to do.

The user experience is wrong - a warning should not be red.

### What was your diagnosis of the problem?

When I looked at the source, I saw immediately that the warning was using `Bundler.ui.error` instead of `Bundler.ui.warn`.

This is a bug fix with a limited lifespan - after setting up a local copy of bundler I see that 2.0's handling of multiple sources A) is smarter and bypasses the error in most of the repos where I saw it with bundler 1.x; and B) fails early with a different error message in the remaining repos.

### What is your fix for the problem, implemented in this PR?

The fix is simply switching to `Bundler.ui.warn` in this case.

### Why did you choose this fix out of the possible options?

_I didn't see any other possible options._
