### PR TITLE
Lower required RubyGems to 2.5 or greater

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,21 @@ matrix:
     # 3.x mode
     - rvm: 2.5.3
       env: RGV=v3.0.1 BUNDLER_SPEC_SUB_VERSION=3.0.0
+    # Ruby 2.5, Rubygems 2.7 and up
+    - rvm: 2.5.3
+      env: RGV=v2.7.7
+    # Ruby 2.4, Rubygems 2.6 and up
+    - rvm: 2.4.5
+      env: RGV=v2.6.14
+    - rvm: 2.4.5
+      env: RGV=v2.7.7
+    # Ruby 2.3, Rubygems 2.5 and up
+    - rvm: 2.3.7
+      env: RGV=v2.5.2
+    - rvm: 2.3.7
+      env: RGV=v2.6.14
+    - rvm: 2.3.7
+      env: RGV=v2.7.7
     # Ruby-head (we want to know how we're doing, but not fail the build)
     - rvm: ruby-head
       env: RGV=master

--- a/bundler.gemspec
+++ b/bundler.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
 
   if s.version >= Gem::Version.new("2.a".dup)
     s.required_ruby_version     = ">= 2.3.0"
-    s.required_rubygems_version = ">= 3.0.0"
+    s.required_rubygems_version = ">= 2.5.0"
   else
     s.required_ruby_version     = ">= 1.8.7"
     s.required_rubygems_version = ">= 1.3.6"


### PR DESCRIPTION
It turns out that every existing version of RubyGems will ignore the required RubyGems version and try to install the newest version of Bundler... until the middle of the install, when it will raise an exception and fail. This PR tries to fix that in the least-bad way possible.

### What was the end-user problem that led to this PR?

The end user problem is that running `gem install bundler` now produces an exception on any Ruby and RubyGems older than 2.6 or 3.0 respectively.

### What was your diagnosis of the problem?

Unfortunately, RubyGems does not use the `required_rubygems_version` to select an older version of Bundler to install. Instead, RubyGems tries to install the newest version even though that version is not compatible, and then raises an exception during installation because it is not compatible.

### What is your fix for the problem, implemented in this PR?

Lower the `required_rubygems_version` in Bundler 2 back down to RubyGems 2.5 or greater.

### Why did you choose this fix out of the possible options?

I chose this fix because it will stop RubyGems from raising an exception while installing Bundler 2, and instead allow the installation to complete successfully.

There are some bugfixes in RubyGems 3 that improve the quality of life for Bundler 2 users, but they are less bad than RubyGems simply exploding anytime you try to run `gem install bundler`.