### PR TITLE
Add patch option in bundle config

### DIFF
--- a/lib/bundler/cli/common.rb
+++ b/lib/bundler/cli/common.rb
@@ -80,7 +80,7 @@ module Bundler
 
     def self.configure_gem_version_promoter(definition, options)
       patch_level = patch_level_options(options)
-      patch_level.append(:patch) if patch_level.empty? && Bundler.settings[:prefer_patch]
+      patch_level << :patch if patch_level.empty? && Bundler.settings[:prefer_patch]
       raise InvalidOption, "Provide only one of the following options: #{patch_level.join(", ")}" unless patch_level.length <= 1
 
       definition.gem_version_promoter.tap do |gvp|

--- a/lib/bundler/cli/common.rb
+++ b/lib/bundler/cli/common.rb
@@ -80,7 +80,7 @@ module Bundler
 
     def self.configure_gem_version_promoter(definition, options)
       patch_level = patch_level_options(options)
-      patch_level.append(:patch) if patch_level.empty? && Bundler.settings[:patch]
+      patch_level.append(:patch) if patch_level.empty? && Bundler.settings[:prefer_patch]
       raise InvalidOption, "Provide only one of the following options: #{patch_level.join(", ")}" unless patch_level.length <= 1
 
       definition.gem_version_promoter.tap do |gvp|

--- a/lib/bundler/cli/common.rb
+++ b/lib/bundler/cli/common.rb
@@ -80,7 +80,9 @@ module Bundler
 
     def self.configure_gem_version_promoter(definition, options)
       patch_level = patch_level_options(options)
+      patch_level.append(:patch) if patch_level.empty? && Bundler.settings[:patch]
       raise InvalidOption, "Provide only one of the following options: #{patch_level.join(", ")}" unless patch_level.length <= 1
+
       definition.gem_version_promoter.tap do |gvp|
         gvp.level = patch_level.first || :major
         gvp.strict = options[:strict] || options["update-strict"] || options["filter-strict"]

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -45,11 +45,11 @@ module Bundler
       no_install
       no_prune
       only_update_to_newer_versions
-      patch
       path_relative_to_cwd
       path.system
       plugins
       prefer_gems_rb
+      prefer_patch
       print_only_version_number
       setup_makes_kernel_gem_public
       silence_root_warning
@@ -77,7 +77,7 @@ module Bundler
 
     DEFAULT_CONFIG = {
       :disable_version_check => true,
-      :patch => false,
+      :prefer_patch => false,
       :redirect => 5,
       :retry => 3,
       :timeout => 10,

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -9,7 +9,6 @@ module Bundler
     autoload :Validator, "bundler/settings/validator"
 
     BOOL_KEYS = %w[
-      patch
       allow_bundler_dependency_conflicts
       allow_deployment_source_credential_changes
       allow_offline_install
@@ -46,6 +45,7 @@ module Bundler
       no_install
       no_prune
       only_update_to_newer_versions
+      patch
       path_relative_to_cwd
       path.system
       plugins
@@ -77,10 +77,10 @@ module Bundler
 
     DEFAULT_CONFIG = {
       :disable_version_check => true,
+      :patch => false,
       :redirect => 5,
       :retry => 3,
       :timeout => 10,
-      :patch => false,
     }.freeze
 
     def initialize(root = nil)

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -9,6 +9,7 @@ module Bundler
     autoload :Validator, "bundler/settings/validator"
 
     BOOL_KEYS = %w[
+      patch
       allow_bundler_dependency_conflicts
       allow_deployment_source_credential_changes
       allow_offline_install
@@ -79,6 +80,7 @@ module Bundler
       :redirect => 5,
       :retry => 3,
       :timeout => 10,
+      :patch => false,
     }.freeze
 
     def initialize(root = nil)

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -220,8 +220,6 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
 * `only_update_to_newer_versions` (`BUNDLE_ONLY_UPDATE_TO_NEWER_VERSIONS`):
    During `bundle update`, only resolve to newer versions of the gems in the
    lockfile.
-* `patch` (BUNDLE_PATCH):
-   Whether to use patch update level, by default set to false.
 * `path` (`BUNDLE_PATH`):
    The location on disk where all gems in your bundle will be located regardless
    of `$GEM_HOME` or `$GEM_PATH` values. Bundle gems not found in this location
@@ -235,6 +233,8 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
    Enable Bundler's experimental plugin system.
 * `prefer_gems_rb` (`BUNDLE_PREFER_GEMS_RB`)
    Prefer `gems.rb` to `Gemfile` when Bundler is searching for a Gemfile.
+* `prefer_patch` (BUNDLE_PREFER_PATCH):
+   Prefer updating only to next patch version during updates. Makes `bundle update` calls equivalent to `bundler update --patch`.
 * `print_only_version_number` (`BUNDLE_PRINT_ONLY_VERSION_NUMBER`)
    Print only version number from `bundler --version`.
 * `redirect` (`BUNDLE_REDIRECT`):

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -220,6 +220,8 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
 * `only_update_to_newer_versions` (`BUNDLE_ONLY_UPDATE_TO_NEWER_VERSIONS`):
    During `bundle update`, only resolve to newer versions of the gems in the
    lockfile.
+* `patch` (BUNDLE_PATCH):
+   Whether to use patch update level, by default set to false.
 * `path` (`BUNDLE_PATH`):
    The location on disk where all gems in your bundle will be located regardless
    of `$GEM_HOME` or `$GEM_PATH` values. Bundle gems not found in this location

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -809,6 +809,15 @@ RSpec.describe "bundle update conservative" do
       G
     end
 
+    context "with patch set as default update level in config" do
+      it "should do a patch level update" do
+        bundle! "config --local patch true"
+        bundle! "update --patch foo"
+
+        expect(the_bundle).to include_gems "foo 1.4.5", "bar 2.1.1", "qux 1.0.0"
+      end
+    end
+
     context "patch preferred" do
       it "single gem updates dependent gem to minor" do
         bundle! "update --patch foo"

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -811,8 +811,8 @@ RSpec.describe "bundle update conservative" do
 
     context "with patch set as default update level in config" do
       it "should do a patch level update" do
-        bundle! "config --local patch true"
-        bundle! "update --patch foo"
+        bundle! "config --local prefer_patch true"
+        bundle! "update foo"
 
         expect(the_bundle).to include_gems "foo 1.4.5", "bar 2.1.1", "qux 1.0.0"
       end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Issue #5994 

### What was your diagnosis of the problem?

As mentioned by @indirect I added a `patch` option in the bundler config, which by default is false. If set to true, patch level update are preferred if no update levels are specified. 

### What is your fix for the problem, implemented in this PR?

A patch level config option which can be opted into. 

