### PR TITLE
Stop gemspec requiring dependencies under Bundler

### DIFF
--- a/lib/bundler/version.rb
+++ b/lib/bundler/version.rb
@@ -14,6 +14,9 @@ module Bundler
       require "rubygems"
     rescue LoadError
       return
+    rescue StandardError => e
+      # We don't need Bundler's dependencies solely for VERSION in the gemspec.
+      raise unless defined?(Bundler::GemNotFound) && e.is_a?(Bundler::GemNotFound)
     end
     return unless bundler_spec = Gem.loaded_specs["bundler"]
     return if bundler_spec.version == VERSION


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that I couldn't use Bundler to set up an environment for hacking on Bundler, making it compatible with other Bundler-derived tools like Bundix.

### What was your diagnosis of the problem?

My diagnosis was that the gemspec requires bundler/version, which then requires rubygems. When running under Bundler, requiring rubygems tries to load all of Bundler's development dependencies.

### What is your fix for the problem, implemented in this PR?

My fix is to ignore missing development dependencies in bundler/version, so that it can be loaded by the gemspec under Bundler.

### Why did you choose this fix out of the possible options?

I chose this fix because I don't see any other ones, and I don't think this should have any impact outside of this edge case.