### PR TITLE
Remove TODO label from default options of gemspec metadata

### DIFF
--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -24,8 +24,8 @@ Gem::Specification.new do |spec|
   spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
 
   spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "TODO: Put your gem's public repo URL here."
-  spec.metadata["changelog_uri"] = "TODO: Put your gem's CHANGELOG.md URL here."
+  spec.metadata["source_code_uri"] = "Put your gem's public repo URL here."
+  spec.metadata["changelog_uri"] = "Put your gem's CHANGELOG.md URL here."
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

When invoking `bundle install` on project directory, It shows the error of bundler.

### What was your diagnosis of the problem?

Bundler put the needless `TODO` label from gemspec template.

### What is your fix for the problem, implemented in this PR?

I removed TODO label from gemspec. They are not always provided at all times.

### Why did you choose this fix out of the possible options?

I understood this metadata was useful, But `TODO:` is unnecessary at first time of `bundle gem`.