### PR TITLE
Following up ruby core changes.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -123,6 +123,12 @@ RSpec.configure do |config|
     Gem.ruby = orig_ruby if ENV["BUNDLE_RUBY"]
   end
 
+  config.before :suite do
+    if ENV["BUNDLE_RUBY"]
+      FileUtils.cp_r Spec::Path.bindir, File.join(Spec::Path.root, "lib", "exe")
+    end
+  end
+
   config.before :all do
     build_repo1
   end
@@ -146,5 +152,11 @@ RSpec.configure do |config|
 
     Dir.chdir(original_wd)
     ENV.replace(original_env)
+  end
+
+  config.after :suite do
+    if ENV["BUNDLE_RUBY"]
+      FileUtils.rm_rf File.join(Spec::Path.root, "lib", "exe")
+    end
   end
 end

--- a/spec/support/path.rb
+++ b/spec/support/path.rb
@@ -13,7 +13,7 @@ module Spec
     end
 
     def bindir
-      @bindir ||= root.join(ruby_core? ? "bin" : "exe")
+      @bindir ||= root.join(ruby_core? ? "libexec" : "exe")
     end
 
     def spec_dir


### PR DESCRIPTION
### What is your fix for the problem, implemented in this PR?

These changes enabled to use the same configuration of executables in ruby core repository.

  * To use libexec instead of bin directory.
  * Restore exe direcotry for bundler.gemspec while running test suite.

### Why did you choose this fix out of the possible options?

The ruby core repository uses `exe` directory for other usage. I chose `libexec` instead of `exe` in ruby core. And, The location of `bundler.gemspec` is not the root of the repository on ruby core. We should restore `libexec` to `exe` under the `lib` dir.

see. https://github.com/ruby/ruby/blob/trunk/lib/bundler.gemspec