### PR TITLE
Ignore to add bundler lib direcotry if it is same as rubylibdir

### DIFF
--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -3,6 +3,7 @@
 require "bundler/compatibility_guard"
 
 require "pathname"
+require "rbconfig"
 require "rubygems"
 
 require "bundler/version"

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -341,7 +341,7 @@ module Bundler
 
     def set_rubylib
       rubylib = (ENV["RUBYLIB"] || "").split(File::PATH_SEPARATOR)
-      rubylib.unshift bundler_ruby_lib
+      rubylib.unshift bundler_ruby_lib unless RbConfig::CONFIG["rubylibdir"] == bundler_ruby_lib
       Bundler::SharedHelpers.set_env "RUBYLIB", rubylib.uniq.join(File::PATH_SEPARATOR)
     end
 

--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -261,6 +261,15 @@ RSpec.describe Bundler::SharedHelpers do
       subject.set_bundle_environment
     end
 
+    it "ignores if bundler_ruby_lib is same as rubylibdir" do
+      allow(Bundler::SharedHelpers).to receive(:bundler_ruby_lib).and_return(RbConfig::CONFIG["rubylibdir"])
+
+      subject.set_bundle_environment
+
+      paths = (ENV["RUBYLIB"]).split(File::PATH_SEPARATOR)
+      expect(paths.count(RbConfig::CONFIG["rubylibdir"])).to eq(0)
+    end
+
     it "exits if bundle path contains the unix-like path separator" do
       if Gem.respond_to?(:path_separator)
         allow(Gem).to receive(:path_separator).and_return(":")


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

In ruby core, the bundled bundler was located same as rubylibdir. When user used the specific version of default gems like json, Bundler uses default gems under the rubylibdir, not a specific version.

Fixed  https://bugs.ruby-lang.org/issues/15469

### What was your diagnosis of the problem?

See the details: https://bugs.ruby-lang.org/issues/15469#note-4

### What is your fix for the problem, implemented in this PR?

I avoid adding bundler directory from RUBYLIB environmental variable Because its directory was already added $LOAD_PATH.



