### PR TITLE
Add check for already installed plugin

### DIFF
--- a/lib/bundler/source/rubygems.rb
+++ b/lib/bundler/source/rubygems.rb
@@ -106,7 +106,7 @@ module Bundler
           end
         end
 
-        if installed?(spec) && !force
+        if (installed?(spec) || Plugin.installed?(spec.name)) && !force
           print_using_message "Using #{version_message(spec)}"
           return nil # no post-install message
         end

--- a/spec/plugins/install_spec.rb
+++ b/spec/plugins/install_spec.rb
@@ -22,6 +22,18 @@ RSpec.describe "bundler plugin install" do
     plugin_should_be_installed("foo")
   end
 
+  context "plugin is already installed" do
+    before do
+      bundle "plugin install foo --source file://#{gem_repo2}"
+    end
+
+    it "doesn't install plugin again" do
+      bundle "plugin install foo --source file://#{gem_repo2}"
+      expect(out).not_to include("Installing plugin foo")
+      expect(out).not_to include("Installed plugin foo")
+    end
+  end
+
   it "installs multiple plugins" do
     bundle "plugin install foo kung-foo --source file://#{gem_repo2}"
 
@@ -165,7 +177,7 @@ RSpec.describe "bundler plugin install" do
         build_plugin "foo", "1.1.0"
       end
 
-      install_gemfile <<-G
+      gemfile <<-G
         source 'file://#{gem_repo2}'
         plugin 'foo', "1.0"
       G


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Fixes #6946 

### What was your diagnosis of the problem?

There was no check to ensure that the plugin was already installed or not. 

### What is your fix for the problem, implemented in this PR?

I added the check [here](https://github.com/bundler/bundler/compare/master...ankitkataria:plugin-fix?expand=1#diff-68bd939cd3589d8fdda08a12433659ebR109)
I also added a small test for the same
