### PR TITLE
Fix Travis head, remove RG 2.7.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,15 @@
 language: ruby
 script: rake spec:travis
 before_script:
+  # fix Travis trunk build as of 2019-01-05
+  - |
+    rv="$(ruby -e 'STDOUT.write RUBY_VERSION')";
+    if [ "$rv" = "2.7.0" ]; then
+      lib="$(ruby -e 'STDOUT.write RbConfig::CONFIG["sitelibdir"]')";
+      echo "Processing 2.7.0 - $lib";
+      rm -rf $lib/rubygems;
+      rm -f  $lib/rubygems.rb $lib/ubygems.rb;
+    fi
   - travis_retry rake -E 'module ::Bundler; VERSION = "0.0.0"; end' override_version
   - travis_retry rake spec:travis:deps
   - travis_retry rake man:build


### PR DESCRIPTION
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

As of 2019-01-05, Travis is installing RG 2.7.7 in ruby trunk.  Fix removes it.

### What was your diagnosis of the problem?

My diagnosis was...

### What is your fix for the problem, implemented in this PR?

My fix...

### Why did you choose this fix out of the possible options?

I chose this fix because...
