### PR TITLE
Update the location of bundler gemspec.

### DIFF
--- a/bundler.gemspec
+++ b/bundler.gemspec
@@ -5,7 +5,7 @@ begin
   require File.expand_path("../lib/bundler/version", __FILE__)
 rescue LoadError
   # for Ruby core repository
-  require File.expand_path("../bundler/version", __FILE__)
+  require File.expand_path("../version", __FILE__)
 end
 
 Gem::Specification.new do |s|

--- a/spec/support/path.rb
+++ b/spec/support/path.rb
@@ -9,7 +9,7 @@ module Spec
     end
 
     def gemspec
-      @gemspec ||= root.join(ruby_core? ? "lib/bundler.gemspec" : "bundler.gemspec")
+      @gemspec ||= root.join(ruby_core? ? "lib/bundler/bundler.gemspec" : "bundler.gemspec")
     end
 
     def bindir


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

On the ruby core repository has the original patch for the test suite. The current bundler repository was inconsistency status with it.

### What was your diagnosis of the problem?

This pull-request was the missing commit of https://github.com/bundler/bundler/pull/6973

### What is your fix for the problem, implemented in this PR?

The test suite of bundler break the inconsistency gemspec location,




