### PR TITLE
Make URLs in document consistent and secure

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -61,7 +61,7 @@ Once the admins get involved, they will follow a documented series of steps and 
 
 You may get in touch with the Bundler admin team through any of the following methods:
 
-- Email [the Bundler maintainers](http://bundler.io/contributors.html) as a group at [team@bundler.io](mailto:team@bundler.io).
+- Email [the Bundler maintainers](https://bundler.io/contributors.html) as a group at [team@bundler.io](mailto:team@bundler.io).
 - Directly message any maintainer in private (through Slack, Twitter, email, or other available option) if that is more comfortable
 
 ### Further Enforcement

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ bundle install
 bundle exec rspec
 ```
 
-See [bundler.io](http://bundler.io) for the full documentation.
+See [bundler.io](https://bundler.io) for the full documentation.
 
 ### Troubleshooting
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,8 +1,8 @@
 # Docs: Contributing and developing Bundler
 
-_If you're looking for documentation on how to use Bundler: visit [bundler.io](http://bundler.io/), or run `bundle help` from the command line. You may also be interested in [troubleshooting common issues](TROUBLESHOOTING.md) found when using Bundler._
+_If you're looking for documentation on how to use Bundler: visit [bundler.io](https://bundler.io/), or run `bundle help` from the command line. You may also be interested in [troubleshooting common issues](TROUBLESHOOTING.md) found when using Bundler._
 
-Bundler welcomes contributions from *everyone*. While contributing, please follow the project [code of conduct](http://bundler.io/conduct.html), so that everyone can be included. Maintainers are expected to work together with the community in accordance with [our project policies](POLICIES.md).
+Bundler welcomes contributions from *everyone*. While contributing, please follow the project [code of conduct](https://bundler.io/conduct.html), so that everyone can be included. Maintainers are expected to work together with the community in accordance with [our project policies](POLICIES.md).
 
 If you'd like to help make Bundler better, you totally rock! Thanks for helping us make Bundler better.
 

--- a/doc/TROUBLESHOOTING.md
+++ b/doc/TROUBLESHOOTING.md
@@ -25,10 +25,10 @@ Please open a ticket with [Heroku](https://www.heroku.com) if you're having trou
 
 ## Other problems
 
-First, figure out exactly what it is that you're trying to do (see [XY Problem](http://xyproblem.info/)). Then, go to the [Bundler documentation website](http://bundler.io) and see if we have instructions on how to do that.
+First, figure out exactly what it is that you're trying to do (see [XY Problem](http://xyproblem.info/)). Then, go to the [Bundler documentation website](https://bundler.io) and see if we have instructions on how to do that.
 
 Second, check [the compatibility
-list](http://bundler.io/compatibility.html), and make sure that the version of Bundler that you are using works with the versions of Ruby and RubyGems that you are using. To see your versions:
+list](https://bundler.io/compatibility.html), and make sure that the version of Bundler that you are using works with the versions of Ruby and RubyGems that you are using. To see your versions:
 
     # Bundler version
     bundle -v

--- a/doc/contributing/COMMUNITY.md
+++ b/doc/contributing/COMMUNITY.md
@@ -4,10 +4,10 @@ Community is an important part of all we do. If you’d like to be part of the B
 
 It would be tremendously helpful to have more people answering questions about Bundler (and often simply about [RubyGems](https://github.com/rubygems/rubygems) or Ruby itself) in our [issue tracker](https://github.com/bundler/bundler/issues) or on [Stack Overflow](http://stackoverflow.com/questions/tagged/bundler).
 
-Additional documentation and explanation is always helpful, too. If you have any suggestions for the Bundler website [bundler.io](http://bundler.io), we would absolutely love it if you opened an issue or pull request on the [bundler-site](https://github.com/bundler/bundler-site) repository.
+Additional documentation and explanation is always helpful, too. If you have any suggestions for the Bundler website [bundler.io](https://bundler.io), we would absolutely love it if you opened an issue or pull request on the [bundler-site](https://github.com/bundler/bundler-site) repository.
 
 Sharing your experiences and discoveries by writing them up is a valuable way to help others who have similar problems or experiences in the future. You can write a blog post, create an example and commit it to GitHub, take screenshots, or make videos.
 
 Publishing examples of how Bundler is used helps everyone, and we’ve discovered that people already use it in ways that we never imagined when we were writing it. If you’re still not sure what to write about, there are also several projects doing interesting things based on Bundler. They could probably use publicity too.
 
-Finally, all contributors to the Bundler project must agree to the contributor [code of conduct](http://bundler.io/conduct.html). By participating in this project you agree to abide by its terms.
+Finally, all contributors to the Bundler project must agree to the contributor [code of conduct](https://bundler.io/conduct.html). By participating in this project you agree to abide by its terms.

--- a/doc/contributing/GETTING_HELP.md
+++ b/doc/contributing/GETTING_HELP.md
@@ -5,7 +5,7 @@ If you have any questions after reading the documentation for contributing, plea
 The best ways to get in touch are:
 
 * [Bundler Slack](https://bundler.slack.com).
-  * Not a member of the Slack? Join the Bundler team slack [here](http://slack.bundler.io/)!
+  * Not a member of the Slack? Join the Bundler team slack [here](https://slack.bundler.io/)!
 * [Bundler mailing list](http://groups.google.com/group/ruby-bundler)
 
 You may also find our guide on [filing issues](ISSUES.md) to be helpful as well!

--- a/doc/contributing/HOW_YOU_CAN_HELP.md
+++ b/doc/contributing/HOW_YOU_CAN_HELP.md
@@ -14,7 +14,7 @@ Generally, great ways to get started helping out with Bundler are:
   - [reporting bugs you encounter or suggesting new features](https://github.com/bundler/bundler/issues/new)
     - see our [issues guide](ISSUES.md) for help on filing issues
     - see the [new features documentation](../development/NEW_FEATURES.md) for more
-  - adding to or editing [the Bundler documentation website](http://bundler.io) and [Bundler man pages](http://bundler.io/man/bundle.1.html)
+  - adding to or editing [the Bundler documentation website](https://bundler.io) and [Bundler man pages](https://bundler.io/man/bundle.1.html)
   - [checking issues for completeness](BUG_TRIAGE.md)
   - closing issues that are not complete
   - adding a failing test for reproducible [reported bugs](https://github.com/bundler/bundler/issues)
@@ -24,4 +24,4 @@ Generally, great ways to get started helping out with Bundler are:
     - get started setting up your dev environment with [these instructions](../development/SETUP.md)
   - backfilling [unit tests](https://github.com/bundler/bundler/tree/master/spec/bundler) for modules that lack [coverage](https://codeclimate.com/github/bundler/bundler/coverage)
 
-If nothing on those lists looks good, [talk to us](http://slack.bundler.io/), and we'll figure out what you can help with. We can absolutely use your help, no matter what level of programming skill you have at the moment.
+If nothing on those lists looks good, [talk to us](https://slack.bundler.io/), and we'll figure out what you can help with. We can absolutely use your help, no matter what level of programming skill you have at the moment.

--- a/doc/contributing/ISSUES.md
+++ b/doc/contributing/ISSUES.md
@@ -6,9 +6,9 @@ Before filing an issue, check our [troubleshooting guide](../TROUBLESHOOTING.md)
 
 ## Documentation
 
-Instructions for common Bundler uses can be found on the [Bundler documentation site](http://bundler.io/).
+Instructions for common Bundler uses can be found on the [Bundler documentation site](https://bundler.io/).
 
-Detailed information about each Bundler command, including help with common problems, can be found in the [Bundler man pages](http://bundler.io/man/bundle.1.html) or [Bundler Command Line Reference](http://bundler.io/v1.11/commands.html).
+Detailed information about each Bundler command, including help with common problems, can be found in the [Bundler man pages](https://bundler.io/man/bundle.1.html) or [Bundler Command Line Reference](https://bundler.io/v1.11/commands.html).
 
 ## Reporting unresolved problems
 

--- a/doc/contributing/README.md
+++ b/doc/contributing/README.md
@@ -1,6 +1,6 @@
 # Bundler Contributor Guidelines
 
-Thank you for your interest in making Bundler better! We welcome contributions from everyone. Dozens of contributors like you have submitted feature improvements, fixed bugs, and written new documentation. [Join the Bundler Slack community](http://slack.bundler.io/) to connect with the Bundler core team and other contributors like you.
+Thank you for your interest in making Bundler better! We welcome contributions from everyone. Dozens of contributors like you have submitted feature improvements, fixed bugs, and written new documentation. [Join the Bundler Slack community](https://slack.bundler.io/) to connect with the Bundler core team and other contributors like you.
 
 Before submitting a contribution, read through the following guidelines:
 

--- a/doc/documentation/README.md
+++ b/doc/documentation/README.md
@@ -5,9 +5,9 @@ Code needs explanation, and sometimes those who know the code well have trouble 
 Currently, Bundler has two main sources of documentation:
 
 1. built-in `help` (including usage information and man pages)
-2. [Bundler documentation site](http://bundler.io)
+2. [Bundler documentation site](https://bundler.io)
 
-If you have a suggestion or proposed change for [bundler.io](http://bundler.io), please open an issue or send a pull request to the [bundler-site](https://github.com/bundler/bundler-site) repository.
+If you have a suggestion or proposed change for [bundler.io](https://bundler.io), please open an issue or send a pull request to the [bundler-site](https://github.com/bundler/bundler-site) repository.
 
 Not sure where to write documentation? In general, follow these guidelines:
 

--- a/doc/documentation/VISION.md
+++ b/doc/documentation/VISION.md
@@ -3,7 +3,7 @@
 Currently, documentation for using Bundler is spread across two places:
 
 1. built-in `help` (including usage information and man pages)
-2. [Bundler documentation site](http://bundler.io)
+2. [Bundler documentation site](https://bundler.io)
 
 Additional documentation about using Bundler to publish gems can also be found on the [RubyGems guides](http://guides.rubygems.org/).
 

--- a/doc/documentation/WRITING.md
+++ b/doc/documentation/WRITING.md
@@ -53,11 +53,11 @@ $ bin/rspec ./spec/commands/help_spec.rb
 $ bin/rspec ./spec/quality_spec.rb
 ```
 
-# Writing docs for [the Bundler documentation site](http://www.bundler.io)
+# Writing docs for [the Bundler documentation site](https://bundler.io)
 
-If you'd like to submit a pull request for any of the primary commands or utilities on [the Bundler documentation site](http://www.bundler.io), please follow the instructions above for writing documentation for man pages from the `bundler/bundler` repository. They are the same in each case.
+If you'd like to submit a pull request for any of the primary commands or utilities on [the Bundler documentation site](https://bundler.io), please follow the instructions above for writing documentation for man pages from the `bundler/bundler` repository. They are the same in each case.
 
-Note: Editing `.ronn` files from the `bundler/bundler` repository for the primary commands and utilities documentation is all you need 🎉. There is no need to manually change anything in the `bundler/bundler-site` repository, because the man pages and the docs for primary commands and utilities on [the Bundler documentation site](http://www.bundler.io) are one in the same. They are generated automatically from the `bundler/bundler` repository's `.ronn` files from the `rake man/build` command. In other words, after updating `.ronn` file and running `rake man/build` in `bundler`, `.ronn` files map to the auto-generated files in the `source/man` directory of `bundler-site`.
+Note: Editing `.ronn` files from the `bundler/bundler` repository for the primary commands and utilities documentation is all you need 🎉. There is no need to manually change anything in the `bundler/bundler-site` repository, because the man pages and the docs for primary commands and utilities on [the Bundler documentation site](https://bundler.io) are one in the same. They are generated automatically from the `bundler/bundler` repository's `.ronn` files from the `rake man/build` command. In other words, after updating `.ronn` file and running `rake man/build` in `bundler`, `.ronn` files map to the auto-generated files in the `source/man` directory of `bundler-site`.
 
 Additionally, if you'd like to add a guide or tutorial: in the `bundler/bundler-site` repository, go to `/bundler-site/source/current_version_of_bundler/guides` and add [a new Markdown file](https://guides.github.com/features/mastering-markdown/) (with an extension ending in `.md`). Be sure to correctly format the title of your new guide, like so:
 ```

--- a/lib/bundler/cli/issue.rb
+++ b/lib/bundler/cli/issue.rb
@@ -13,10 +13,10 @@ module Bundler
         https://github.com/bundler/bundler/blob/master/doc/TROUBLESHOOTING.md
 
         2. Instructions for common Bundler uses can be found on the documentation
-        site: http://bundler.io/
+        site: https://bundler.io/
 
         3. Information about each Bundler command can be found in the Bundler
-        man pages: http://bundler.io/man/bundle.1.html
+        man pages: https://bundler.io/man/bundle.1.html
 
         Hopefully the troubleshooting steps above resolved your problem!  If things
         still aren't working the way you expect them to, please let us know so

--- a/man/bundle-init.ronn
+++ b/man/bundle-init.ronn
@@ -26,4 +26,4 @@ results in all string literals in the file being implicitly frozen.
 
 ## SEE ALSO
 
-[Gemfile(5)](http://bundler.io/man/gemfile.5.html)
+[Gemfile(5)](https://bundler.io/man/gemfile.5.html)

--- a/man/bundle.ronn
+++ b/man/bundle.ronn
@@ -10,7 +10,7 @@ bundle(1) -- Ruby Dependency Management
 Bundler manages an `application's dependencies` through its entire life
 across many machines systematically and repeatably.
 
-See [the bundler website](http://bundler.io) for information on getting
+See [the bundler website](https://bundler.io) for information on getting
 started, and Gemfile(5) for more information on the `Gemfile` format.
 
 ## OPTIONS

--- a/man/gemfile.5.ronn
+++ b/man/gemfile.5.ronn
@@ -176,7 +176,7 @@ are not available).
 Note that on `bundle install`, bundler downloads and evaluates all gems, in order to
 create a single canonical list of all of the required gems and their dependencies.
 This means that you cannot list different versions of the same gems in different
-groups. For more details, see [Understanding Bundler](http://bundler.io/rationale.html).
+groups. For more details, see [Understanding Bundler](https://bundler.io/rationale.html).
 
 ### PLATFORMS
 

--- a/spec/resolver/basic_spec.rb
+++ b/spec/resolver/basic_spec.rb
@@ -226,7 +226,7 @@ Bundler could not find compatible versions for gem "a":
       # dependencies and since the dependency of the selected foo gem changes, the latest matching
       # dependency of "bar", "~> 2.1" -- bar-2.1.1 -- is selected. This is not a bug and follows
       # the long-standing documented Conservative Updating behavior of bundle install.
-      # http://bundler.io/v1.12/man/bundle-install.1.html#CONSERVATIVE-UPDATING
+      # https://bundler.io/v1.12/man/bundle-install.1.html#CONSERVATIVE-UPDATING
       should_conservative_resolve_and_include :patch, ["foo"], %w[foo-1.4.5 bar-2.1.1]
     end
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

There are 3 documentation problems

* End-users experience 301 redirect when visiting http://www.bundler.io and http://bundler.io
* End-users might accidentally send email addresses via http version of https://slack.bundler.io, which is not redirected automatically.
* Partially fixing this is O.K., but consistent URLs throughout the documentation are easy to use.

### What was your diagnosis of the problem?

I have manually visited the Slack invitation URL on https://bundler.io/ and noticed the problem.
Following are the simple curl command to explain this problem.

```
$ curl -I  http://slack.bundler.io
HTTP/1.1 200 OK
Server: Cowboy
Connection: keep-alive
X-Powered-By: Express
Content-Type: text/html; charset=utf-8
Content-Length: 3726
Etag: W/"QPm3qygnJrqeFm+KK+VifA=="
Date: Mon, 28 Jan 2019 07:32:02 GMT
Via: 1.1 vegur
```

```
$ curl -I http://www.bundler.io
HTTP/1.1 301 Moved Permanently
Content-Type: text/html; charset=utf-8
Location: https://bundler.io
X-Redirector-Version: 84a0a5c
Date: Mon, 28 Jan 2019 07:32:28 GMT
```

```
$ curl -I http://bundler.io
HTTP/1.1 301 Moved Permanently
Server: GitHub.com
Content-Type: text/html
Location: https://bundler.io/
X-GitHub-Request-Id: FF7E:37F3:4DD47F:595032:5C4EB012
Content-Length: 178
Accept-Ranges: bytes
Date: Mon, 28 Jan 2019 07:32:35 GMT
Via: 1.1 varnish
Age: 0
Connection: keep-alive
X-Served-By: cache-nrt6127-NRT
X-Cache: MISS
X-Cache-Hits: 0
X-Timer: S1548660755.461639,VS0,VE91
Vary: Accept-Encoding
X-Fastly-Request-ID: 8c832766ee3154dc26abd3e1adcd1258a243e4ce
```

### What is your fix for the problem, implemented in this PR?

My fix is to replace old URLs with new URLs.

* Replace Slack invitation URLs with safe https ones
* Replace http://www.bundler.io with https://bundler.io
* Replace http://bundler.io with https://bundler.io

### Why did you choose this fix out of the possible options?

Because rewriting URLs on document is easy and simple.
Optionally, if someone could implement 301 redirect on Slack invitation URL, it would further help the issue.