### PR TITLE
Ensure Bundler home exists

### DIFF
--- a/lib/bundler/cli/doctor.rb
+++ b/lib/bundler/cli/doctor.rb
@@ -94,12 +94,23 @@ module Bundler
     end
 
   private
+    
+    def ensure_path_exists(path)
+      does_exist = File.exist?(path)
+      unless does_exist
+        Bundler.ui.error "Bundler's home path does not exist. Expected to be at #{path} which does not exist."
+      end
+      does_exist
+    end
 
     def check_home_permissions
       require "find"
       files_not_readable_or_writable = []
       files_not_rw_and_owned_by_different_user = []
       files_not_owned_by_current_user_but_still_rw = []
+      
+      return false unless ensure_path_exists(Bundler.home.to_s)
+      
       Find.find(Bundler.home.to_s).each do |f|
         if !File.writable?(f) || !File.readable?(f)
           if File.stat(f).uid != Process.uid


### PR DESCRIPTION
Resolves #6820

Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was...
That the Bundler home path does not exist and so `Find#find` fails because it raises an error.

### What was your diagnosis of the problem?

My diagnosis was...
In the `collect!` `Find#find` throws if the path does not exist. As seen in the source here https://ruby-doc.org/stdlib-2.2.2/libdoc/find/rdoc/Find.html#method-c-find

### What is your fix for the problem, implemented in this PR?
I ensured the path exists and provided an error if it does not. This should help the user diagnose the problem. 

### Why did you choose this fix out of the possible options?

I chose this fix because...
It seemed to solve the exact issue. I'm not sure if the error is the best error or if the home checking code should be placed else where so we can handle this in other places but I thought I would make the PR and see what the maintainers think would be best.