### PR TITLE
set https to the default protocol for git

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -305,7 +305,7 @@ module Bundler
         #   end
         repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
         if Bundler.settings["github.https"] || Bundler.feature_flag.github_https_source?
-          Bundler::SharedHelpers.major_deprecation 2, "The `github.https` setting will ba removed" if Bundler.settings["github.https"]
+          Bundler::SharedHelpers.major_deprecation 2, "The `github.https` setting will be removed" if Bundler.settings["github.https"]
           "https://github.com/#{repo_name}.git"
         else
           "git://github.com/#{repo_name}.git"

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -304,9 +304,8 @@ module Bundler
         #     "https://github.com/#{repo_name}.git"
         #   end
         repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
-        # TODO: 2.0 upgrade this setting to the default
-        if Bundler.settings["github.https"]
-          Bundler::SharedHelpers.major_deprecation 2, "The `github.https` setting will be removed"
+        if Bundler.settings["github.https"] || Bundler.feature_flag.github_https_source?
+          Bundler::SharedHelpers.major_deprecation 2, "The `github.https` setting will ba removed" if Bundler.settings["github.https"]
           "https://github.com/#{repo_name}.git"
         else
           "git://github.com/#{repo_name}.git"

--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -39,6 +39,7 @@ module Bundler
     settings_flag(:disable_multisource) { bundler_2_mode? }
     settings_flag(:error_on_stderr) { bundler_2_mode? }
     settings_flag(:forget_cli_options) { bundler_2_mode? }
+    settings_flag(:github_https_source) { bundler_2_mode? }
     settings_flag(:global_path_appends_ruby_scope) { bundler_2_mode? }
     settings_flag(:global_gem_cache) { bundler_2_mode? }
     settings_flag(:init_gems_rb) { bundler_2_mode? }

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -35,6 +35,7 @@ module Bundler
       frozen
       gem.coc
       gem.mit
+      github_https_source
       global_path_appends_ruby_scope
       global_gem_cache
       ignore_messages

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -195,6 +195,9 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
    relative paths in the `Gemfile`, among other things. By default, bundler
    will search up from the current working directory until it finds a
    `Gemfile`.
+* `github_https_source` (`GITHUB_HTTPS_SOURCE`)
+   Set Bundler to use https by default when using the `github:` source in the
+   Gemfile
 * `global_gem_cache` (`BUNDLE_GLOBAL_GEM_CACHE`):
    Whether Bundler should cache all gems globally, rather than locally to the
    installing Ruby installation.

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Bundler::Dsl do
     end
 
     context "default hosts (git, gist)" do
-      # Note: There is a feature flag that will disabled these soruces by
+      # Note: There is a feature flag that will disable these sources by
       # default
       before { bundle "config skip_default_git_sources false" }
 

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -25,8 +25,18 @@ RSpec.describe Bundler::Dsl do
       expect { subject.git_source(:example) }.to raise_error(Bundler::InvalidOption)
     end
 
-    context "default hosts (git, gist)", :bundler => "< 2" do
+    context "default hosts (git, gist)" do
+      # Note: There is a feature flag that will disabled these soruces by
+      # default
+      before { bundle "config skip_default_git_sources false" }
+
       it "converts :github to :git" do
+        subject.gem("sparks", :github => "indirect/sparks")
+        github_uri = "https://github.com/indirect/sparks.git"
+        expect(subject.dependencies.first.source.uri).to eq(github_uri)
+      end
+
+      it "converts :github to :git with git scheme", :bundler => "< 2" do
         subject.gem("sparks", :github => "indirect/sparks")
         github_uri = "git://github.com/indirect/sparks.git"
         expect(subject.dependencies.first.source.uri).to eq(github_uri)
@@ -46,7 +56,7 @@ RSpec.describe Bundler::Dsl do
 
       it "converts 'rails' to 'rails/rails'" do
         subject.gem("rails", :github => "rails")
-        github_uri = "git://github.com/rails/rails.git"
+        github_uri = "https://github.com/rails/rails.git"
         expect(subject.dependencies.first.source.uri).to eq(github_uri)
       end
 


### PR DESCRIPTION
This PR is setting Git gems to be fetched over `https` by default.

See #6785 