### PR TITLE
use '|' to preserve line breaks in welcome message

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,4 +1,4 @@
-newPRWelcomeComment: >
+newPRWelcomeComment: |
   Thanks for opening a pull request and helping make Bundler better! Someone from the Bundler team will take a look at your pull request shortly and leave any feedback. Please make sure that your pull request has tests for any changes or added functionality.
 
   We use Travis CI to test and make sure your change works functionally and uses acceptable conventions, you can review the current progress of Travis CI in the PR status window below.


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

I used the wrong block in the welcome message YAML. `>` strips the new line breaks, we want to use `|` instead.