### PR TITLE
Allow to `bundle exec` default gems

### DIFF
--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -512,7 +512,7 @@ module Bundler
         h
       end
 
-      Gem::Specification.send(:default_stubs, "*.gemspec").each do |stub|
+      Bundler.rubygems.default_stubs.each do |stub|
         default_spec = stub.to_spec
         default_spec_name = default_spec.name
         next if specs_by_name.key?(default_spec_name)
@@ -854,6 +854,16 @@ module Bundler
           Gem::Specification.stubs.find_all do |spec|
             spec.name == name
           end.map(&:to_spec)
+        end
+      end
+
+      if Gem::Specification.respond_to?(:default_stubs)
+        def default_stubs
+          Gem::Specification.default_stubs("*.gemspec")
+        end
+      else
+        def default_stubs
+          Gem::Specification.send(:default_stubs, "*.gemspec")
         end
       end
 

--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -512,6 +512,15 @@ module Bundler
         h
       end
 
+      Gem::Specification.send(:default_stubs, "*.gemspec").each do |stub|
+        default_spec = stub.to_spec
+        default_spec_name = default_spec.name
+        next if specs_by_name.key?(default_spec_name)
+
+        specs << default_spec
+        specs_by_name[default_spec_name] = default_spec
+      end
+
       replace_gem(specs, specs_by_name)
       stub_rubygems(specs)
       replace_bin_path(specs, specs_by_name)


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that since `irb` and others were moved to default gems, users cannot directly use them in a bundler context, unless they add it to their gemfiles. In my opinion, this completely defeats the purpose of default gems, and makes bundler degrade the user experience instead of making it better.

### What was your diagnosis of the problem?

My diagnosis was that when bundler replaces the set of gems known to rubygems, it restricts the world to what's in the Gemfile (or resolved from it), and that doesn't include default gems.

### What is your fix for the problem, implemented in this PR?

My fix is to also include the set of default gems, unless they are already included in the gemfile dependencies.

### Why did you choose this fix out of the possible options?

I chose this fix because it's reasonably simple and I think it shouldn't affect how other parts of bundler function.

Fixes #6929.
Fixes https://bugs.ruby-lang.org/issues/15503.