### PR TITLE
Multiple without-group support for bundler list

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -314,7 +314,7 @@ module Bundler
       desc "list", "List all gems in the bundle"
       method_option "name-only", :type => :boolean, :banner => "print only the gem names"
       method_option "only-group", :type => :string, :banner => "print gems from a particular group"
-      method_option "without-group", :type => :string, :banner => "print all gems expect from a group"
+      method_option "without-group", :type => :string, :banner => "print all gems expect from 1 or multiple groups"
       method_option "paths", :type => :boolean, :banner => "print the path to each gem in the bundle"
       def list
         require "bundler/cli/list"

--- a/man/bundle-list.ronn
+++ b/man/bundle-list.ronn
@@ -15,7 +15,7 @@ bundle list --name-only
 
 bundle list --paths
 
-bundle list --without-group test
+bundle list --without-group test[,other_group,...]
 
 bundle list --only-group dev
 
@@ -28,6 +28,6 @@ bundle list --only-group dev --paths
 * `--paths`:
   Print the path to each gem in the bundle.
 * `--without-group`:
-  Print all gems expect from a group.
+  Print all gems expect from 1 or multiple groups.
 * `--only-group`:
   Print gems from a particular group.

--- a/spec/commands/list_spec.rb
+++ b/spec/commands/list_spec.rb
@@ -43,6 +43,30 @@ RSpec.describe "bundle list", :bundler => "2" do
         expect(out).to eq "`random` group could not be found."
       end
     end
+
+    describe "with multiple without-groups" do
+      before do
+        install_gemfile <<-G
+          source "file://#{gem_repo1}"
+
+          gem "rack"
+          gem "rspec", :group => [:test]
+          gem "rails", :group => [:development]
+          gem "git_test", group: %i[test development]
+          gem "rspec_in_context", group: %i[production development]
+        G
+      end
+
+      it "removes all the needed gems" do
+        bundle! 'list --without-group "development, test"'
+
+        expect(out).to include(/rack/)
+        expect(out).to include(/rspec_in_context/)
+        expect(out).not_to include(/rails/)
+        expect(out).not_to include(/git_test/)
+        expect(out).not_to include(/rspec/)
+      end
+    end
   end
 
   describe "with only-group option" do


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that I needed to list all gems and dependencies that weren't in group :development or :test (or both of the together) but `bundler list --without-group` was only accepting one group at a time.

### What was your diagnosis of the problem?

My diagnosis was I should just make it work for multiple groups

### What is your fix for the problem, implemented in this PR?

My fix is I split groups by `,` in args.

### Why did you choose this fix out of the possible options?

I chose this fix because it's simple and look like you can find in other cli.

I have two questions: Should I take care of the case where you have multiple `--without-group` specified ? Should I support `--without-groups` ?
