### PR TITLE
Fix warning message about bundler version

### DIFF
--- a/lib/bundler/lockfile_parser.rb
+++ b/lib/bundler/lockfile_parser.rb
@@ -107,9 +107,9 @@ module Bundler
       when 0
         if current_version < bundler_version
           Bundler.ui.warn "Warning: the running version of Bundler (#{current_version}) is older " \
-               "than the version that created the lockfile (#{bundler_version}). We suggest you " \
-               "upgrade to the latest version of Bundler by running `gem " \
-               "install bundler#{prerelease_text}`.\n"
+               "than the version that created the lockfile (#{bundler_version}). We suggest you to " \
+               "upgrade to the version that created the lockfile by running `gem install " \
+               "bundler:#{bundler_version}#{prerelease_text}`.\n"
         end
       end
     end

--- a/spec/lock/lockfile_bundler_1_spec.rb
+++ b/spec/lock/lockfile_bundler_1_spec.rb
@@ -180,7 +180,9 @@ RSpec.describe "the lockfile format", :bundler => "< 2" do
     end
 
     warning_message = "the running version of Bundler (9999999.0.0) is older " \
-                      "than the version that created the lockfile (9999999.1.0)"
+                      "than the version that created the lockfile (9999999.1.0). " \
+                      "We suggest you to upgrade to the version that created the " \
+                      "lockfile by running `gem install bundler:9999999.1.0`."
     expect(last_command.stderr.scan(warning_message).size).to eq(1)
 
     lockfile_should_be <<-G

--- a/spec/lock/lockfile_spec.rb
+++ b/spec/lock/lockfile_spec.rb
@@ -180,7 +180,9 @@ RSpec.describe "the lockfile format", :bundler => "2" do
     end
 
     warning_message = "the running version of Bundler (9999999.0.0) is older " \
-                      "than the version that created the lockfile (9999999.1.0)"
+                      "than the version that created the lockfile (9999999.1.0). " \
+                      "We suggest you to upgrade to the version that created the " \
+                      "lockfile by running `gem install bundler:9999999.1.0`."
     expect(last_command.bundler_err).to include warning_message
 
     lockfile_should_be <<-G


### PR DESCRIPTION
Fixes #6909.

### What was the end-user problem that led to this PR?

The problem was that we're recommending a command to make a warning go away that doesn't really make the warning go away.

### What was your diagnosis of the problem?

My diagnosis was that the current recommendation installs the latest bundler, which might not be the same as the version the lock file was created with. If it's not the same, the warning will not go away.

### What is your fix for the problem, implemented in this PR?

My fix is to recommend installing exactly the version the lockfile was created with.

### Why did you choose this fix out of the possible options?

I chose this fix because it's really simple and it should work.
