### PR TITLE
Split test assertions by stream

### DIFF
--- a/lib/bundler/cli/show.rb
+++ b/lib/bundler/cli/show.rb
@@ -24,7 +24,7 @@ module Bundler
           return unless spec
           path = spec.full_gem_path
           unless File.directory?(path)
-            Bundler.ui.warn "The gem #{gem_name} has been deleted. It was installed at:"
+            return Bundler.ui.warn "The gem #{gem_name} has been deleted. It was installed at: #{path}"
           end
         end
         return Bundler.ui.info(path)

--- a/lib/bundler/setup.rb
+++ b/lib/bundler/setup.rb
@@ -6,13 +6,14 @@ if Bundler::SharedHelpers.in_bundle?
   require "bundler"
 
   if STDOUT.tty? || ENV["BUNDLER_FORCE_TTY"]
+    Bundler.ui = Bundler::UI::Shell.new
     begin
       Bundler.setup
     rescue Bundler::BundlerError => e
-      puts "\e[31m#{e.message}\e[0m"
-      puts e.backtrace.join("\n") if ENV["DEBUG"]
+      Bundler.ui.warn "\e[31m#{e.message}\e[0m"
+      Bundler.ui.warn e.backtrace.join("\n") if ENV["DEBUG"]
       if e.is_a?(Bundler::GemNotFound)
-        puts "\e[33mRun `bundle install` to install missing gems.\e[0m"
+        Bundler.ui.warn "\e[33mRun `bundle install` to install missing gems.\e[0m"
       end
       exit e.status_code
     end

--- a/lib/bundler/source/git/git_proxy.rb
+++ b/lib/bundler/source/git/git_proxy.rb
@@ -253,7 +253,7 @@ module Bundler
           ensure
             STDERR.reopen backup_stderr
           end
-          $stderr.puts URICredentialsFilter.credential_filtered_string(captured_err, uri) if uri && !captured_err.empty?
+          Bundler.ui.warn URICredentialsFilter.credential_filtered_string(captured_err, uri) if uri && !captured_err.empty?
           return_value
         end
       end

--- a/spec/bundler/cli_spec.rb
+++ b/spec/bundler/cli_spec.rb
@@ -60,11 +60,11 @@ RSpec.describe "bundle executable" do
       G
 
       bundle :install, :env => { "RUBYGEMS_GEMDEPS" => "foo" }
-      expect(out).to include("RUBYGEMS_GEMDEPS")
-      expect(out).to include("conflict with Bundler")
+      expect(err).to include("RUBYGEMS_GEMDEPS")
+      expect(err).to include("conflict with Bundler")
 
       bundle :install, :env => { "RUBYGEMS_GEMDEPS" => "" }
-      expect(out).not_to include("RUBYGEMS_GEMDEPS")
+      expect(err).not_to include("RUBYGEMS_GEMDEPS")
     end
   end
 

--- a/spec/cache/gems_spec.rb
+++ b/spec/cache/gems_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe "bundle cache" do
 
       bundle :cache
       expect(exitstatus).to_not eq(0) if exitstatus
-      expect(out).to include("builtin_gem-1.0.2 is built in to Ruby, and can't be cached")
+      expect(err).to include("builtin_gem-1.0.2 is built in to Ruby, and can't be cached")
     end
   end
 

--- a/spec/commands/add_spec.rb
+++ b/spec/commands/add_spec.rb
@@ -106,23 +106,23 @@ RSpec.describe "bundle add" do
 
   it "shows error message when version is not formatted correctly" do
     bundle "add 'foo' -v='~>1 . 0'"
-    expect(out).to match("Invalid gem requirement pattern '~>1 . 0'")
+    expect(err).to match("Invalid gem requirement pattern '~>1 . 0'")
   end
 
   it "shows error message when gem cannot be found" do
     bundle "add 'werk_it'"
-    expect(out).to match("Could not find gem 'werk_it' in")
+    expect(err).to match("Could not find gem 'werk_it' in")
 
     bundle "add 'werk_it' -s='file://#{gem_repo2}'"
-    expect(out).to match("Could not find gem 'werk_it' in rubygems repository")
+    expect(err).to match("Could not find gem 'werk_it' in rubygems repository")
   end
 
   it "shows error message when source cannot be reached" do
     bundle "add 'baz' --source='http://badhostasdf'"
-    expect(out).to include("Could not reach host badhostasdf. Check your network connection and try again.")
+    expect(err).to include("Could not reach host badhostasdf. Check your network connection and try again.")
 
     bundle "add 'baz' --source='file://does/not/exist'"
-    expect(out).to include("Could not fetch specs from file://does/not/exist/")
+    expect(err).to include("Could not fetch specs from file://does/not/exist/")
   end
 
   describe "with --optimistic" do
@@ -153,7 +153,7 @@ RSpec.describe "bundle add" do
     it "throws error" do
       bundle "add 'foo' --strict --optimistic"
 
-      expect(out).to include("You can not specify `--strict` and `--optimistic` at the same time")
+      expect(err).to include("You can not specify `--strict` and `--optimistic` at the same time")
     end
   end
 
@@ -168,8 +168,8 @@ RSpec.describe "bundle add" do
     it "throws error if any of the specified gems are present in the gemfile with different version" do
       bundle "add weakling bar"
 
-      expect(out).to include("You cannot specify the same gem twice with different version requirements")
-      expect(out).to include("You specified: weakling (~> 0.0.1) and weakling (>= 0).")
+      expect(err).to include("You cannot specify the same gem twice with different version requirements")
+      expect(err).to include("You specified: weakling (~> 0.0.1) and weakling (>= 0).")
     end
   end
 
@@ -182,8 +182,8 @@ RSpec.describe "bundle add" do
 
       bundle "add 'rack' --version=1.1"
 
-      expect(out).to include("You cannot specify the same gem twice with different version requirements")
-      expect(out).to include("If you want to update the gem version, run `bundle update rack`. You may also need to change the version requirement specified in the Gemfile if it's too restrictive")
+      expect(err).to include("You cannot specify the same gem twice with different version requirements")
+      expect(err).to include("If you want to update the gem version, run `bundle update rack`. You may also need to change the version requirement specified in the Gemfile if it's too restrictive")
     end
 
     it "shows error when added without version requirements" do
@@ -194,9 +194,9 @@ RSpec.describe "bundle add" do
 
       bundle "add 'rack'"
 
-      expect(out).to include("Gem already added.")
-      expect(out).to include("You cannot specify the same gem twice with different version requirements")
-      expect(out).not_to include("If you want to update the gem version, run `bundle update rack`. You may also need to change the version requirement specified in the Gemfile if it's too restrictive")
+      expect(err).to include("Gem already added.")
+      expect(err).to include("You cannot specify the same gem twice with different version requirements")
+      expect(err).not_to include("If you want to update the gem version, run `bundle update rack`. You may also need to change the version requirement specified in the Gemfile if it's too restrictive")
     end
   end
 
@@ -209,9 +209,9 @@ RSpec.describe "bundle add" do
 
       bundle "add 'rack' --version=1.1"
 
-      expect(out).to include("You cannot specify the same gem twice with different version requirements")
-      expect(out).to include("If you want to update the gem version, run `bundle update rack`.")
-      expect(out).not_to include("You may also need to change the version requirement specified in the Gemfile if it's too restrictive")
+      expect(err).to include("You cannot specify the same gem twice with different version requirements")
+      expect(err).to include("If you want to update the gem version, run `bundle update rack`.")
+      expect(err).not_to include("You may also need to change the version requirement specified in the Gemfile if it's too restrictive")
     end
   end
 end

--- a/spec/commands/binstubs_spec.rb
+++ b/spec/commands/binstubs_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "bundle binstubs <gem>" do
 
       bundle "binstubs"
       expect(exitstatus).to eq(1) if exitstatus
-      expect(out).to include("`bundle binstubs` needs at least one gem to run.")
+      expect(err).to include("`bundle binstubs` needs at least one gem to run.")
     end
 
     it "displays an error when used with --all and gems" do
@@ -278,7 +278,7 @@ RSpec.describe "bundle binstubs <gem>" do
       bundle "binstubs doesnt_exist"
 
       expect(exitstatus).to eq(7) if exitstatus
-      expect(out).to include("Could not find gem 'doesnt_exist'.")
+      expect(err).to include("Could not find gem 'doesnt_exist'.")
     end
   end
 
@@ -350,8 +350,8 @@ RSpec.describe "bundle binstubs <gem>" do
 
       expect(bundled_app("bin/rackup")).to exist
       expect(File.read(bundled_app("bin/rackup"))).to eq("OMG")
-      expect(out).to include("Skipped rackup")
-      expect(out).to include("overwrite skipped stubs, use --force")
+      expect(err).to include("Skipped rackup")
+      expect(err).to include("overwrite skipped stubs, use --force")
     end
 
     context "when using --force" do
@@ -382,8 +382,8 @@ RSpec.describe "bundle binstubs <gem>" do
       G
 
       bundle "binstubs rack-obama"
-      expect(out).to include("rack-obama has no executables")
-      expect(out).to include("rack has: rackup")
+      expect(err).to include("rack-obama has no executables")
+      expect(err).to include("rack has: rackup")
     end
 
     it "works if child gems don't have bins" do
@@ -393,7 +393,7 @@ RSpec.describe "bundle binstubs <gem>" do
       G
 
       bundle "binstubs actionpack"
-      expect(out).to include("no executables for the gem actionpack")
+      expect(err).to include("no executables for the gem actionpack")
     end
 
     it "works if the gem has development dependencies" do
@@ -403,7 +403,7 @@ RSpec.describe "bundle binstubs <gem>" do
       G
 
       bundle "binstubs with_development_dependency"
-      expect(out).to include("no executables for the gem with_development_dependency")
+      expect(err).to include("no executables for the gem with_development_dependency")
     end
   end
 

--- a/spec/commands/check_spec.rb
+++ b/spec/commands/check_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "bundle check" do
     G
 
     bundle :check
-    expect(out).to include("Bundler can't satisfy your Gemfile's dependencies.")
+    expect(err).to include("Bundler can't satisfy your Gemfile's dependencies.")
   end
 
   it "prints a generic error if a Gemfile.lock does not exist and a toplevel dependency does not exist" do
@@ -69,7 +69,7 @@ RSpec.describe "bundle check" do
 
     bundle :check
     expect(exitstatus).to be > 0 if exitstatus
-    expect(out).to include("Bundler can't satisfy your Gemfile's dependencies.")
+    expect(err).to include("Bundler can't satisfy your Gemfile's dependencies.")
   end
 
   it "prints a generic message if you changed your lockfile" do
@@ -89,7 +89,7 @@ RSpec.describe "bundle check" do
     G
 
     bundle :check
-    expect(out).to include("Bundler can't satisfy your Gemfile's dependencies.")
+    expect(err).to include("Bundler can't satisfy your Gemfile's dependencies.")
   end
 
   it "remembers --without option from install", :bundler => "< 2" do
@@ -132,7 +132,7 @@ RSpec.describe "bundle check" do
     G
 
     bundle "check"
-    expect(out).to include("* rack (1.0.0)")
+    expect(err).to include("* rack (1.0.0)")
     expect(exitstatus).to eq(1) if exitstatus
   end
 
@@ -201,13 +201,13 @@ RSpec.describe "bundle check" do
   it "outputs an error when the default Gemfile is not found" do
     bundle :check
     expect(exitstatus).to eq(10) if exitstatus
-    expect(out).to include("Could not locate Gemfile")
+    expect(err).to include("Could not locate Gemfile")
   end
 
   it "does not output fatal error message" do
     bundle :check
     expect(exitstatus).to eq(10) if exitstatus
-    expect(out).not_to include("Unfortunately, a fatal error has occurred. ")
+    expect(err).not_to include("Unfortunately, a fatal error has occurred. ")
   end
 
   it "should not crash when called multiple times on a new machine" do
@@ -269,7 +269,7 @@ RSpec.describe "bundle check" do
 
       bundle "check --path vendor/bundle"
       expect(exitstatus).to eq(1) if exitstatus
-      expect(out).to match(/The following gems are missing/)
+      expect(err).to match(/The following gems are missing/)
     end
   end
 
@@ -292,8 +292,8 @@ RSpec.describe "bundle check" do
     it "shows what is missing with the current Gemfile if it is not satisfied" do
       simulate_new_machine
       bundle :check
-      expect(out).to match(/The following gems are missing/)
-      expect(out).to include("* rack (1.0")
+      expect(err).to match(/The following gems are missing/)
+      expect(err).to include("* rack (1.0")
     end
   end
 

--- a/spec/commands/clean_spec.rb
+++ b/spec/commands/clean_spec.rb
@@ -286,7 +286,7 @@ RSpec.describe "bundle clean" do
     bundle :clean
 
     expect(exitstatus).to eq(15) if exitstatus
-    expect(out).to include("--force")
+    expect(err).to include("--force")
   end
 
   # handling bundle clean upgrade path from the pre's
@@ -516,8 +516,8 @@ RSpec.describe "bundle clean" do
 
       bundle :clean, :force => true
 
-      expect(out).to include(system_gem_path.to_s)
-      expect(out).to include("grant write permissions")
+      expect(err).to include(system_gem_path.to_s)
+      expect(err).to include("grant write permissions")
 
       sys_exec "gem list"
       expect(out).to include("foo (1.0)")

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -199,8 +199,8 @@ RSpec.describe "bundle exec" do
 
     bundle "exec foobarbaz"
     expect(exitstatus).to eq(127) if exitstatus
-    expect(out).to include("bundler: command not found: foobarbaz")
-    expect(out).to include("Install missing gem executables with `bundle install`")
+    expect(err).to include("bundler: command not found: foobarbaz")
+    expect(err).to include("Install missing gem executables with `bundle install`")
   end
 
   it "errors nicely when the argument is not executable" do
@@ -211,7 +211,7 @@ RSpec.describe "bundle exec" do
     bundle "exec touch foo"
     bundle "exec ./foo"
     expect(exitstatus).to eq(126) if exitstatus
-    expect(out).to include("bundler: not executable: ./foo")
+    expect(err).to include("bundler: not executable: ./foo")
   end
 
   it "errors nicely when no arguments are passed" do
@@ -221,7 +221,7 @@ RSpec.describe "bundle exec" do
 
     bundle "exec"
     expect(exitstatus).to eq(128) if exitstatus
-    expect(out).to include("bundler: exec needs a command to run")
+    expect(err).to include("bundler: exec needs a command to run")
   end
 
   it "raises a helpful error when exec'ing to something outside of the bundle", :ruby_repo, :rubygems => ">= 2.5.2" do
@@ -662,7 +662,8 @@ RSpec.describe "bundle exec" do
       end
 
       let(:exit_code) { Bundler::GemNotFound.new.status_code }
