### PR TITLE
Reenable deprecation specs (and make up a plan)

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -304,7 +304,6 @@ module Bundler
         #     "https://github.com/#{repo_name}.git"
         #   end
         repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
-        # TODO: 2.0 upgrade this setting to the default
         if Bundler.feature_flag.github_https?
           Bundler::SharedHelpers.major_deprecation 2, "The `github.https` setting will be removed"
           "https://github.com/#{repo_name}.git"
@@ -313,14 +312,12 @@ module Bundler
         end
       end
 
-      # TODO: 2.0 remove this deprecated git source
       git_source(:gist) do |repo_name|
         warn_deprecated_git_source(:gist, '"https://gist.github.com/#{repo_name}.git"')
 
         "https://gist.github.com/#{repo_name}.git"
       end
 
-      # TODO: 2.0 remove this deprecated git source
       git_source(:bitbucket) do |repo_name|
         warn_deprecated_git_source(:bitbucket, <<-'RUBY'.strip)
 user_name, repo_name = repo_name.split("/")
@@ -488,7 +485,6 @@ repo_name ||= user_name
     end
 
     def warn_deprecated_git_source(name, replacement, additional_message = nil)
-      # TODO: 2.0 remove deprecation
       additional_message &&= " #{additional_message}"
       replacement = if replacement.count("\n").zero?
         "{|repo_name| #{replacement} }"

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -290,24 +290,11 @@ module Bundler
         warn_deprecated_git_source(:github, <<-'RUBY'.strip, 'Change any "reponame" :github sources to "username/reponame".')
 "https://github.com/#{repo_name}.git"
         RUBY
-        # It would be better to use https instead of the git protocol, but this
-        # can break deployment of existing locked bundles when switching between
-        # different versions of Bundler. The change will be made in 2.0, which
-        # does not guarantee compatibility with the 1.x series.
-        #
-        # See https://github.com/bundler/bundler/pull/2569 for discussion
-        #
-        # This can be overridden by adding this code to your Gemfiles:
-        #
-        #   git_source(:github) do |repo_name|
-        #     repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
-        #     "https://github.com/#{repo_name}.git"
-        #   end
         repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
         if Bundler.feature_flag.github_https?
-          Bundler::SharedHelpers.major_deprecation 2, "The `github.https` setting will be removed"
           "https://github.com/#{repo_name}.git"
         else
+          Bundler::SharedHelpers.major_deprecation 2, "Setting `github.https` to false is deprecated and won't be supported in the future."
           "git://github.com/#{repo_name}.git"
         end
       end
@@ -492,8 +479,8 @@ repo_name ||= user_name
         "do |repo_name|\n#{replacement.to_s.gsub(/^/, "      ")}\n    end"
       end
 
