### PR TITLE
Clean up first `bin/rake spec:deps` output

### DIFF
--- a/bin/rake
+++ b/bin/rake
@@ -5,15 +5,17 @@ load File.expand_path("../with_rubygems", __FILE__) if ENV["RGV"]
 
 require "rubygems"
 
-bundler_spec = Gem::Specification.load(File.expand_path("../../bundler.gemspec", __FILE__))
-bundler_spec.dependencies.each do |dep|
-  begin
-    gem dep.name, dep.requirement
-  rescue Gem::LoadError => e
-    $stderr.puts "#{e.message} (#{e.class})"
+unless ARGV[0] == "spec:deps"
+  bundler_spec = Gem::Specification.load(File.expand_path("../../bundler.gemspec", __FILE__))
+  bundler_spec.dependencies.each do |dep|
+    begin
+      gem dep.name, dep.requirement
+    rescue Gem::LoadError => e
+      $stderr.puts "#{e.message} (#{e.class})"
+    end
   end
-end
 
-Gem.finish_resolve if Gem.respond_to?(:finish_resolve)
+  Gem.finish_resolve if Gem.respond_to?(:finish_resolve)
+end
 
 load Gem.bin_path("rake", "rake")


### PR DESCRIPTION


Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was that on a fresh ruby install (docker, I'm looking at you), running `bin/rake spec:deps` prints the following errors, even if nothing end up going wrong and the dependencies get installed:

```
Could not find 'automatiek' (~> 0.1.0) among 17 total gem(s)
Checked in 'GEM_PATH=/usr/local/rvm/gems/ruby-2.3.7:/usr/local/rvm/gems/ruby-2.3.7@global', execute `gem env` for more information (Gem::MissingSpecError)
Could not find 'mustache' (= 0.99.6) among 17 total gem(s)
Checked in 'GEM_PATH=/usr/local/rvm/gems/ruby-2.3.7:/usr/local/rvm/gems/ruby-2.3.7@global', execute `gem env` for more information (Gem::MissingSpecError)
Could not find 'rake' (~> 12.0) - did find: [rake-10.4.2]
Checked in 'GEM_PATH=/usr/local/rvm/gems/ruby-2.3.7:/usr/local/rvm/gems/ruby-2.3.7@global', execute `gem env` for more information (Gem::MissingSpecVersionError)
Could not find 'rdiscount' (~> 2.2) among 17 total gem(s)
Checked in 'GEM_PATH=/usr/local/rvm/gems/ruby-2.3.7:/usr/local/rvm/gems/ruby-2.3.7@global', execute `gem env` for more information (Gem::MissingSpecError)
Could not find 'ronn' (~> 0.7.3) among 17 total gem(s)
Checked in 'GEM_PATH=/usr/local/rvm/gems/ruby-2.3.7:/usr/local/rvm/gems/ruby-2.3.7@global', execute `gem env` for more information (Gem::MissingSpecError)
Could not find 'rspec' (~> 3.6) among 17 total gem(s)
Checked in 'GEM_PATH=/usr/local/rvm/gems/ruby-2.3.7:/usr/local/rvm/gems/ruby-2.3.7@global', execute `gem env` for more information (Gem::MissingSpecError)
Could not find 'rubocop' (= 0.50.0) among 17 total gem(s)
Checked in 'GEM_PATH=/usr/local/rvm/gems/ruby-2.3.7:/usr/local/rvm/gems/ruby-2.3.7@global', execute `gem env` for more information (Gem::MissingSpecError)
```

### What was your diagnosis of the problem?

My diagnosis was that the rake's binstub tries to activate the development depedencies even in the case when we're installing them. In that case, they will most likely not be installed, and give errors.

### What is your fix for the problem, implemented in this PR?

My fix is to exclude development dependency activation in this specific case.

### Why did you choose this fix out of the possible options?

I chose this fix because it's simple and fixes the problem.
