### PR TITLE
Don't check for the existence of a writable home directory if BUNDLE_USER_HOME is set

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -198,19 +198,19 @@ module Bundler
     def user_bundle_path(dir = "home")
       env_var, fallback = case dir
                           when "home"
-                            ["BUNDLE_USER_HOME", Pathname.new(user_home).join(".bundle")]
+                            ["BUNDLE_USER_HOME", proc { Pathname.new(user_home).join(".bundle") }]
                           when "cache"
-                            ["BUNDLE_USER_CACHE", user_bundle_path.join("cache")]
+                            ["BUNDLE_USER_CACHE", proc { user_bundle_path.join("cache") }]
                           when "config"
-                            ["BUNDLE_USER_CONFIG", user_bundle_path.join("config")]
+                            ["BUNDLE_USER_CONFIG", proc { user_bundle_path.join("config") }]
                           when "plugin"
-                            ["BUNDLE_USER_PLUGIN", user_bundle_path.join("plugin")]
+                            ["BUNDLE_USER_PLUGIN", proc { user_bundle_path.join("plugin") }]
                           else
                             raise BundlerError, "Unknown user path requested: #{dir}"
       end
       # `fallback` will already be a Pathname, but Pathname.new() is
       # idempotent so it's OK
-      Pathname.new(ENV.fetch(env_var, fallback))
+      Pathname.new(ENV.fetch(env_var, &fallback))
     end
 
     def user_cache

--- a/spec/bundler/bundler_spec.rb
+++ b/spec/bundler/bundler_spec.rb
@@ -465,6 +465,7 @@ MESSAGE
 
       it "should use custom home path as root for other paths" do
         ENV["BUNDLE_USER_HOME"] = bundle_user_home_custom.to_s
+        allow(Bundler.rubygems).to receive(:user_home).and_raise
         expect(Bundler.user_bundle_path).to           eq(bundle_user_home_custom)
         expect(Bundler.user_bundle_path("home")).to   eq(bundle_user_home_custom)
         expect(Bundler.user_bundle_path("cache")).to  eq(bundle_user_home_custom.join("cache"))


### PR DESCRIPTION
#6024 added support for specifying an alternate bundler home directory via the `BUNDLE_USER_HOME` environment variable. Unfortunately bundler still checks for a writable user home directory even if the `BUNDLE_USER_HOME` override is specified resulting in warnings like this:
```
`/home/appuser` is not a directory.
Bundler will use `/tmp/bundler/home/unknown' as your home directory temporarily.
```
The fix for this problem is to only evaluate bundler path fallbacks if environment variable overrides are not specified.