### PR TITLE
Remove rdiscount indirect development dependency

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -44,11 +44,8 @@ namespace :spec do
       [d.name, d.requirement.to_s]
     end]
 
-    # JRuby can't build ronn or rdiscount, so we skip that
-    if defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby"
-      deps.delete("ronn")
-      deps.delete("rdiscount")
-    end
+    # JRuby can't build ronn, so we skip that
+    deps.delete("ronn") if defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby"
 
     gem_install_command = "install --no-document --conservative " + deps.sort_by {|name, _| name }.map do |name, version|
       "'#{name}:#{version}'"

--- a/bundler.gemspec
+++ b/bundler.gemspec
@@ -43,7 +43,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "automatiek", "~> 0.1.0"
   s.add_development_dependency "mustache",   "0.99.6"
   s.add_development_dependency "rake",       "~> 12.0"
-  s.add_development_dependency "rdiscount",  "~> 2.2"
   s.add_development_dependency "ronn",       "~> 0.7.3"
   s.add_development_dependency "rspec",      "~> 3.6"
   s.add_development_dependency "rubocop",    "= 0.50.0"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that I was confused about the `rdiscount` dependency since I didn't see it used anywhere.

### What was your diagnosis of the problem?

My diagnosis was that it's just an indirect dependency (through ronn).

### What is your fix for the problem, implemented in this PR?

My fix is to remove the dependency.

### Why did you choose this fix out of the possible options?

I chose this fix because it will no longer confuse devs into thinking we're actually using it directly.
