### PR TITLE
Fix FIPS detection

### DIFF
--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -210,14 +210,11 @@ module Bundler
 
     def md5_available?
       return @md5_available if defined?(@md5_available)
-      @md5_available = begin
-        require "openssl"
-        OpenSSL::Digest::MD5.digest("")
-        true
-      rescue LoadError
-        true
-      rescue OpenSSL::Digest::DigestError
+      require 'openssl'
+      @md5_available = if OpenSSL::OPENSSL_FIPS && OpenSSL.fips_mode
         false
+      else
+        true
       end
     end
 

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -210,7 +210,7 @@ module Bundler
 
     def md5_available?
       return @md5_available if defined?(@md5_available)
-      require 'openssl'
+      require "openssl"
       @md5_available = if OpenSSL::OPENSSL_FIPS && OpenSSL.fips_mode
         false
       else

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -222,10 +222,10 @@ module Bundler
           OpenSSL::Digest::MD5.digest("")
           true
         end
-        rescue LoadError
-          true
-        rescue OpenSSL::Digest::DigestError
-          false
+      rescue LoadError
+        true
+      rescue OpenSSL::Digest::DigestError
+        false
       end
     end
 

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -210,11 +210,22 @@ module Bundler
 
     def md5_available?
       return @md5_available if defined?(@md5_available)
-      require "openssl"
-      @md5_available = if defined?(OpenSSL::OPENSSL_FIPS) && OpenSSL::OPENSSL_FIPS && OpenSSL.fips_mode
-        false
-      else
-        true
+      @md5_available = begin
+        require "openssl"
+        if defined?(OpenSSL::OPENSSL_FIPS) && OpenSSL.respond_to?(:fips_mode)
+          if OpenSSL.fips_mode
+            false
+          else
+            true
+          end
+        else
+          OpenSSL::Digest::MD5.digest("")
+          true
+        end
+        rescue LoadError
+          true
+        rescue OpenSSL::Digest::DigestError
+          false
       end
     end
 

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -211,7 +211,7 @@ module Bundler
     def md5_available?
       return @md5_available if defined?(@md5_available)
       require "openssl"
-      @md5_available = if OpenSSL::OPENSSL_FIPS && OpenSSL.fips_mode
+      @md5_available = if defined?(OpenSSL::OPENSSL_FIPS) && OpenSSL::OPENSSL_FIPS && OpenSSL.fips_mode
         false
       else
         true

--- a/spec/bundler/fetcher/compact_index_spec.rb
+++ b/spec/bundler/fetcher/compact_index_spec.rb
@@ -69,22 +69,21 @@ RSpec.describe Bundler::Fetcher::CompactIndex do
         end
       end
 
-      unless defined?(OpenSSL::OPENSSL_FIPS)
-        context "when OpenSSL is not FIPS-enabled" do
-          context "when FIPS-mode is active" do
-            before do
-              allow(OpenSSL::Digest::MD5).to receive(:digest).
-                and_raise(OpenSSL::Digest::DigestError)
-            end
-
-            it "returns false" do
-              expect(compact_index).to_not be_available
-            end
+      context "when OpenSSL is FIPS-enabled with OPENSSL_FIPS not available" do
+        context "when FIPS-mode is active" do
+          before do
+            OpenSSL.send(:remove_const, 'OPENSSL_FIPS') if defined? OpenSSL::OPENSSL_FIPS
+            allow(OpenSSL::Digest::MD5).to receive(:digest).
+              and_raise(OpenSSL::Digest::DigestError)
           end
 
-          it "returns true" do
-            expect(compact_index).to be_available
+          it "returns false" do
+            expect(compact_index).to_not be_available
           end
+        end
+
+        it "returns true" do
+          expect(compact_index).to be_available
         end
       end
     end

--- a/spec/bundler/fetcher/compact_index_spec.rb
+++ b/spec/bundler/fetcher/compact_index_spec.rb
@@ -25,18 +25,44 @@ RSpec.describe Bundler::Fetcher::CompactIndex do
     end
 
     describe "#available?" do