-      let(:expected) { <<-EOS.strip }
+      let(:expected) { "" }
+      let(:expected_err) { <<-EOS.strip }
 \e[31mCould not find gem 'rack (= 2)' in locally installed gems.
 The source contains 'rack' at: 1.0.0\e[0m
 \e[33mRun `bundle install` to install missing gems.\e[0m

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -93,14 +93,14 @@ RSpec.describe "bundle exec" do
       expect(out).to eq("Ruby version #{RUBY_VERSION} defaults to keeping non-standard file descriptors on Kernel#exec.")
     end
 
-    expect(err).to be_empty
+    expect(last_command.stderr).to be_empty
   end
 
   it "accepts --keep-file-descriptors" do
     install_gemfile ""
     bundle "exec --keep-file-descriptors echo foobar"
 
-    expect(err).to be_empty
+    expect(last_command.stderr).to be_empty
   end
 
   it "can run a command named --verbose" do
@@ -465,8 +465,8 @@ RSpec.describe "bundle exec" do
 
       bundle "exec irb"
 
-      expect(err).to match("The gemspec at #{lib_path("foo-1.0").join("foo.gemspec")} is not valid")
-      expect(err).to match('"TODO" is not a summary')
+      expect(last_command.stderr).to match("The gemspec at #{lib_path("foo-1.0").join("foo.gemspec")} is not valid")
+      expect(last_command.stderr).to match('"TODO" is not a summary')
     end
   end
 

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -93,14 +93,14 @@ RSpec.describe "bundle exec" do
       expect(out).to eq("Ruby version #{RUBY_VERSION} defaults to keeping non-standard file descriptors on Kernel#exec.")
     end
 
-    expect(err).to lack_errors
+    expect(err).to be_empty
   end
 
   it "accepts --keep-file-descriptors" do
     install_gemfile ""
     bundle "exec --keep-file-descriptors echo foobar"
 
-    expect(err).to lack_errors
+    expect(err).to be_empty
   end
 
   it "can run a command named --verbose" do

--- a/spec/commands/help_spec.rb
+++ b/spec/commands/help_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe "bundle help" do
     with_fake_man do
       bundle "instill -h"
     end
-    expect(out).to include('Could not find command "instill".')
+    expect(err).to include('Could not find command "instill".')
   end
 
   it "is called when only using the --help flag" do

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "bundle info" do
     context "given a gem that is not installed" do
       it "prints missing gem error" do
         bundle "info foo"
-        expect(out).to eq "Could not find gem 'foo'."
+        expect(err).to eq "Could not find gem 'foo'."
       end
     end
 

--- a/spec/commands/init_spec.rb
+++ b/spec/commands/init_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "bundle init" do
 
     it "notifies the user that an existing Gemfile already exists" do
       bundle :init
-      expect(out).to include("Gemfile already exists")
+      expect(err).to include("Gemfile already exists")
     end
   end
 
@@ -43,7 +43,7 @@ RSpec.describe "bundle init" do
 
     it "notifies the user that an existing gems.rb already exists" do
       bundle :init
-      expect(out).to include("gems.rb already exists")
+      expect(err).to include("gems.rb already exists")
     end
   end
 
@@ -77,7 +77,7 @@ RSpec.describe "bundle init" do
         bundle :init
       end
 
-      expect(out).to include("directory is not writable")
+      expect(err).to include("directory is not writable")
       expect(Dir[bundled_app("#{subdir}/*")]).to be_empty
     end
   end

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "bundle install with gem sources" do
       G
 
       bundle :install
-      expect(out).to match(/no dependencies/)
+      expect(err).to match(/no dependencies/)
     end
 
     it "does not make a lockfile if the install fails" do
@@ -311,7 +311,7 @@ RSpec.describe "bundle install with gem sources" do
       G
 
       bundle :install
-      expect(out).to include("Your Gemfile has no gem server sources")
+      expect(err).to include("Your Gemfile has no gem server sources")
     end
 
     it "creates a Gemfile.lock on a blank Gemfile" do
@@ -329,9 +329,9 @@ RSpec.describe "bundle install with gem sources" do
           gem "rack"
         G
 
-        expect(out).to include("Your Gemfile lists the gem rack (>= 0) more than once.")
-        expect(out).to include("Remove any duplicate entries and specify the gem only once (per group).")
-        expect(out).to include("While it's not a problem now, it could cause errors if you change the version of one of them later.")
+        expect(err).to include("Your Gemfile lists the gem rack (>= 0) more than once.")
+        expect(err).to include("Remove any duplicate entries and specify the gem only once (per group).")
+        expect(err).to include("While it's not a problem now, it could cause errors if you change the version of one of them later.")
       end
 
       it "with same versions" do
@@ -341,9 +341,9 @@ RSpec.describe "bundle install with gem sources" do
           gem "rack", "1.0"
         G
 
-        expect(out).to include("Your Gemfile lists the gem rack (= 1.0) more than once.")
-        expect(out).to include("Remove any duplicate entries and specify the gem only once (per group).")
-        expect(out).to include("While it's not a problem now, it could cause errors if you change the version of one of them later.")
+        expect(err).to include("Your Gemfile lists the gem rack (= 1.0) more than once.")
+        expect(err).to include("Remove any duplicate entries and specify the gem only once (per group).")
+        expect(err).to include("While it's not a problem now, it could cause errors if you change the version of one of them later.")
       end
     end
 
@@ -355,8 +355,8 @@ RSpec.describe "bundle install with gem sources" do
           gem "rack", "1.0"
         G
 
-        expect(out).to include("You cannot specify the same gem twice with different version requirements")
-        expect(out).to include("You specified: rack (>= 0) and rack (= 1.0).")
+        expect(err).to include("You cannot specify the same gem twice with different version requirements")
+        expect(err).to include("You specified: rack (>= 0) and rack (= 1.0).")
       end
 
       it "when different versions of both dependencies are specified" do
@@ -366,8 +366,8 @@ RSpec.describe "bundle install with gem sources" do
           gem "rack", "1.1"
         G
 
-        expect(out).to include("You cannot specify the same gem twice with different version requirements")
-        expect(out).to include("You specified: rack (= 1.0) and rack (= 1.1).")
+        expect(err).to include("You cannot specify the same gem twice with different version requirements")
+        expect(err).to include("You specified: rack (= 1.0) and rack (= 1.1).")
       end
     end
 
@@ -380,8 +380,8 @@ RSpec.describe "bundle install with gem sources" do
       G
 
       bundle :install, :artifice => nil
-      expect(out).to include("Could not fetch specs from http://localhost:9384/")
-      expect(out).not_to include("file://")
+      expect(err).to include("Could not fetch specs from http://localhost:9384/")
+      expect(err).not_to include("file://")
     end
 
     it "fails gracefully when downloading an invalid specification from the full index", :rubygems => "2.5" do
@@ -442,7 +442,7 @@ RSpec.describe "bundle install with gem sources" do
           ::RUBY_VERSION = '2.0.1'
           ruby '~> 2.2'
         G
-        expect(out).to include("Your Ruby version is 2.0.1, but your Gemfile specified ~> 2.2")
+        expect(err).to include("Your Ruby version is 2.0.1, but your Gemfile specified ~> 2.2")
       end
     end
 
@@ -529,8 +529,8 @@ RSpec.describe "bundle install with gem sources" do
       G
 
       bundle :install, :quiet => true
-      expect(out).to include("Could not find gem 'rack'")
-      expect(out).to_not include("Your Gemfile has no gem server sources")
+      expect(err).to include("Could not find gem 'rack'")
+      expect(err).to_not include("Your Gemfile has no gem server sources")
     end
   end
 
@@ -547,8 +547,8 @@ RSpec.describe "bundle install with gem sources" do
       FileUtils.chmod(0o500, bundled_app("vendor"))
 
       bundle :install, forgotten_command_line_options(:path => "vendor")
-      expect(out).to include(bundled_app("vendor").to_s)
-      expect(out).to include("grant write permissions")
+      expect(err).to include(bundled_app("vendor").to_s)
+      expect(err).to include("grant write permissions")
     end
   end
 
@@ -580,7 +580,7 @@ RSpec.describe "bundle install with gem sources" do
     it "should display a helpful message explaining how to fix it" do
       bundle :install, :env => { "BUNDLE_RUBYGEMS__ORG" => "user:pass{word" }
       expect(exitstatus).to eq(17) if exitstatus
-      expect(out).to eq("Please CGI escape your usernames and passwords before " \
+      expect(err).to eq("Please CGI escape your usernames and passwords before " \
                         "setting them for authentication.")
     end
   end

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -577,7 +577,7 @@ RSpec.describe "bundle install with gem sources" do
       G
     end
 
-    it "should display a helpful messag explaining how to fix it" do
+    it "should display a helpful message explaining how to fix it" do
       bundle :install, :env => { "BUNDLE_RUBYGEMS__ORG" => "user:pass{word" }
       expect(exitstatus).to eq(17) if exitstatus
       expect(out).to eq("Please CGI escape your usernames and passwords before " \

--- a/spec/commands/licenses_spec.rb
+++ b/spec/commands/licenses_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "bundle licenses" do
   it "prints license information for all gems in the bundle" do
     bundle "licenses"
 
-    expect(out).to include("bundler: Unknown")
+    expect(err).to include("bundler: Unknown")
     expect(out).to include("with_license: MIT")
   end
 

--- a/spec/commands/list_spec.rb
+++ b/spec/commands/list_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "bundle list", :bundler => "2" do
     it "raises an error" do
       bundle "list --name-only --paths"
 
-      expect(out).to eq "The `--name-only` and `--paths` options cannot be used together"
+      expect(err).to eq "The `--name-only` and `--paths` options cannot be used together"
     end
   end
 
@@ -22,7 +22,7 @@ RSpec.describe "bundle list", :bundler => "2" do
     it "raises an error" do
       bundle "list --without-group dev --only-group test"
 
-      expect(out).to eq "The `--only-group` and `--without-group` options cannot be used together"
+      expect(err).to eq "The `--only-group` and `--without-group` options cannot be used together"
     end
   end
 
@@ -40,7 +40,7 @@ RSpec.describe "bundle list", :bundler => "2" do
       it "raises an error" do
         bundle "list --without-group random"
 
-        expect(out).to eq "`random` group could not be found."
+        expect(err).to eq "`random` group could not be found."
       end
     end
   end
@@ -59,7 +59,7 @@ RSpec.describe "bundle list", :bundler => "2" do
       it "raises an error" do
         bundle "list --only-group random"
 
-        expect(out).to eq "`random` group could not be found."
+        expect(err).to eq "`random` group could not be found."
       end
     end
   end

--- a/spec/commands/lock_spec.rb
+++ b/spec/commands/lock_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "bundle lock" do
   it "does not fetch remote specs when using the --local option" do
     bundle "lock --update --local"
 
-    expect(out).to match(/sources listed in your Gemfile|installed locally/)
+    expect(err).to match(/sources listed in your Gemfile|installed locally/)
   end
 
   it "works with --gemfile flag" do
@@ -144,7 +144,7 @@ RSpec.describe "bundle lock" do
     lockfile @lockfile
 
     bundle "lock --update blahblah"
-    expect(out).to eq("Could not find gem 'blahblah'.")
+    expect(err).to eq("Could not find gem 'blahblah'.")
 
     expect(read_lockfile).to eq(@lockfile)
   end
@@ -225,7 +225,7 @@ RSpec.describe "bundle lock" do
 
   it "warns when adding an unknown platform" do
     bundle "lock --add-platform foobarbaz"
-    expect(out).to include("The platform `foobarbaz` is unknown to RubyGems and adding it will likely lead to resolution errors")
+    expect(err).to include("The platform `foobarbaz` is unknown to RubyGems and adding it will likely lead to resolution errors")
   end
 
   it "allows removing platforms" do

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -802,22 +802,22 @@ Usage: "bundle gem NAME [OPTIONS]"
 
     context "with an existing const name" do
       subject { "gem" }
-      it { expect(out).to include("Invalid gem name #{subject}") }
+      it { expect(err).to include("Invalid gem name #{subject}") }
     end
 
     context "with an existing hyphenated const name" do
       subject { "gem-specification" }
-      it { expect(out).to include("Invalid gem name #{subject}") }
+      it { expect(err).to include("Invalid gem name #{subject}") }
     end
 
     context "starting with an existing const name" do
       subject { "gem-somenewconstantname" }
-      it { expect(out).not_to include("Invalid gem name #{subject}") }
+      it { expect(err).not_to include("Invalid gem name #{subject}") }
     end
 
     context "ending with an existing const name" do
       subject { "somenewconstantname-gem" }
-      it { expect(out).not_to include("Invalid gem name #{subject}") }
+      it { expect(err).not_to include("Invalid gem name #{subject}") }
     end
   end
 

--- a/spec/commands/open_spec.rb
+++ b/spec/commands/open_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "bundle open" do
 
   it "complains if gem not in bundle" do
     bundle "open missing", :env => { "EDITOR" => "echo editor", "VISUAL" => "", "BUNDLER_EDITOR" => "" }
-    expect(out).to match(/could not find gem 'missing'/i)
+    expect(err).to match(/could not find gem 'missing'/i)
   end
 
   it "does not blow up if the gem to open does not have a Gemfile" do
@@ -48,7 +48,7 @@ RSpec.describe "bundle open" do
 
   it "suggests alternatives for similar-sounding gems" do
     bundle "open Rails", :env => { "EDITOR" => "echo editor", "VISUAL" => "", "BUNDLER_EDITOR" => "" }
-    expect(out).to match(/did you mean rails\?/i)
+    expect(err).to match(/did you mean rails\?/i)
   end
 
   it "opens the gem with short words" do

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -398,7 +398,7 @@ RSpec.describe "bundle outdated" do
   describe "with invalid gem name" do
     it "returns could not find gem name" do
       bundle "outdated invalid_gem_name"
-      expect(out).to include("Could not find gem 'invalid_gem_name'.")
+      expect(err).to include("Could not find gem 'invalid_gem_name'.")
     end
 
     it "returns non-zero exit code" do
@@ -434,10 +434,10 @@ RSpec.describe "bundle outdated" do
 
       bundle "outdated"
       expect(last_command).to be_failure
-      expect(out).to include("You are trying to check outdated gems in deployment mode.")
-      expect(out).to include("Run `bundle outdated` elsewhere.")
-      expect(out).to include("If this is a development machine, remove the ")
-      expect(out).to include("Gemfile freeze\nby running `bundle install --no-deployment`.")
+      expect(err).to include("You are trying to check outdated gems in deployment mode.")
+      expect(err).to include("Run `bundle outdated` elsewhere.")
+      expect(err).to include("If this is a development machine, remove the ")
+      expect(err).to include("Gemfile freeze\nby running `bundle install --no-deployment`.")
     end
   end
 
@@ -457,10 +457,10 @@ RSpec.describe "bundle outdated" do
 
       bundle "outdated"
       expect(last_command).to be_failure
-      expect(out).to include("You are trying to check outdated gems in deployment mode.")
-      expect(out).to include("Run `bundle outdated` elsewhere.")
-      expect(out).to include("If this is a development machine, remove the ")
-      expect(out).to include("Gemfile freeze\nby running `bundle config --delete deployment`.")
+      expect(err).to include("You are trying to check outdated gems in deployment mode.")
+      expect(err).to include("Run `bundle outdated` elsewhere.")
+      expect(err).to include("If this is a development machine, remove the ")
+      expect(err).to include("Gemfile freeze\nby running `bundle config --delete deployment`.")
     end
   end
 

--- a/spec/commands/package_spec.rb
+++ b/spec/commands/package_spec.rb
@@ -266,7 +266,7 @@ RSpec.describe "bundle install with gem sources" do
       end
 
       bundle :install
-      expect(err).to be_empty
+      expect(last_command.stderr).to be_empty
       expect(the_bundle).to include_gems "rack 1.0"
     end
 

--- a/spec/commands/package_spec.rb
+++ b/spec/commands/package_spec.rb
@@ -266,7 +266,7 @@ RSpec.describe "bundle install with gem sources" do
       end
 
       bundle :install
-      expect(err).to lack_errors
+      expect(err).to be_empty
       expect(the_bundle).to include_gems "rack 1.0"
     end
 

--- a/spec/commands/package_spec.rb
+++ b/spec/commands/package_spec.rb
@@ -213,9 +213,9 @@ RSpec.describe "bundle package" do
       G
       subject
       expect(exitstatus).to eq(16) if exitstatus
-      expect(out).to include("deployment mode")
-      expect(out).to include("You have added to the Gemfile")
-      expect(out).to include("* rack-obama")
+      expect(err).to include("deployment mode")
+      expect(err).to include("You have added to the Gemfile")
+      expect(err).to include("* rack-obama")
       bundle "env"
       expect(out).to include("frozen").or include("deployment")
     end

--- a/spec/commands/pristine_spec.rb
+++ b/spec/commands/pristine_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "bundle pristine", :ruby_repo do
 
       bundle "pristine"
       expect(File.read(changed_file)).to include(diff)
-      expect(out).to include("Cannot pristine #{spec.name} (#{spec.version}#{spec.git_version}). Gem is sourced from local path.")
+      expect(err).to include("Cannot pristine #{spec.name} (#{spec.version}#{spec.git_version}). Gem is sourced from local path.")
     end
 
     it "reinstall gemspec dependency" do
@@ -111,7 +111,7 @@ RSpec.describe "bundle pristine", :ruby_repo do
       FileUtils.touch(changes_txt)
       expect(changes_txt).to be_file
       bundle "pristine"
-      expect(out).to include("Cannot pristine #{spec.name} (#{spec.version}#{spec.git_version}). Gem is sourced from local path.")
+      expect(err).to include("Cannot pristine #{spec.name} (#{spec.version}#{spec.git_version}). Gem is sourced from local path.")
       expect(changes_txt).to be_file
     end
   end
@@ -135,8 +135,8 @@ RSpec.describe "bundle pristine", :ruby_repo do
 
       bundle! "pristine foo bar weakling"
 
-      expect(out).to include("Cannot pristine bar (1.0). Gem is sourced from local path.").
-        and include("Installing weakling 1.0")
+      expect(err).to include("Cannot pristine bar (1.0). Gem is sourced from local path.")
+      expect(out).to include("Installing weakling 1.0")
 
       expect(weakling_changes_txt).not_to be_file
       expect(foo_changes_txt).not_to be_file
@@ -145,7 +145,7 @@ RSpec.describe "bundle pristine", :ruby_repo do
 
     it "raises when one of them is not in the lockfile" do
       bundle "pristine abcabcabc"
-      expect(out).to include("Could not find gem 'abcabcabc'.")
+      expect(err).to include("Could not find gem 'abcabcabc'.")
     end
   end
 

--- a/spec/commands/remove_spec.rb
+++ b/spec/commands/remove_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "bundle remove" do
 
       bundle "remove"
 
-      expect(out).to include("Please specify gems to remove.")
+      expect(err).to include("Please specify gems to remove.")
     end
   end
 
@@ -54,7 +54,7 @@ RSpec.describe "bundle remove" do
 
         bundle "remove rack"
 
-        expect(out).to include("`rack` is not specified in #{bundled_app("Gemfile")} so it could not be removed.")
+        expect(err).to include("`rack` is not specified in #{bundled_app("Gemfile")} so it could not be removed.")
       end
     end
   end
@@ -91,7 +91,7 @@ RSpec.describe "bundle remove" do
 
         bundle "remove rails rack minitest"
 
-        expect(out).to include("`rack` is not specified in #{bundled_app("Gemfile")} so it could not be removed.")
+        expect(err).to include("`rack` is not specified in #{bundled_app("Gemfile")} so it could not be removed.")
         gemfile_should_be <<-G
           source "file://#{gem_repo1}"
 
@@ -318,7 +318,7 @@ RSpec.describe "bundle remove" do
 
         bundle "remove rails"
 
-        expect(out).to include("Gems could not be removed. rack (>= 0) would also have been removed.")
+        expect(err).to include("Gems could not be removed. rack (>= 0) would also have been removed.")
         gemfile_should_be <<-G
           source "file://#{gem_repo1}"
           gem "rack"; gem "rails"
@@ -436,7 +436,7 @@ RSpec.describe "bundle remove" do
 
         bundle "remove rack"
 
-        expect(out).to include("`rack` is not specified in #{bundled_app("Gemfile")} so it could not be removed.")
+        expect(err).to include("`rack` is not specified in #{bundled_app("Gemfile")} so it could not be removed.")
       end
     end
 
@@ -456,7 +456,7 @@ RSpec.describe "bundle remove" do
         bundle "remove rack"
 
         expect(out).to include("rack was removed.")
-        expect(out).to include("`rack` is not specified in #{bundled_app("Gemfile-other")} so it could not be removed.")
+        expect(err).to include("`rack` is not specified in #{bundled_app("Gemfile-other")} so it could not be removed.")
         gemfile_should_be <<-G
           source "file://#{gem_repo1}"
 
@@ -481,7 +481,7 @@ RSpec.describe "bundle remove" do
         bundle "remove rack"
 
         expect(out).to include("rack was removed.")
-        expect(out).to include("Gems could not be removed. rails (>= 0) would also have been removed.")
+        expect(err).to include("Gems could not be removed. rails (>= 0) would also have been removed.")
         gemfile_should_be <<-G
           source "file://#{gem_repo1}"
 
@@ -505,7 +505,7 @@ RSpec.describe "bundle remove" do
 
         bundle "remove rack"
 
-        expect(out).to include("Gems could not be removed. rails (>= 0) would also have been removed.")
+        expect(err).to include("Gems could not be removed. rails (>= 0) would also have been removed.")
         expect(bundled_app("Gemfile-other").read).to include("gem \"rack\"")
         gemfile_should_be <<-G
           source "file://#{gem_repo1}"

--- a/spec/commands/show_spec.rb
+++ b/spec/commands/show_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe "bundle show" do
 
     it "does not output git errors" do
       bundle :show
-      expect(err).to be_empty
+      expect(last_command.stderr).to eq_err("")
     end
   end
 

--- a/spec/commands/show_spec.rb
+++ b/spec/commands/show_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe "bundle show" do
 
     it "does not output git errors" do
       bundle :show
-      expect(err).to lack_errors
+      expect(err).to be_empty
     end
   end
 

--- a/spec/commands/show_spec.rb
+++ b/spec/commands/show_spec.rb
@@ -25,30 +25,24 @@ RSpec.describe "bundle show" do
       expect(bundled_app("Gemfile.lock")).to exist
     end
 
-    it "prints path if gem exists in bundle", :bundler => "< 2" do
+    it "prints path if gem exists in bundle" do
       bundle "show rails"
       expect(out).to eq(default_bundle_path("gems", "rails-2.3.2").to_s)
     end
 
-    it "prints path if gem exists in bundle", :bundler => "2" do
+    it "prints deprecation", :bundler => "2" do
       bundle "show rails"
-      expect(out).to eq(
-        "[DEPRECATED FOR 2.0] use `bundle info rails` instead of `bundle show rails`\n" +
-        default_bundle_path("gems", "rails-2.3.2").to_s
-      )
+      expect(err).to eq("[DEPRECATED FOR 2.0] use `bundle info rails` instead of `bundle show rails`")
     end
 
-    it "prints path if gem exists in bundle (with --paths option)", :bundler => "< 2" do
+    it "prints path if gem exists in bundle (with --paths option)" do
       bundle "show rails --paths"
       expect(out).to eq(default_bundle_path("gems", "rails-2.3.2").to_s)
     end
 
-    it "prints path if gem exists in bundle (with --paths option)", :bundler => "2" do
+    it "prints deprecation when called with a gem and the --paths option", :bundler => "2" do
       bundle "show rails --paths"
-      expect(out).to eq(
-        "[DEPRECATED FOR 2.0] use `bundle info rails --path` instead of `bundle show rails --paths`\n" +
-        default_bundle_path("gems", "rails-2.3.2").to_s
-      )
+      expect(err).to eq("[DEPRECATED FOR 2.0] use `bundle info rails --path` instead of `bundle show rails --paths`")
     end
 
     it "warns if path no longer exists on disk" do
@@ -56,29 +50,25 @@ RSpec.describe "bundle show" do
 
       bundle "show rails"
 
-      expect(out).to match(/has been deleted/i).
-        and include(default_bundle_path("gems", "rails-2.3.2").to_s)
+      expect(err).to match(/has been deleted/i)
+      expect(err).to match(default_bundle_path("gems", "rails-2.3.2").to_s)
     end
 
-    it "prints the path to the running bundler", :bundler => "< 2" do
+    it "prints the path to the running bundler" do
       bundle "show bundler"
       expect(out).to eq(root.to_s)
     end
 
-    it "prints the path to the running bundler", :bundler => "2" do
+    it "prints deprecation when called with bundler", :bundler => "2" do
       bundle "show bundler"
-      expect(out).to eq(
-        "[DEPRECATED FOR 2.0] use `bundle info bundler` instead of `bundle show bundler`\n" +
-        root.to_s
-      )
+      expect(err).to eq("[DEPRECATED FOR 2.0] use `bundle info bundler` instead of `bundle show bundler`")
     end
-
     it "complains if gem not in bundle" do
       bundle "show missing"
-      expect(out).to match(/could not find gem 'missing'/i)
+      expect(err).to match(/could not find gem 'missing'/i)
     end
 
-    it "prints path of all gems in bundle sorted by name", :bundler => "< 2" do
+    it "prints path of all gems in bundle sorted by name" do
       bundle "show --paths"
 
       expect(out).to include(default_bundle_path("gems", "rake-12.3.2").to_s)
@@ -89,18 +79,10 @@ RSpec.describe "bundle show" do
       expect(gem_list).to eq(gem_list.sort)
     end
 
-    it "prints path of all gems in bundle sorted by name", :bundler => "2" do
+    it "prints a deprecation when called with the --paths option", :bundler => 2 do
       bundle "show --paths"
 
-      expect(out).to include(default_bundle_path("gems", "rake-12.3.2").to_s)
-      expect(out).to include(default_bundle_path("gems", "rails-2.3.2").to_s)
-
-      out_lines = out.split("\n")
-      expect(out_lines[0]).to eq("[DEPRECATED FOR 2.0] use `bundle list` instead of `bundle show --paths`")
-
-      # Gem names are the last component of their path.
-      gem_list = out_lines[1..-1].map {|p| p.split("/").last }
-      expect(gem_list).to eq(gem_list.sort)
+      expect(err).to eq("[DEPRECATED FOR 2.0] use `bundle list` instead of `bundle show --paths`")
     end
 
     it "prints summary of gems" do
@@ -200,7 +182,7 @@ RSpec.describe "bundle show" do
       invalid_regexp = "[]"
 
       bundle "show #{invalid_regexp}"
-      expect(out).to include("Could not find gem '#{invalid_regexp}'.")
+      expect(err).to include("Could not find gem '#{invalid_regexp}'.")
     end
   end
 

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -77,13 +77,13 @@ RSpec.describe "bundle update" do
     it "errors when passed nothing" do
       install_gemfile! ""
       bundle :update
-      expect(out).to eq("To update everything, pass the `--all` flag.")
+      expect(err).to eq("To update everything, pass the `--all` flag.")
     end
 
     it "errors when passed --all and another option" do
       install_gemfile! ""
       bundle "update --all foo"
-      expect(out).to eq("Cannot specify --all along with specific options.")
+      expect(err).to eq("Cannot specify --all along with specific options.")
     end
 
     it "updates everything when passed --all" do
@@ -114,11 +114,11 @@ RSpec.describe "bundle update" do
   describe "with an unknown dependency" do
     it "should inform the user" do
       bundle "update halting-problem-solver"
-      expect(out).to include "Could not find gem 'halting-problem-solver'"
+      expect(err).to include "Could not find gem 'halting-problem-solver'"
     end
     it "should suggest alternatives" do
       bundle "update platformspecific"
-      expect(out).to include "Did you mean platform_specific?"
+      expect(err).to include "Did you mean platform_specific?"
     end
   end
 
@@ -299,7 +299,7 @@ RSpec.describe "bundle update" do
     it "should suggest different command when frozen is set globally", :bundler => "2" do
       bundle! "config --global deployment true"
       bundle "update", :all => bundle_update_requires_all?
-      expect(out).to match(/You are trying to install in deployment mode after changing.your Gemfile/m).
+      expect(err).to match(/You are trying to install in deployment mode after changing.your Gemfile/m).
         and match(/freeze \nby running `bundle config --delete deployment`./m)
     end
   end
@@ -639,7 +639,7 @@ RSpec.describe "bundle update" do
     G
 
     bundle "update nonexisting"
-    expect(out).to include("This Bundle hasn't been installed yet. Run `bundle install` to update and install the bundled gems.")
+    expect(err).to include("This Bundle hasn't been installed yet. Run `bundle install` to update and install the bundled gems.")
     expect(exitstatus).to eq(22) if exitstatus
   end
 end
@@ -719,7 +719,7 @@ RSpec.describe "bundle update --ruby" do
     it "shows a helpful error message" do
       bundle "update --ruby"
 
-      expect(out).to include("Your Ruby version is 2.2.2, but your Gemfile specified ~> 2.1.0")
+      expect(err).to include("Your Ruby version is 2.2.2, but your Gemfile specified ~> 2.1.0")
     end
   end
 

--- a/spec/install/allow_offline_install_spec.rb
+++ b/spec/install/allow_offline_install_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "bundle install with :allow_offline_install" do
         source "http://testgemserver.local"
         gem "rack-obama"
       G
-      expect(out).to include("Could not reach host testgemserver.local.")
+      expect(err).to include("Could not reach host testgemserver.local.")
       expect(the_bundle).to_not be_locked
     end
   end
@@ -77,7 +77,7 @@ RSpec.describe "bundle install with :allow_offline_install" do
       G
 
       break_git_remote_ops! { bundle! :update, :all => true }
-      expect(out).to include("Using cached git data because of network errors")
+      expect(err).to include("Using cached git data because of network errors")
       expect(the_bundle).to be_locked
 
       break_git_remote_ops! do
@@ -85,7 +85,7 @@ RSpec.describe "bundle install with :allow_offline_install" do
           gem "a", :git => #{git.path.to_s.dump}, :branch => "new_branch"
         G
       end
-      expect(out).to include("Using cached git data because of network errors")
+      expect(err).to include("Using cached git data because of network errors")
       expect(the_bundle).to be_locked
     end
   end

--- a/spec/install/bundler_spec.rb
+++ b/spec/install/bundler_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe "bundle install" do
           gem "requires_nonexistant_bundler"
         G
 
-        expect(out).to include "requires_nonexistant_bundler (1.0) has dependency bundler (= 99.99.99.99), " \
+        expect(err).to include "requires_nonexistant_bundler (1.0) has dependency bundler (= 99.99.99.99), " \
                                "which is unsatisfied by the current bundler version #{Bundler::VERSION}, so the dependency is being ignored"
 
         expect(the_bundle).to include_gems "bundler #{Bundler::VERSION}", "requires_nonexistant_bundler 1.0"

--- a/spec/install/deploy_spec.rb
+++ b/spec/install/deploy_spec.rb
@@ -129,11 +129,11 @@ RSpec.describe "install with --deployment or --frozen" do
       G
 
       bundle :install, forgotten_command_line_options(:deployment => true)
-      expect(out).to include("deployment mode")
-      expect(out).to include("You have added to the Gemfile")
-      expect(out).to include("* rack-obama")
-      expect(out).not_to include("You have deleted from the Gemfile")
-      expect(out).not_to include("You have changed in the Gemfile")
+      expect(err).to include("deployment mode")
+      expect(err).to include("You have added to the Gemfile")
+      expect(err).to include("* rack-obama")
+      expect(err).not_to include("You have deleted from the Gemfile")
+      expect(err).not_to include("You have changed in the Gemfile")
     end
 
     it "works if a path gem is missing but is in a without group" do
@@ -162,7 +162,7 @@ RSpec.describe "install with --deployment or --frozen" do
       FileUtils.rm_r lib_path("path_gem-1.0")
 
       bundle :install, forgotten_command_line_options(:path => ".bundle", :deployment => true)
-      expect(out).to include("The path `#{lib_path("path_gem-1.0")}` does not exist.")
+      expect(err).to include("The path `#{lib_path("path_gem-1.0")}` does not exist.")
     end
 
     it "can have --frozen set via an environment variable", :bundler => "< 2" do
@@ -190,11 +190,11 @@ RSpec.describe "install with --deployment or --frozen" do
 
       ENV["BUNDLE_DEPLOYMENT"] = "true"
       bundle "install"
-      expect(out).to include("deployment mode")
-      expect(out).to include("You have added to the Gemfile")
-      expect(out).to include("* rack-obama")
-      expect(out).not_to include("You have deleted from the Gemfile")
-      expect(out).not_to include("You have changed in the Gemfile")
+      expect(err).to include("deployment mode")
+      expect(err).to include("You have added to the Gemfile")
+      expect(err).to include("* rack-obama")
+      expect(err).not_to include("You have deleted from the Gemfile")
+      expect(err).not_to include("You have changed in the Gemfile")
     end
 
     it "can have --frozen set to false via an environment variable" do
@@ -220,11 +220,11 @@ RSpec.describe "install with --deployment or --frozen" do
       G
 
       bundle :install, forgotten_command_line_options(:frozen => true)
-      expect(out).to include("deployment mode")
-      expect(out).to include("You have added to the Gemfile")
-      expect(out).to include("* rack-obama (= 1.1)")
-      expect(out).not_to include("You have deleted from the Gemfile")
-      expect(out).not_to include("You have changed in the Gemfile")
+      expect(err).to include("deployment mode")
+      expect(err).to include("You have added to the Gemfile")
+      expect(err).to include("* rack-obama (= 1.1)")
+      expect(err).not_to include("You have deleted from the Gemfile")
+      expect(err).not_to include("You have changed in the Gemfile")
     end
 
     it "explodes if you remove a gem and don't check in the lockfile" do
@@ -234,10 +234,10 @@ RSpec.describe "install with --deployment or --frozen" do
       G
 
       bundle :install, forgotten_command_line_options(:deployment => true)
-      expect(out).to include("deployment mode")
-      expect(out).to include("You have added to the Gemfile:\n* activesupport\n\n")
-      expect(out).to include("You have deleted from the Gemfile:\n* rack")
-      expect(out).not_to include("You have changed in the Gemfile")
+      expect(err).to include("deployment mode")
+      expect(err).to include("You have added to the Gemfile:\n* activesupport\n\n")
+      expect(err).to include("You have deleted from the Gemfile:\n* rack")
+      expect(err).not_to include("You have changed in the Gemfile")
     end
 
     it "explodes if you add a source" do
@@ -247,9 +247,9 @@ RSpec.describe "install with --deployment or --frozen" do
       G
 
       bundle :install, forgotten_command_line_options(:deployment => true)
-      expect(out).to include("deployment mode")
-      expect(out).to include("You have added to the Gemfile:\n* source: git://hubz.com (at master)")
-      expect(out).not_to include("You have changed in the Gemfile")
+      expect(err).to include("deployment mode")
+      expect(err).to include("You have added to the Gemfile:\n* source: git://hubz.com (at master)")
+      expect(err).not_to include("You have changed in the Gemfile")
     end
 
     it "explodes if you unpin a source" do
@@ -266,10 +266,10 @@ RSpec.describe "install with --deployment or --frozen" do
       G
 
       bundle :install, forgotten_command_line_options(:deployment => true)
-      expect(out).to include("deployment mode")
-      expect(out).to include("You have deleted from the Gemfile:\n* source: #{lib_path("rack-1.0")} (at master@#{revision_for(lib_path("rack-1.0"))[0..6]}")
-      expect(out).not_to include("You have added to the Gemfile")
-      expect(out).not_to include("You have changed in the Gemfile")
+      expect(err).to include("deployment mode")
+      expect(err).to include("You have deleted from the Gemfile:\n* source: #{lib_path("rack-1.0")} (at master@#{revision_for(lib_path("rack-1.0"))[0..6]}")
+      expect(err).not_to include("You have added to the Gemfile")
+      expect(err).not_to include("You have changed in the Gemfile")
     end
 
     it "explodes if you unpin a source, leaving it pinned somewhere else" do
@@ -289,10 +289,10 @@ RSpec.describe "install with --deployment or --frozen" do
       G
 
       bundle :install, forgotten_command_line_options(:deployment => true)
-      expect(out).to include("deployment mode")
-      expect(out).to include("You have changed in the Gemfile:\n* rack from `no specified source` to `#{lib_path("rack")} (at master@#{revision_for(lib_path("rack"))[0..6]})`")
-      expect(out).not_to include("You have added to the Gemfile")
-      expect(out).not_to include("You have deleted from the Gemfile")
+      expect(err).to include("deployment mode")
+      expect(err).to include("You have changed in the Gemfile:\n* rack from `no specified source` to `#{lib_path("rack")} (at master@#{revision_for(lib_path("rack"))[0..6]})`")
+      expect(err).not_to include("You have added to the Gemfile")
+      expect(err).not_to include("You have deleted from the Gemfile")
     end
 
     context "when replacing a host with the same host with credentials" do
@@ -327,7 +327,7 @@ RSpec.describe "install with --deployment or --frozen" do
       it "prevents the replace by default" do
         bundle :install, forgotten_command_line_options(:deployment => true)
 
-        expect(out).to match(/The list of sources changed/)
+        expect(err).to match(/The list of sources changed/)
       end
 
       context "when allow_deployment_source_credential_changes is true" do
@@ -346,7 +346,7 @@ RSpec.describe "install with --deployment or --frozen" do
         it "prevents the replace" do
           bundle :install, forgotten_command_line_options(:deployment => true)
 
-          expect(out).to match(/The list of sources changed/)
+          expect(err).to match(/The list of sources changed/)
         end
       end
 
@@ -366,7 +366,7 @@ RSpec.describe "install with --deployment or --frozen" do
         it "prevents the replace" do
           bundle :install, forgotten_command_line_options(:deployment => true)
 
-          expect(out).to match(/The list of sources changed/)
+          expect(err).to match(/The list of sources changed/)
         end
       end
     end

--- a/spec/install/deploy_spec.rb
+++ b/spec/install/deploy_spec.rb
@@ -383,7 +383,7 @@ RSpec.describe "install with --deployment or --frozen" do
       G
 
       expect(the_bundle).not_to include_gems "rack 1.0.0"
-      expect(err).to include strip_whitespace(<<-E).strip
+      expect(last_command.stderr).to include strip_whitespace(<<-E).strip
 The dependencies in your gemfile changed
 
 You have added to the Gemfile:

--- a/spec/install/gemfile/gemspec_spec.rb
+++ b/spec/install/gemfile/gemspec_spec.rb
@@ -297,7 +297,7 @@ RSpec.describe "bundle install from an existing gemspec" do
 
         bundle :install, forgotten_command_line_options(:deployment => true)
 
-        expect(out).to include("changed")
+        expect(err).to include("changed")
       end
     end
   end

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe "bundle install with git sources" do
         gem "foo", "1.1", :git => "#{lib_path("foo-1.0")}"
       G
 
-      expect(out).to include("The source contains 'foo' at: 1.0")
+      expect(err).to include("The source contains 'foo' at: 1.0")
     end
 
     it "complains with version and platform if pinned specs don't exist in the git repo" do
@@ -103,7 +103,7 @@ RSpec.describe "bundle install with git sources" do
         end
       G
 
-      expect(out).to include("The source contains 'only_java' at: 1.0 java")
+      expect(err).to include("The source contains 'only_java' at: 1.0 java")
     end
 
     it "complains with multiple versions and platforms if pinned specs don't exist in the git repo" do
@@ -124,7 +124,7 @@ RSpec.describe "bundle install with git sources" do
         end
       G
 
-      expect(out).to include("The source contains 'only_java' at: 1.0 java, 1.1 java")
+      expect(err).to include("The source contains 'only_java' at: 1.0 java, 1.1 java")
     end
 
     it "still works after moving the application directory" do
@@ -507,7 +507,7 @@ RSpec.describe "bundle install with git sources" do
 
       bundle %(config local.rack #{lib_path("local-rack")})
       bundle :install
-      expect(out).to match(/Cannot use local override for rack-0.8 because #{Regexp.escape(lib_path('local-rack').to_s)} does not exist/)
+      expect(err).to match(/Cannot use local override for rack-0.8 because #{Regexp.escape(lib_path('local-rack').to_s)} does not exist/)
     end
 
     it "explodes if branch is not given on install" do
@@ -521,7 +521,7 @@ RSpec.describe "bundle install with git sources" do
 
       bundle %(config local.rack #{lib_path("local-rack")})
       bundle :install
-      expect(out).to match(/cannot use local override/i)
+      expect(err).to match(/cannot use local override/i)
     end
 
     it "does not explode if disable_local_branch_check is given" do
@@ -555,7 +555,7 @@ RSpec.describe "bundle install with git sources" do
 
       bundle %(config local.rack #{lib_path("local-rack")})
       bundle :install
-      expect(out).to match(/is using branch another but Gemfile specifies master/)
+      expect(err).to match(/is using branch another but Gemfile specifies master/)
     end
 
     it "explodes on invalid revision on install" do
@@ -572,7 +572,7 @@ RSpec.describe "bundle install with git sources" do
 
       bundle %(config local.rack #{lib_path("local-rack")})
       bundle :install
-      expect(out).to match(/The Gemfile lock is pointing to revision \w+/)
+      expect(err).to match(/The Gemfile lock is pointing to revision \w+/)
     end
   end
 
@@ -769,7 +769,7 @@ RSpec.describe "bundle install with git sources" do
 
     bundle :install
 
-    expect(out).to include("Git error:")
+    expect(err).to include("Git error:")
     expect(err).to include("fatal")
     expect(err).to include("omgomg")
   end
@@ -824,7 +824,7 @@ RSpec.describe "bundle install with git sources" do
         gem "has_submodule"
       end
     G
-    expect(out).to match(/could not find gem 'submodule/i)
+    expect(err).to match(/could not find gem 'submodule/i)
 
     expect(the_bundle).not_to include_gems "has_submodule 1.0"
   end
@@ -910,7 +910,7 @@ RSpec.describe "bundle install with git sources" do
     G
 
     expect(exitstatus).to_not eq(0) if exitstatus
-    expect(out).to include("Bundler could not install a gem because it " \
+    expect(err).to include("Bundler could not install a gem because it " \
                            "needs to create a directory, but a file exists " \
                            "- #{default_bundle_path("bundler")}")
   end
@@ -1014,7 +1014,7 @@ RSpec.describe "bundle install with git sources" do
       install_gemfile <<-G
         gem "foo", :git => "file://#{lib_path("foo-1.0")}", :ref => "deadbeef"
       G
-      expect(out).to include("Revision deadbeef does not exist in the repository")
+      expect(err).to include("Revision deadbeef does not exist in the repository")
     end
   end
 
@@ -1091,7 +1091,7 @@ RSpec.describe "bundle install with git sources" do
 
       bundle :install,
         :requires => [lib_path("install_hooks.rb")]
-      expect(out).to include("failed for foo-1.0")
+      expect(err).to include("failed for foo-1.0")
     end
   end
 

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe "bundle install with git sources" do
           gem "foo"
         end
       G
-      expect(err).to be_empty
+      expect(last_command.stderr).to be_empty
 
       run <<-RUBY
         require 'foo'
@@ -234,7 +234,7 @@ RSpec.describe "bundle install with git sources" do
           gem "foo"
         end
       G
-      expect(err).to be_empty
+      expect(last_command.stderr).to be_empty
 
       run! <<-RUBY
         require 'foo'
@@ -270,7 +270,7 @@ RSpec.describe "bundle install with git sources" do
           gem "foo"
         end
       G
-      expect(err).to be_empty
+      expect(last_command.stderr).to be_empty
 
       run! <<-RUBY
         require 'foo'
@@ -1051,7 +1051,7 @@ RSpec.describe "bundle install with git sources" do
 
       bundle :install,
         :requires => [lib_path("install_hooks.rb")]
-      expect(err).to eq_err("Ran pre-install hook: foo-1.0")
+      expect(last_command.stderr).to eq_err("Ran pre-install hook: foo-1.0")
     end
 
     it "runs post-install hooks" do
@@ -1071,7 +1071,7 @@ RSpec.describe "bundle install with git sources" do
 
       bundle :install,
         :requires => [lib_path("install_hooks.rb")]
-      expect(err).to eq_err("Ran post-install hook: foo-1.0")
+      expect(last_command.stderr).to eq_err("Ran post-install hook: foo-1.0")
     end
 
     it "complains if the install hook fails" do

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe "bundle install with git sources" do
           gem "foo"
         end
       G
-      expect(err).to lack_errors
+      expect(err).to be_empty
 
       run <<-RUBY
         require 'foo'
@@ -234,7 +234,7 @@ RSpec.describe "bundle install with git sources" do
           gem "foo"
         end
       G
-      expect(err).to lack_errors
+      expect(err).to be_empty
 
       run! <<-RUBY
         require 'foo'
@@ -270,7 +270,7 @@ RSpec.describe "bundle install with git sources" do
           gem "foo"
         end
       G
-      expect(err).to lack_errors
+      expect(err).to be_empty
 
       run! <<-RUBY
         require 'foo'

--- a/spec/install/gemfile/groups_spec.rb
+++ b/spec/install/gemfile/groups_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "bundle install with groups" do
         puts ACTIVESUPPORT
       R
 
-      expect(err).to eq_err("ZOMG LOAD ERROR")
+      expect(last_command.stderr).to eq_err("ZOMG LOAD ERROR")
     end
 
     it "installs gems with inline :groups into those groups" do
@@ -36,7 +36,7 @@ RSpec.describe "bundle install with groups" do
         puts THIN
       R
 
-      expect(err).to eq_err("ZOMG LOAD ERROR")
+      expect(last_command.stderr).to eq_err("ZOMG LOAD ERROR")
     end
 
     it "sets up everything if Bundler.setup is used with no groups" do
@@ -57,7 +57,7 @@ RSpec.describe "bundle install with groups" do
         puts THIN
       RUBY
 
-      expect(err).to eq_err("ZOMG LOAD ERROR")
+      expect(last_command.stderr).to eq_err("ZOMG LOAD ERROR")
     end
 
     it "sets up old groups when they have previously been removed" do

--- a/spec/install/gemfile/path_spec.rb
+++ b/spec/install/gemfile/path_spec.rb
@@ -313,7 +313,7 @@ RSpec.describe "bundle install with explicit source paths" do
     install_gemfile <<-G
       gem 'foo', '1.0', :path => "#{lib_path("foo-1.0")}"
     G
-    expect(err).to be_empty
+    expect(last_command.stderr).to be_empty
   end
 
   it "removes the .gem file after installing" do
@@ -575,7 +575,7 @@ RSpec.describe "bundle install with explicit source paths" do
 
       bundle :install,
         :requires => [lib_path("install_hooks.rb")]
-      expect(err).to eq_err("Ran pre-install hook: foo-1.0")
+      expect(last_command.stderr).to eq_err("Ran pre-install hook: foo-1.0")
     end
 
     it "runs post-install hooks" do
@@ -595,7 +595,7 @@ RSpec.describe "bundle install with explicit source paths" do
 
       bundle :install,
         :requires => [lib_path("install_hooks.rb")]
-      expect(err).to eq_err("Ran post-install hook: foo-1.0")
+      expect(last_command.stderr).to eq_err("Ran post-install hook: foo-1.0")
     end
 
     it "complains if the install hook fails" do

--- a/spec/install/gemfile/path_spec.rb
+++ b/spec/install/gemfile/path_spec.rb
@@ -313,7 +313,7 @@ RSpec.describe "bundle install with explicit source paths" do
     install_gemfile <<-G
       gem 'foo', '1.0', :path => "#{lib_path("foo-1.0")}"
     G
-    expect(err).to lack_errors
+    expect(err).to be_empty
   end
 
   it "removes the .gem file after installing" do

--- a/spec/install/gemfile/path_spec.rb
+++ b/spec/install/gemfile/path_spec.rb
@@ -66,8 +66,8 @@ RSpec.describe "bundle install with explicit source paths" do
     install_gemfile <<-G
       gem 'foo', :path => "~#{username}/#{relative_path}"
     G
-    expect(out).to match("There was an error while trying to use the path `~#{username}/#{relative_path}`.")
-    expect(out).to match("user #{username} doesn't exist")
+    expect(err).to match("There was an error while trying to use the path `~#{username}/#{relative_path}`.")
+    expect(err).to match("user #{username} doesn't exist")
   end
 
   it "expands paths relative to Bundler.root" do
@@ -183,11 +183,11 @@ RSpec.describe "bundle install with explicit source paths" do
       gem "foo", :path => "#{lib_path("foo-1.0")}"
     G
 
-    expect(out).to_not include("ERROR REPORT")
-    expect(out).to_not include("Your Gemfile has no gem server sources.")
-    expect(out).to match(/is not valid. Please fix this gemspec./)
-    expect(out).to match(/The validation error was 'missing value for attribute version'/)
-    expect(out).to match(/You have one or more invalid gemspecs that need to be fixed/)
+    expect(err).to_not include("ERROR REPORT")
+    expect(err).to_not include("Your Gemfile has no gem server sources.")
+    expect(err).to match(/is not valid. Please fix this gemspec./)
+    expect(err).to match(/The validation error was 'missing value for attribute version'/)
+    expect(err).to match(/You have one or more invalid gemspecs that need to be fixed/)
   end
 
   it "supports gemspec syntax" do
@@ -274,7 +274,7 @@ RSpec.describe "bundle install with explicit source paths" do
     G
 
     expect(exitstatus).to eq(15) if exitstatus
-    expect(out).to match(/There are multiple gemspecs/)
+    expect(err).to match(/There are multiple gemspecs/)
   end
 
   it "allows :name to be specified to resolve ambiguity" do
@@ -615,7 +615,7 @@ RSpec.describe "bundle install with explicit source paths" do
 
       bundle :install,
         :requires => [lib_path("install_hooks.rb")]
-      expect(out).to include("failed for foo-1.0")
+      expect(err).to include("failed for foo-1.0")
     end
 
     it "loads plugins from the path gem" do

--- a/spec/install/gemfile/platform_spec.rb
+++ b/spec/install/gemfile/platform_spec.rb
@@ -385,7 +385,7 @@ RSpec.describe "bundle install with platform conditionals" do
 
     bundle! "install"
 
-    expect(out).to include <<-O.strip
+    expect(err).to include <<-O.strip
 The dependency #{Gem::Dependency.new("rack", ">= 0")} will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for x86-mingw32, x86-mswin32, x64-mingw32, java. To add those platforms to the bundle, run `bundle lock --add-platform x86-mingw32 x86-mswin32 x64-mingw32 java`.
     O
   end

--- a/spec/install/gemfile/ruby_spec.rb
+++ b/spec/install/gemfile/ruby_spec.rb
@@ -103,6 +103,6 @@ RSpec.describe "ruby requirement" do
       gem "rack"
     G
 
-    expect(out).to include("There was an error parsing") # i.e. DSL error, not error template
+    expect(err).to include("There was an error parsing") # i.e. DSL error, not error template
   end
 end

--- a/spec/install/gemfile/sources_spec.rb
+++ b/spec/install/gemfile/sources_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
       it "errors when disable_multisource is set" do
         bundle "config disable_multisource true"
         bundle :install
-        expect(out).to include("Each source after the first must include a block")
+        expect(err).to include("Each source after the first must include a block")
         expect(exitstatus).to eq(4) if exitstatus
       end
     end
@@ -348,7 +348,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
           it "does not find the dependency" do
             bundle :install
-            expect(out).to include("Could not find gem 'rack', which is required by gem 'depends_on_rack', in any of the relevant sources")
+            expect(err).to include("Could not find gem 'rack', which is required by gem 'depends_on_rack', in any of the relevant sources")
           end
         end
 
@@ -388,7 +388,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
       it "does not install the gem" do
         bundle :install
-        expect(out).to include("Could not find gem 'not_in_repo1'")
+        expect(err).to include("Could not find gem 'not_in_repo1'")
       end
     end
 

--- a/spec/install/gemfile_spec.rb
+++ b/spec/install/gemfile_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "bundle install" do
         gem 'rails', '~> 4.0.0'
         gem 'rails', '~> 4.0.0'
       G
-      expect(out).to include("more than once")
+      expect(err).to include("more than once")
     end
   end
 
@@ -65,7 +65,7 @@ RSpec.describe "bundle install" do
       G
 
       bundle :install
-      expect(out).to match(/You passed :lib as an option for gem 'rack', but it is invalid/)
+      expect(err).to match(/You passed :lib as an option for gem 'rack', but it is invalid/)
     end
   end
 

--- a/spec/install/gems/compact_index_spec.rb
+++ b/spec/install/gems/compact_index_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "compact index api" do
     G
 
     bundle :install, :artifice => "compact_index"
-    expect(out).to include("' sinatra' is not a valid gem name because it contains whitespace.")
+    expect(err).to include("' sinatra' is not a valid gem name because it contains whitespace.")
   end
 
   it "should handle nested dependencies" do
@@ -226,7 +226,7 @@ The checksum of /versions does not match the checksum provided by the server! So
     G
 
     bundle :install, :artifice => "compact_index_redirects"
-    expect(out).to match(/Too many redirects/)
+    expect(err).to match(/Too many redirects/)
   end
 
   context "when --full-index is specified" do
@@ -691,14 +691,14 @@ The checksum of /versions does not match the checksum provided by the server! So
 
       it "shows instructions if auth is not provided for the source" do
         bundle :install, :artifice => "compact_index_strict_basic_authentication"
-        expect(out).to include("bundle config #{source_hostname} username:password")
+        expect(err).to include("bundle config #{source_hostname} username:password")
       end
 
       it "fails if authentication has already been provided, but failed" do
         bundle "config #{source_hostname} #{user}:wrong"
 
         bundle :install, :artifice => "compact_index_strict_basic_authentication"
-        expect(out).to include("Bad username or password")
+        expect(err).to include("Bad username or password")
       end
     end
 
@@ -737,7 +737,7 @@ The checksum of /versions does not match the checksum provided by the server! So
       G
 
       bundle :install, :env => { "RUBYOPT" => "-I#{bundled_app("broken_ssl")}" }
-      expect(out).to include("OpenSSL")
+      expect(err).to include("OpenSSL")
     end
   end
 
@@ -757,7 +757,7 @@ The checksum of /versions does not match the checksum provided by the server! So
       G
 
       bundle :install
-      expect(out).to match(/could not verify the SSL certificate/i)
+      expect(err).to match(/could not verify the SSL certificate/i)
     end
   end
 
@@ -858,7 +858,7 @@ The checksum of /versions does not match the checksum provided by the server! So
       gem "rack"
     G
     expect(exitstatus).to eq(15) if exitstatus
-    expect(out).to end_with(<<-E.strip)
+    expect(err).to end_with(<<-E.strip)
       The request uri `htps://index.rubygems.org/versions` has an invalid scheme (`htps`). Did you mean `http` or `https`?
     E
   end
@@ -871,7 +871,7 @@ The checksum of /versions does not match the checksum provided by the server! So
       G
 
       expect(exitstatus).to eq(19) if exitstatus
-      expect(out).
+      expect(err).
         to  include("Bundler cannot continue installing rack (1.0.0).").
         and include("The checksum for the downloaded `rack-1.0.0.gem` does not match the checksum given by the server.").
         and include("This means the contents of the downloaded gem is different from what was uploaded to the server, and could be a potential security issue.").
@@ -890,7 +890,7 @@ The checksum of /versions does not match the checksum provided by the server! So
         gem "rack"
       G
       expect(exitstatus).to eq(5) if exitstatus
-      expect(out).to include("The given checksum for rack-1.0.0 (\"checksum!\") is not a valid SHA256 hexdigest nor base64digest")
+      expect(err).to include("The given checksum for rack-1.0.0 (\"checksum!\") is not a valid SHA256 hexdigest nor base64digest")
     end
 
     it "does not raise when disable_checksum_validation is set" do

--- a/spec/install/gems/dependency_api_spec.rb
+++ b/spec/install/gems/dependency_api_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "gemcutter's dependency API" do
     G
 
     bundle :install, :artifice => "endpoint"
-    expect(out).to include("' sinatra' is not a valid gem name because it contains whitespace.")
+    expect(err).to include("' sinatra' is not a valid gem name because it contains whitespace.")
   end
 
   it "should handle nested dependencies" do
@@ -216,7 +216,7 @@ RSpec.describe "gemcutter's dependency API" do
     G
 
     bundle :install, :artifice => "endpoint_redirect"
-    expect(out).to match(/Too many redirects/)
+    expect(err).to match(/Too many redirects/)
   end
 
   context "when --full-index is specified" do
@@ -665,14 +665,14 @@ RSpec.describe "gemcutter's dependency API" do
 
       it "shows instructions if auth is not provided for the source" do
         bundle :install, :artifice => "endpoint_strict_basic_authentication"
-        expect(out).to include("bundle config #{source_hostname} username:password")
+        expect(err).to include("bundle config #{source_hostname} username:password")
       end
 
       it "fails if authentication has already been provided, but failed" do
         bundle "config #{source_hostname} #{user}:wrong"
 
         bundle :install, :artifice => "endpoint_strict_basic_authentication"
-        expect(out).to include("Bad username or password")
+        expect(err).to include("Bad username or password")
       end
     end
 
@@ -711,7 +711,7 @@ RSpec.describe "gemcutter's dependency API" do
       G
 
       bundle :install, :env => { "RUBYOPT" => "-I#{bundled_app("broken_ssl")}" }
-      expect(out).to include("OpenSSL")
+      expect(err).to include("OpenSSL")
     end
   end
 
@@ -731,7 +731,7 @@ RSpec.describe "gemcutter's dependency API" do
       G
 
       bundle :install
-      expect(out).to match(/could not verify the SSL certificate/i)
+      expect(err).to match(/could not verify the SSL certificate/i)
     end
   end
 

--- a/spec/install/gems/flex_spec.rb
+++ b/spec/install/gems/flex_spec.rb
@@ -233,9 +233,9 @@ RSpec.describe "bundle flex_install" do
         bundle "install"
       end.not_to change { File.read(bundled_app("Gemfile.lock")) }
 
-      expect(out).to include("rack = 0.9.1")
-      expect(out).to include("locked at 1.0.0")
-      expect(out).to include("bundle update rack")
+      expect(err).to include("rack = 0.9.1")
+      expect(err).to include("locked at 1.0.0")
+      expect(err).to include("bundle update rack")
     end
 
     it "should work when you update" do
@@ -345,7 +345,7 @@ RSpec.describe "bundle flex_install" do
         gem "capybara", "0.3.9"
       G
 
-      expect(out).to include("Gemfile.lock")
+      expect(err).to include("Gemfile.lock")
     end
   end
 end

--- a/spec/install/gems/flex_spec.rb
+++ b/spec/install/gems/flex_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe "bundle flex_install" do
       ruby <<-RUBY
         require 'bundler/setup'
       RUBY
-      expect(err).to match(/could not find gem 'rack-obama/i)
+      expect(last_command.stderr).to match(/could not find gem 'rack-obama/i)
     end
 
     it "suggests bundle update when the Gemfile requires different versions than the lock" do

--- a/spec/install/gems/resolving_spec.rb
+++ b/spec/install/gems/resolving_spec.rb
@@ -187,8 +187,8 @@ RSpec.describe "bundle install with install-time dependencies" do
         gem 'require_rubygems'
       G
 
-      expect(out).to_not include("Gem::InstallError: require_rubygems requires RubyGems version > 9000")
-      expect(out).to include("require_rubygems-1.0 requires rubygems version > 9000, which is incompatible with the current version, #{Gem::VERSION}")
+      expect(err).to_not include("Gem::InstallError: require_rubygems requires RubyGems version > 9000")
+      expect(err).to include("require_rubygems-1.0 requires rubygems version > 9000, which is incompatible with the current version, #{Gem::VERSION}")
     end
   end
 end

--- a/spec/install/gems/resolving_spec.rb
+++ b/spec/install/gems/resolving_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe "bundle install with install-time dependencies" do
 
         bundle :install, :env => { "DEBUG_RESOLVER" => "1" }
 
-        expect(err).to include("Creating possibility state for net_c")
+        expect(last_command.stderr).to include("Creating possibility state for net_c")
       end
     end
 
@@ -91,7 +91,7 @@ RSpec.describe "bundle install with install-time dependencies" do
 
         bundle :install, :env => { "DEBUG_RESOLVER_TREE" => "1" }
 
-        expect(err).to include(" net_b").
+        expect(last_command.stderr).to include(" net_b").
           and include("Starting resolution").
           and include("Finished resolution").
           and include("Attempting to activate")

--- a/spec/install/gems/standalone_spec.rb
+++ b/spec/install/gems/standalone_spec.rb
@@ -108,8 +108,8 @@ RSpec.shared_examples "bundle install --standalone" do
     end
 
     it "outputs a helpful error message" do
-      expect(out).to include("You have one or more invalid gemspecs that need to be fixed.")
-      expect(out).to include("bar 1.0 has an invalid gemspec")
+      expect(err).to include("You have one or more invalid gemspecs that need to be fixed.")
+      expect(err).to include("bar 1.0 has an invalid gemspec")
     end
   end
 

--- a/spec/install/gems/sudo_spec.rb
+++ b/spec/install/gems/sudo_spec.rb
@@ -158,20 +158,20 @@ RSpec.describe "when using sudo", :sudo => true do
 
     it "warns against that" do
       bundle :install, :sudo => true
-      expect(out).to include(warning)
+      expect(err).to include(warning)
     end
 
     context "when ENV['BUNDLE_SILENCE_ROOT_WARNING'] is set" do
       it "skips the warning" do
         bundle :install, :sudo => :preserve_env, :env => { "BUNDLE_SILENCE_ROOT_WARNING" => true }
-        expect(out).to_not include(warning)
+        expect(err).to_not include(warning)
       end
     end
 
     context "when silence_root_warning = false" do
       it "warns against that" do
         bundle :install, :sudo => true, :env => { "BUNDLE_SILENCE_ROOT_WARNING" => "false" }
-        expect(out).to include(warning)
+        expect(err).to include(warning)
       end
     end
   end

--- a/spec/install/gemspecs_spec.rb
+++ b/spec/install/gemspecs_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "bundle install" do
         gem "yaml_spec"
       G
       bundle :install
-      expect(err).to lack_errors
+      expect(err).to be_empty
     end
 
     it "still installs correctly when using path" do
@@ -24,7 +24,7 @@ RSpec.describe "bundle install" do
       install_gemfile <<-G
         gem 'yaml_spec', :path => "#{lib_path("yaml_spec-1.0")}"
       G
-      expect(err).to lack_errors
+      expect(err).to be_empty
     end
   end
 

--- a/spec/install/gemspecs_spec.rb
+++ b/spec/install/gemspecs_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "bundle install" do
         gem "yaml_spec"
       G
       bundle :install
-      expect(err).to be_empty
+      expect(last_command.stderr).to be_empty
     end
 
     it "still installs correctly when using path" do
@@ -24,7 +24,7 @@ RSpec.describe "bundle install" do
       install_gemfile <<-G
         gem 'yaml_spec', :path => "#{lib_path("yaml_spec-1.0")}"
       G
-      expect(err).to be_empty
+      expect(last_command.stderr).to be_empty
     end
   end
 

--- a/spec/install/gemspecs_spec.rb
+++ b/spec/install/gemspecs_spec.rb
@@ -129,8 +129,8 @@ RSpec.describe "bundle install" do
         gemspec
       G
 
-      expect(out).to include("Ruby patchlevel")
-      expect(out).to include("but your Gemfile specified")
+      expect(err).to include("Ruby patchlevel")
+      expect(err).to include("but your Gemfile specified")
       expect(exitstatus).to eq(18) if exitstatus
     end
 
@@ -146,8 +146,8 @@ RSpec.describe "bundle install" do
         gemspec
       G
 
-      expect(out).to include("Ruby version")
-      expect(out).to include("but your Gemfile specified")
+      expect(err).to include("Ruby version")
+      expect(err).to include("but your Gemfile specified")
       expect(exitstatus).to eq(18) if exitstatus
     end
   end

--- a/spec/install/global_cache_spec.rb
+++ b/spec/install/global_cache_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe "global gem caching" do
         expect(source_global_cache("rack-1.0.0.gem")).to exist
         expect(source2_global_cache("rack-0.9.1.gem")).to exist
         bundle :install, :artifice => "compact_index_no_gem"
-        expect(out).to include("Internal Server Error 500")
+        expect(err).to include("Internal Server Error 500")
         # rack 1.0.0 is not installed and rack 0.9.1 is not
         expect(the_bundle).not_to include_gems "rack 1.0.0"
         expect(the_bundle).not_to include_gems "rack 0.9.1"
@@ -125,7 +125,7 @@ RSpec.describe "global gem caching" do
         expect(source_global_cache("rack-1.0.0.gem")).to exist
         expect(source2_global_cache("rack-0.9.1.gem")).to exist
         bundle :install, :artifice => "compact_index_no_gem"
-        expect(out).to include("Internal Server Error 500")
+        expect(err).to include("Internal Server Error 500")
         # rack 0.9.1 is not installed and rack 1.0.0 is not
         expect(the_bundle).not_to include_gems "rack 0.9.1"
         expect(the_bundle).not_to include_gems "rack 1.0.0"

--- a/spec/install/path_spec.rb
+++ b/spec/install/path_spec.rb
@@ -250,7 +250,7 @@ RSpec.describe "bundle install" do
       G
 
       bundle :install, forgotten_command_line_options(:path => "bundle")
-      expect(out).to include("file already exists")
+      expect(err).to include("file already exists")
     end
   end
 end

--- a/spec/install/path_spec.rb
+++ b/spec/install/path_spec.rb
@@ -226,7 +226,7 @@ RSpec.describe "bundle install" do
       vendored_gems("extensions").rmtree
 
       run "require 'very_simple_binary_c'"
-      expect(err).to include("Bundler::GemNotFound")
+      expect(last_command.stderr).to include("Bundler::GemNotFound")
 
       bundle :install, forgotten_command_line_options(:path => "./vendor/bundle")
 

--- a/spec/install/post_bundle_message_spec.rb
+++ b/spec/install/post_bundle_message_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe "post bundle message" do
           gem "rack"
           gem "not-a-gem", :group => :development
         G
-        expect(out).to include normalize_uri_file(<<-EOS.strip)
+        expect(err).to include normalize_uri_file(<<-EOS.strip)
 Could not find gem 'not-a-gem' in rubygems repository file://localhost#{gem_repo1}/ or installed locally.
 The source does not contain any versions of 'not-a-gem'
         EOS
@@ -134,7 +134,7 @@ The source does not contain any versions of 'not-a-gem'
           gem "rack"
           gem "not-a-gem", :group => :development
         G
-        expect(out).to include("Could not find gem 'not-a-gem' in").
+        expect(err).to include("Could not find gem 'not-a-gem' in").
           and include("or in gems cached in vendor/cache.")
       end
     end

--- a/spec/install/redownload_spec.rb
+++ b/spec/install/redownload_spec.rb
@@ -63,12 +63,12 @@ RSpec.describe "bundle install" do
 
     it "shows a deprecation when single flag passed", :bundler => 2 do
       bundle! "install --force"
-      expect(out).to include "[DEPRECATED FOR 2.0] The `--force` option has been renamed to `--redownload`"
+      expect(err).to include "[DEPRECATED FOR 2.0] The `--force` option has been renamed to `--redownload`"
     end
 
     it "shows a deprecation when multiple flags passed", :bundler => 2 do
       bundle! "install --no-color --force"
-      expect(out).to include "[DEPRECATED FOR 2.0] The `--force` option has been renamed to `--redownload`"
+      expect(err).to include "[DEPRECATED FOR 2.0] The `--force` option has been renamed to `--redownload`"
     end
 
     it "does not show a deprecation when single flag passed", :bundler => "< 2" do
@@ -89,12 +89,12 @@ RSpec.describe "bundle install" do
 
     it "does not show a deprecation when single flag passed" do
       bundle! "install --redownload"
-      expect(out).not_to include "[DEPRECATED FOR 2.0] The `--force` option has been renamed to `--redownload`"
+      expect(err).not_to include "[DEPRECATED FOR 2.0] The `--force` option has been renamed to `--redownload`"
     end
 
     it "does not show a deprecation when single multiple flags passed" do
       bundle! "install --no-color --redownload"
-      expect(out).not_to include "[DEPRECATED FOR 2.0] The `--force` option has been renamed to `--redownload`"
+      expect(err).not_to include "[DEPRECATED FOR 2.0] The `--force` option has been renamed to `--redownload`"
     end
   end
 end

--- a/spec/install/security_policy_spec.rb
+++ b/spec/install/security_policy_spec.rb
@@ -24,18 +24,18 @@ RSpec.describe "policies with unsigned gems" do
 
   it "will fail when given invalid security policy" do
     bundle "install --trust-policy=InvalidPolicyName"
-    expect(out).to include("RubyGems doesn't know about trust policy")
+    expect(err).to include("RubyGems doesn't know about trust policy")
   end
 
   it "will fail with High Security setting due to presence of unsigned gem" do
     bundle "install --trust-policy=HighSecurity"
-    expect(out).to include("security policy didn't allow")
+    expect(err).to include("security policy didn't allow")
   end
 
   # This spec will fail on RubyGems 2 rc1 due to a bug in policy.rb. the bug is fixed in rc3.
   it "will fail with Medium Security setting due to presence of unsigned gem", :unless => ENV["RGV"] == "v2.0.0.rc.1" do
     bundle "install --trust-policy=MediumSecurity"
-    expect(out).to include("security policy didn't allow")
+    expect(err).to include("security policy didn't allow")
   end
 
   it "will succeed with no policy" do
@@ -55,12 +55,12 @@ RSpec.describe "policies with signed gems and no CA" do
 
   it "will fail with High Security setting, gem is self-signed" do
     bundle "install --trust-policy=HighSecurity"
-    expect(out).to include("security policy didn't allow")
+    expect(err).to include("security policy didn't allow")
   end
 
   it "will fail with Medium Security setting, gem is self-signed" do
     bundle "install --trust-policy=MediumSecurity"
-    expect(out).to include("security policy didn't allow")
+    expect(err).to include("security policy didn't allow")
   end
 
   it "will succeed with Low Security setting, low security accepts self signed gem" do

--- a/spec/install/yanked_spec.rb
+++ b/spec/install/yanked_spec.rb
@@ -27,7 +27,7 @@ RSpec.context "when installing a bundle that includes yanked gems" do
         gem "foo", "10.0.0"
     G
 
-    expect(out).to include("Your bundle is locked to foo (10.0.0)")
+    expect(err).to include("Your bundle is locked to foo (10.0.0)")
   end
 
   it "throws the original error when only the Gemfile specifies a gem version that doesn't exist" do
@@ -36,8 +36,8 @@ RSpec.context "when installing a bundle that includes yanked gems" do
         gem "foo", "10.0.0"
     G
 
-    expect(out).not_to include("Your bundle is locked to foo (10.0.0)")
-    expect(out).to include("Could not find gem 'foo (= 10.0.0)' in")
+    expect(err).not_to include("Your bundle is locked to foo (10.0.0)")
+    expect(err).to include("Could not find gem 'foo (= 10.0.0)' in")
   end
 end
 
@@ -63,9 +63,9 @@ RSpec.context "when using gem before installing" do
 
     bundle :list
 
-    expect(out).to include("Could not find rack-0.9.1 in any of the sources")
-    expect(out).to_not include("Your bundle is locked to rack (0.9.1), but that version could not be found in any of the sources listed in your Gemfile.")
-    expect(out).to_not include("If you haven't changed sources, that means the author of rack (0.9.1) has removed it.")
-    expect(out).to_not include("You'll need to update your bundle to a different version of rack (0.9.1) that hasn't been removed in order to install.")
+    expect(err).to include("Could not find rack-0.9.1 in any of the sources")
+    expect(err).to_not include("Your bundle is locked to rack (0.9.1), but that version could not be found in any of the sources listed in your Gemfile.")
+    expect(err).to_not include("If you haven't changed sources, that means the author of rack (0.9.1) has removed it.")
+    expect(err).to_not include("You'll need to update your bundle to a different version of rack (0.9.1) that hasn't been removed in order to install.")
   end
 end

--- a/spec/lock/lockfile_bundler_1_spec.rb
+++ b/spec/lock/lockfile_bundler_1_spec.rb
@@ -291,8 +291,8 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
       G
     end
 
-    expect(err).to include("Warning: the lockfile is being updated to Bundler " \
-                          "9999999, after which you will be unable to return to Bundler 1.")
+    expect(last_command.stderr).to include("Warning: the lockfile is being updated to Bundler " \
+                                           "9999999, after which you will be unable to return to Bundler 1.")
 
     lockfile_should_be <<-G
       GEM

--- a/spec/lock/lockfile_bundler_1_spec.rb
+++ b/spec/lock/lockfile_bundler_1_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
 
     warning_message = "the running version of Bundler (9999999.0.0) is older " \
                       "than the version that created the lockfile (9999999.1.0)"
-    expect(out.scan(warning_message).size).to eq(1)
+    expect(last_command.stderr.scan(warning_message).size).to eq(1)
 
     lockfile_should_be <<-G
       GEM
@@ -263,7 +263,7 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
     G
 
     expect(exitstatus > 0) if exitstatus
-    expect(out).to include("You must use Bundler 9999999 or greater with this lockfile.")
+    expect(err).to include("You must use Bundler 9999999 or greater with this lockfile.")
   end
 
   it "warns when updating bundler major version" do
@@ -291,7 +291,7 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
       G
     end
 
-    expect(out).to include("Warning: the lockfile is being updated to Bundler " \
+    expect(err).to include("Warning: the lockfile is being updated to Bundler " \
                           "9999999, after which you will be unable to return to Bundler 1.")
 
     lockfile_should_be <<-G
@@ -1123,7 +1123,7 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
     G
 
     expect(bundled_app("Gemfile.lock")).not_to exist
-    expect(out).to include "rack (= 1.0) and rack (= 1.1)"
+    expect(err).to include "rack (= 1.0) and rack (= 1.1)"
   end
 
   it "raises if two different sources are used" do
@@ -1134,7 +1134,7 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
     G
 
     expect(bundled_app("Gemfile.lock")).not_to exist
-    expect(out).to include "rack (>= 0) should come from an unspecified source and git://hubz.com (at master)"
+    expect(err).to include "rack (>= 0) should come from an unspecified source and git://hubz.com (at master)"
   end
 
   it "works correctly with multiple version dependencies" do
@@ -1282,7 +1282,7 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
       gem "rack_middleware"
     G
 
-    expect(out).to include("Downloading rack_middleware-1.0 revealed dependencies not in the API or the lockfile (#{Gem::Dependency.new("rack", "= 0.9.1")}).").
+    expect(err).to include("Downloading rack_middleware-1.0 revealed dependencies not in the API or the lockfile (#{Gem::Dependency.new("rack", "= 0.9.1")}).").
       and include("Either installing with `--full-index` or running `bundle update rack_middleware` should fix the problem.")
   end
 

--- a/spec/lock/lockfile_spec.rb
+++ b/spec/lock/lockfile_spec.rb
@@ -262,7 +262,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
     G
 
     expect(last_command).to be_failure
-    expect(out).to include("You must use Bundler 9999999 or greater with this lockfile.")
+    expect(err).to include("You must use Bundler 9999999 or greater with this lockfile.")
   end
 
   it "warns when updating bundler major version" do
@@ -290,7 +290,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
       G
     end
 
-    expect(out).to include("Warning: the lockfile is being updated to Bundler " \
+    expect(err).to include("Warning: the lockfile is being updated to Bundler " \
                           "9999999, after which you will be unable to return to Bundler 1.")
 
     lockfile_should_be <<-G
@@ -1162,7 +1162,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
     G
 
     expect(bundled_app("Gemfile.lock")).not_to exist
-    expect(out).to include "rack (= 1.0) and rack (= 1.1)"
+    expect(err).to include "rack (= 1.0) and rack (= 1.1)"
   end
 
   it "raises if two different sources are used" do
@@ -1173,7 +1173,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
     G
 
     expect(bundled_app("Gemfile.lock")).not_to exist
-    expect(out).to include "rack (>= 0) should come from an unspecified source and git://hubz.com (at master)"
+    expect(err).to include "rack (>= 0) should come from an unspecified source and git://hubz.com (at master)"
   end
 
   it "works correctly with multiple version dependencies" do
@@ -1321,7 +1321,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
       gem "rack_middleware"
     G
 
-    expect(out).to include("Downloading rack_middleware-1.0 revealed dependencies not in the API or the lockfile (#{Gem::Dependency.new("rack", "= 0.9.1")}).").
+    expect(err).to include("Downloading rack_middleware-1.0 revealed dependencies not in the API or the lockfile (#{Gem::Dependency.new("rack", "= 0.9.1")}).").
       and include("Either installing with `--full-index` or running `bundle update rack_middleware` should fix the problem.")
   end
 

--- a/spec/other/compatibility_guard_spec.rb
+++ b/spec/other/compatibility_guard_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "bundler compatibility guard" do
 
       it "raises a friendly error" do
         bundle :version
-        expect(err).to eq("Bundler 2 requires RubyGems 2.5 or later. Either install bundler 1 or update to a supported RubyGems version.")
+        expect(last_command.stderr).to eq("Bundler 2 requires RubyGems 2.5 or later. Either install bundler 1 or update to a supported RubyGems version.")
       end
     end
   end

--- a/spec/other/platform_spec.rb
+++ b/spec/other/platform_spec.rb
@@ -268,27 +268,27 @@ G
 
   def should_be_ruby_version_incorrect
     expect(exitstatus).to eq(18) if exitstatus
-    expect(out).to be_include("Your Ruby version is #{RUBY_VERSION}, but your Gemfile specified #{not_local_ruby_version}")
+    expect(err).to be_include("Your Ruby version is #{RUBY_VERSION}, but your Gemfile specified #{not_local_ruby_version}")
   end
 
   def should_be_engine_incorrect
     expect(exitstatus).to eq(18) if exitstatus
-    expect(out).to be_include("Your Ruby engine is #{local_ruby_engine}, but your Gemfile specified #{not_local_tag}")
+    expect(err).to be_include("Your Ruby engine is #{local_ruby_engine}, but your Gemfile specified #{not_local_tag}")
   end
 
   def should_be_engine_version_incorrect
     expect(exitstatus).to eq(18) if exitstatus
-    expect(out).to be_include("Your #{local_ruby_engine} version is #{local_engine_version}, but your Gemfile specified #{local_ruby_engine} #{not_local_engine_version}")
+    expect(err).to be_include("Your #{local_ruby_engine} version is #{local_engine_version}, but your Gemfile specified #{local_ruby_engine} #{not_local_engine_version}")
   end
 
   def should_be_patchlevel_incorrect
     expect(exitstatus).to eq(18) if exitstatus
-    expect(out).to be_include("Your Ruby patchlevel is #{RUBY_PATCHLEVEL}, but your Gemfile specified #{not_local_patchlevel}")
+    expect(err).to be_include("Your Ruby patchlevel is #{RUBY_PATCHLEVEL}, but your Gemfile specified #{not_local_patchlevel}")
   end
 
   def should_be_patchlevel_fixnum
     expect(exitstatus).to eq(18) if exitstatus
-    expect(out).to be_include("The Ruby patchlevel in your Gemfile must be a string")
+    expect(err).to be_include("The Ruby patchlevel in your Gemfile must be a string")
   end
 
   context "bundle install" do

--- a/spec/other/platform_spec.rb
+++ b/spec/other/platform_spec.rb
@@ -863,7 +863,7 @@ G
       G
 
       bundle "exec rackup"
-      expect(out).to eq("0.9.1")
+      expect(out).to include("0.9.1")
     end
 
     it "activates the correct gem when ruby version matches any engine" do
@@ -876,7 +876,7 @@ G
         G
 
         bundle "exec rackup"
-        expect(out).to eq("0.9.1")
+        expect(out).to include("0.9.1")
       end
     end
 

--- a/spec/plugins/command_spec.rb
+++ b/spec/plugins/command_spec.rb
@@ -73,8 +73,8 @@ RSpec.describe "command plugins" do
 
     expect(out).not_to include("Installed plugin copycat")
 
-    expect(out).to include("Failed to install plugin")
+    expect(err).to include("Failed to install plugin")
 
-    expect(out).to include("Command(s) `mahcommand` declared by copycat are already registered.")
+    expect(err).to include("Command(s) `mahcommand` declared by copycat are already registered.")
   end
 end

--- a/spec/plugins/install_spec.rb
+++ b/spec/plugins/install_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "bundler plugin install" do
   it "shows proper message when gem in not found in the source" do
     bundle "plugin install no-foo --source file://#{gem_repo1}"
 
-    expect(out).to include("Could not find")
+    expect(err).to include("Could not find")
     plugin_should_not_be_installed("no-foo")
   end
 
@@ -86,7 +86,7 @@ RSpec.describe "bundler plugin install" do
 
       bundle "plugin install charlie --source file://#{gem_repo2}"
 
-      expect(out).to include("plugins.rb was not found")
+      expect(err).to include("plugins.rb was not found")
 
       expect(global_plugin_gem("charlie-1.0")).not_to be_directory
 
@@ -138,7 +138,7 @@ RSpec.describe "bundler plugin install" do
       bundle "plugin install foo --local_git /phony/path/project --git git@gitphony.com:/repo/project"
 
       expect(exitstatus).not_to eq(0) if exitstatus
-      expect(out).to eq("Remote and local plugin git sources can't be both specified")
+      expect(err).to eq("Remote and local plugin git sources can't be both specified")
     end
   end
 

--- a/spec/realworld/edgecases_spec.rb
+++ b/spec/realworld/edgecases_spec.rb
@@ -376,7 +376,7 @@ RSpec.describe "real world edgecases", :realworld => true, :sometimes => true do
       source 'https://rubygems.org'
       gem "resque-scheduler", "2.2.0"
     G
-    expect(out).to include("You have one or more invalid gemspecs that need to be fixed.")
-    expect(out).to include("resque-scheduler 2.2.0 has an invalid gemspec")
+    expect(err).to include("You have one or more invalid gemspecs that need to be fixed.")
+    expect(err).to include("resque-scheduler 2.2.0 has an invalid gemspec")
   end
 end

--- a/spec/realworld/edgecases_spec.rb
+++ b/spec/realworld/edgecases_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "real world edgecases", :realworld => true, :sometimes => true do
       gem "linecache", "0.46"
     G
     bundle :lock
-    expect(err).to be_empty
+    expect(last_command.stderr).to be_empty
     expect(exitstatus).to eq(0) if exitstatus
   end
 
@@ -241,7 +241,7 @@ RSpec.describe "real world edgecases", :realworld => true, :sometimes => true do
 
     bundle! :install, forgotten_command_line_options(:path => "vendor/bundle")
     expect(err).not_to include("Could not find rake")
-    expect(err).to be_empty
+    expect(last_command.stderr).to be_empty
   end
 
   it "checks out git repos when the lockfile is corrupted" do

--- a/spec/realworld/edgecases_spec.rb
+++ b/spec/realworld/edgecases_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "real world edgecases", :realworld => true, :sometimes => true do
       gem "linecache", "0.46"
     G
     bundle :lock
-    expect(err).to lack_errors
+    expect(err).to be_empty
     expect(exitstatus).to eq(0) if exitstatus
   end
 
@@ -241,7 +241,7 @@ RSpec.describe "real world edgecases", :realworld => true, :sometimes => true do
 
     bundle! :install, forgotten_command_line_options(:path => "vendor/bundle")
     expect(err).not_to include("Could not find rake")
-    expect(err).to lack_errors
+    expect(err).to be_empty
   end
 
   it "checks out git repos when the lockfile is corrupted" do
@@ -368,7 +368,7 @@ RSpec.describe "real world edgecases", :realworld => true, :sometimes => true do
     L
 
     bundle! :lock
-    expect(last_command.stderr).to lack_errors
+    expect(last_command.stderr).to be_empty
   end
 
   it "outputs a helpful error message when gems have invalid gemspecs" do

--- a/spec/realworld/mirror_probe_spec.rb
+++ b/spec/realworld/mirror_probe_spec.rb
@@ -74,10 +74,10 @@ RSpec.describe "fetching dependencies with a not available mirror", :realworld =
       bundle :install, :artifice => nil
 
       expect(out).to include("Fetching source index from #{mirror}")
-      expect(out).to include("Retrying fetcher due to error (2/4): Bundler::HTTPError Could not fetch specs from #{mirror}")
-      expect(out).to include("Retrying fetcher due to error (3/4): Bundler::HTTPError Could not fetch specs from #{mirror}")
-      expect(out).to include("Retrying fetcher due to error (4/4): Bundler::HTTPError Could not fetch specs from #{mirror}")
-      expect(out).to include("Could not fetch specs from #{mirror}")
+      expect(err).to include("Retrying fetcher due to error (2/4): Bundler::HTTPError Could not fetch specs from #{mirror}")
+      expect(err).to include("Retrying fetcher due to error (3/4): Bundler::HTTPError Could not fetch specs from #{mirror}")
+      expect(err).to include("Retrying fetcher due to error (4/4): Bundler::HTTPError Could not fetch specs from #{mirror}")
+      expect(err).to include("Could not fetch specs from #{mirror}")
     end
 
     it "prints each error and warning on a new line" do
@@ -112,10 +112,10 @@ Could not fetch specs from #{mirror}/
       bundle :install, :artifice => nil
 
       expect(out).to include("Fetching source index from #{mirror}")
-      expect(out).to include("Retrying fetcher due to error (2/4): Bundler::HTTPError Could not fetch specs from #{mirror}")
-      expect(out).to include("Retrying fetcher due to error (3/4): Bundler::HTTPError Could not fetch specs from #{mirror}")
-      expect(out).to include("Retrying fetcher due to error (4/4): Bundler::HTTPError Could not fetch specs from #{mirror}")
-      expect(out).to include("Could not fetch specs from #{mirror}")
+      expect(err).to include("Retrying fetcher due to error (2/4): Bundler::HTTPError Could not fetch specs from #{mirror}")
+      expect(err).to include("Retrying fetcher due to error (3/4): Bundler::HTTPError Could not fetch specs from #{mirror}")
+      expect(err).to include("Retrying fetcher due to error (4/4): Bundler::HTTPError Could not fetch specs from #{mirror}")
+      expect(err).to include("Could not fetch specs from #{mirror}")
     end
   end
 

--- a/spec/runtime/gem_tasks_spec.rb
+++ b/spec/runtime/gem_tasks_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "require 'bundler/gem_tasks'", :ruby_repo do
       sys_exec "#{rake} -T"
     end
 
-    expect(err).to eq("")
+    expect(last_command.stderr).to eq("")
     expected_tasks = [
       "rake build",
       "rake clean",

--- a/spec/runtime/inline_spec.rb
+++ b/spec/runtime/inline_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "bundler/inline#gemfile" do
       puts "success"
     RUBY
 
-    expect(err).to include "Could not find gem 'eleven'"
+    expect(last_command.stderr).to include "Could not find gem 'eleven'"
     expect(out).not_to include "success"
 
     script <<-RUBY
@@ -90,7 +90,7 @@ RSpec.describe "bundler/inline#gemfile" do
     expect(out).to include("Installing activesupport")
     err.gsub! %r{.*lib/sinatra/base\.rb:\d+: warning: constant ::Fixnum is deprecated$}, ""
     err.strip!
-    expect(err).to be_empty
+    expect(last_command.stderr).to be_empty
     expect(exitstatus).to be_zero if exitstatus
   end
 
@@ -134,7 +134,7 @@ RSpec.describe "bundler/inline#gemfile" do
 
       puts "success"
     RUBY
-    expect(err).to include "Unknown options: arglebargle"
+    expect(last_command.stderr).to include "Unknown options: arglebargle"
     expect(out).not_to include "success"
   end
 
@@ -165,7 +165,7 @@ RSpec.describe "bundler/inline#gemfile" do
     RUBY
 
     expect(out).to eq("1.0.0")
-    expect(err).to be_empty
+    expect(last_command.stderr).to be_empty
     expect(exitstatus).to be_zero if exitstatus
   end
 
@@ -183,7 +183,7 @@ RSpec.describe "bundler/inline#gemfile" do
     RUBY
 
     expect(out).to eq("1.0.0\n2.0.0")
-    expect(err).to be_empty
+    expect(last_command.stderr).to be_empty
     expect(exitstatus).to be_zero if exitstatus
   end
 
@@ -203,7 +203,7 @@ RSpec.describe "bundler/inline#gemfile" do
     RUBY
 
     expect(out).to eq("two\nfour")
-    expect(err).to be_empty
+    expect(last_command.stderr).to be_empty
     expect(exitstatus).to be_zero if exitstatus
   end
 
@@ -240,7 +240,7 @@ RSpec.describe "bundler/inline#gemfile" do
       RUBY
     end
 
-    expect(err).to be_empty
+    expect(last_command.stderr).to be_empty
     expect(exitstatus).to be_zero if exitstatus
   end
 
@@ -258,7 +258,7 @@ RSpec.describe "bundler/inline#gemfile" do
       RUBY
     end
 
-    expect(err).to be_empty
+    expect(last_command.stderr).to be_empty
     expect(exitstatus).to be_zero if exitstatus
   end
 

--- a/spec/runtime/inline_spec.rb
+++ b/spec/runtime/inline_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe "bundler/inline#gemfile" do
     expect(out).to include("Installing activesupport")
     err.gsub! %r{.*lib/sinatra/base\.rb:\d+: warning: constant ::Fixnum is deprecated$}, ""
     err.strip!
-    expect(err).to lack_errors
+    expect(err).to be_empty
     expect(exitstatus).to be_zero if exitstatus
   end
 

--- a/spec/runtime/require_spec.rb
+++ b/spec/runtime/require_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe "Bundler.require" do
       RUBY
       ruby(cmd)
 
-      expect(err).to lack_errors
+      expect(err).to be_empty
     end
 
     it "does not mangle explicitly given requires" do
@@ -432,7 +432,7 @@ RSpec.describe "Bundler.require with platform specific dependencies" do
     G
 
     run "Bundler.require"
-    expect(err).to lack_errors
+    expect(err).to be_empty
   end
 
   it "requires gems pinned to multiple platforms, including the current one" do
@@ -447,6 +447,6 @@ RSpec.describe "Bundler.require with platform specific dependencies" do
     run "Bundler.require; puts RACK"
 
     expect(out).to eq("1.0.0")
-    expect(err).to lack_errors
+    expect(err).to be_empty
   end
 end

--- a/spec/runtime/require_spec.rb
+++ b/spec/runtime/require_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe "Bundler.require" do
       Bundler.require
     R
 
-    expect(err).to eq_err("ZOMG LOAD ERROR")
+    expect(last_command.stderr).to eq_err("ZOMG LOAD ERROR")
   end
 
   it "displays a helpful message if the required gem throws an error" do
@@ -136,8 +136,8 @@ RSpec.describe "Bundler.require" do
     G
 
     run "Bundler.require"
-    expect(err).to match("error while trying to load the gem 'faulty'")
-    expect(err).to match("Gem Internal Error Message")
+    expect(last_command.stderr).to match("error while trying to load the gem 'faulty'")
+    expect(last_command.stderr).to match("Gem Internal Error Message")
   end
 
   it "doesn't swallow the error when the library has an unrelated error" do
@@ -160,7 +160,7 @@ RSpec.describe "Bundler.require" do
     RUBY
     run(cmd)
 
-    expect(err).to eq_err("ZOMG LOAD ERROR: cannot load such file -- load-bar")
+    expect(last_command.stderr).to eq_err("ZOMG LOAD ERROR: cannot load such file -- load-bar")
   end
 
   describe "with namespaced gems" do
@@ -198,7 +198,7 @@ RSpec.describe "Bundler.require" do
       RUBY
       ruby(cmd)
 
-      expect(err).to be_empty
+      expect(last_command.stderr).to be_empty
     end
 
     it "does not mangle explicitly given requires" do
@@ -211,7 +211,7 @@ RSpec.describe "Bundler.require" do
       load_error_run <<-R, "jquery-rails"
         Bundler.require
       R
-      expect(err).to eq_err("ZOMG LOAD ERROR")
+      expect(last_command.stderr).to eq_err("ZOMG LOAD ERROR")
     end
 
     it "handles the case where regex fails" do
@@ -234,7 +234,7 @@ RSpec.describe "Bundler.require" do
       RUBY
       run(cmd)
 
-      expect(err).to eq_err("ZOMG LOAD ERROR")
+      expect(last_command.stderr).to eq_err("ZOMG LOAD ERROR")
     end
 
     it "doesn't swallow the error when the library has an unrelated error" do
@@ -258,7 +258,7 @@ RSpec.describe "Bundler.require" do
       RUBY
       run(cmd)
 
-      expect(err).to eq_err("ZOMG LOAD ERROR: cannot load such file -- load-bar")
+      expect(last_command.stderr).to eq_err("ZOMG LOAD ERROR: cannot load such file -- load-bar")
     end
   end
 
@@ -366,7 +366,7 @@ RSpec.describe "Bundler.require" do
         load_error_run <<-R, "no_such_file_omg"
           Bundler.require
         R
-        expect(err).to eq_err("ZOMG LOAD ERROR")
+        expect(last_command.stderr).to eq_err("ZOMG LOAD ERROR")
       end
     end
   end
@@ -432,7 +432,7 @@ RSpec.describe "Bundler.require with platform specific dependencies" do
     G
 
     run "Bundler.require"
-    expect(err).to be_empty
+    expect(last_command.stderr).to be_empty
   end
 
   it "requires gems pinned to multiple platforms, including the current one" do
@@ -447,6 +447,6 @@ RSpec.describe "Bundler.require with platform specific dependencies" do
     run "Bundler.require; puts RACK"
 
     expect(out).to eq("1.0.0")
-    expect(err).to be_empty
+    expect(last_command.stderr).to be_empty
   end
 end

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -1089,7 +1089,7 @@ end
       end.ref_for("HEAD")
       bundle :install
 
-      expect(out.lines.map(&:chomp)).to include(
+      expect(err.lines.map(&:chomp)).to include(
         a_string_starting_with("[!] There was an error while loading `bar.gemspec`:"),
         RUBY_VERSION >= "1.9" ? a_string_starting_with("Does it try to require a relative path? That's been removed in Ruby 1.9.") : "",
         " #  from #{default_bundle_path "bundler", "gems", "bar-1.0-#{ref[0, 12]}", "bar.gemspec"}:1",

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Bundler.setup" do
         require 'rack'
         puts RACK
       RUBY
-      expect(err).to be_empty
+      expect(last_command.stderr).to be_empty
       expect(out).to eq("1.0.0")
     end
   end
@@ -42,7 +42,7 @@ RSpec.describe "Bundler.setup" do
           puts "WIN"
         end
       RUBY
-      expect(err).to be_empty
+      expect(last_command.stderr).to be_empty
       expect(out).to eq("WIN")
     end
 
@@ -55,7 +55,7 @@ RSpec.describe "Bundler.setup" do
         require 'rack'
         puts RACK
       RUBY
-      expect(err).to be_empty
+      expect(last_command.stderr).to be_empty
       expect(out).to eq("1.0.0")
     end
 
@@ -69,7 +69,7 @@ RSpec.describe "Bundler.setup" do
         require 'rack'
         puts RACK
       RUBY
-      expect(err).to be_empty
+      expect(last_command.stderr).to be_empty
       expect(out).to eq("1.0.0")
     end
 
@@ -87,7 +87,7 @@ RSpec.describe "Bundler.setup" do
           puts "FAIL"
         end
       RUBY
-      expect(err).to be_empty
+      expect(last_command.stderr).to be_empty
       expect(out).to match("WIN")
     end
 
@@ -101,8 +101,8 @@ RSpec.describe "Bundler.setup" do
         puts "FAIL"
       RUBY
 
-      expect(err).to match("rack")
-      expect(err).to match("LoadError")
+      expect(last_command.stderr).to match("rack")
+      expect(last_command.stderr).to match("LoadError")
       expect(out).not_to match("FAIL")
     end
   end
@@ -138,7 +138,7 @@ RSpec.describe "Bundler.setup" do
       load_path = out.split("\n")
       rack_load_order = load_path.index {|path| path.include?("rack") }
 
-      expect(err).to eq("")
+      expect(last_command.stderr).to eq("")
       expect(load_path).to include(a_string_ending_with("dash_i_dir"), "rubylib_dir")
       expect(rack_load_order).to be > 0
     end
@@ -361,7 +361,7 @@ RSpec.describe "Bundler.setup" do
           end
         R
 
-        expect(err).to be_empty
+        expect(last_command.stderr).to be_empty
       end
 
       it "replaces #gem but raises when the version is wrong" do
@@ -387,7 +387,7 @@ RSpec.describe "Bundler.setup" do
           end
         R
 
-        expect(err).to be_empty
+        expect(last_command.stderr).to be_empty
       end
     end
 
@@ -446,7 +446,7 @@ RSpec.describe "Bundler.setup" do
 
     it "provides a useful exception when the git repo is not checked out yet" do
       run "1"
-      expect(err).to match(/the git source #{lib_path('rack-1.0.0')} is not yet checked out. Please run `bundle install`/i)
+      expect(last_command.stderr).to match(/the git source #{lib_path('rack-1.0.0')} is not yet checked out. Please run `bundle install`/i)
     end
 
     it "does not hit the git binary if the lockfile is available and up to date" do
@@ -532,7 +532,7 @@ RSpec.describe "Bundler.setup" do
 
       FileUtils.rm_rf(lib_path("local-rack"))
       run "require 'rack'"
-      expect(err).to match(/Cannot use local override for rack-0.8 because #{Regexp.escape(lib_path('local-rack').to_s)} does not exist/)
+      expect(last_command.stderr).to match(/Cannot use local override for rack-0.8 because #{Regexp.escape(lib_path('local-rack').to_s)} does not exist/)
     end
 
     it "explodes if branch is not given on runtime" do
@@ -554,7 +554,7 @@ RSpec.describe "Bundler.setup" do
       G
 
       run "require 'rack'"
-      expect(err).to match(/because :branch is not specified in Gemfile/)
+      expect(last_command.stderr).to match(/because :branch is not specified in Gemfile/)
     end
 
     it "explodes on different branches on runtime" do
@@ -576,7 +576,7 @@ RSpec.describe "Bundler.setup" do
       G
 
       run "require 'rack'"
-      expect(err).to match(/is using branch master but Gemfile specifies changed/)
+      expect(last_command.stderr).to match(/is using branch master but Gemfile specifies changed/)
     end
 
     it "explodes on refs with different branches on runtime" do
@@ -596,7 +596,7 @@ RSpec.describe "Bundler.setup" do
 
       bundle %(config local.rack #{lib_path("local-rack")})
       run "require 'rack'"
-      expect(err).to match(/is using branch master but Gemfile specifies nonexistant/)
+      expect(last_command.stderr).to match(/is using branch master but Gemfile specifies nonexistant/)
     end
   end
 
@@ -701,7 +701,7 @@ RSpec.describe "Bundler.setup" do
           end
         R
 
-        expect(err).to be_empty
+        expect(last_command.stderr).to be_empty
       end
     end
   end
@@ -764,7 +764,7 @@ end
     ENV["GEM_HOME"] = ""
     bundle %(exec ruby -e "require 'set'")
 
-    expect(err).to be_empty
+    expect(last_command.stderr).to be_empty
   end
 
   describe "$MANPATH" do
@@ -933,7 +933,7 @@ end
           require 'foo'
         R
       end
-      expect(err).to be_empty
+      expect(last_command.stderr).to be_empty
     end
 
     it "should make sure the Bundler.root is really included in the path relative to the Gemfile" do
@@ -958,7 +958,7 @@ end
         R
       end
 
-      expect(err).to be_empty
+      expect(last_command.stderr).to be_empty
     end
   end
 
@@ -1108,7 +1108,7 @@ end
         Bundler.load
       RUBY
 
-      expect(err).to be_empty
+      expect(last_command.stderr).to be_empty
       expect(out).to eq("")
     end
   end
@@ -1120,7 +1120,7 @@ end
       G
 
       bundle %(exec ruby -e "require 'bundler'; Bundler.setup")
-      expect(err).to be_empty
+      expect(last_command.stderr).to be_empty
     end
   end
 

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Bundler.setup" do
         require 'rack'
         puts RACK
       RUBY
-      expect(err).to lack_errors
+      expect(err).to be_empty
       expect(out).to eq("1.0.0")
     end
   end
@@ -42,7 +42,7 @@ RSpec.describe "Bundler.setup" do
           puts "WIN"
         end
       RUBY
-      expect(err).to lack_errors
+      expect(err).to be_empty
       expect(out).to eq("WIN")
     end
 
@@ -55,7 +55,7 @@ RSpec.describe "Bundler.setup" do
         require 'rack'
         puts RACK
       RUBY
-      expect(err).to lack_errors
+      expect(err).to be_empty
       expect(out).to eq("1.0.0")
     end
 
@@ -69,7 +69,7 @@ RSpec.describe "Bundler.setup" do
         require 'rack'
         puts RACK
       RUBY
-      expect(err).to lack_errors
+      expect(err).to be_empty
       expect(out).to eq("1.0.0")
     end
 
@@ -87,7 +87,7 @@ RSpec.describe "Bundler.setup" do
           puts "FAIL"
         end
       RUBY
-      expect(err).to lack_errors
+      expect(err).to be_empty
       expect(out).to match("WIN")
     end
 
@@ -361,7 +361,7 @@ RSpec.describe "Bundler.setup" do
           end
         R
 
-        expect(err).to lack_errors
+        expect(err).to be_empty
       end
 
       it "replaces #gem but raises when the version is wrong" do
@@ -387,7 +387,7 @@ RSpec.describe "Bundler.setup" do
           end
         R
 
-        expect(err).to lack_errors
+        expect(err).to be_empty
       end
     end
 
@@ -701,7 +701,7 @@ RSpec.describe "Bundler.setup" do
           end
         R
 
-        expect(err).to lack_errors
+        expect(err).to be_empty
       end
     end
   end
@@ -764,7 +764,7 @@ end
     ENV["GEM_HOME"] = ""
     bundle %(exec ruby -e "require 'set'")
 
-    expect(err).to lack_errors
+    expect(err).to be_empty
   end
 
   describe "$MANPATH" do
@@ -933,7 +933,7 @@ end
           require 'foo'
         R
       end
-      expect(err).to lack_errors
+      expect(err).to be_empty
     end
 
     it "should make sure the Bundler.root is really included in the path relative to the Gemfile" do
@@ -958,7 +958,7 @@ end
         R
       end
 
-      expect(err).to lack_errors
+      expect(err).to be_empty
     end
   end
 
@@ -1108,7 +1108,7 @@ end
         Bundler.load
       RUBY
 
-      expect(err).to lack_errors
+      expect(err).to be_empty
       expect(out).to eq("")
     end
   end
@@ -1120,7 +1120,7 @@ end
       G
 
       bundle %(exec ruby -e "require 'bundler'; Bundler.setup")
-      expect(err).to lack_errors
+      expect(err).to be_empty
     end
   end
 

--- a/spec/runtime/with_unbundled_env_spec.rb
+++ b/spec/runtime/with_unbundled_env_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "Bundler.with_env helpers" do
         build_bundler_context
         bundle! "exec '#{Gem.ruby}' #{bundled_app("exe.rb")} 2"
       end
-      expect(err).to eq <<-EOS.strip
+      expect(last_command.stderr).to eq <<-EOS.strip
 2 false
 1 true
 0 true

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -41,11 +41,11 @@ module Spec
     end
 
     def out
-      last_command.stdboth
+      last_command.stdout
     end
 
     def err
-      last_command.stderr
+      Bundler.feature_flag.error_on_stderr? ? last_command.stderr : last_command.stdout
     end
 
     def exitstatus

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -62,13 +62,6 @@ module Spec
 
     MAJOR_DEPRECATION = /^\[DEPRECATED FOR 2\.0\]\s*/
 
-    RSpec::Matchers.define :lack_errors do
-      diffable
-      match do |actual|
-        actual.gsub(/#{MAJOR_DEPRECATION}.+[\n]?/, "") == ""
-      end
-    end
-
     RSpec::Matchers.define :eq_err do |expected|
       diffable
       match do |actual|

--- a/spec/update/git_spec.rb
+++ b/spec/update/git_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "bundle update" do
         gem "foo", "1.0", :git => "#{lib_path("foo_two")}"
       G
 
-      expect(err).to be_empty
+      expect(last_command.stderr).to be_empty
       expect(out).to include("Fetching #{lib_path}/foo_two")
       expect(out).to include("Bundle complete!")
     end

--- a/spec/update/git_spec.rb
+++ b/spec/update/git_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "bundle update" do
         gem "foo", "1.0", :git => "#{lib_path("foo_two")}"
       G
 
-      expect(err).to lack_errors
+      expect(err).to be_empty
       expect(out).to include("Fetching #{lib_path}/foo_two")
       expect(out).to include("Bundle complete!")
     end

--- a/spec/update/redownload_spec.rb
+++ b/spec/update/redownload_spec.rb
@@ -11,12 +11,12 @@ RSpec.describe "bundle update" do
   describe "with --force" do
     it "shows a deprecation when single flag passed", :bundler => 2 do
       bundle! "update rack --force"
-      expect(out).to include "[DEPRECATED FOR 2.0] The `--force` option has been renamed to `--redownload`"
+      expect(err).to include "[DEPRECATED FOR 2.0] The `--force` option has been renamed to `--redownload`"
     end
 
     it "shows a deprecation when multiple flags passed", :bundler => 2 do
       bundle! "update rack --no-color --force"
-      expect(out).to include "[DEPRECATED FOR 2.0] The `--force` option has been renamed to `--redownload`"
+      expect(err).to include "[DEPRECATED FOR 2.0] The `--force` option has been renamed to `--redownload`"
     end
 
     it "does not show a deprecation when single flag passed", :bundler => "< 2" do


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that once we enable deprecations, they will start getting printed to the screen and will affect existing output assertions, thus breaking unrelated tests.

### What was your diagnosis of the problem?

My diagnosis was that we started printing errors to the stderr stream in bundler 2, but our `out` test helper [checks both streams combined](). That means deprecations affect the result of this helper, and any test runninng commands that print deprecations and checking for the exact output will be affected.

### What is your fix for the problem, implemented in this PR?

My fix is to consider only output in the `out` helper, and error in the `err` helper. That involves a simple change in the helper to return only `stdout` instead of `stdboth`, and fixing a bunch of tests that used to check `out` for errors and now need to check `err`.

### Why did you choose this fix out of the possible options?

I chose this fix because even if it was tedious, it simplifies enabling deprecations, and slightly improves the readability of tests.
