### PR TITLE
Change default setting allow_sudo is 'false'

### DIFF
--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -282,8 +282,7 @@ module Bundler
 
     def allow_sudo?
       key = key_for(:path)
-      path_configured = @temporary.key?(key) || @local_config.key?(key)
-      !path_configured
+      @temporary.key?(key) || @local_config.key?(key)
     end
 
     def ignore_config?


### PR DESCRIPTION
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was very Danger

### What was your diagnosis of the problem?

If your `/etc/sudoers` set `NOPASSWD`
look like:
```
%wheel ALL=(ALL) NOPASSWD: ALL
```
bunlde install default install to my `/usr/lib`

But I don't know, there is no need for me to confirm

So. very Danger

### What is your fix for the problem, implemented in this PR?

default setting disable sudo
