### PR TITLE
When a 401 response is received, raise BadAuthenticationError if credentials were present in the request URI

### DIFF
--- a/lib/bundler/fetcher/downloader.rb
+++ b/lib/bundler/fetcher/downloader.rb
@@ -35,6 +35,7 @@ module Bundler
         when Net::HTTPRequestEntityTooLarge
           raise FallbackError, response.body
         when Net::HTTPUnauthorized
+          raise BadAuthenticationError, uri.host if uri.userinfo
           raise AuthenticationRequiredError, uri.host
         when Net::HTTPNotFound
           raise FallbackError, "Net::HTTPNotFound: #{URICredentialsFilter.credential_filtered_uri(uri)}"

--- a/lib/bundler/fetcher/index.rb
+++ b/lib/bundler/fetcher/index.rb
@@ -13,6 +13,7 @@ module Bundler
         when /certificate verify failed/
           raise CertificateFailureError.new(display_uri)
         when /401/
+          raise BadAuthenticationError, remote_uri if remote_uri.userinfo
           raise AuthenticationRequiredError, remote_uri
         when /403/
           raise BadAuthenticationError, remote_uri if remote_uri.userinfo

--- a/spec/bundler/fetcher/downloader_spec.rb
+++ b/spec/bundler/fetcher/downloader_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Bundler::Fetcher::Downloader do
   let(:connection)     { double(:connection) }
   let(:redirect_limit) { 5 }
   let(:uri)            { URI("http://www.uri-to-fetch.com/api/v2/endpoint") }
+  let(:uri_with_creds) { URI("http://user:password@uri-to-fetch.com/api/v2/endpoint")}
   let(:options)        { double(:options) }
 
   subject { described_class.new(connection, redirect_limit) }
@@ -81,6 +82,15 @@ RSpec.describe Bundler::Fetcher::Downloader do
       it "should raise a Bundler::Fetcher::AuthenticationRequiredError with the uri host" do
         expect { subject.fetch(uri, options, counter) }.to raise_error(Bundler::Fetcher::AuthenticationRequiredError,
           /Authentication is required for www.uri-to-fetch.com/)
+      end
+
+      context "when the there are credentials provided in the request" do
+        let(:uri) { URI("http://user:password@www.uri-to-fetch.com") }
+
+        it "should raise a Bundler::Fetcher::BadAuthenticationError that doesn't contain the password" do
+          expect { subject.fetch(uri, options, counter) }.
+            to raise_error(Bundler::Fetcher::BadAuthenticationError, %r{Bad username or password for www.uri-to-fetch.com})
+        end
       end
     end
 

--- a/spec/bundler/fetcher/downloader_spec.rb
+++ b/spec/bundler/fetcher/downloader_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe Bundler::Fetcher::Downloader do
   let(:connection)     { double(:connection) }
   let(:redirect_limit) { 5 }
   let(:uri)            { URI("http://www.uri-to-fetch.com/api/v2/endpoint") }
-  let(:uri_with_creds) { URI("http://user:password@uri-to-fetch.com/api/v2/endpoint") }
   let(:options)        { double(:options) }
 
   subject { described_class.new(connection, redirect_limit) }

--- a/spec/bundler/fetcher/downloader_spec.rb
+++ b/spec/bundler/fetcher/downloader_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Bundler::Fetcher::Downloader do
   let(:connection)     { double(:connection) }
   let(:redirect_limit) { 5 }
   let(:uri)            { URI("http://www.uri-to-fetch.com/api/v2/endpoint") }
-  let(:uri_with_creds) { URI("http://user:password@uri-to-fetch.com/api/v2/endpoint")}
+  let(:uri_with_creds) { URI("http://user:password@uri-to-fetch.com/api/v2/endpoint") }
   let(:options)        { double(:options) }
 
   subject { described_class.new(connection, redirect_limit) }
@@ -89,7 +89,7 @@ RSpec.describe Bundler::Fetcher::Downloader do
 
         it "should raise a Bundler::Fetcher::BadAuthenticationError that doesn't contain the password" do
           expect { subject.fetch(uri, options, counter) }.
-            to raise_error(Bundler::Fetcher::BadAuthenticationError, %r{Bad username or password for www.uri-to-fetch.com})
+            to raise_error(Bundler::Fetcher::BadAuthenticationError, /Bad username or password for www.uri-to-fetch.com/)
         end
       end
     end

--- a/spec/bundler/fetcher/index_spec.rb
+++ b/spec/bundler/fetcher/index_spec.rb
@@ -35,9 +35,26 @@ RSpec.describe Bundler::Fetcher::Index do
       context "when a 401 response occurs" do
         let(:error_message) { "401" }
 
-        it "should raise a Bundler::Fetcher::AuthenticationRequiredError" do
-          expect { subject.specs(gem_names) }.to raise_error(Bundler::Fetcher::AuthenticationRequiredError,
-            %r{Authentication is required for http://remote-uri.org})
+        before do
+          allow(remote_uri).to receive(:userinfo).and_return(userinfo)
+        end
+
+        context "and there was userinfo" do
+          let(:userinfo) { double(:userinfo) }
+
+          it "should raise a Bundler::Fetcher::BadAuthenticationError" do
+            expect { subject.specs(gem_names) }.to raise_error(Bundler::Fetcher::BadAuthenticationError,
+              %r{Bad username or password for http://remote-uri.org})
+          end
+        end
+
+        context "and there was no userinfo" do
+          let(:userinfo) { nil }
+
+          it "should raise a Bundler::Fetcher::AuthenticationRequiredError" do
+            expect { subject.specs(gem_names) }.to raise_error(Bundler::Fetcher::AuthenticationRequiredError,
+              %r{Authentication is required for http://remote-uri.org})
+          end
         end
       end
 


### PR DESCRIPTION

### What was the end-user problem that led to this PR?

Some gem servers respond to bad username/password request with a 401 instead of a 403.

### What was your diagnosis of the problem?

When a 401 response was received, bundler would automatically assume no credentials were supplied, leading to a response of

```
Authentication is required for http://moto@gems.motologic.com/.
Please supply credentials for this source. You can do this by running:
 bundle config http://moto@gems.motologic.com/ username:password
```

even when a username and password was present in the bundler config.

### What is your fix for the problem, implemented in this PR?

There already exists a check for credentials in the request URI for 403 responses.  I took that pattern and implemented it for 401 responses as well.

### Why did you choose this fix out of the possible options?

I chose this fix because a very similar pattern already exists in bundler, I just applied the same logic to another response code.