### PR TITLE
Bring CI matrix back to its previous state

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,12 +31,6 @@ rvm:
   - 2.4.5
   - 2.3.8
 
-jobs:
-  include:
-    - stage: linting
-      rvm: 2.5
-      script: rake rubocop
-
 stages:
   - linting
   - test
@@ -49,24 +43,33 @@ env:
   # Test the latest rubygems release with all of our supported rubies
   - RGV=v2.7.7
 
-matrix:
+jobs:
   include:
+    - rvm: 2.5
+      script: rake rubocop
+      stage: linting
     # Ruby 2.4, Rubygems 2.6 and up
     - rvm: 2.4.2
       env: RGV=v2.6.14
+      stage: test
     # Ruby 2.3, Rubygems 2.5 and up
     - rvm: 2.3.7
       env: RGV=v2.5.2
+      stage: test
     - rvm: 2.3.7
       env: RGV=v2.6.14
+      stage: test
     # Ruby-head (we want to know how we're doing, but not fail the build)
     - rvm: ruby-head
       env: RGV=master
+      stage: test
     # 1.x mode (we want to keep stuff passing in 1.x mode for now)
     - rvm: 2.5.1
       env: RGV=v2.7.7 BUNDLER_SPEC_SUB_VERSION=1.98
+      stage: test
     - rvm: 1.8.7
       env: RGV=v2.7.7 BUNDLER_SPEC_SUB_VERSION=1.98
+      stage: test
 
   allow_failures:
     - rvm: ruby-head


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that we lost some CI matrix entries after #6830.

### What was your diagnosis of the problem?

My diagnosis was that extra entries should be defined under `jobs:` now, specifying their stage.

### What is your fix for the problem, implemented in this PR?

My fix is to merge the `jobs` and `matrix` section, and specify the `stage` of each entry.

### Why did you choose this fix out of the possible options?

I chose this fix because it seems to bring back the matrix to the way it was before (except for the extra linting stage).
