### PR TITLE
Actually switch the default behavior of github sources.

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -290,25 +290,11 @@ module Bundler
         warn_deprecated_git_source(:github, <<-'RUBY'.strip, 'Change any "reponame" :github sources to "username/reponame".')
 "https://github.com/#{repo_name}.git"
         RUBY
-        # It would be better to use https instead of the git protocol, but this
-        # can break deployment of existing locked bundles when switching between
-        # different versions of Bundler. The change will be made in 2.0, which
-        # does not guarantee compatibility with the 1.x series.
-        #
-        # See https://github.com/bundler/bundler/pull/2569 for discussion
-        #
-        # This can be overridden by adding this code to your Gemfiles:
-        #
-        #   git_source(:github) do |repo_name|
-        #     repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
-        #     "https://github.com/#{repo_name}.git"
-        #   end
         repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
-        # TODO: 2.0 upgrade this setting to the default
-        if Bundler.settings["github.https"]
-          Bundler::SharedHelpers.major_deprecation 3, "The `github.https` setting will be removed"
+        if Bundler.feature_flag.github_https?
           "https://github.com/#{repo_name}.git"
         else
+          Bundler::SharedHelpers.major_deprecation 3, "Setting `github.https` to false is deprecated and won't be supported in the future."
           "git://github.com/#{repo_name}.git"
         end
       end

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Bundler::Dsl do
 
       it "converts :github to :git" do
         subject.gem("sparks", :github => "indirect/sparks")
-        github_uri = "git://github.com/indirect/sparks.git"
+        github_uri = "https://github.com/indirect/sparks.git"
         expect(subject.dependencies.first.source.uri).to eq(github_uri)
       end
 
@@ -62,7 +62,7 @@ RSpec.describe Bundler::Dsl do
 
       it "converts 'rails' to 'rails/rails'" do
         subject.gem("rails", :github => "rails")
-        github_uri = "git://github.com/rails/rails.git"
+        github_uri = "https://github.com/rails/rails.git"
         expect(subject.dependencies.first.source.uri).to eq(github_uri)
       end
 
@@ -253,7 +253,7 @@ RSpec.describe Bundler::Dsl do
         end
 
         subject.dependencies.each do |d|
-          expect(d.source.uri).to eq("git://github.com/spree/spree.git")
+          expect(d.source.uri).to eq("https://github.com/spree/spree.git")
         end
       end
     end

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -209,8 +209,8 @@ The :github git source is deprecated, and will be removed in Bundler 3.0. Change
         subject.gem("sparks", :github => "indirect/sparks")
       end
 
-      it "upgrades to https on request" do
-        Bundler.settings.temporary "github.https" => true
+      it "downgrades to http on request" do
+        Bundler.settings.temporary "github.https" => "false"
         msg = <<-EOS
 The :github git source is deprecated, and will be removed in Bundler 3.0. Change any "reponame" :github sources to "username/reponame". Add this code to the top of your Gemfile to ensure it continues to work:
 
@@ -218,9 +218,9 @@ The :github git source is deprecated, and will be removed in Bundler 3.0. Change
 
         EOS
         expect(Bundler::SharedHelpers).to receive(:major_deprecation).with(3, msg)
-        expect(Bundler::SharedHelpers).to receive(:major_deprecation).with(3, "The `github.https` setting will be removed")
+        expect(Bundler::SharedHelpers).to receive(:major_deprecation).with(3, "Setting `github.https` to false is deprecated and won't be supported in the future.")
         subject.gem("sparks", :github => "indirect/sparks")
-        github_uri = "https://github.com/indirect/sparks.git"
+        github_uri = "git://github.com/indirect/sparks.git"
         expect(subject.dependencies.first.source.uri).to eq(github_uri)
       end
     end


### PR DESCRIPTION
This fixes #6910. I also took this opportunity to remove some other code
that the comments imply should have been removed in 2.0, but it looks
like never actually got removed.