+      def remove_cached_md5_availability
+        return unless Bundler::SharedHelpers.instance_variable_defined?(:@md5_available)
+        Bundler::SharedHelpers.remove_instance_variable(:@md5_available)
+      end
+
       before do
+        remove_cached_md5_availability
         allow(compact_index).to receive(:compact_index_client).
           and_return(double(:compact_index_client, :update_and_parse_checksums! => true))
       end
+
+      after { remove_cached_md5_availability }
 
       it "returns true" do
         expect(compact_index).to be_available
       end
 
       context "when OpenSSL is not available" do
+        it "returns true" do
+          allow(Bundler::SharedHelpers).to receive(:require).with("openssl").and_raise(LoadError)
+          expect(compact_index).to be_available
+        end
+      end
+
+      context "when OpenSSL is FIPS-enabled", :ruby => ">= 2.0.0" do
+
         before do
-          allow(compact_index).to receive(:require).with("openssl").and_raise(LoadError)
+          stub_const("OpenSSL::OPENSSL_FIPS", true)
+        end
+
+        context "when FIPS-mode is active" do
+          before do
+            allow(OpenSSL).to receive(:fips_mode).and_return(true)
+          end
+
+          it "returns false" do
+            expect(compact_index).to_not be_available
+          end
         end
 
         it "returns true" do
@@ -44,22 +70,16 @@ RSpec.describe Bundler::Fetcher::CompactIndex do
         end
       end
 
-      context "when OpenSSL is FIPS-enabled", :ruby => ">= 2.0.0" do
-        def remove_cached_md5_availability
-          return unless Bundler::SharedHelpers.instance_variable_defined?(:@md5_available)
-          Bundler::SharedHelpers.remove_instance_variable(:@md5_available)
-        end
+      context "when OpenSSL is FIPS-enabled", :ruby => "< 2.0.0" do
 
         before do
-          remove_cached_md5_availability
           stub_const("OpenSSL::OPENSSL_FIPS", true)
         end
 
-        after { remove_cached_md5_availability }
-
         context "when FIPS-mode is active" do
           before do
-            allow(OpenSSL).to receive(:fips_mode).and_return(true)
+            allow(OpenSSL::Digest::MD5).to receive(:digest).
+              and_raise(OpenSSL::Digest::DigestError)
           end
 
           it "returns false" do

--- a/spec/bundler/fetcher/compact_index_spec.rb
+++ b/spec/bundler/fetcher/compact_index_spec.rb
@@ -70,18 +70,18 @@ RSpec.describe Bundler::Fetcher::CompactIndex do
       end
     end
 
-      context "when OpenSSL is FIPS-enabled with OPENSSL_FIPS not available" do
-        context "when FIPS-mode is active" do
-          before do
-            OpenSSL.send(:remove_const, "OPENSSL_FIPS") if defined? OpenSSL::OPENSSL_FIPS
-          end
+    context "when OpenSSL is FIPS-enabled with OPENSSL_FIPS not available" do
+      context "when FIPS-mode is active" do
+        before do
+          OpenSSL.send(:remove_const, "OPENSSL_FIPS") if defined? OpenSSL::OPENSSL_FIPS
+        end
 
-          it "returns false" do
-            allow(OpenSSL::Digest::MD5).to receive(:digest).and_raise(OpenSSL::Digest::DigestError)
-            expect(compact_index).to_not be_available
-          end
+        it "returns false" do
+          allow(OpenSSL::Digest::MD5).to receive(:digest).and_raise(OpenSSL::Digest::DigestError)
+          expect(compact_index).to_not be_available
         end
       end
+    end
 
     context "logging" do
       before { allow(compact_index).to receive(:log_specs).and_call_original }

--- a/spec/bundler/fetcher/compact_index_spec.rb
+++ b/spec/bundler/fetcher/compact_index_spec.rb
@@ -25,18 +25,10 @@ RSpec.describe Bundler::Fetcher::CompactIndex do
     end
 
     describe "#available?" do
