### PR TITLE
Travis "bundle gem" template: Drop unused sudo: false option

### DIFF
--- a/lib/bundler/templates/newgem/travis.yml.tt
+++ b/lib/bundler/templates/newgem/travis.yml.tt
@@ -1,5 +1,4 @@
 ---
-sudo: false
 language: ruby
 cache: bundler
 rvm:


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

I reviewed a PR in an Open Source project, and it had this defunct setting from Travis.

### What was your diagnosis of the problem?

I was told the `bundle gem` command outputs this directive, and I looked here, and lo, it was.

See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration for historical detail about when it was removed.

### What is your fix for the problem, implemented in this PR?

My fix is to **drop** this **unused directive** from the template.

### Why did you choose this fix out of the possible options?

I chose this fix because it works the same for the user, with less configuration.
