### PR TITLE
stop circular require warnings - guard require "rubygems"

### DIFF
--- a/lib/bundler/compatibility_guard.rb
+++ b/lib/bundler/compatibility_guard.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: false
 
-require "rubygems"
+require "rubygems" unless Object.const_defined? :Gem
 require "bundler/version"
 
 if Bundler::VERSION.split(".").first.to_i >= 2

--- a/lib/bundler/rubygems_ext.rb
+++ b/lib/bundler/rubygems_ext.rb
@@ -7,8 +7,7 @@ if defined?(Gem::QuickLoader)
   Gem::QuickLoader.load_full_rubygems_library
 end
 
-require "rubygems"
-require "rubygems/specification"
+require "rubygems" unless Object.const_defined? :Gem
 
 begin
   # Possible use in Gem::Specification#source below and require

--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "monitor"
-require "rubygems"
+require "rubygems" unless Object.const_defined? :Gem
 require "rubygems/config_file"
 
 module Bundler

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -3,7 +3,7 @@
 require "bundler/compatibility_guard"
 
 require "pathname"
-require "rubygems"
+require "rubygems" unless Object.const_defined? :Gem
 
 require "bundler/version"
 require "bundler/constants"

--- a/lib/bundler/version.rb
+++ b/lib/bundler/version.rb
@@ -11,7 +11,7 @@ module Bundler
 
   def self.overwrite_loaded_gem_version
     begin
-      require "rubygems"
+      require "rubygems" unless Object.const_defined? :Gem
     rescue LoadError
       return
     end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Testing rubygems/rubygems with warnings on, specifically, `test_gem.rb`.  Several 'circular require' warnings.

### What was your diagnosis of the problem?

RubyGems gets required, then requires Bundler.  Several places in Bundler then require RubyGems.

### What is your fix for the problem, implemented in this PR?

Guard the RubyGems requires.  Note that rubygems/specification is one of the few files loaded by RubyGems, most are autoload.  I kept adding guards until all warnings were removed.

### Why did you choose this fix out of the possible options?

Unaware of other possible options