### PR TITLE
[Plugin] Ignore the deployment setting

### DIFF
--- a/spec/plugins/install_spec.rb
+++ b/spec/plugins/install_spec.rb
@@ -191,6 +191,28 @@ RSpec.describe "bundler plugin install" do
       expect(out).to include("Installed plugin ga-plugin")
       plugin_should_be_installed("ga-plugin")
     end
+
+    context "in deployment mode" do
+      it "installs plugins" do
+        install_gemfile! <<-G
+          source 'file://#{gem_repo2}'
+          gem 'rack', "1.0.0"
+        G
+
+        install_gemfile! <<-G, forgotten_command_line_options(:deployment => true)
+          source 'file://#{gem_repo2}'
+          plugin 'foo'
+          gem 'rack', "1.0.0"
+        G
+
+        expect(out).to include("Installed plugin foo")
+
+        expect(out).to include("Bundle complete!")
+
+        expect(the_bundle).to include_gems("rack 1.0.0")
+        plugin_should_be_installed("foo")
+      end
+    end
   end
 
   context "inline gemfiles" do


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was installing a new plugin in deployment mode would fail with a suggestion the lock file was corrupted, when it installed fine without deployment mode.

Fixes #6795.

### What was your diagnosis of the problem?

My diagnosis was deployment mode was interfering with installing a new plugin.

### What is your fix for the problem, implemented in this PR?

My fix overrides the deployment and frozen settings when creating the plugin Definition.

### Why did you choose this fix out of the possible options?

I chose this fix because having a "frozen" plugin bundle makes no sense, since plugins aren't written to the lockfile.