### PR TITLE
add bundle-remove entry to bundler man page

### DIFF
--- a/man/bundle.ronn
+++ b/man/bundle.ronn
@@ -94,6 +94,9 @@ We divide `bundle` subcommands into primary commands and utilities:
 * [`bundle doctor(1)`](bundle-doctor.1.html):
   Display warnings about common problems
 
+* [`bundle remove(1)`](bundle-remove.1.html):
+  Removes gems from the Gemfile
+
 ## PLUGINS
 
 When running a command that isn't listed in PRIMARY COMMANDS or UTILITIES,


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The manual entry for `bundle remove` was missing in `bundle.ronn`

### What was your diagnosis of the problem?

See #6846

Fixes #6846