### PR TITLE
fixed 'critical' codereview warning about complex conditional

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -425,7 +425,7 @@ module Bundler
       deleted_deps = @locked_deps.values - @dependencies
 
       # Check if it is possible that the source is only changed thing
-      if (new_deps.empty? && deleted_deps.empty?) && (!new_sources.empty? && !deleted_sources.empty?)
+      if new_deps.empty? == deleted_deps.empty?
         new_sources.reject! {|source| (source.path? && source.path.exist?) || equivalent_rubygems_remotes?(source) }
         deleted_sources.reject! {|source| (source.path? && source.path.exist?) || equivalent_rubygems_remotes?(source) }
       end


### PR DESCRIPTION
I went to codereview.com and made an adjustment to how a conditional statement was written because it was judged too complicated.