### PR TITLE
Remove unnecessary condition

### DIFF
--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -19,7 +19,7 @@ module Bundler
     def self.settings_method(name, key, &default)
       define_method(name) do
         value = Bundler.settings[key]
-        value = instance_eval(&default) if value.nil? && !default.nil?
+        value = instance_eval(&default) if value.nil?
         value
       end
     end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that some code in the feature flags implementation seemed uncovered.

### What was your diagnosis of the problem?

My diagnosis was that the code should be either covered or removed.

### What is your fix for the problem, implemented in this PR?

My fix was to remove the code.

### Why did you choose this fix out of the possible options?

I chose this fix because the scenario where that code would get covered is more likely to be unintentional and risk introducing a bug. Defining a feature flag without a default block is the same as don't defining a feature flag and just relying on the default value for the setting. In these circumstances, it's more likely that the developer forgot to include a default block, so letting that case crash would be better, I think.