### PR TITLE
Backport the latest commits on ruby core repository.

### DIFF
--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -75,7 +75,8 @@ module Bundler
 
     def build_gem
       file_name = nil
-      sh(%W[gem build -V #{spec_path}]) do
+      gem = ENV["BUNDLE_GEM"] ? ENV["BUNDLE_GEM"] : "gem"
+      sh(%W[#{gem} build -V #{spec_path}]) do
         file_name = File.basename(built_gem_path)
         SharedHelpers.filesystem_access(File.join(base, "pkg")) {|p| FileUtils.mkdir_p(p) }
         FileUtils.mv(built_gem_path, "pkg")
@@ -86,7 +87,8 @@ module Bundler
 
     def install_gem(built_gem_path = nil, local = false)
       built_gem_path ||= build_gem
-      cmd = %W[gem install #{built_gem_path}]
+      gem = ENV["BUNDLE_GEM"] ? ENV["BUNDLE_GEM"] : "gem"
+      cmd = %W[#{gem} install #{built_gem_path}]
       cmd << "--local" if local
       out, status = sh_with_status(cmd)
       unless status.success? && out[/Successfully installed/]

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -278,7 +278,7 @@ module Bundler
           # avoid stepping above the tmp directory when testing
           gemspec = if ENV["BUNDLE_RUBY"] && ENV["BUNDLE_GEM"]
             # for Ruby Core
-            "lib/bundler.gemspec"
+            "lib/bundler/bundler.gemspec"
           else
             "bundler.gemspec"
           end

--- a/spec/commands/clean_spec.rb
+++ b/spec/commands/clean_spec.rb
@@ -464,7 +464,7 @@ RSpec.describe "bundle clean" do
 
     gem = ruby_core? ? ENV["BUNDLE_GEM"] : "gem"
     sys_exec! "#{gem} list"
-  expect(out).to include("foo (1.0.1, 1.0)")
+    expect(out).to include("foo (1.0.1, 1.0)")
   end
 
   it "cleans system gems when --force is used" do

--- a/spec/commands/clean_spec.rb
+++ b/spec/commands/clean_spec.rb
@@ -339,7 +339,8 @@ RSpec.describe "bundle clean" do
       gem "rack"
     G
 
-    sys_exec! "gem list"
+    gem = ruby_core? ? ENV["BUNDLE_GEM"] : "gem"
+    sys_exec! "#{gem} list"
     expect(out).to include("rack (1.0.0)").and include("thin (1.0)")
   end
 
@@ -461,8 +462,9 @@ RSpec.describe "bundle clean" do
     end
     bundle! :update, :all => bundle_update_requires_all?
 
-    sys_exec! "gem list"
-    expect(out).to include("foo (1.0.1, 1.0)")
+    gem = ruby_core? ? ENV["BUNDLE_GEM"] : "gem"
+    sys_exec! "#{gem} list"
+  expect(out).to include("foo (1.0.1, 1.0)")
   end
 
   it "cleans system gems when --force is used" do
@@ -485,7 +487,8 @@ RSpec.describe "bundle clean" do
     bundle "clean --force"
 
     expect(out).to include("Removing foo (1.0)")
-    sys_exec "gem list"
+    gem = ruby_core? ? ENV["BUNDLE_GEM"] : "gem"
+    sys_exec "#{gem} list"
     expect(out).not_to include("foo (1.0)")
     expect(out).to include("rack (1.0.0)")
   end
@@ -519,7 +522,8 @@ RSpec.describe "bundle clean" do
       expect(err).to include(system_gem_path.to_s)
       expect(err).to include("grant write permissions")
 
-      sys_exec "gem list"
+      gem = ruby_core? ? ENV["BUNDLE_GEM"] : "gem"
+      sys_exec "#{gem} list"
       expect(out).to include("foo (1.0)")
       expect(out).to include("rack (1.0.0)")
     end

--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -219,7 +219,7 @@ RSpec.describe "The library itself" do
         if ruby_core?
           spec = Gem::Specification.load(gemspec.to_s)
           spec.bindir = "libexec"
-          File.open(root.join("bundler.gemspec").to_s, "w"){|f| f.write spec.to_ruby }
+          File.open(root.join("bundler.gemspec").to_s, "w") {|f| f.write spec.to_ruby }
           gem_command! :build, root.join("bundler.gemspec").to_s
           FileUtils.rm(root.join("bundler.gemspec").to_s)
         else

--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -216,7 +216,16 @@ RSpec.describe "The library itself" do
   it "can still be built" do
     Dir.chdir(root) do
       begin
-        gem_command! :build, gemspec
+        if ruby_core?
+          spec = Gem::Specification.load(gemspec.to_s)
+          spec.bindir = "libexec"
+          File.open(root.join("bundler.gemspec").to_s, "w"){|f| f.write spec.to_ruby }
+          gem_command! :build, root.join("bundler.gemspec").to_s
+          FileUtils.rm(root.join("bundler.gemspec").to_s)
+        else
+          gem_command! :build, gemspec
+        end
+
         if Bundler.rubygems.provides?(">= 2.4")
           # there's no way around this warning
           last_command.stderr.sub!(/^YAML safe loading.*/, "")
@@ -227,8 +236,7 @@ RSpec.describe "The library itself" do
         end
       ensure
         # clean up the .gem generated
-        path_prefix = ruby_core? ? "lib/" : "./"
-        FileUtils.rm("#{path_prefix}bundler-#{Bundler::VERSION}.gem")
+        FileUtils.rm("bundler-#{Bundler::VERSION}.gem")
       end
     end
   end

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -871,7 +871,7 @@ end
 
       FileUtils.ln_s(bundler_dir, File.join(gems_dir, "bundler-#{Bundler::VERSION}"))
 
-      gemspec_file = ruby_core? ? "#{bundler_dir}/lib/bundler.gemspec" : "#{bundler_dir}/bundler.gemspec"
+      gemspec_file = ruby_core? ? "#{bundler_dir}/lib/bundler/bundler.gemspec" : "#{bundler_dir}/bundler.gemspec"
       gemspec = File.read(gemspec_file).
                 sub("Bundler::VERSION", %("#{Bundler::VERSION}"))
       gemspec = gemspec.lines.reject {|line| line =~ %r{lib/bundler/version} }.join

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -311,7 +311,7 @@ module Spec
           if ruby_core?
             spec = Gem::Specification.load(gemspec.to_s)
             spec.bindir = "libexec"
-            File.open(root.join("bundler.gemspec").to_s, "w"){|f| f.write spec.to_ruby }
+            File.open(root.join("bundler.gemspec").to_s, "w") {|f| f.write spec.to_ruby }
             Dir.chdir(root) { gem_command! :build, root.join("bundler.gemspec").to_s }
             FileUtils.rm(root.join("bundler.gemspec"))
           else

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -308,12 +308,16 @@ module Spec
       gem_repo = options.fetch(:gem_repo) { gem_repo1 }
       gems.each do |g|
         path = if g == :bundler
-          Dir.chdir(root) { gem_command! :build, gemspec.to_s }
-          bundler_path = if ruby_core?
-            root + "lib/bundler-#{Bundler::VERSION}.gem"
+          if ruby_core?
+            spec = Gem::Specification.load(gemspec.to_s)
+            spec.bindir = "libexec"
+            File.open(root.join("bundler.gemspec").to_s, "w"){|f| f.write spec.to_ruby }
+            Dir.chdir(root) { gem_command! :build, root.join("bundler.gemspec").to_s }
+            FileUtils.rm(root.join("bundler.gemspec"))
           else
-            root + "bundler-#{Bundler::VERSION}.gem"
+            Dir.chdir(root) { gem_command! :build, gemspec.to_s }
           end
+          bundler_path = root + "bundler-#{Bundler::VERSION}.gem"
         elsif g.to_s =~ %r{\A/.*\.gem\z}
           g
         else

--- a/spec/support/rubygems_ext.rb
+++ b/spec/support/rubygems_ext.rb
@@ -52,7 +52,8 @@ module Spec
       no_reqs.map!(&:first)
       reqs.map! {|name, req| "'#{name}:#{req}'" }
       deps = reqs.concat(no_reqs).join(" ")
-      cmd = "#{Gem.ruby} -S gem install #{deps} --no-document --conservative"
+      gem = Spec::Path.ruby_core? ? ENV["BUNDLE_GEM"] : "#{Gem.ruby} -S gem"
+      cmd = "#{gem} install #{deps} --no-document --conservative"
       puts cmd
       system(cmd) || raise("Installing gems #{deps} for the tests to use failed!")
     end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

RSpec example of the bundled bundler was failed on Ruby 2.7 from ruby core repository. I fixed some of the issues on ruby core repository.

### What was your diagnosis of the problem?

1. I fixed the location of `lib/bundler.gemspec` to `lib/bundler/bundler.gemspec` for fixing gemspec issue of Ruby 2.6.1: https://github.com/ruby/ruby/commit/7c9771be02ddc707fea8ec96089c8a100c59f806
2. The current Bundler examples relied on the same versions of Ruby that are the first binary of PATH and rspec invocation binary. But the ruby core repository uses the different versions for them.

### What is your fix for the problem, implemented in this PR?

I fixed the location path of bundler.gemspec and uses `ENV['BUNDLE_GEM']` instead of hard-coded `gem` command.

### Why did you choose this fix out of the possible options?

There is no options on ruby core repository. I welcome to another options.
