### PR TITLE
Add bundle lock --update --bundler

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -638,6 +638,8 @@ module Bundler
       "If updating, do not allow any gem to be updated past latest --patch | --minor | --major"
     method_option "conservative", :type => :boolean, :banner =>
       "If updating, use bundle install conservative update behavior and do not allow shared dependencies to be updated"
+    method_option "bundler", :type => :string, :lazy_default => "> 0.a", :banner =>
+      "Update the locked version of bundler"
     def lock
       require "bundler/cli/lock"
       Lock.new(options).run

--- a/lib/bundler/cli/lock.rb
+++ b/lib/bundler/cli/lock.rb
@@ -23,7 +23,7 @@ module Bundler
       update = options[:update]
       if update.is_a?(Array) # unlocking specific gems
         Bundler::CLI::Common.ensure_all_gems_in_lockfile!(update)
-        update = { :gems => update, :lock_shared_dependencies => options[:conservative] }
+        update = { :gems => update, :lock_shared_dependencies => options[:conservative], :bundler => options[:bundler] }
       end
       definition = Bundler.definition(update)
 

--- a/spec/commands/lock_spec.rb
+++ b/spec/commands/lock_spec.rb
@@ -360,3 +360,24 @@ RSpec.describe "bundle lock" do
     end
   end
 end
+
+RSpec.describe "bundle update --bundler" do
+  it "updates the bundler version in the lockfile without re-resolving" do
+    build_repo4 do
+      build_gem "rack", "1.0"
+    end
+
+    install_gemfile! <<-G
+      source "file:#{gem_repo4}"
+      gem "rack"
+    G
+    lockfile lockfile.sub(/(^\s*)#{Bundler::VERSION}($)/, '\11.0.0\2')
+
+    FileUtils.rm_r gem_repo4
+
+    bundle! :update, :bundler => true, :verbose => true
+    expect(the_bundle).to include_gem "rack 1.0"
+
+    expect(the_bundle.locked_gems.bundler_version).to eq v(Bundler::VERSION)
+  end
+end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that I couldn't generate a Bundler 2.0 lockfile on a machine that doesn't have the libraries available to be able to build native extensions, which is part of my normal workflow.

### What was your diagnosis of the problem?

My diagnosis was that `bundle lock --update`, which I can usually use instead of `bundle update`, didn't support the `--bundler` switch like `bundle update` does.

### What is your fix for the problem, implemented in this PR?

My fix implements the `--bundler` flag for `bundle lock --update`.

### Why did you choose this fix out of the possible options?

I chose this fix because I think it makes sense for `bundle lock --update` to remain consistent with `bundle update`, except for not actually installing gems.