### PR TITLE
Add output to bundle info to show the dependent gems

### DIFF
--- a/lib/bundler/cli/info.rb
+++ b/lib/bundler/cli/info.rb
@@ -74,8 +74,9 @@ module Bundler
     end
 
     def specs_as_tree(specs)
-      specs.each_with_object({}) do |spec, hash|
+      specs.inject({}) do |hash, spec|
         hash[spec.name] = spec
+        hash
       end
     end
 

--- a/lib/bundler/cli/info.rb
+++ b/lib/bundler/cli/info.rb
@@ -14,6 +14,7 @@ module Bundler
       spec_not_found(gem_name) unless spec
       return print_gem_path(spec) if @options[:path]
       print_gem_info(spec)
+      print_gem_dependencies(gem_name)
     end
 
   private
@@ -45,6 +46,65 @@ module Bundler
       gem_info << "\tPath: #{spec.full_gem_path}\n"
       gem_info << "\tDefault Gem: yes" if spec.respond_to?(:default_gem?) && spec.default_gem?
       Bundler.ui.info gem_info
+    end
+
+    def print_gem_dependencies(spec)
+      top_level_dependencies = summarize(spec)
+
+      stat_info = String.new
+      stat_info << "\tDependents:\n"
+      if top_level_dependencies.count > 0
+        top_level_dependencies.each do |stat_line|
+          stat_info << format("\t\t%s (%s)\n", stat_line[:name], stat_line[:version])
+        end
+      else
+        stat_info << "\t\tNone"
+      end
+
+      Bundler.ui.info stat_info
+    end
+
+    def summarize(spec)
+      definition = Bundler.definition
+      lockfile_contents = definition.to_lock
+      parser = Bundler::LockfileParser.new(lockfile_contents)
+      @tree = specs_as_tree(parser.specs)
+
+      reverse_dependencies_with_versions(spec)
+    end
+
+    def specs_as_tree(specs)
+      specs.each_with_object({}) do |spec, hash|
+        hash[spec.name] = spec
+      end
+    end
+
+    def transitive_dependencies(target)
+      raise ArgumentError, "Unknown gem #{target}" unless @tree.key? target
+
+      top_level = @tree[target].dependencies
+      all_level = top_level + top_level.inject([]) do |arr, dep|
+        next arr if dep.name == "bundler"
+
+        arr + transitive_dependencies(dep.name)
+      end
+
+      all_level.uniq(&:name)
+    end
+
+    def reverse_dependencies_with_versions(target)
+      @tree.map do |name, dep|
+        transitive_dependencies(name).map do |transitive_dependency|
+          next unless transitive_dependency.name == target
+          {
+            :name => dep.name,
+            :version => transitive_dependency.requirement.to_s,
+            :requirement => transitive_dependency.requirement,
+          }
+        end
+      end.flatten.compact.sort do |a, b|
+        a[:requirement].as_list <=> b[:requirement].as_list
+      end
     end
   end
 end

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -9,6 +9,11 @@ RSpec.describe "bundle info" do
       G
     end
 
+    it "prints the gems dependent on the gem in argument" do
+      bundle "info rails"
+      expect(out).to include "\tDependents:\n\t\tNone"
+    end
+
     it "prints information about the current gem" do
       bundle "info rails"
       expect(out).to include "* rails (2.3.2)

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -5,13 +5,14 @@ RSpec.describe "bundle info" do
     before do
       install_gemfile <<-G
         source "file://#{gem_repo1}"
+        gem "rake"
         gem "rails"
       G
     end
 
     it "prints the gems dependent on the gem in argument" do
-      bundle "info rails"
-      expect(out).to include "\tDependents:\n\t\tNone"
+      bundle "info rake"
+      expect(out).to include "\tDependents:\n\t\trails (= 10.0.2)"
     end
 
     it "prints information about the current gem" do

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "bundle info" do
 
     it "prints the gems dependent on the gem in argument" do
       bundle "info rake"
-      expect(out).to include "\tDependents:\n\t\trails (= 10.0.2)"
+      expect(out).to include "\tDependents:\n\t\trails"
     end
 
     it "prints information about the current gem" do


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Fixes #6800 
- adds functionality to show the dependent gems

### What is your fix for the problem, implemented in this PR?

- Replicated the functionality from `bundler-stats` gem using jmmastey/bundler-stats#1 as a reference as mentioned in the issue
