### PR TITLE
fix installing gems on _really_ old versions of RubyGems

### DIFF
--- a/lib/bundler/rubygems_gem_installer.rb
+++ b/lib/bundler/rubygems_gem_installer.rb
@@ -10,6 +10,14 @@ module Bundler
       end
     end
 
+
+    attr_reader :options
+
+    def initialize(gem, options = {})
+      @options = {}
+      super
+    end
+
     def check_executable_overwrite(filename)
       # Bundler needs to install gems regardless of binstub overwriting
     end

--- a/lib/bundler/rubygems_gem_installer.rb
+++ b/lib/bundler/rubygems_gem_installer.rb
@@ -10,7 +10,6 @@ module Bundler
       end
     end
 
-
     attr_reader :options
 
     def initialize(gem, options = {})


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Installing gems on _really really_ old versions of RubyGems is not working. See #6839

### What was your diagnosis of the problem?

We were accessing an instance variable which did not exist

### What is your fix for the problem, implemented in this PR?

instantiate the instance variable ourselves.

### Why did you choose this fix out of the possible options?

This was the simplest solution that can be easily merged with `1-17-stable`

Fixes #6839
