### PR TITLE
Turn on deprecations by default

### DIFF
--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -44,7 +44,6 @@ module Bundler
     settings_flag(:init_gems_rb) { bundler_2_mode? }
     settings_flag(:list_command) { bundler_2_mode? }
     settings_flag(:lockfile_uses_separate_rubygems_sources) { bundler_2_mode? }
-    settings_flag(:major_deprecations) { bundler_2_mode? }
     settings_flag(:only_update_to_newer_versions) { bundler_2_mode? }
     settings_flag(:path_relative_to_cwd) { bundler_2_mode? }
     settings_flag(:plugins) { @bundler_version >= Gem::Version.new("1.14") }

--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -44,6 +44,7 @@ module Bundler
     settings_flag(:init_gems_rb) { bundler_2_mode? }
     settings_flag(:list_command) { bundler_2_mode? }
     settings_flag(:lockfile_uses_separate_rubygems_sources) { bundler_2_mode? }
+    settings_flag(:major_deprecations) { bundler_2_mode? }
     settings_flag(:only_update_to_newer_versions) { bundler_2_mode? }
     settings_flag(:path_relative_to_cwd) { bundler_2_mode? }
     settings_flag(:plugins) { @bundler_version >= Gem::Version.new("1.14") }

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -41,7 +41,6 @@ module Bundler
       init_gems_rb
       list_command
       lockfile_uses_separate_rubygems_sources
-      major_deprecations
       no_install
       no_prune
       only_update_to_newer_versions
@@ -52,6 +51,7 @@ module Bundler
       prefer_patch
       print_only_version_number
       setup_makes_kernel_gem_public
+      silence_deprecations
       silence_root_warning
       skip_default_git_sources
       specific_platform
