### PR TITLE
Bump rake version to 12.0 on gemspec template

### DIFF
--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
 <%- end -%>
 
   spec.add_development_dependency "bundler", "~> <%= config[:bundler_version] %>"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 12.0"
 <%- if config[:ext] -%>
   spec.add_development_dependency "rake-compiler"
 <%- end -%>

--- a/spec/commands/lock_spec.rb
+++ b/spec/commands/lock_spec.rb
@@ -38,8 +38,8 @@ RSpec.describe "bundle lock" do
             actionpack (= 2.3.2)
             activerecord (= 2.3.2)
             activeresource (= 2.3.2)
-            rake (= 10.0.2)
-          rake (10.0.2)
+            rake (= 12.3.2)
+          rake (12.3.2)
           with_license (1.0)
 
       PLATFORMS
@@ -133,7 +133,7 @@ RSpec.describe "bundle lock" do
   end
 
   it "update specific gems using --update" do
-    lockfile @lockfile.gsub("2.3.2", "2.3.1").gsub("10.0.2", "10.0.1")
+    lockfile @lockfile.gsub("2.3.2", "2.3.1").gsub("12.3.2", "10.0.1")
 
     bundle "lock --update rails rake"
 

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -197,7 +197,7 @@ RSpec.describe "bundle gem" do
     end
 
     Dir.chdir(bundled_app("newgem")) do
-      gems = ["rake-10.0.2", :bundler]
+      gems = ["rake-12.3.2", :bundler]
       # for Ruby core repository, Ruby 2.6+ has bundler as standard library.
       gems.delete(:bundler) if ruby_core?
       system_gems gems, :path => :bundle_path
@@ -303,7 +303,7 @@ RSpec.describe "bundle gem" do
     end
 
     it "runs rake without problems" do
-      system_gems ["rake-10.0.2"]
+      system_gems ["rake-12.3.2"]
 
       rakefile = strip_whitespace <<-RAKEFILE
         task :default do
@@ -585,7 +585,7 @@ RSpec.describe "bundle gem" do
     end
 
     it "runs rake without problems" do
-      system_gems ["rake-10.0.2"]
+      system_gems ["rake-12.3.2"]
 
       rakefile = strip_whitespace <<-RAKEFILE
         task :default do

--- a/spec/commands/show_spec.rb
+++ b/spec/commands/show_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe "bundle show" do
     it "prints path of all gems in bundle sorted by name", :bundler => "< 2" do
       bundle "show --paths"
 
-      expect(out).to include(default_bundle_path("gems", "rake-10.0.2").to_s)
+      expect(out).to include(default_bundle_path("gems", "rake-12.3.2").to_s)
       expect(out).to include(default_bundle_path("gems", "rails-2.3.2").to_s)
 
       # Gem names are the last component of their path.
@@ -92,7 +92,7 @@ RSpec.describe "bundle show" do
     it "prints path of all gems in bundle sorted by name", :bundler => "2" do
       bundle "show --paths"
 
-      expect(out).to include(default_bundle_path("gems", "rake-10.0.2").to_s)
+      expect(out).to include(default_bundle_path("gems", "rake-12.3.2").to_s)
       expect(out).to include(default_bundle_path("gems", "rails-2.3.2").to_s)
 
       out_lines = out.split("\n")

--- a/spec/install/gemfile/gemspec_spec.rb
+++ b/spec/install/gemfile/gemspec_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe "bundle install from an existing gemspec" do
     build_lib("foo", :path => tmp.join("foo")) do |s|
       s.write("Gemfile", "source 'file://#{gem_repo1}'\ngemspec")
       s.add_dependency "actionpack", "=2.3.2"
-      s.add_development_dependency "rake", "=10.0.2"
+      s.add_development_dependency "rake", "=12.3.2"
     end
 
     Dir.chdir(tmp.join("foo")) do

--- a/spec/install/gems/compact_index_spec.rb
+++ b/spec/install/gems/compact_index_spec.rb
@@ -915,7 +915,7 @@ The checksum of /versions does not match the checksum provided by the server! So
       source "#{source_uri}"
       gem "rails"
     G
-    deps = [Gem::Dependency.new("rake", "= 10.0.2"),
+    deps = [Gem::Dependency.new("rake", "= 12.3.2"),
             Gem::Dependency.new("actionpack", "= 2.3.2"),
             Gem::Dependency.new("activerecord", "= 2.3.2"),
             Gem::Dependency.new("actionmailer", "= 2.3.2"),

--- a/spec/lock/lockfile_bundler_1_spec.rb
+++ b/spec/lock/lockfile_bundler_1_spec.rb
@@ -737,8 +737,8 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
             actionpack (= 2.3.2)
             activerecord (= 2.3.2)
             activeresource (= 2.3.2)
-            rake (= 10.0.2)
-          rake (10.0.2)
+            rake (= 12.3.2)
+          rake (12.3.2)
 
       PLATFORMS
         #{generic_local_platform}

--- a/spec/lock/lockfile_spec.rb
+++ b/spec/lock/lockfile_spec.rb
@@ -772,8 +772,8 @@ RSpec.describe "the lockfile format", :bundler => "2" do
             actionpack (= 2.3.2)
             activerecord (= 2.3.2)
             activeresource (= 2.3.2)
-            rake (= 10.0.2)
-          rake (10.0.2)
+            rake (= 12.3.2)
+          rake (12.3.2)
 
       PLATFORMS
         #{lockfile_platforms}

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe "Bundler.setup" do
         "/gems/actionpack-2.3.2/lib",
         "/gems/actionmailer-2.3.2/lib",
         "/gems/activesupport-2.3.2/lib",
-        "/gems/rake-10.0.2/lib"
+        "/gems/rake-12.3.2/lib"
       )
     end
 

--- a/spec/support/builders.rb
+++ b/spec/support/builders.rb
@@ -40,7 +40,7 @@ module Spec
 
         build_gem "rails", "2.3.2" do |s|
           s.executables = "rails"
-          s.add_dependency "rake",           "10.0.2"
+          s.add_dependency "rake",           "12.3.2"
           s.add_dependency "actionpack",     "2.3.2"
           s.add_dependency "activerecord",   "2.3.2"
           s.add_dependency "actionmailer",   "2.3.2"

--- a/spec/support/rubygems_ext.rb
+++ b/spec/support/rubygems_ext.rb
@@ -19,7 +19,7 @@ module Spec
         "compact_index" => "~> 0.11.0",
         "sinatra" => "~> 1.4.7",
         # Rake version has to be consistent for tests to pass
-        "rake" => "10.0.2",
+        "rake" => "12.3.2",
         # 3.0.0 breaks 1.9.2 specs
         "builder" => "2.1.2",
       }


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Related with https://github.com/bundler/bundler/pull/6923

### What was your diagnosis of the problem?

rake-10.x displayed the warnings of `Object =~` with Ruby 2.7.0-dev.

### What is your fix for the problem, implemented in this PR?

Rake 10.0 is EOL. I'm a maintainer of Rake. I have no plan to avoid `Object =~` warnings with Rake 10.x.

