### PR TITLE
revert commit b490e73

### DIFF
--- a/lib/bundler/source/metadata.rb
+++ b/lib/bundler/source/metadata.rb
@@ -21,9 +21,8 @@ module Bundler
             # can't point to the actual gemspec or else the require paths will be wrong
             s.loaded_from = File.expand_path("..", __FILE__)
           end
-          if loaded_spec = Bundler.rubygems.loaded_specs("bundler")
-            idx << loaded_spec # this has to come after the fake gemspec, to override it
-          elsif local_spec = Bundler.rubygems.find_name("bundler").find {|s| s.version.to_s == VERSION }
+
+          if local_spec = Bundler.rubygems.find_name("bundler").find {|s| s.version.to_s == VERSION }
             idx << local_spec
           end
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

There is a *really* obscure bug in Bundler that is causing deploys in Heroku to fail for certain environments. 

The environment in this case being Ruby 1.9.3 and RubyGems 1.8

I also think that this is the same bug causing https://github.com/bundler/bundler/issues/6829

### What was your diagnosis of the problem?

See https://gist.github.com/schneems/0247e3d5c3e079ecffd7cd10887c3cc9

### What is your fix for the problem, implemented in this PR?

Revert the commit that was causing this bug. The original PR can be found at https://github.com/bundler/bundler/pull/6687

I can confirm the fix by being able to deploy to Heroku succesfully using Bundler 1.17.2 + the commit to revert the change being applied on top.