@@ -76,7 +76,7 @@ module Bundler
     ].freeze
 
     DEFAULT_CONFIG = {
-      :major_deprecations => true,
+      :silence_deprecations => false,
       :disable_version_check => true,
       :prefer_patch => false,
       :redirect => 5,

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -76,6 +76,7 @@ module Bundler
     ].freeze
 
     DEFAULT_CONFIG = {
+      :major_deprecations => true,
       :disable_version_check => true,
       :prefer_patch => false,
       :redirect => 5,

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -374,7 +374,7 @@ module Bundler
 
     def prints_major_deprecations?
       require "bundler"
-      return false unless Bundler.settings[:major_deprecations]
+      return false unless Bundler.feature_flag.major_deprecations?
       require "bundler/deprecate"
       return false if Bundler::Deprecate.skip
       true

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -147,7 +147,7 @@ module Bundler
         raise DeprecatedError, "[REMOVED] #{message}"
       end
 
-      return unless bundler_major_version >= major_version || prints_major_deprecations?
+      return unless bundler_major_version >= major_version && prints_major_deprecations?
       @major_deprecation_ui ||= Bundler::UI::Shell.new("no-color" => true)
       ui = Bundler.ui.is_a?(@major_deprecation_ui.class) ? Bundler.ui : @major_deprecation_ui
       ui.warn("[DEPRECATED] #{message}")

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -144,13 +144,13 @@ module Bundler
       bundler_major_version = Bundler.bundler_major_version
       if bundler_major_version > major_version
         require "bundler/errors"
-        raise DeprecatedError, "[REMOVED FROM #{major_version.succ}.0] #{message}"
+        raise DeprecatedError, "[REMOVED] #{message}"
       end
 
       return unless bundler_major_version >= major_version || prints_major_deprecations?
       @major_deprecation_ui ||= Bundler::UI::Shell.new("no-color" => true)
       ui = Bundler.ui.is_a?(@major_deprecation_ui.class) ? Bundler.ui : @major_deprecation_ui
-      ui.warn("[DEPRECATED FOR #{major_version}.0] #{message}")
+      ui.warn("[DEPRECATED] #{message}")
     end
 
     def print_major_deprecations!

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -374,7 +374,7 @@ module Bundler
 
     def prints_major_deprecations?
       require "bundler"
-      return false unless Bundler.settings[:major_deprecations]
+      return false if Bundler.settings[:silence_deprecations]
       require "bundler/deprecate"
       return false if Bundler::Deprecate.skip
       true

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -374,8 +374,7 @@ module Bundler
 
     def prints_major_deprecations?
       require "bundler"
-      deprecation_release = Bundler::VERSION.split(".").drop(1).include?("99")
-      return false if !deprecation_release && !Bundler.settings[:major_deprecations]
+      return false unless Bundler.settings[:major_deprecations]
       require "bundler/deprecate"
       return false if Bundler::Deprecate.skip
       true

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -374,7 +374,7 @@ module Bundler
 
     def prints_major_deprecations?
       require "bundler"
-      return false unless Bundler.feature_flag.major_deprecations?
+      return false unless Bundler.settings[:major_deprecations]
       require "bundler/deprecate"
       return false if Bundler::Deprecate.skip
       true

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -210,9 +210,6 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
    The number of gems Bundler can install in parallel. Defaults to 1.
 * `list_command` (`BUNDLE_LIST_COMMAND`)
    Enable new list command feature
-* `major_deprecations` (`BUNDLE_MAJOR_DEPRECATIONS`):
-   Whether Bundler should print deprecation warnings for behavior that will
-   be changed in the next major version.
 * `no_install` (`BUNDLE_NO_INSTALL`):
    Whether `bundle package` should skip installing gems.
 * `no_prune` (`BUNDLE_NO_PRUNE`):
@@ -247,6 +244,9 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
 * `shebang` (`BUNDLE_SHEBANG`):
    The program name that should be invoked for generated binstubs. Defaults to
    the ruby install name used to generate the binstub.
+* `silence_deprecations` (`BUNDLE_SILENCE_DEPRECATIONS`):
+   Whether Bundler should silence deprecation warnings for behavior that will
+   be changed in the next major version.
 * `silence_root_warning` (`BUNDLE_SILENCE_ROOT_WARNING`):
    Silence the warning Bundler prints when installing gems as root.
 * `skip_default_git_sources` (`BUNDLE_SKIP_DEFAULT_GIT_SOURCES`):

--- a/spec/commands/show_spec.rb
+++ b/spec/commands/show_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "bundle show" do
 
     it "prints deprecation", :bundler => "2" do
       bundle "show rails"
-      expect(err).to eq("[DEPRECATED FOR 2.0] use `bundle info rails` instead of `bundle show rails`")
+      expect(err).to eq("[DEPRECATED] use `bundle info rails` instead of `bundle show rails`")
     end
 
     it "prints path if gem exists in bundle (with --paths option)" do
@@ -42,7 +42,7 @@ RSpec.describe "bundle show" do
 
     it "prints deprecation when called with a gem and the --paths option", :bundler => "2" do
       bundle "show rails --paths"
-      expect(err).to eq("[DEPRECATED FOR 2.0] use `bundle info rails --path` instead of `bundle show rails --paths`")
+      expect(err).to eq("[DEPRECATED] use `bundle info rails --path` instead of `bundle show rails --paths`")
     end
 
     it "warns if path no longer exists on disk" do
@@ -61,7 +61,7 @@ RSpec.describe "bundle show" do
 
     it "prints deprecation when called with bundler", :bundler => "2" do
       bundle "show bundler"
-      expect(err).to eq("[DEPRECATED FOR 2.0] use `bundle info bundler` instead of `bundle show bundler`")
+      expect(err).to eq("[DEPRECATED] use `bundle info bundler` instead of `bundle show bundler`")
     end
     it "complains if gem not in bundle" do
       bundle "show missing"
@@ -82,7 +82,7 @@ RSpec.describe "bundle show" do
     it "prints a deprecation when called with the --paths option", :bundler => 2 do
       bundle "show --paths"
 
-      expect(err).to eq("[DEPRECATED FOR 2.0] use `bundle list` instead of `bundle show --paths`")
+      expect(err).to eq("[DEPRECATED] use `bundle list` instead of `bundle show --paths`")
     end
 
     it "prints summary of gems" do

--- a/spec/install/gemfile/sources_spec.rb
+++ b/spec/install/gemfile/sources_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe "bundle install with gems on multiple sources" do
           gem "rack-obama"
           gem "rack"
         G
-        bundle "config set major_deprecations true"
       end
 
       it "warns about ambiguous gems, but installs anyway, prioritizing sources last to first", :bundler => "< 2" do
@@ -55,7 +54,6 @@ RSpec.describe "bundle install with gems on multiple sources" do
           gem "rack-obama"
           gem "rack", "1.0.0" # force it to install the working version in repo1
         G
-        bundle "config set major_deprecations true"
       end
 
       it "warns about ambiguous gems, but installs anyway", :bundler => "< 2" do
@@ -249,7 +247,6 @@ RSpec.describe "bundle install with gems on multiple sources" do
           end
 
           it "installs from the other source and warns about ambiguous gems", :bundler => "< 2" do
-            bundle "config set major_deprecations true"
             bundle :install
             expect(out).to have_major_deprecation a_string_including("Your Gemfile contains multiple primary sources.")
             expect(out).to include("Warning: the gem 'rack' was found in multiple sources.")

--- a/spec/install/redownload_spec.rb
+++ b/spec/install/redownload_spec.rb
@@ -63,22 +63,22 @@ RSpec.describe "bundle install" do
 
     it "shows a deprecation when single flag passed", :bundler => 2 do
       bundle! "install --force"
-      expect(err).to include "[DEPRECATED FOR 2.0] The `--force` option has been renamed to `--redownload`"
+      expect(err).to include "[DEPRECATED] The `--force` option has been renamed to `--redownload`"
     end
 
     it "shows a deprecation when multiple flags passed", :bundler => 2 do
       bundle! "install --no-color --force"
-      expect(err).to include "[DEPRECATED FOR 2.0] The `--force` option has been renamed to `--redownload`"
+      expect(err).to include "[DEPRECATED] The `--force` option has been renamed to `--redownload`"
     end
 
     it "does not show a deprecation when single flag passed", :bundler => "< 2" do
       bundle! "install --force"
-      expect(out).not_to include "[DEPRECATED FOR 2.0] The `--force` option has been renamed to `--redownload`"
+      expect(out).not_to include "[DEPRECATED] The `--force` option has been renamed to `--redownload`"
     end
 
     it "does not show a deprecation when multiple flags passed", :bundler => "< 2" do
       bundle! "install --no-color --force"
-      expect(out).not_to include "[DEPRECATED FOR 2.0] The `--force` option has been renamed to `--redownload`"
+      expect(out).not_to include "[DEPRECATED] The `--force` option has been renamed to `--redownload`"
     end
   end
 
@@ -89,12 +89,12 @@ RSpec.describe "bundle install" do
 
     it "does not show a deprecation when single flag passed" do
       bundle! "install --redownload"
-      expect(err).not_to include "[DEPRECATED FOR 2.0] The `--force` option has been renamed to `--redownload`"
+      expect(err).not_to include "[DEPRECATED] The `--force` option has been renamed to `--redownload`"
     end
 
     it "does not show a deprecation when single multiple flags passed" do
       bundle! "install --no-color --redownload"
-      expect(err).not_to include "[DEPRECATED FOR 2.0] The `--force` option has been renamed to `--redownload`"
+      expect(err).not_to include "[DEPRECATED] The `--force` option has been renamed to `--redownload`"
     end
   end
 end

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -4,22 +4,6 @@ RSpec.describe "major deprecations", :bundler => "< 2" do
   let(:warnings) { last_command.bundler_err } # change to err in 2.0
   let(:warnings_without_version_messages) { warnings.gsub(/#{Spec::Matchers::MAJOR_DEPRECATION}Bundler will only support ruby(gems)? >= .*/, "") }
 
-  context "in a .99 version" do
-    before do
-      simulate_bundler_version "1.99.1"
-      bundle "config unset major_deprecations"
-    end
-
-    it "prints major deprecations without being configured" do
-      ruby <<-R
-        require "bundler"
-        Bundler::SharedHelpers.major_deprecation(Bundler::VERSION)
-      R
-
-      expect(warnings).to have_major_deprecation("1.99.1")
-    end
-  end
-
   before do
     bundle "config set major_deprecations true"
 

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe "major deprecations", :bundler => "< 2" do
   let(:warnings_without_version_messages) { warnings.gsub(/#{Spec::Matchers::MAJOR_DEPRECATION}Bundler will only support ruby(gems)? >= .*/, "") }
 
   before do
-    bundle "config set major_deprecations true"
-
     create_file "gems.rb", <<-G
       source "file:#{gem_repo1}"
       ruby #{RUBY_VERSION.dump}

--- a/spec/runtime/with_unbundled_env_spec.rb
+++ b/spec/runtime/with_unbundled_env_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe "Bundler.with_env helpers" do
       code = "Bundler.clean_env"
       bundle_exec_ruby! code.dump
       expect(err).to include(
-        "[DEPRECATED FOR 2.0] `Bundler.clean_env` has been deprecated in favor of `Bundler.unbundled_env`. " \
+        "[DEPRECATED] `Bundler.clean_env` has been deprecated in favor of `Bundler.unbundled_env`. " \
         "If you instead want the environment before bundler was originally loaded, use `Bundler.original_env`"
       )
     end
@@ -116,7 +116,7 @@ RSpec.describe "Bundler.with_env helpers" do
       code = "Bundler.clean_env"
       bundle_exec_ruby! code.dump
       expect(out).not_to include(
-        "[DEPRECATED FOR 2.0] `Bundler.clean_env` has been deprecated in favor of `Bundler.unbundled_env`. " \
+        "[DEPRECATED] `Bundler.clean_env` has been deprecated in favor of `Bundler.unbundled_env`. " \
         "If you instead want the environment before bundler was originally loaded, use `Bundler.original_env`"
       )
     end
@@ -157,7 +157,7 @@ RSpec.describe "Bundler.with_env helpers" do
       code = "Bundler.with_clean_env {}"
       bundle_exec_ruby! code.dump
       expect(err).to include(
-        "[DEPRECATED FOR 2.0] `Bundler.with_clean_env` has been deprecated in favor of `Bundler.with_unbundled_env`. " \
+        "[DEPRECATED] `Bundler.with_clean_env` has been deprecated in favor of `Bundler.with_unbundled_env`. " \
         "If you instead want the environment before bundler was originally loaded, use `Bundler.with_original_env`"
       )
     end
@@ -166,7 +166,7 @@ RSpec.describe "Bundler.with_env helpers" do
       code = "Bundler.with_clean_env {}"
       bundle_exec_ruby! code.dump
       expect(out).not_to include(
-        "[DEPRECATED FOR 2.0] `Bundler.with_clean_env` has been deprecated in favor of `Bundler.with_unbundled_env`. " \
+        "[DEPRECATED] `Bundler.with_clean_env` has been deprecated in favor of `Bundler.with_unbundled_env`. " \
         "If you instead want the environment before bundler was originally loaded, use `Bundler.with_original_env`"
       )
     end

--- a/spec/runtime/with_unbundled_env_spec.rb
+++ b/spec/runtime/with_unbundled_env_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe "Bundler.with_env helpers" do
     it "prints a deprecation", :bundler => 2 do
       code = "Bundler.clean_env"
       bundle_exec_ruby! code.dump
-      expect(last_command.stdboth).to include(
+      expect(err).to include(
         "[DEPRECATED FOR 2.0] `Bundler.clean_env` has been deprecated in favor of `Bundler.unbundled_env`. " \
         "If you instead want the environment before bundler was originally loaded, use `Bundler.original_env`"
       )
@@ -115,7 +115,7 @@ RSpec.describe "Bundler.with_env helpers" do
     it "does not print a deprecation", :bundler => "< 2" do
       code = "Bundler.clean_env"
       bundle_exec_ruby! code.dump
-      expect(last_command.stdboth).not_to include(
+      expect(out).not_to include(
         "[DEPRECATED FOR 2.0] `Bundler.clean_env` has been deprecated in favor of `Bundler.unbundled_env`. " \
         "If you instead want the environment before bundler was originally loaded, use `Bundler.original_env`"
       )
@@ -156,7 +156,7 @@ RSpec.describe "Bundler.with_env helpers" do
     it "prints a deprecation", :bundler => 2 do
       code = "Bundler.with_clean_env {}"
       bundle_exec_ruby! code.dump
-      expect(last_command.stdboth).to include(
+      expect(err).to include(
         "[DEPRECATED FOR 2.0] `Bundler.with_clean_env` has been deprecated in favor of `Bundler.with_unbundled_env`. " \
         "If you instead want the environment before bundler was originally loaded, use `Bundler.with_original_env`"
       )
@@ -165,7 +165,7 @@ RSpec.describe "Bundler.with_env helpers" do
     it "does not print a deprecation", :bundler => "< 2" do
       code = "Bundler.with_clean_env {}"
       bundle_exec_ruby! code.dump
-      expect(last_command.stdboth).not_to include(
+      expect(out).not_to include(
         "[DEPRECATED FOR 2.0] `Bundler.with_clean_env` has been deprecated in favor of `Bundler.with_unbundled_env`. " \
         "If you instead want the environment before bundler was originally loaded, use `Bundler.with_original_env`"
       )

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -60,7 +60,7 @@ module Spec
       end
     end
 
-    MAJOR_DEPRECATION = /^\[DEPRECATED FOR 2\.0\]\s*/
+    MAJOR_DEPRECATION = /^\[DEPRECATED\]\s*/
 
     RSpec::Matchers.define :eq_err do |expected|
       diffable

--- a/spec/update/redownload_spec.rb
+++ b/spec/update/redownload_spec.rb
@@ -33,12 +33,12 @@ RSpec.describe "bundle update" do
   describe "with --redownload" do
     it "does not show a deprecation when single flag passed" do
       bundle! "update rack --redownload"
-      expect(out).not_to include "[DEPRECATED FOR 2.0] The `--force` option has been renamed to `--redownload`"
+      expect(err).not_to include "[DEPRECATED FOR 2.0] The `--force` option has been renamed to `--redownload`"
     end
 
     it "does not show a deprecation when single multiple flags passed" do
       bundle! "update rack --no-color --redownload"
-      expect(out).not_to include "[DEPRECATED FOR 2.0] The `--force` option has been renamed to `--redownload`"
+      expect(err).not_to include "[DEPRECATED FOR 2.0] The `--force` option has been renamed to `--redownload`"
     end
   end
 end

--- a/spec/update/redownload_spec.rb
+++ b/spec/update/redownload_spec.rb
@@ -11,34 +11,34 @@ RSpec.describe "bundle update" do
   describe "with --force" do
     it "shows a deprecation when single flag passed", :bundler => 2 do
       bundle! "update rack --force"
-      expect(err).to include "[DEPRECATED FOR 2.0] The `--force` option has been renamed to `--redownload`"
+      expect(err).to include "[DEPRECATED] The `--force` option has been renamed to `--redownload`"
     end
 
     it "shows a deprecation when multiple flags passed", :bundler => 2 do
       bundle! "update rack --no-color --force"
-      expect(err).to include "[DEPRECATED FOR 2.0] The `--force` option has been renamed to `--redownload`"
+      expect(err).to include "[DEPRECATED] The `--force` option has been renamed to `--redownload`"
     end
 
     it "does not show a deprecation when single flag passed", :bundler => "< 2" do
       bundle! "update rack --force"
-      expect(out).not_to include "[DEPRECATED FOR 2.0] The `--force` option has been renamed to `--redownload`"
+      expect(out).not_to include "[DEPRECATED] The `--force` option has been renamed to `--redownload`"
     end
 
     it "does not show a deprecation when multiple flags passed", :bundler => "< 2" do
       bundle! "update rack --no-color --force"
-      expect(out).not_to include "[DEPRECATED FOR 2.0] The `--force` option has been renamed to `--redownload`"
+      expect(out).not_to include "[DEPRECATED] The `--force` option has been renamed to `--redownload`"
     end
   end
 
   describe "with --redownload" do
     it "does not show a deprecation when single flag passed" do
       bundle! "update rack --redownload"
-      expect(err).not_to include "[DEPRECATED FOR 2.0] The `--force` option has been renamed to `--redownload`"
+      expect(err).not_to include "[DEPRECATED] The `--force` option has been renamed to `--redownload`"
     end
 
     it "does not show a deprecation when single multiple flags passed" do
       bundle! "update rack --no-color --redownload"
-      expect(err).not_to include "[DEPRECATED FOR 2.0] The `--force` option has been renamed to `--redownload`"
+      expect(err).not_to include "[DEPRECATED] The `--force` option has been renamed to `--redownload`"
     end
   end
 end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was we've had deprecations in place for a long time, but we've never displayed them to users by default. 

### What was your diagnosis of the problem?

My diagnosis was that the current strategy doesn't work because:

* Printing deprecations as an optin feature almost never get enabled, so most users don't know about the stuff we'll be deprecating in the future.

* Printing deprecations in "deprecation releases" doesn't work well either, because it's unclear how long the deprecation release should last and thus how long we need to hold the final release (that will inhibit installation of the deprecation release).

### What is your fix for the problem, implemented in this PR?

My fix is to remove the concept of deprecation releases, and to add a feature flag for printing major deprecations that it's enabled by default.

As a extra related change, I also reworded the deprecation messages, because I find the current message "[DEPRECATED FOR 2.0] <Message about the deprecation>" a bit confusing because it's unclear what the version printed is referring to (deprecation horizon? current running version?), so I changed it to just "[DEPRECATED] <Message about the deprecation>".

### Why did you choose this fix out of the possible options?

I chose this fix because it (once released) finally makes it so that users will know about our deprecations.
