### PR TITLE
Include gem name in native extension build directory path

### DIFF
--- a/lib/bundler/rubygems_ext.rb
+++ b/lib/bundler/rubygems_ext.rb
@@ -80,7 +80,8 @@ module Gem
       alias_method :rg_extension_dir, :extension_dir
       def extension_dir
         @bundler_extension_dir ||= if source.respond_to?(:extension_dir_name)
-          File.expand_path(File.join(extensions_dir, source.extension_dir_name))
+          unique_extension_dir = [source.extension_dir_name, File.basename(full_gem_path)].uniq.join("-")
+          File.expand_path(File.join(extensions_dir, unique_extension_dir))
         else
           rg_extension_dir
         end


### PR DESCRIPTION
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was that when including multiple gems from the same git repo, and more than one of them has native extensions, Bundler would only build the _first_ one and the other native extensions would not get built.

Example Gemfile:

```
git "git@github.com:/foo/bar_and_baz.git", :branch => "master" do
  gem "bar"
  gem "baz"
end
```

(In this scenario, gems `bar` and `baz` are both located in the `bar_and_baz.git` repo, in different subdirectories, each with their own `gemspec` and both provide a native extension.)

### What was your diagnosis of the problem?

Our diagnosis was that Bundler would build the first native extension in a path named for the whole repo, and when finished place a file there indicating that no more extensions should be built. Subsequently, when the 2nd gem is installed, the native extension is then skipped.

### What is your fix for the problem, implemented in this PR?

Our fix was to include the name of the subdir containing each gem in the `extension_dir` so that each separate gem within the repo is treated separately with regard to building their native extensions.

### Why did you choose this fix out of the possible options?

We chose this fix because it solved the problem!

---

Thanks to @crugg for digging into this and coming up with the fix.
