### PR TITLE
move welcome message to new welcome bot

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,9 @@
+newPRWelcomeComment: >
+  Thanks for opening a pull request and helping make Bundler better! Someone from the Bundler team will take a look at your pull request shortly and leave any feedback. Please make sure that your pull request has tests for any changes or added functionality.
+
+  We use Travis CI to test and make sure your change works functionally and uses acceptable conventions, you can review the current progress of Travis CI in the PR status window below.
+
+  If you have any questions or concerns that you wish to ask, feel free to leave a comment in this PR or join our #bundler channel on [Slack](http://slack.bundler.io/).
+
+  For more information about contributing to the Bundler project feel free to review our [CONTRIBUTING](https://github.com/bundler/bundler/blob/master/doc/contributing/README.md) guide
+

--- a/.github/welcome_message.md
+++ b/.github/welcome_message.md
@@ -1,7 +1,0 @@
-Thanks for opening a pull request and helping make Bundler better! Someone from the Bundler team will take a look at your pull request shortly and leave any feedback. Please make sure that your pull request has tests for any changes or added functionality.
-
-We use Travis CI to test and make sure your change works functionally and uses acceptable conventions, you can review the current progress of Travis CI in the PR status window below.
-
-If you have any questions or concerns that you wish to ask, feel free to leave a comment in this PR or join our #bundler channel on [Slack](http://slack.bundler.io/).
-
-For more information about contributing to the Bundler project feel free to review our [CONTRIBUTING](https://github.com/bundler/bundler/blob/master/doc/contributing/README.md) guide


### PR DESCRIPTION
This PR is moving the functionality of the welcome bot to https://github.com/apps/welcome and will deprecate https://github.com/bundler/bundlerbot.