### PR TITLE
Fix symlink spec on ruby 2.6

### DIFF
--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "tmpdir"
+
 RSpec.describe "Bundler.setup" do
   describe "with no arguments" do
     it "makes all groups available" do

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -807,6 +807,7 @@ end
     let(:gem_home) { Dir.mktmpdir }
     let(:symlinked_gem_home) { Tempfile.new("gem_home").path }
     let(:bundler_dir) { ruby_core? ? File.expand_path("../../../..", __FILE__) : File.expand_path("../../..", __FILE__) }
+    let(:full_name) { "bundler-#{Bundler::VERSION}" }
 
     before do
       FileUtils.ln_sf(gem_home, symlinked_gem_home)
@@ -815,14 +816,14 @@ end
       Dir.mkdir(gems_dir)
       Dir.mkdir(specifications_dir)
 
-      FileUtils.ln_s(bundler_dir, File.join(gems_dir, "bundler-#{Bundler::VERSION}"))
+      FileUtils.ln_s(bundler_dir, File.join(gems_dir, full_name))
 
       gemspec_file = ruby_core? ? "#{bundler_dir}/lib/bundler/bundler.gemspec" : "#{bundler_dir}/bundler.gemspec"
       gemspec = File.read(gemspec_file).
                 sub("Bundler::VERSION", %("#{Bundler::VERSION}"))
       gemspec = gemspec.lines.reject {|line| line =~ %r{lib/bundler/version} }.join
 
-      File.open(File.join(specifications_dir, "bundler.gemspec"), "wb") do |f|
+      File.open(File.join(specifications_dir, "#{full_name}.gemspec"), "wb") do |f|
         f.write(gemspec)
       end
     end

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "tmpdir"
+require "tempfile"
 
 RSpec.describe "Bundler.setup" do
   describe "with no arguments" do

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -804,7 +804,6 @@ end
     let(:gem_home) { Dir.mktmpdir }
     let(:symlinked_gem_home) { Tempfile.new("gem_home").path }
     let(:bundler_dir) { ruby_core? ? File.expand_path("../../../..", __FILE__) : File.expand_path("../../..", __FILE__) }
-    let(:bundler_lib) { File.join(bundler_dir, "lib") }
 
     before do
       FileUtils.ln_sf(gem_home, symlinked_gem_home)

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -819,7 +819,7 @@ end
       FileUtils.ln_s(bundler_dir, File.join(gems_dir, full_name))
 
       gemspec_file = ruby_core? ? "#{bundler_dir}/lib/bundler/bundler.gemspec" : "#{bundler_dir}/bundler.gemspec"
-      gemspec = File.read(gemspec_file).
+      gemspec = File.binread(gemspec_file).
                 sub("Bundler::VERSION", %("#{Bundler::VERSION}"))
       gemspec = gemspec.lines.reject {|line| line =~ %r{lib/bundler/version} }.join
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that we were skipping this test on ruby 2.6. Skipping tests on old versions is not much of a problem, but doing it on the latest version is opening the door for regressions. So I want to fix it.

### What was your diagnosis of the problem?

My diagnosis was that since bundler is now a default gem, that bundler version is being activated by the spec, but since we are on a 2.0.1 locked bundle, the spec runs into a version mismatch error.

### What is your fix for the problem, implemented in this PR?

My fix is to enable the `Kernel.require` rubygems monkeypatch for this case (the `bundle` gem itself), that requires default gem files without activating the specific default version, and thus not forcing end users to use that. Since... that's exactly the problem here.

### Why did you choose this fix out of the possible options?

I chose this fix because it makes sense to me.