-      Bundler::SharedHelpers.major_deprecation 2, <<-EOS
-The :#{name} git source is deprecated, and will be removed in Bundler 2.0.#{additional_message} Add this code to the top of your Gemfile to ensure it continues to work:
+      Bundler::SharedHelpers.major_deprecation 3, <<-EOS
+The :#{name} git source is deprecated, and will be removed in Bundler 3.0.#{additional_message} Add this code to the top of your Gemfile to ensure it continues to work:
 
     git_source(:#{name}) #{replacement}
 

--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -50,7 +50,7 @@ module Bundler
     settings_flag(:prefer_gems_rb) { bundler_2_mode? }
     settings_flag(:print_only_version_number) { bundler_2_mode? }
     settings_flag(:setup_makes_kernel_gem_public) { !bundler_2_mode? }
-    settings_flag(:skip_default_git_sources) { bundler_2_mode? }
+    settings_flag(:skip_default_git_sources) { bundler_3_mode? }
     settings_flag(:specific_platform) { bundler_2_mode? }
     settings_flag(:suppress_install_using_messages) { bundler_2_mode? }
     settings_flag(:unlock_source_unlocks_spec) { !bundler_2_mode? }

--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -38,7 +38,7 @@ module Bundler
     settings_flag(:deployment_means_frozen) { bundler_2_mode? }
     settings_flag(:disable_multisource) { bundler_2_mode? }
     settings_flag(:error_on_stderr) { bundler_2_mode? }
-    settings_flag(:forget_cli_options) { bundler_2_mode? }
+    settings_flag(:forget_cli_options) { bundler_3_mode? }
     settings_flag(:global_path_appends_ruby_scope) { bundler_2_mode? }
     settings_flag(:global_gem_cache) { bundler_2_mode? }
     settings_flag(:init_gems_rb) { bundler_2_mode? }

--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -54,7 +54,7 @@ module Bundler
     settings_flag(:specific_platform) { bundler_2_mode? }
     settings_flag(:suppress_install_using_messages) { bundler_2_mode? }
     settings_flag(:unlock_source_unlocks_spec) { !bundler_2_mode? }
-    settings_flag(:update_requires_all_flag) { bundler_2_mode? }
+    settings_flag(:update_requires_all_flag) { bundler_3_mode? }
     settings_flag(:use_gem_version_promoter_for_major_updates) { bundler_2_mode? }
     settings_flag(:viz_command) { !bundler_2_mode? }
 

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -117,7 +117,7 @@ module Bundler
         end
 
         unless Bundler.settings[:forget_cli_options] == false
-          Bundler::SharedHelpers.major_deprecation 2,\
+          Bundler::SharedHelpers.major_deprecation 3,\
             "flags passed to commands " \
             "will no longer be automatically remembered. Instead please set flags " \
             "you want remembered between commands using `bundle config set " \

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -35,6 +35,7 @@ module Bundler
       frozen
       gem.coc
       gem.mit
+      github.https
       global_path_appends_ruby_scope
       global_gem_cache
       ignore_messages

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -115,13 +115,19 @@ module Bundler
           "bundle config set #{key} #{Array(value).join(":")}"
         end
 
-        Bundler::SharedHelpers.major_deprecation 2,\
-          "flags passed to commands " \
-          "will no longer be automatically remembered. Instead please set flags " \
-          "you want remembered between commands using `bundle config set " \
-          "<setting name> <setting value>`, i.e. `#{command}`. Once you are " \
-          "ready for the new behavior, use `bundle config set forget_cli_options " \
-          "true` to get rid of this message"
+        unless Bundler.settings[:forget_cli_options] == false
+          Bundler::SharedHelpers.major_deprecation 2,\
+            "flags passed to commands " \
+            "will no longer be automatically remembered. Instead please set flags " \
+            "you want remembered between commands using `bundle config set " \
+            "<setting name> <setting value>`, i.e. `#{command}`. Once you are " \
+            "ready for the new behavior, use `bundle config set forget_cli_options " \
+            "true` to get rid of this message. Or if you want to get rid of " \
+            "this message and stick with the old behavior for now, run " \
+            "`bundle config set forget_cli_options false`, but keep in mind " \
+            "that this behavior will be fully removed in future versions of " \
+            "bundler."
+        end
 
         set_local(key, value)
       end

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -119,7 +119,9 @@ module Bundler
           "flags passed to commands " \
           "will no longer be automatically remembered. Instead please set flags " \
           "you want remembered between commands using `bundle config set " \
-          "<setting name> <setting value>`, i.e. `#{command}`"
+          "<setting name> <setting value>`, i.e. `#{command}`. Once you are " \
+          "ready for the new behavior, use `bundle config set forget_cli_options " \
+          "true` to get rid of this message"
 
         set_local(key, value)
       end

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -157,11 +157,13 @@ module Bundler
       multiple_gemfiles = search_up(".") do |dir|
         gemfiles = gemfile_names.select {|gf| File.file? File.expand_path(gf, dir) }
         next if gemfiles.empty?
-        break false if gemfiles.size == 1
+        break gemfiles.size != 1
       end
-      return unless multiple_gemfiles && Bundler.bundler_major_version == 1
-      Bundler::SharedHelpers.major_deprecation 2, \
-        "gems.rb and gems.locked will be preferred to Gemfile and Gemfile.lock."
+
+      return unless multiple_gemfiles
+
+      Bundler.ui.warn \
+        "Multiple gemfiles (gems.rb and Gemfile) detected. Make sure you remove Gemfile and Gemfile.lock since bundler will ignore them."
     end
 
     def trap(signal, override = false, &block)

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Bundler::Dsl do
     context "github_https feature flag" do
       it "is true when github.https is true" do
         bundle "config set github.https true"
-        expect(Bundler.feature_flag.github_https?).to eq "true"
+        expect(Bundler.feature_flag.github_https?).to eq true
       end
     end
 

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Bundler::Dsl do
 
       it "converts :github to :git" do
         subject.gem("sparks", :github => "indirect/sparks")
-        github_uri = "git://github.com/indirect/sparks.git"
+        github_uri = "https://github.com/indirect/sparks.git"
         expect(subject.dependencies.first.source.uri).to eq(github_uri)
       end
 
@@ -62,7 +62,7 @@ RSpec.describe Bundler::Dsl do
 
       it "converts 'rails' to 'rails/rails'" do
         subject.gem("rails", :github => "rails")
-        github_uri = "git://github.com/rails/rails.git"
+        github_uri = "https://github.com/rails/rails.git"
         expect(subject.dependencies.first.source.uri).to eq(github_uri)
       end
 
@@ -79,7 +79,7 @@ RSpec.describe Bundler::Dsl do
       end
     end
 
-    context "default git sources", :bundler => "2" do
+    context "default git sources", :bundler => "3" do
       it "has none" do
         expect(subject.instance_variable_get(:@git_sources)).to eq({})
       end
@@ -245,7 +245,7 @@ RSpec.describe Bundler::Dsl do
     #   gem 'spree_api'
     #   gem 'spree_backend'
     # end
-    describe "#github", :bundler => "< 2" do
+    describe "#github", :bundler => "< 3" do
       it "from github" do
         spree_gems = %w[spree_core spree_api spree_backend]
         subject.github "spree" do
@@ -253,12 +253,12 @@ RSpec.describe Bundler::Dsl do
         end
 
         subject.dependencies.each do |d|
-          expect(d.source.uri).to eq("git://github.com/spree/spree.git")
+          expect(d.source.uri).to eq("https://github.com/spree/spree.git")
         end
       end
     end
 
-    describe "#github", :bundler => "2" do
+    describe "#github", :bundler => "3" do
       it "from github" do
         expect do
           spree_gems = %w[spree_core spree_api spree_backend]

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -78,15 +78,15 @@ RSpec.describe "major deprecations", :bundler => "< 2" do
       expect(warnings).not_to have_major_deprecation
     end
 
-    it "should print a Gemfile deprecation warning" do
+    it "should print a Gemfile deprecation warning when both types present" do
       create_file "gems.rb"
       install_gemfile! <<-G
         source "file://#{gem_repo1}"
         gem "rack"
       G
-      expect(the_bundle).to include_gem "rack 1.0"
+      expect(the_bundle).not_to include_gem "rack 1.0"
 
-      expect(warnings).to have_major_deprecation a_string_including("gems.rb and gems.locked will be preferred to Gemfile and Gemfile.lock.")
+      expect(warnings).to have_major_deprecation("Multiple gemfiles (gems.rb and Gemfile) detected. Make sure you remove Gemfile and Gemfile.lock since bundler will ignore them.")
     end
 
     context "with flags" do
@@ -121,7 +121,7 @@ RSpec.describe "major deprecations", :bundler => "< 2" do
         Bundler.setup
       RUBY
 
-      expect(warnings).to have_major_deprecation("gems.rb and gems.locked will be preferred to Gemfile and Gemfile.lock.")
+      expect(warnings).to include("Multiple gemfiles (gems.rb and Gemfile) detected. Make sure you remove Gemfile and Gemfile.lock since bundler will ignore them.")
     end
   end
 

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "major deprecations", :bundler => "< 2" do
+RSpec.describe "major deprecations" do
   let(:warnings) { last_command.bundler_err } # change to err in 2.0
 
   before do
@@ -145,27 +145,31 @@ RSpec.describe "major deprecations", :bundler => "< 2" do
     end
 
     context "with github gems" do
-      it "warns about the https change" do
-        msg = <<-EOS
-The :github git source is deprecated, and will be removed in Bundler 2.0. Change any "reponame" :github sources to "username/reponame". Add this code to the top of your Gemfile to ensure it continues to work:
+      let(:msg) do
+        <<-EOS
+The :github git source is deprecated, and will be removed in Bundler 3.0. Change any "reponame" :github sources to "username/reponame". Add this code to the top of your Gemfile to ensure it continues to work:
 
     git_source(:github) {|repo_name| "https://github.com/\#{repo_name}.git" }
 
         EOS
-        expect(Bundler::SharedHelpers).to receive(:major_deprecation).with(2, msg)
+      end
+
+      it "warns about future removal" do
+        expect(Bundler::SharedHelpers).to receive(:major_deprecation).with(3, msg)
         subject.gem("sparks", :github => "indirect/sparks")
       end
 
-      it "upgrades to https on request" do
-        Bundler.settings.temporary "github.https" => true
-        msg = <<-EOS
-The :github git source is deprecated, and will be removed in Bundler 2.0. Change any "reponame" :github sources to "username/reponame". Add this code to the top of your Gemfile to ensure it continues to work:
+      it "downgrades to http on request" do
+        Bundler.settings.temporary "github.https" => false
+        expect(Bundler::SharedHelpers).to receive(:major_deprecation).with(3, msg)
+        expect(Bundler::SharedHelpers).to receive(:major_deprecation).with(2, "Setting `github.https` to false is deprecated and won't be supported in the future.")
+        subject.gem("sparks", :github => "indirect/sparks")
+        github_uri = "git://github.com/indirect/sparks.git"
+        expect(subject.dependencies.first.source.uri).to eq(github_uri)
+      end
 
-    git_source(:github) {|repo_name| "https://github.com/\#{repo_name}.git" }
-
-        EOS
-        expect(Bundler::SharedHelpers).to receive(:major_deprecation).with(2, msg)
-        expect(Bundler::SharedHelpers).to receive(:major_deprecation).with(2, "The `github.https` setting will be removed")
+      it "uses https by default" do
+        expect(Bundler::SharedHelpers).to receive(:major_deprecation).with(3, msg)
         subject.gem("sparks", :github => "indirect/sparks")
         github_uri = "https://github.com/indirect/sparks.git"
         expect(subject.dependencies.first.source.uri).to eq(github_uri)
@@ -176,7 +180,7 @@ The :github git source is deprecated, and will be removed in Bundler 2.0. Change
       it "warns about removal" do
         allow(Bundler.ui).to receive(:deprecate)
         msg = <<-EOS
-The :bitbucket git source is deprecated, and will be removed in Bundler 2.0. Add this code to the top of your Gemfile to ensure it continues to work:
+The :bitbucket git source is deprecated, and will be removed in Bundler 3.0. Add this code to the top of your Gemfile to ensure it continues to work:
 
     git_source(:bitbucket) do |repo_name|
       user_name, repo_name = repo_name.split("/")
@@ -185,7 +189,7 @@ The :bitbucket git source is deprecated, and will be removed in Bundler 2.0. Add
     end
 
         EOS
-        expect(Bundler::SharedHelpers).to receive(:major_deprecation).with(2, msg)
+        expect(Bundler::SharedHelpers).to receive(:major_deprecation).with(3, msg)
         subject.gem("not-really-a-gem", :bitbucket => "mcorp/flatlab-rails")
       end
     end
@@ -194,10 +198,10 @@ The :bitbucket git source is deprecated, and will be removed in Bundler 2.0. Add
       it "warns about removal" do
         allow(Bundler.ui).to receive(:deprecate)
         msg = "The :gist git source is deprecated, and will be removed " \
-          "in Bundler 2.0. Add this code to the top of your Gemfile to ensure it " \
+          "in Bundler 3.0. Add this code to the top of your Gemfile to ensure it " \
           "continues to work:\n\n    git_source(:gist) {|repo_name| " \
           "\"https://gist.github.com/\#{repo_name}.git\" }\n\n"
-        expect(Bundler::SharedHelpers).to receive(:major_deprecation).with(2, msg)
+        expect(Bundler::SharedHelpers).to receive(:major_deprecation).with(3, msg)
         subject.gem("not-really-a-gem", :gist => "1234")
       end
     end

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "major deprecations" do
     end
   end
 
-  context "when bundle is run" do
+  context "when bundle install is run" do
     it "should not warn about gems.rb" do
       create_file "gems.rb", <<-G
         source "file://#{gem_repo1}"

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe "major deprecations" do
     end
 
     context "with flags" do
-      it "should print a deprecation warning about autoremembering flags" do
+      it "should print a deprecation warning about autoremembering flags", :bundler => "3" do
         install_gemfile <<-G, :path => "vendor/bundle"
           source "file://#{gem_repo1}"
           gem "rack"
@@ -99,6 +99,34 @@ RSpec.describe "major deprecations" do
         expect(warnings).to have_major_deprecation a_string_including(
           "flags passed to commands will no longer be automatically remembered."
         )
+      end
+
+      {
+        :clean => true,
+        :deployment => true,
+        :frozen => true,
+        :"no-cache" => true,
+        :"no-prune" => true,
+        :path => "vendor/bundle",
+        :shebang => "ruby27",
+        :system => true,
+        :without => "development",
+        :with => "development",
+      }.each do |name, value|
+        flag_name = "--#{name}"
+
+        context "with the #{flag_name} flag" do
+          it "should print a deprecation warning" do
+            bundle "install #{flag_name} #{value}"
+
+            expect(warnings).to have_major_deprecation(
+              "The `#{flag_name}` flag is deprecated because it relied on " \
+              "being remembered accross bundler invokations, which bundler " \
+              "will no longer do in future versions. Instead please use " \
+              "`bundle config #{name} '#{value}'`, and stop using this flag"
+            )
+          end
+        end
       end
     end
   end

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -2,7 +2,6 @@
 
 RSpec.describe "major deprecations", :bundler => "< 2" do
   let(:warnings) { last_command.bundler_err } # change to err in 2.0
-  let(:warnings_without_version_messages) { warnings.gsub(/#{Spec::Matchers::MAJOR_DEPRECATION}Bundler will only support ruby >= .*/, "") }
 
   before do
     create_file "gems.rb", <<-G
@@ -35,7 +34,7 @@ RSpec.describe "major deprecations", :bundler => "< 2" do
     describe "bundle update --quiet" do
       it "does not print any deprecations" do
         bundle :update, :quiet => true
-        expect(warnings_without_version_messages).not_to have_major_deprecation
+        expect(warnings).not_to have_major_deprecation
       end
     end
 
@@ -52,7 +51,7 @@ RSpec.describe "major deprecations", :bundler => "< 2" do
 
       it "does not warn when --all is passed" do
         bundle! "update --all"
-        expect(warnings_without_version_messages).not_to have_major_deprecation
+        expect(warnings).not_to have_major_deprecation
       end
     end
 
@@ -76,7 +75,7 @@ RSpec.describe "major deprecations", :bundler => "< 2" do
       G
 
       bundle :install
-      expect(warnings_without_version_messages).not_to have_major_deprecation
+      expect(warnings).not_to have_major_deprecation
     end
 
     it "should print a Gemfile deprecation warning" do
@@ -122,7 +121,7 @@ RSpec.describe "major deprecations", :bundler => "< 2" do
         Bundler.setup
       RUBY
 
-      expect(warnings_without_version_messages).to have_major_deprecation("gems.rb and gems.locked will be preferred to Gemfile and Gemfile.lock.")
+      expect(warnings).to have_major_deprecation("gems.rb and gems.locked will be preferred to Gemfile and Gemfile.lock.")
     end
   end
 

--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -172,6 +172,7 @@ RSpec.describe "The library itself" do
       forget_cli_options
       gem.coc
       gem.mit
+      github.https
       inline
       lockfile_uses_separate_rubygems_sources
       use_gem_version_promoter_for_major_updates


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that need to deprecate stuff and we are not yet ready (not for removing it, for deprecating it!)

### What was your diagnosis of the problem?

My diagnosis was we need to make a plan at least for the most important deprecations, since there's some of them are not clear how they will happen.

### What is your fix for the problem, implemented in this PR?

My fix is to:

* [x] ~Get deprecation specs passing.~ Done in #6991. 

* [ ] ~Make a plan for stopping remembering options. For this, I propose the following:~ Extracted to #7006.
  - ~In bundler 2 (next release, 2.1 for example), print a deprecation message to warn about the removal of all the flags that currently depend on the options being remembered.~
  - ~In bundler 3, remove the options and deprecate remembering command line flags.~
 
* [ ] ~Make a plan for the removal of custom sources :github, :gist, and :bitbucket, and switching to https. I also propose to do this in 2 steps.~ Extracted to #7000.
  - ~In bundler 2 (next release, 2.1 for example), start using https by default for those sources, and deprecate setting the `github.https` setting to false.~
  - ~In bundler 3, make the setting `github.https` a noop, using `https` nevertheless, and go ahead and deprecate the sources.~

* [x] ~Remove the deprecations about old rubies and rubygems, since that code will never be run.~ Extracted to (and expanded in) #6982 and #6983.

* [ ] ~Remove the deprecation about prefering `gems.rb` to `Gemfile`. The deprecation was unclear, only showed when there were multiple gemfiles in the same folder, and we had decided to delay this anyways. I changed this deprecation to instead warn about having multiple gemfiles in the same folder.~ Extracted to #6999.

### Why did you choose this fix out of the possible options?

I chose this fix because although a bit slow, it's the smoothest path for our users that I could think of.