### PR TITLE
Don't leak to system rubygems during specs

### DIFF
--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "bundle exec" do
       gem "rack"
     G
 
-    bundle "exec 'cd #{tmp("gems")} && rackup'", :env => { :RUBYOPT => "-r#{spec_dir.join("support/hax")}" }
+    bundle "exec 'cd #{tmp("gems")} && rackup'"
 
     expect(out).to include("1.0.0")
   end
@@ -51,7 +51,7 @@ RSpec.describe "bundle exec" do
 
   it "works when exec'ing to ruby" do
     install_gemfile 'gem "rack"'
-    bundle "exec ruby -e 'puts %{hi}'", :env => { :RUBYOPT => "-r#{spec_dir.join("support/hax")}" }
+    bundle "exec ruby -e 'puts %{hi}'"
     expect(out).to eq("hi")
   end
 
@@ -85,9 +85,7 @@ RSpec.describe "bundle exec" do
     G
 
     install_gemfile ""
-    with_env_vars "RUBYOPT" => "-r#{spec_dir.join("support/hax")}" do
-      sys_exec "#{Gem.ruby} #{command.path}"
-    end
+    sys_exec "#{Gem.ruby} #{command.path}"
 
     if Bundler.current_ruby.ruby_2?
       expect(out).to eq("")
@@ -248,7 +246,7 @@ RSpec.describe "bundle exec" do
     G
     [true, false].each do |l|
       bundle! "config disable_exec_load #{l}"
-      bundle "exec rackup", :env => { :RUBYOPT => "-r#{spec_dir.join("support/hax")}" }
+      bundle "exec rackup"
       expect(last_command.stderr).to include "rack is not part of the bundle. Add it to your Gemfile."
     end
   end
@@ -350,14 +348,14 @@ RSpec.describe "bundle exec" do
       end
 
       it "works when unlocked" do
-        bundle "exec 'cd #{tmp("gems")} && rackup'", :env => { :RUBYOPT => "-r#{spec_dir.join("support/hax")}" }
+        bundle "exec 'cd #{tmp("gems")} && rackup'"
         expect(out).to eq("1.0.0")
         expect(out).to include("1.0.0")
       end
 
       it "works when locked" do
         expect(the_bundle).to be_locked
-        bundle "exec 'cd #{tmp("gems")} && rackup'", :env => { :RUBYOPT => "-r#{spec_dir.join("support/hax")}" }
+        bundle "exec 'cd #{tmp("gems")} && rackup'"
         expect(out).to include("1.0.0")
       end
     end
@@ -483,7 +481,7 @@ RSpec.describe "bundle exec" do
       Bundler.rubygems.extend(Monkey)
       G
       bundle "install --deployment"
-      bundle "exec ruby -e '`#{bindir.join("bundler")} -v`; puts $?.success?'", :env => { :RUBYOPT => "-r#{spec_dir.join("support/hax")}" }
+      bundle "exec ruby -e '`#{bindir.join("bundler")} -v`; puts $?.success?'"
       expect(out).to match("true")
     end
   end
@@ -523,7 +521,7 @@ RSpec.describe "bundle exec" do
     let(:expected) { [exec, args, rack, process].join("\n") }
     let(:expected_err) { "" }
 
-    subject { bundle "exec #{path} arg1 arg2", :env => { :RUBYOPT => "-r#{spec_dir.join("support/hax")}" } }
+    subject { bundle "exec #{path} arg1 arg2" }
 
     shared_examples_for "it runs" do
       it "like a normally executed executable" do

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -559,7 +559,7 @@ RSpec.describe "bundle exec" do
         ex << "raise SignalException, 'SIGTERM'\n"
         ex
       end
-      let(:expected_err) { RUBY_PLATFORM =~ /darwin/ ? "" : "Terminated" }
+      let(:expected_err) { "" }
       let(:exit_code) do
         # signal mask 128 + plus signal 15 -> TERM
         # this is specified by C99

--- a/spec/install/gemfile/sources_spec.rb
+++ b/spec/install/gemfile/sources_spec.rb
@@ -437,7 +437,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
       it "does not unlock the non-path gem after install" do
         bundle! :install
 
-        bundle! %(exec ruby -e 'puts "OK"'), :env => { :RUBYOPT => "-r#{spec_dir.join("support/hax")}" }
+        bundle! %(exec ruby -e 'puts "OK"')
 
         expect(out).to include("OK")
       end

--- a/spec/runtime/require_spec.rb
+++ b/spec/runtime/require_spec.rb
@@ -264,13 +264,13 @@ RSpec.describe "Bundler.require" do
 
   describe "using bundle exec" do
     it "requires the locked gems" do
-      bundle "exec ruby -e 'Bundler.require'", :env => { :RUBYOPT => "-r#{spec_dir.join("support/hax")}" }
+      bundle "exec ruby -e 'Bundler.require'"
       expect(out).to eq("two")
 
-      bundle "exec ruby -e 'Bundler.require(:bar)'", :env => { :RUBYOPT => "-r#{spec_dir.join("support/hax")}" }
+      bundle "exec ruby -e 'Bundler.require(:bar)'"
       expect(out).to eq("baz\nqux")
 
-      bundle "exec ruby -e 'Bundler.require(:default, :bar)'", :env => { :RUBYOPT => "-r#{spec_dir.join("support/hax")}" }
+      bundle "exec ruby -e 'Bundler.require(:default, :bar)'"
       expect(out).to eq("baz\nqux\ntwo")
     end
   end

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe "Bundler.setup" do
         gem "rack"
       G
 
