### PR TITLE
Move Rubocop development dependency into gemspec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -43,7 +43,6 @@ namespace :spec do
     deps = Hash[bundler_spec.development_dependencies.map do |d|
       [d.name, d.requirement.to_s]
     end]
-    deps["rubocop"] ||= "= 0.50.0" if RUBY_VERSION >= "2.0.0" # can't go in the gemspec because of the ruby version requirement
 
     # JRuby can't build ronn or rdiscount, so we skip that
     if defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby"
@@ -95,13 +94,9 @@ begin
   RSpec::Core::RakeTask.new
   task :spec => "man:build"
 
-  if RUBY_VERSION >= "2.0.0"
-    # can't go in the gemspec because of the ruby version requirement
-    gem "rubocop", "= 0.50.0"
-    require "rubocop/rake_task"
-    rubocop = RuboCop::RakeTask.new
-    rubocop.options = ["--parallel"]
-  end
+  require "rubocop/rake_task"
+  rubocop = RuboCop::RakeTask.new
+  rubocop.options = ["--parallel"]
 
   namespace :spec do
     task :clean do

--- a/bundler.gemspec
+++ b/bundler.gemspec
@@ -46,6 +46,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rdiscount",  "~> 2.2"
   s.add_development_dependency "ronn",       "~> 0.7.3"
   s.add_development_dependency "rspec",      "~> 3.6"
+  s.add_development_dependency "rubocop",    "= 0.50.0"
 
   base_dir = File.dirname(__FILE__).gsub(%r{([^A-Za-z0-9_\-.,:\/@\n])}, "\\\\\\1")
   s.files = IO.popen("git -C #{base_dir} ls-files -z", &:read).split("\x0").select {|f| f.match(%r{^(lib|exe)/}) }


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that tools like RubyGems.org or Bundix that use the gemspec as the source of truth for dependencies didn't pick up on the development dependency on Rubocop.

### What was your diagnosis of the problem?

My diagnosis was that the reason for this, which was that Rubocop had a minimum Ruby version of 2.0.0, was no longer an issue, since Bundler 2 doesn't support Rubies that old anyway.

### What is your fix for the problem, implemented in this PR?

My fix was to move the Rubocop requirement into the gemspec.

### Why did you choose this fix out of the possible options?

I chose this fix because it addresses the problem I was having, feels right, and the old workaround doesn't look like it's necessary any more.