### PR TITLE
deleting portion of code supporting Ruby < 1.9 for Bundler 2.0

### DIFF
--- a/spec/bundler/bundler_spec.rb
+++ b/spec/bundler/bundler_spec.rb
@@ -386,10 +386,6 @@ EOF
       if Bundler.respond_to?(:remove_instance_variable)
         Bundler.remove_instance_variable(:@requires_sudo_ran)
         Bundler.remove_instance_variable(:@requires_sudo)
-      else
-        # TODO: Remove these code when Bundler drops Ruby 1.8.7 support
-        Bundler.send(:remove_instance_variable, :@requires_sudo_ran)
-        Bundler.send(:remove_instance_variable, :@requires_sudo)
       end
     end
     context "writable paths" do


### PR DESCRIPTION
I think this should be the last of the intended (valid) changes from #6803 