### PR TITLE
Use https in the Github shortcut by default in Bundler 2

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -305,7 +305,7 @@ module Bundler
         #   end
         repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
         # TODO: 2.0 upgrade this setting to the default
-        if Bundler.settings["github.https"]
+        if Bundler.feature_flag.github_https?
           Bundler::SharedHelpers.major_deprecation 2, "The `github.https` setting will be removed"
           "https://github.com/#{repo_name}.git"
         else

--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -60,6 +60,8 @@ module Bundler
 
     settings_option(:default_cli_command) { bundler_2_mode? ? :cli_help : :install }
 
+    settings_method(:github_https?, "github.https") { bundler_2_mode? }
+
     def initialize(bundler_version)
       @bundler_version = Gem::Version.create(bundler_version)
     end

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -25,7 +25,23 @@ RSpec.describe Bundler::Dsl do
       expect { subject.git_source(:example) }.to raise_error(Bundler::InvalidOption)
     end
 
+    context "github_https feature flag" do
+      it "is true when github.https is true" do
+        bundle "config github.https true"
+        expect(Bundler.feature_flag.github_https?).to eq "true"
+      end
+    end
+
     context "default hosts (git, gist)", :bundler => "< 2" do
+      context "when github.https config is true" do
+        before { bundle "config github.https true" }
+        it "converts :github to :git using https" do
+          subject.gem("sparks", :github => "indirect/sparks")
+          github_uri = "https://github.com/indirect/sparks.git"
+          expect(subject.dependencies.first.source.uri).to eq(github_uri)
+        end
+      end
+
       it "converts :github to :git" do
         subject.gem("sparks", :github => "indirect/sparks")
         github_uri = "git://github.com/indirect/sparks.git"


### PR DESCRIPTION
This PR is setting Git gems to be fetched over https by default.

Note: This PR is successing #6791 

Closes #6785 