```
$ git push heroku master
Enumerating objects: 87, done.
Counting objects: 100% (87/87), done.
Delta compression using up to 4 threads
Compressing objects: 100% (72/72), done.
Writing objects: 100% (87/87), 28.14 KiB | 1.48 MiB/s, done.
Total 87 (delta 13), reused 0 (delta 0)
remote: Compressing source files... done.
remote: Building source:
remote:
remote: -----> Ruby app detected
remote: -----> Compiling Ruby/Rails
remote: -----> Using Ruby version: ruby-1.9.3
remote: -----> Installing dependencies using bundler 1.17.2
remote:        Running: bundle install --without development:test --path vendor/bundle --binstubs vendor/bundle/bin -j4 --deployment
remote:        Fetching gem metadata from https://rubygems.org/..........
remote:        RubyGems 1.8.23.2 is not threadsafe, so your gems will be installed one at a time. Upgrade to RubyGems 2.1.0 or higher to enable parallel gem installation.
remote:        Fetching rake 10.0.3
remote:        Installing rake 10.0.3
remote:        Fetching i18n 0.6.1
remote:        Installing i18n 0.6.1
remote:        Fetching multi_json 1.5.0
remote:        Installing multi_json 1.5.0
remote:        Fetching activesupport 3.2.11
remote:        Installing activesupport 3.2.11
remote:        Fetching builder 3.0.4
remote:        Installing builder 3.0.4
remote:        Fetching activemodel 3.2.11
remote:        Installing activemodel 3.2.11
remote:        Fetching erubis 2.7.0
remote:        Installing erubis 2.7.0
remote:        Fetching journey 1.0.4
remote:        Installing journey 1.0.4
remote:        Fetching rack 1.4.4
remote:        Installing rack 1.4.4
remote:        Fetching rack-cache 1.2
remote:        Installing rack-cache 1.2
remote:        Fetching rack-test 0.6.2
remote:        Installing rack-test 0.6.2
remote:        Fetching hike 1.2.1
remote:        Installing hike 1.2.1
remote:        Fetching tilt 1.3.3
remote:        Installing tilt 1.3.3
remote:        Fetching sprockets 2.2.2
remote:        Installing sprockets 2.2.2
remote:        Fetching actionpack 3.2.11
remote:        Installing actionpack 3.2.11
remote:        Fetching mime-types 1.19
remote:        Installing mime-types 1.19
remote:        Fetching polyglot 0.3.3
remote:        Installing polyglot 0.3.3
remote:        Fetching treetop 1.4.12
remote:        Installing treetop 1.4.12
remote:        Fetching mail 2.4.4
remote:        Installing mail 2.4.4
remote:        Fetching actionmailer 3.2.11
remote:        Installing actionmailer 3.2.11
remote:        Fetching arel 3.0.2
remote:        Installing arel 3.0.2
remote:        Fetching tzinfo 0.3.35
remote:        Installing tzinfo 0.3.35
remote:        Fetching activerecord 3.2.11
remote:        Installing activerecord 3.2.11
remote:        Fetching activeresource 3.2.11
remote:        Installing activeresource 3.2.11
remote:        Using bundler 1.17.2
remote:        Fetching coffee-script-source 1.4.0
remote:        Installing coffee-script-source 1.4.0
remote:        Fetching execjs 1.4.0
remote:        Installing execjs 1.4.0
remote:        Fetching coffee-script 2.2.0
remote:        Installing coffee-script 2.2.0
remote:        Fetching rack-ssl 1.3.2
remote:        Installing rack-ssl 1.3.2
remote:        Fetching json 1.7.6
remote:        Installing json 1.7.6 with native extensions
remote:        Fetching rdoc 3.12
remote:        Installing rdoc 3.12
remote:        Fetching thor 0.16.0
remote:        Installing thor 0.16.0
remote:        Fetching railties 3.2.11
remote:        Installing railties 3.2.11
remote:        Fetching coffee-rails 3.2.2
remote:        Installing coffee-rails 3.2.2
remote:        Fetching jquery-rails 2.2.0
remote:        Installing jquery-rails 2.2.0
remote:        Fetching pg 0.14.1
remote:        Installing pg 0.14.1 with native extensions
remote:        Fetching rails 3.2.11
remote:        Installing rails 3.2.11
remote:        Fetching sass 3.2.5
remote:        Installing sass 3.2.5
remote:        Fetching sass-rails 3.2.6
remote:        Installing sass-rails 3.2.6
remote:        Fetching uglifier 1.3.0
remote:        Installing uglifier 1.3.0
remote:        Bundle complete! 6 Gemfile dependencies, 40 gems now installed.
remote:        Gems in the groups development and test were not installed.
remote:        Bundled gems are installed into `./vendor/bundle`
remote:        Post-install message from rdoc:
remote:        Depending on your version of ruby, you may need to install ruby rdoc/ri data:
remote:
remote:        <= 1.8.6 : unsupported
remote:         = 1.8.7 : gem install rdoc-data; rdoc-data --install
remote:         = 1.9.1 : gem install rdoc-data; rdoc-data --install
remote:        >= 1.9.2 : nothing to do! Yay!
remote:        Bundle completed (14.08s)
remote:        Cleaning up the bundler cache.
remote: -----> Writing config/database.yml to read from DATABASE_URL
remote: -----> Installing node-v8.10.0-linux-x64
remote: -----> Detecting rake tasks
remote: -----> Preparing app for Rails asset pipeline
remote:        Running: rake assets:precompile
remote:        DEPRECATION WARNING: You have Rails 2.3-style plugins in vendor/plugins! Support for these plugins will be removed in Rails 4.0. Move them out and bundle them in your Gemfile, or fold them in to your app as lib/myplugin/* and config/initializers/myplugin.rb. See the release notes for more on this: http://weblog.rubyonrails.org/2012/1/4/rails-3-2-0-rc2-has-been-released. (called from <top (required)> at /tmp/build_d734e3b0c78f48698e0d4217410bcdd9/Rakefile:7)
remote:        DEPRECATION WARNING: You have Rails 2.3-style plugins in vendor/plugins! Support for these plugins will be removed in Rails 4.0. Move them out and bundle them in your Gemfile, or fold them in to your app as lib/myplugin/* and config/initializers/myplugin.rb. See the release notes for more on this: http://weblog.rubyonrails.org/2012/1/4/rails-3-2-0-rc2-has-been-released. (called from <top (required)> at /tmp/build_d734e3b0c78f48698e0d4217410bcdd9/Rakefile:7)
remote:        DEPRECATION WARNING: You have Rails 2.3-style plugins in vendor/plugins! Support for these plugins will be removed in Rails 4.0. Move them out and bundle them in your Gemfile, or fold them in to your app as lib/myplugin/* and config/initializers/myplugin.rb. See the release notes for more on this: http://weblog.rubyonrails.org/2012/1/4/rails-3-2-0-rc2-has-been-released. (called from <top (required)> at /tmp/build_d734e3b0c78f48698e0d4217410bcdd9/Rakefile:7)
remote:        DEPRECATION WARNING: You have Rails 2.3-style plugins in vendor/plugins! Support for these plugins will be removed in Rails 4.0. Move them out and bundle them in your Gemfile, or fold them in to your app as lib/myplugin/* and config/initializers/myplugin.rb. See the release notes for more on this: http://weblog.rubyonrails.org/2012/1/4/rails-3-2-0-rc2-has-been-released. (called from <top (required)> at /tmp/build_d734e3b0c78f48698e0d4217410bcdd9/Rakefile:7)
remote:        Asset precompilation completed (6.29s)
remote: -----> Detecting rails configuration
remote:
remote: ###### WARNING:
remote:
remote:        Injecting plugin 'rails_log_stdout'
remote:
remote: ###### WARNING:
remote:
remote:        Injecting plugin 'rails3_serve_static_assets'
remote:
remote: ###### WARNING:
remote:
remote:        Add 'rails_12factor' gem to your Gemfile to skip plugin injection
remote:
remote: ###### WARNING:
remote:
remote:        No Procfile detected, using the default web server.
remote:        We recommend explicitly declaring how to boot your server process via a Procfile.
remote:        https://devcenter.heroku.com/articles/ruby-default-web-server
remote:
remote:
remote: -----> Discovering process types
remote:        Procfile declares types     -> (none)
remote:        Default types for buildpack -> console, rake, web
remote:
remote: -----> Compressing...
remote:        Done: 31.9M
remote: -----> Launching...
remote:        Released v6
remote:        https://glacial-ravine-68630.herokuapp.com/ deployed to Heroku
remote:
remote:  !   Warning: You are running on a deprecated stack.
remote:  !   Please upgrade to the latest stack by following the instructions on:
remote:  !   https://devcenter.heroku.com/articles/upgrading-to-the-latest-stack
remote:
remote: Verifying deploy... done.
To https://git.heroku.com/glacial-ravine-68630.git
 * [new branch]      master -> master
```

