### PR TITLE
Ignore `Object =~` warnings.

### DIFF
--- a/bundler.gemspec
+++ b/bundler.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "automatiek", "~> 0.1.0"
   s.add_development_dependency "mustache",   "0.99.6"
-  s.add_development_dependency "rake",       "~> 10.0"
+  s.add_development_dependency "rake",       "~> 12.0"
   s.add_development_dependency "rdiscount",  "~> 2.2"
   s.add_development_dependency "ronn",       "~> 0.7.3"
   s.add_development_dependency "rspec",      "~> 3.6"

--- a/spec/support/less_than_proc.rb
+++ b/spec/support/less_than_proc.rb
@@ -6,7 +6,7 @@ class LessThanProc < Proc
   def self.with(present)
     provided = Gem::Version.new(present.dup)
     new do |required|
-      if required =~ /[=><~]/
+      if required.is_a?(String) && required =~ /[=><~]/
         !Gem::Requirement.new(required).satisfied_by?(provided)
       else
         provided < Gem::Version.new(required)


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

We faced a lot of warnings with `rake spec` of bundler repository.

### What was your diagnosis of the problem?

Ruby 2.7.0-dev added the warnings for `Object =~` comparison. 

### What is your fix for the problem, implemented in this PR?

I added the additional condition and bump a version of the development dependency.



