### PR TITLE
move rubocop into a separate stage in Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,16 @@ rvm:
   - 2.4.5
   - 2.3.8
 
+jobs:
+  include:
+    - stage: linting
+      rvm: 2.5
+      script: rake rubocop
+
+stages:
+  - linting
+  - test
+
 # Rubygems versions MUST be available as rake tasks
 # see Rakefile:125 for the list of possible RGV values
 env:

--- a/Rakefile
+++ b/Rakefile
@@ -207,11 +207,6 @@ begin
       # disallow making network requests on CI
       ENV["BUNDLER_SPEC_PRE_RECORDED"] = "TRUE"
 
-      if RUBY_VERSION >= "2.0.0"
-        puts "\n\e[1;33m[Travis CI] Running bundler linter\e[m\n\n"
-        Rake::Task["rubocop"].invoke
-      end
-
       puts "\n\e[1;33m[Travis CI] Running bundler specs against RubyGems #{rg}\e[m\n\n"
       specs = safe_task { Rake::Task["spec:rubygems:#{rg}"].invoke }
 


### PR DESCRIPTION
## Overview

This PR is pretty much a copy of https://github.com/rubygems/rubygems/pull/2510. It moves rubocop into a separate stage that is run before any tests are executed. This will allow for faster feedback and mean that we don't have to run rubocop on all our available instances in Travis.