### PR TITLE
Include URL in Bundler::Fetcher::FallbackError message for Net::HTTPNotFound

### DIFF
--- a/lib/bundler/fetcher/downloader.rb
+++ b/lib/bundler/fetcher/downloader.rb
@@ -37,7 +37,7 @@ module Bundler
         when Net::HTTPUnauthorized
           raise AuthenticationRequiredError, uri.host
         when Net::HTTPNotFound
-          raise FallbackError, "Net::HTTPNotFound: #{uri}"
+          raise FallbackError, "Net::HTTPNotFound: #{URICredentialsFilter.credential_filtered_uri(uri)}"
         else
           raise HTTPError, "#{response.class}#{": #{response.body}" unless response.body.empty?}"
         end

--- a/spec/bundler/fetcher/downloader_spec.rb
+++ b/spec/bundler/fetcher/downloader_spec.rb
@@ -91,6 +91,15 @@ RSpec.describe Bundler::Fetcher::Downloader do
         expect { subject.fetch(uri, options, counter) }.
           to raise_error(Bundler::Fetcher::FallbackError, "Net::HTTPNotFound: http://www.uri-to-fetch.com/api/v2/endpoint")
       end
+
+      context "when the there are credentials provided in the request" do
+        let(:uri) { URI("http://username:password@www.uri-to-fetch.com/api/v2/endpoint") }
+
+        it "should raise a Bundler::Fetcher::FallbackError that doesn't contain the password" do
+          expect { subject.fetch(uri, options, counter) }.
+            to raise_error(Bundler::Fetcher::FallbackError, "Net::HTTPNotFound: http://username@www.uri-to-fetch.com/api/v2/endpoint")
+        end
+      end
     end
 
     context "when the request response is some other type" do


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

It was really painful to debug persistent NotFound errors, as it wasn't clear where they were coming from,

### What was your diagnosis of the problem?

Bundler was obfuscating the URL that wasn't found unnecessarily.

### What is your fix for the problem, implemented in this PR?

My fix is to add the URL to the `Bundler::Fetcher::FallbackError` message for `Net::HTTPNotFound` errors.

### Why did you choose this fix out of the possible options?

I chose this fix because it was simple and easy to test.