### PR TITLE
Bump test MRI 2.3 version in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,14 +52,14 @@ jobs:
       stage: linting
     # Ruby 2.5, Rubygems 2.7 and up
     - rvm: 2.5.3
-      env: RGV=v2.7.7
+      env: RGV=v2.7.8
       stage: test
     # Ruby 2.4, Rubygems 2.6 and up
     - rvm: 2.4.5
       env: RGV=v2.6.14
       stage: test
     - rvm: 2.4.5
-      env: RGV=v2.7.7
+      env: RGV=v2.7.8
       stage: test
     # Ruby 2.3, Rubygems 2.5 and up
     - rvm: 2.3.8
@@ -69,7 +69,7 @@ jobs:
       env: RGV=v2.6.14
       stage: test
     - rvm: 2.3.8
-      env: RGV=v2.7.7
+      env: RGV=v2.7.8
       stage: test
     # Ruby-head (we want to know how we're doing, but not fail the build)
     - rvm: ruby-head
@@ -77,7 +77,7 @@ jobs:
       stage: test
     # 1.x mode (we want to keep stuff passing in 1.x mode for now)
     - rvm: 2.6.1
-      env: RGV=v2.7.7 BUNDLER_SPEC_SUB_VERSION=1.98
+      env: RGV=v2.7.8 BUNDLER_SPEC_SUB_VERSION=1.98
       stage: test
 
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,13 +62,13 @@ jobs:
       env: RGV=v2.7.7
       stage: test
     # Ruby 2.3, Rubygems 2.5 and up
-    - rvm: 2.3.7
+    - rvm: 2.3.8
       env: RGV=v2.5.2
       stage: test
-    - rvm: 2.3.7
+    - rvm: 2.3.8
       env: RGV=v2.6.14
       stage: test
-    - rvm: 2.3.7
+    - rvm: 2.3.8
       env: RGV=v2.7.7
       stage: test
     # Ruby-head (we want to know how we're doing, but not fail the build)

--- a/Rakefile
+++ b/Rakefile
@@ -143,7 +143,7 @@ begin
       rubyopt = ENV["RUBYOPT"]
       # When editing this list, also edit .travis.yml!
       branches = %w[master]
-      releases = %w[v2.5.2 v2.6.14 v2.7.7 v3.0.2]
+      releases = %w[v2.5.2 v2.6.14 v2.7.8 v3.0.2]
       (branches + releases).each do |rg|
         desc "Run specs with RubyGems #{rg}"
         RSpec::Core::RakeTask.new(rg) do |t|

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -797,7 +797,7 @@ __FILE__: #{path.to_s.inspect}
         bundle :install, :system_bundler => true, :path => "vendor/bundler"
       end
 
-      it "overrides disable_shared_gems so bundler can be found" do
+      it "overrides disable_shared_gems so bundler can be found", :rubygems => ">= 2.6.2" do
         skip "bundler 1.16.x is not support with Ruby 2.6 on Travis CI" if RUBY_VERSION >= "2.6"
 
         system_gems :bundler

--- a/spec/commands/pristine_spec.rb
+++ b/spec/commands/pristine_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "bundle pristine", :ruby_repo do
       expect(changes_txt).to_not be_file
     end
 
-    it "does not delete the bundler gem" do
+    it "does not delete the bundler gem", :rubygems => ">= 2.6.2" do
       ENV["BUNDLER_SPEC_KEEP_DEFAULT_BUNDLER_GEM"] = "true"
       system_gems :bundler
       bundle! "install"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that we don't know whether bundler works against the latest patch level version of MRI 2.3.

### What was your diagnosis of the problem?

My diagnosis was that we should test it.

### What is your fix for the problem, implemented in this PR?

My fix is to bump the 2.3 matrix entries in TravisCI config to 2.3.8. This MRI version comes with rubygems 2.7.8, so bump that too.

### Why did you choose this fix out of the possible options?

I chose this fix because it's the only one, given the CI setup we currently have.