-      ENV["RUBYOPT"] = "-Idash_i_dir"
+      ENV["RUBYOPT"] = "#{ENV["RUBYOPT"]} -Idash_i_dir"
       ENV["RUBYLIB"] = "rubylib_dir"
 
       ruby <<-RUBY
@@ -139,8 +139,7 @@ RSpec.describe "Bundler.setup" do
       rack_load_order = load_path.index {|path| path.include?("rack") }
 
       expect(err).to eq("")
-      expect(load_path[1]).to include "dash_i_dir"
-      expect(load_path[2]).to include "rubylib_dir"
+      expect(load_path).to include(a_string_ending_with("dash_i_dir"), "rubylib_dir")
       expect(rack_load_order).to be > 0
     end
 
@@ -763,7 +762,7 @@ end
     G
 
     ENV["GEM_HOME"] = ""
-    bundle %(exec ruby -e "require 'set'"), :env => { :RUBYOPT => "-r#{spec_dir.join("support/hax")}" }
+    bundle %(exec ruby -e "require 'set'")
 
     expect(err).to lack_errors
   end
@@ -1120,7 +1119,7 @@ end
         gem "bundler", :path => "#{File.expand_path("..", lib)}"
       G
 
-      bundle %(exec ruby -e "require 'bundler'; Bundler.setup"), :env => { :RUBYOPT => "-r#{spec_dir.join("support/hax")}" }
+      bundle %(exec ruby -e "require 'bundler'; Bundler.setup")
       expect(err).to lack_errors
     end
   end

--- a/spec/runtime/with_unbundled_env_spec.rb
+++ b/spec/runtime/with_unbundled_env_spec.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe "Bundler.with_env helpers" do
-  def bundle_exec_ruby!(code, *args)
+  def bundle_exec_ruby!(code)
     build_bundler_context
-    opts = args.last.is_a?(Hash) ? args.pop : {}
-    opts[:env] ||= {}
-    args.push opts
-    bundle! "exec '#{Gem.ruby}' -e #{code}", *args
+    bundle! "exec '#{Gem.ruby}' -e #{code}"
   end
 
   def build_bundler_context

--- a/spec/runtime/with_unbundled_env_spec.rb
+++ b/spec/runtime/with_unbundled_env_spec.rb
@@ -4,8 +4,7 @@ RSpec.describe "Bundler.with_env helpers" do
   def bundle_exec_ruby!(code, *args)
     build_bundler_context
     opts = args.last.is_a?(Hash) ? args.pop : {}
-    env = opts[:env] ||= {}
-    env[:RUBYOPT] ||= "-r#{spec_dir.join("support/hax")}"
+    opts[:env] ||= {}
     args.push opts
     bundle! "exec '#{Gem.ruby}' -e #{code}", *args
   end
@@ -48,7 +47,7 @@ RSpec.describe "Bundler.with_env helpers" do
       path = `getconf PATH`.strip + File::PATH_SEPARATOR + File.dirname(Gem.ruby)
       with_path_as(path) do
         build_bundler_context
-        bundle! "exec '#{Gem.ruby}' #{bundled_app("exe.rb")} 2", :env => { :RUBYOPT => "-r#{spec_dir.join("support/hax")}" }
+        bundle! "exec '#{Gem.ruby}' #{bundled_app("exe.rb")} 2"
       end
       expect(err).to eq <<-EOS.strip
 2 false
@@ -58,7 +57,7 @@ RSpec.describe "Bundler.with_env helpers" do
     end
 
     it "removes variables that bundler added", :ruby_repo do
-      original = ruby!('puts ENV.to_a.map {|e| e.join("=") }.sort.join("\n")', :env => { :RUBYOPT => "-r#{spec_dir.join("support/hax")}" })
+      original = ruby!('puts ENV.to_a.map {|e| e.join("=") }.sort.join("\n")')
       code = 'puts Bundler.original_env.to_a.map {|e| e.join("=") }.sort.join("\n")'
       bundle_exec_ruby! code.dump
       expect(out).to eq original
@@ -75,7 +74,7 @@ RSpec.describe "Bundler.with_env helpers" do
 
     it "should remove '-rbundler/setup' from RUBYOPT" do
       code = "print #{modified_env}['RUBYOPT']"
-      ENV["RUBYOPT"] = "-W2 -rbundler/setup"
+      ENV["RUBYOPT"] = "-W2 -rbundler/setup #{ENV["RUBYOPT"]}"
       bundle_exec_ruby! code.dump
       expect(last_command.stdboth).not_to include("-rbundler/setup")
     end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that sometimes one get warnings on the system rubygems files, or maybe when modifying the `tmp` copy of rubygems, the changes seem not applied.

### What was your diagnosis of the problem?

My diagnosis was our specs sometimes use the system rubygems version, not the one controlled by the `RVG` environment variable.

### What is your fix for the problem, implemented in this PR?

My fix is to remove most occurrences of `:env => { :RUBYOPT => "-r#{spec_dir.join("support/hax")}" }` when spawning subprocesses. The reason is that in order to use the tmp copy of rubygems, our specs need to include `-I tmp/rubygems/lib` in the `RUBYOPT` environment variable. If we overwrite it in subprocesses, it won't use it. We can remove those however, since the "hax file" is already included in the main spec helper, while also keeping the previous value of `RUBYOPT`.

https://github.com/bundler/bundler/blob/189d56f2341d64ec5440242f42dbf84002be1238/spec/spec_helper.rb#L47

### Why did you choose this fix out of the possible options?

I chose this fix because it simplifies the spec setup while also making it more correct.
