### PR TITLE
Fix using gemspec & force_ruby_platform on windows

### DIFF
--- a/lib/bundler/current_ruby.rb
+++ b/lib/bundler/current_ruby.rb
@@ -38,6 +38,8 @@ module Bundler
     ].freeze
 
     def ruby?
+      return true if Bundler::GemHelpers.generic_local_platform == Gem::Platform::RUBY
+
       !mswin? && (RUBY_ENGINE == "ruby" || RUBY_ENGINE == "rbx" || RUBY_ENGINE == "maglev" || RUBY_ENGINE == "truffleruby")
     end
 

--- a/lib/bundler/gem_helpers.rb
+++ b/lib/bundler/gem_helpers.rb
@@ -2,7 +2,7 @@
 
 module Bundler
   module GemHelpers
-    GENERIC_CACHE = {} # rubocop:disable MutableConstant
+    GENERIC_CACHE = { Gem::Platform::RUBY => Gem::Platform::RUBY } # rubocop:disable MutableConstant
     GENERICS = [
       [Gem::Platform.new("java"), Gem::Platform.new("java")],
       [Gem::Platform.new("mswin32"), Gem::Platform.new("mswin32")],
@@ -14,8 +14,6 @@ module Bundler
     ].freeze
 
     def generic(p)
-      return p if p == Gem::Platform::RUBY
-
       GENERIC_CACHE[p] ||= begin
         _, found = GENERICS.find do |match, _generic|
           p.os == match.os && (!match.cpu || p.cpu == match.cpu)

--- a/spec/install/gemfile/gemspec_spec.rb
+++ b/spec/install/gemfile/gemspec_spec.rb
@@ -331,22 +331,10 @@ RSpec.describe "bundle install from an existing gemspec" do
 
     context "previously bundled for Ruby" do
       let(:platform) { "ruby" }
-      let(:explicit_platform) { false }
 
       before do
         build_lib("foo", :path => tmp.join("foo")) do |s|
           s.add_dependency "rack", "=1.0.0"
-        end
-
-        if explicit_platform
-          create_file(
-            tmp.join("foo", "foo-#{platform}.gemspec"),
-            build_spec("foo", "1.0", platform) do
-              dep "rack", "=1.0.0"
-              @spec.authors = "authors"
-              @spec.summary = "summary"
-            end.first.to_ruby
-          )
         end
 
         gemfile <<-G
@@ -379,7 +367,17 @@ RSpec.describe "bundle install from an existing gemspec" do
 
       context "using JRuby with explicit platform" do
         let(:platform) { "java" }
-        let(:explicit_platform) { true }
+
+        before do
+          create_file(
+            tmp.join("foo", "foo-#{platform}.gemspec"),
+            build_spec("foo", "1.0", platform) do
+              dep "rack", "=1.0.0"
+              @spec.authors = "authors"
+              @spec.summary = "summary"
+            end.first.to_ruby
+          )
+        end
 
         it "should install" do
           simulate_ruby_engine "jruby" do

--- a/spec/runtime/platform_spec.rb
+++ b/spec/runtime/platform_spec.rb
@@ -116,6 +116,25 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
     end
   end
 
+  it "allows specifying only-ruby-platform on windows with gemspec dependency" do
+    build_lib("foo", "1.0", :path => ".") do |s|
+      s.add_dependency "rack"
+    end
+
+    gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
+      gemspec
+    G
+    bundle! :lock
+
+    simulate_windows do
+      bundle! "config set force_ruby_platform true"
+      bundle! "install"
+
+      expect(the_bundle).to include_gems "rack 1.0"
+    end
+  end
+
   it "recovers when the lockfile is missing a platform-specific gem" do
     build_repo2 do
       build_gem "requires_platform_specific" do |s|


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was using `gemspec` and `force_ruby_platform` on Windows would lead to gems not being requirable.

Fixes #6801.

### What was your diagnosis of the problem?

My diagnosis was there was a place where `force_ruby_platform` wasn't being taken into account, namely the query methods on `Bundler.current_ruby`

### What is your fix for the problem, implemented in this PR?

My fix was to add a check for the local platform in `current_ruby`, so the `force_ruby_platform` override would be taken into account.

### Why did you choose this fix out of the possible options?

I chose this fix because it avoids hard-coding knowledge of the setting in more places.