### PR TITLE
Add missing space inside block braces

### DIFF
--- a/lib/bundler/templates/newgem/Gemfile.tt
+++ b/lib/bundler/templates/newgem/Gemfile.tt
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in <%= config[:name] %>.gemspec
 gemspec


### PR DESCRIPTION

### What was the end-user problem that led to this PR?

When using `bundle gem GEM_NAME`, the Gemfile bundler generated was missing a space in the `git_source(:github)` block