-      def remove_cached_md5_availability
-        return unless Bundler::SharedHelpers.instance_variable_defined?(:@md5_available)
-        Bundler::SharedHelpers.remove_instance_variable(:@md5_available)
-      end
-
       before do
-        remove_cached_md5_availability
         allow(compact_index).to receive(:compact_index_client).
           and_return(double(:compact_index_client, :update_and_parse_checksums! => true))
       end
-
-      after { remove_cached_md5_availability }
 
       it "returns true" do
         expect(compact_index).to be_available
@@ -50,9 +42,17 @@ RSpec.describe Bundler::Fetcher::CompactIndex do
       end
 
       context "when OpenSSL is FIPS-enabled", :ruby => ">= 2.0.0" do
+        def remove_cached_md5_availability
+          return unless Bundler::SharedHelpers.instance_variable_defined?(:@md5_available)
+          Bundler::SharedHelpers.remove_instance_variable(:@md5_available)
+        end
+
         before do
+          remove_cached_md5_availability
           stub_const("OpenSSL::OPENSSL_FIPS", true)
         end
+
+        after { remove_cached_md5_availability }
 
         context "when FIPS-mode is active" do
           before do
@@ -70,10 +70,6 @@ RSpec.describe Bundler::Fetcher::CompactIndex do
       end
 
       context "when OpenSSL is FIPS-enabled", :ruby => "< 2.0.0" do
-        before do
-          stub_const("OpenSSL::OPENSSL_FIPS", true)
-        end
-
         context "when FIPS-mode is active" do
           before do
             allow(OpenSSL::Digest::MD5).to receive(:digest).

--- a/spec/bundler/fetcher/compact_index_spec.rb
+++ b/spec/bundler/fetcher/compact_index_spec.rb
@@ -59,8 +59,7 @@ RSpec.describe Bundler::Fetcher::CompactIndex do
 
         context "when FIPS-mode is active" do
           before do
-            allow(OpenSSL::Digest::MD5).to receive(:digest).
-              and_raise(OpenSSL::Digest::DigestError)
+            allow(OpenSSL.fips_mode).to return(true)
           end
 
           it "returns false" do

--- a/spec/bundler/fetcher/compact_index_spec.rb
+++ b/spec/bundler/fetcher/compact_index_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Bundler::Fetcher::CompactIndex do
         end
       end
 
-      if defined?(OpenSSL::OPENSSL_FIPS)
+      unless defined?(OpenSSL::OPENSSL_FIPS)
         context "when OpenSSL is not FIPS-enabled" do
           context "when FIPS-mode is active" do
             before do

--- a/spec/bundler/fetcher/compact_index_spec.rb
+++ b/spec/bundler/fetcher/compact_index_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Bundler::Fetcher::CompactIndex do
 
         context "when FIPS-mode is active" do
           before do
-            allow(OpenSSL.fips_mode).to return(true)
+            allow(OpenSSL).to receive(:fips_mode).and_return(true)
           end
 
           it "returns false" do

--- a/spec/bundler/fetcher/compact_index_spec.rb
+++ b/spec/bundler/fetcher/compact_index_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Bundler::Fetcher::CompactIndex do
       context "when OpenSSL is FIPS-enabled with OPENSSL_FIPS not available" do
         context "when FIPS-mode is active" do
           before do
-            OpenSSL.send(:remove_const, 'OPENSSL_FIPS') if defined? OpenSSL::OPENSSL_FIPS
+            OpenSSL.send(:remove_const, "OPENSSL_FIPS") if defined? OpenSSL::OPENSSL_FIPS
             allow(OpenSSL::Digest::MD5).to receive(:digest).
               and_raise(OpenSSL::Digest::DigestError)
           end

--- a/spec/bundler/fetcher/compact_index_spec.rb
+++ b/spec/bundler/fetcher/compact_index_spec.rb
@@ -68,25 +68,20 @@ RSpec.describe Bundler::Fetcher::CompactIndex do
           expect(compact_index).to be_available
         end
       end
