### PR TITLE
Fix redefinition warning

### DIFF
--- a/spec/quality_es_spec.rb
+++ b/spec/quality_es_spec.rb
@@ -43,14 +43,6 @@ RSpec.describe "La biblioteca si misma" do
     failing_line_message unless failing_line_message.empty?
   end
 
-  RSpec::Matchers.define :be_well_formed do
-    match(&:empty?)
-
-    failure_message do |actual|
-      actual.join("\n")
-    end
-  end
-
   it "mantiene la calidad de lenguaje de la documentación" do
     included = /ronn/
     error_messages = []

--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -96,14 +96,6 @@ RSpec.describe "The library itself" do
     failing_line_message unless failing_line_message.empty?
   end
 
-  RSpec::Matchers.define :be_well_formed do
-    match(&:empty?)
-
-    failure_message do |actual|
-      actual.join("\n")
-    end
-  end
-
   it "has no malformed whitespace" do
     exempt = /\.gitmodules|\.marshal|fixtures|vendor|ssl_certs|LICENSE|vcr_cassettes/
     error_messages = []

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -121,6 +121,14 @@ module Spec
       end
     end
 
+    RSpec::Matchers.define :be_well_formed do
+      match(&:empty?)
+
+      failure_message do |actual|
+        actual.join("\n")
+      end
+    end
+
     define_compound_matcher :read_as, [exist] do |file_contents|
       diffable
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that the test suite spits some warnings

```
/home/deivid/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rspec-expectations-3.8.2/lib/rspec/matchers/dsl.rb:72: warning: method redefined; discarding old be_well_formed
/home/deivid/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rspec-expectations-3.8.2/lib/rspec/matchers/dsl.rb:72: warning: previous definition of be_well_formed was here
```

### What was your diagnosis of the problem?

My diagnosis was that we are redefining an RSpec matcher.

### What is your fix for the problem, implemented in this PR?

My fix is to define the matcher just once.

### Why did you choose this fix out of the possible options?

I chose this fix because moving it to the centralized place where custom matchers are defined made sense to me.
