### PR TITLE
Allow files other than Gemfile.lock to be opened in definition specs

### DIFF
--- a/spec/bundler/definition_spec.rb
+++ b/spec/bundler/definition_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Bundler::Definition do
       subject { Bundler::Definition.new(nil, [], Bundler::SourceList.new, []) }
 
       it "raises an PermissionError with explanation" do
+        allow(File).to receive(:open).and_call_original
         expect(File).to receive(:open).with("Gemfile.lock", "wb").
           and_raise(Errno::EACCES)
         expect { subject.lock("Gemfile.lock") }.
@@ -23,6 +24,7 @@ RSpec.describe Bundler::Definition do
       subject { Bundler::Definition.new(nil, [], Bundler::SourceList.new, []) }
 
       it "raises a TemporaryResourceError with explanation" do
+        allow(File).to receive(:open).and_call_original
         expect(File).to receive(:open).with("Gemfile.lock", "wb").
           and_raise(Errno::EAGAIN)
         expect { subject.lock("Gemfile.lock") }.


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was the specs are brittle.

### What was your diagnosis of the problem?

My diagnosis was  we should assume code can open other files.

### What is your fix for the problem, implemented in this PR?

My fix allows other files to be opened, and only raises when opening the file under test.