### PR TITLE
Filter credentials from gemfile for bundler 2.0

### DIFF
--- a/lib/bundler/lockfile_generator.rb
+++ b/lib/bundler/lockfile_generator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "bundler/uri_credentials_filter.rb"
+require "bundler/uri_credentials_filter"
 
 module Bundler
   class LockfileGenerator
@@ -32,11 +32,13 @@ module Bundler
     def add_sources
       definition.send(:sources).lock_sources.each_with_index do |source, idx|
         # Filter out credentials from Gemfile as of Bundler 2.0
-        source.replace_remotes(
-          source.remotes.map do |remote|
-            URICredentialsFilter.credential_filtered_uri(remote)
-          end
-        )
+        if (source.instance_of? Bundler::Source::Rubygems)
+          source.replace_remotes(
+            source.remotes.map do |remote|
+              URICredentialsFilter.credential_filtered_uri(remote)
+            end
+          )
+        end
 
         out << "\n" unless idx.zero?
 

--- a/lib/bundler/lockfile_generator.rb
+++ b/lib/bundler/lockfile_generator.rb
@@ -32,7 +32,7 @@ module Bundler
     def add_sources
       definition.send(:sources).lock_sources.each_with_index do |source, idx|
         # Filter out credentials from Gemfile as of Bundler 2.0
-        if (source.instance_of? Bundler::Source::Rubygems)
+        if source.instance_of? Bundler::Source::Rubygems
           source.replace_remotes(
             source.remotes.map do |remote|
               URICredentialsFilter.credential_filtered_uri(remote)

--- a/lib/bundler/lockfile_generator.rb
+++ b/lib/bundler/lockfile_generator.rb
@@ -2,7 +2,6 @@
 
 require "bundler/uri_credentials_filter.rb"
 
-
 module Bundler
   class LockfileGenerator
     attr_reader :definition

--- a/lib/bundler/lockfile_generator.rb
+++ b/lib/bundler/lockfile_generator.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "bundler/uri_credentials_filter.rb"
+
+
 module Bundler
   class LockfileGenerator
     attr_reader :definition
@@ -29,8 +32,15 @@ module Bundler
 
     def add_sources
       definition.send(:sources).lock_sources.each_with_index do |source, idx|
-        out << "\n" unless idx.zero?
+        # Filter out credentials from Gemfile as of Bundler 2.0
+        source.replace_remotes(
+          source.remotes.map do |remote|
+            URICredentialsFilter.credential_filtered_uri(remote)
+          end
+        )
 
+        out << "\n" unless idx.zero?
+        
         # Add the source header
         out << source.to_lock
 

--- a/lib/bundler/lockfile_generator.rb
+++ b/lib/bundler/lockfile_generator.rb
@@ -40,7 +40,7 @@ module Bundler
         )
 
         out << "\n" unless idx.zero?
-        
+
         # Add the source header
         out << source.to_lock
 

--- a/spec/bundler/lockfile_generator_spec.rb
+++ b/spec/bundler/lockfile_generator_spec.rb
@@ -2,7 +2,6 @@
 
 RSpec.describe "Bundler::LockfileGenerator" do
   context "Gemfile contains private credentials in source", :bundler => ">= 2" do
-
     it "filters out private token for lockfile" do
       gemfile <<-G
 source "https://my-secret-token:x-oauth-basic@github.com/foo/bar.git"

--- a/spec/bundler/lockfile_generator_spec.rb
+++ b/spec/bundler/lockfile_generator_spec.rb
@@ -2,12 +2,13 @@
 
 RSpec.describe "Bundler::LockfileGenerator" do
   context "Gemfile contains private credentials in source", :bundler => ">= 2" do
+    
     it "filters out private token for lockfile" do
       gemfile <<-G
 source "https://my-secret-token:x-oauth-basic@github.com/foo/bar.git"
       G
       bundle "install"
-      expect("gems.locked").not_to have_file_content "my-secret-token"
+      expect(lockfile).not_to match "my-secret-token"
     end
 
     it "filters out private password for lockfile" do
@@ -15,7 +16,7 @@ source "https://my-secret-token:x-oauth-basic@github.com/foo/bar.git"
 source "https://username:my-secret-password@github.com/foo/bar.git"
       G
       bundle "install"
-      expect("gems.locked").not_to have_file_content "my-secret-password"
+      expect(lockfile).not_to match "my-secret-password"
     end
   end
 end

--- a/spec/bundler/lockfile_generator_spec.rb
+++ b/spec/bundler/lockfile_generator_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.describe "Bundler::LockfileGenerator" do
+  context "Gemfile contains private credentials in source", :bundler => ">= 2" do
+    it "filters out private token for lockfile" do
+      gemfile <<-G
+source "https://my-secret-token:x-oauth-basic@github.com/foo/bar.git"
+      G
+      bundle "install"
+      expect("gems.locked").not_to have_file_content "my-secret-token"
+    end
+
+    it "filters out private password for lockfile" do
+      gemfile <<-G
+source "https://username:my-secret-password@github.com/foo/bar.git"
+      G
+      bundle "install"
+      expect("gems.locked").not_to have_file_content "my-secret-password"
+    end
+  end
+end

--- a/spec/bundler/lockfile_generator_spec.rb
+++ b/spec/bundler/lockfile_generator_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe "Bundler::LockfileGenerator" do
   context "Gemfile contains private credentials in source", :bundler => ">= 2" do
-    
+
     it "filters out private token for lockfile" do
       gemfile <<-G
 source "https://my-secret-token:x-oauth-basic@github.com/foo/bar.git"


### PR DESCRIPTION
### What was the end-user problem that led to this PR

The problem was that private credentials in the gemfile were sent to the lockfile to preserve backwards-compatibility in bundler < 2, but for bundler >= 2 this security should be offered to users.

### What was your diagnosis of the problem?

#6489 

### What is your fix for the problem, implemented in this PR?

My fix was to filter credentials on the remotes of sources.

### Why did you choose this fix out of the possible options?

I chose this fix because it is minimal and mimics #6490 in behavior, I believe.

Fixes #6489.