### PR TITLE
Added quiet flag to inline bundler

### DIFF
--- a/lib/bundler/inline.rb
+++ b/lib/bundler/inline.rb
@@ -36,6 +36,7 @@ def gemfile(install = false, options = {}, &gemfile)
 
   opts = options.dup
   ui = opts.delete(:ui) { Bundler::UI::Shell.new }
+  ui.level = "silent" if opts.delete(:quiet)
   raise ArgumentError, "Unknown options: #{opts.keys.join(", ")}" unless opts.empty?
 
   old_root = Bundler.method(:root)

--- a/spec/runtime/inline_spec.rb
+++ b/spec/runtime/inline_spec.rb
@@ -112,6 +112,19 @@ RSpec.describe "bundler/inline#gemfile" do
     expect(exitstatus).to be_zero if exitstatus
   end
 
+  it "has an option for quiet installation" do
+    script <<-RUBY, :artifice => "endpoint"
+      require 'bundler'
+
+      gemfile(true, :quiet => true) do
+        source "https://notaserver.com"
+        gem "activesupport", :require => true
+      end
+    RUBY
+
+    expect(out).to be_empty
+  end
+
   it "raises an exception if passed unknown arguments" do
     script <<-RUBY
       gemfile(true, :arglebargle => true) do


### PR DESCRIPTION
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

I'm using inline bundler on my CI minitest file. I wanted to make it quiet so output is clean and meaningful.

### What was your diagnosis of the problem?

Bundler inline's gemfile method only accepted :ui option.

### What is your fix for the problem, implemented in this PR?

I added quiet option flag to gemfile method.

### Why did you choose this fix out of the possible options?

I chose this fix because it looked simple and clean.
