### PR TITLE
Bump base rubygems version to 3.0.2

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -73,7 +73,7 @@ namespace :spec do
       sh "sudo apt-get install graphviz -y 2>&1 | tail -n 2"
 
       # Install the gems with a consistent version of RubyGems
-      sh "gem update --system 2.6.13"
+      sh "gem update --system 3.0.2"
 
       # Fix incorrect default gem specifications on ruby 2.6.1. Can be removed
       # when 2.6.2 is released and we start testing against it


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that we are using old rubygems versions internally.

### What was your diagnosis of the problem?

My diagnosis was that we should use the newest version of our own software.

### What is your fix for the problem, implemented in this PR?

My fix is to upgrade the rubygems version used in the Rakefile for development tasks.

### Why did you choose this fix out of the possible options?

I chose this fix because it's good for us.