+    end
 
       context "when OpenSSL is FIPS-enabled with OPENSSL_FIPS not available" do
         context "when FIPS-mode is active" do
           before do
             OpenSSL.send(:remove_const, "OPENSSL_FIPS") if defined? OpenSSL::OPENSSL_FIPS
-            allow(OpenSSL::Digest::MD5).to receive(:digest).
-              and_raise(OpenSSL::Digest::DigestError)
           end
 
           it "returns false" do
+            allow(OpenSSL::Digest::MD5).to receive(:digest).and_raise(OpenSSL::Digest::DigestError)
             expect(compact_index).to_not be_available
           end
         end
-
-        it "returns true" do
-          expect(compact_index).to be_available
-        end
       end
-    end
 
     context "logging" do
       before { allow(compact_index).to receive(:log_specs).and_call_original }

--- a/spec/bundler/fetcher/compact_index_spec.rb
+++ b/spec/bundler/fetcher/compact_index_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Bundler::Fetcher::CompactIndex do
         end
       end
 
-      context "when OpenSSL is FIPS-enabled", :ruby => "< 2.0.0" do
+      context "when OpenSSL is not FIPS-enabled" do
         context "when FIPS-mode is active" do
           before do
             allow(OpenSSL::Digest::MD5).to receive(:digest).
@@ -85,7 +85,7 @@ RSpec.describe Bundler::Fetcher::CompactIndex do
           expect(compact_index).to be_available
         end
       end
-    end
+    end if defined?(OpenSSL::OPENSSL_FIPS)
 
     context "logging" do
       before { allow(compact_index).to receive(:log_specs).and_call_original }

--- a/spec/bundler/fetcher/compact_index_spec.rb
+++ b/spec/bundler/fetcher/compact_index_spec.rb
@@ -50,7 +50,6 @@ RSpec.describe Bundler::Fetcher::CompactIndex do
       end
 
       context "when OpenSSL is FIPS-enabled", :ruby => ">= 2.0.0" do
-
         before do
           stub_const("OpenSSL::OPENSSL_FIPS", true)
         end
@@ -71,7 +70,6 @@ RSpec.describe Bundler::Fetcher::CompactIndex do
       end
 
       context "when OpenSSL is FIPS-enabled", :ruby => "< 2.0.0" do
-
         before do
           stub_const("OpenSSL::OPENSSL_FIPS", true)
         end

--- a/spec/bundler/fetcher/compact_index_spec.rb
+++ b/spec/bundler/fetcher/compact_index_spec.rb
@@ -69,23 +69,25 @@ RSpec.describe Bundler::Fetcher::CompactIndex do
         end
       end
 
-      context "when OpenSSL is not FIPS-enabled" do
-        context "when FIPS-mode is active" do
-          before do
-            allow(OpenSSL::Digest::MD5).to receive(:digest).
-              and_raise(OpenSSL::Digest::DigestError)
+      if defined?(OpenSSL::OPENSSL_FIPS)
+        context "when OpenSSL is not FIPS-enabled" do
+          context "when FIPS-mode is active" do
+            before do
+              allow(OpenSSL::Digest::MD5).to receive(:digest).
+                and_raise(OpenSSL::Digest::DigestError)
+            end
+
+            it "returns false" do
+              expect(compact_index).to_not be_available
+            end
           end
 
-          it "returns false" do
-            expect(compact_index).to_not be_available
+          it "returns true" do
+            expect(compact_index).to be_available
           end
-        end
-
-        it "returns true" do
-          expect(compact_index).to be_available
         end
       end
-    end if defined?(OpenSSL::OPENSSL_FIPS)
+    end
 
     context "logging" do
       before { allow(compact_index).to receive(:log_specs).and_call_original }


### PR DESCRIPTION
Signed-off-by: Noel Georgi <git@frezbo.com>

Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

Ruby compiled with latest OpenSSL FIPS would not raise a `DigestError` rather raise a `RuntimeError`, so it better to detect as how the ruby OpenSSL library sets values. 

### What is your fix for the problem, implemented in this PR?

detect as how the ruby OpenSSL library sets values. 

