### PR TITLE
Remove unnecessary rubygems filters

### DIFF
--- a/lib/bundler/compatibility_guard.rb
+++ b/lib/bundler/compatibility_guard.rb
@@ -7,8 +7,4 @@ if Bundler::VERSION.split(".").first.to_i >= 2
   if Gem::Version.new(Object::RUBY_VERSION.dup) < Gem::Version.new("2.3")
     abort "Bundler 2 requires Ruby 2.3 or later. Either install bundler 1 or update to a supported Ruby version."
   end
-
-  if Gem::Version.new(Gem::VERSION.dup) < Gem::Version.new("2.5")
-    abort "Bundler 2 requires RubyGems 2.5 or later. Either install bundler 1 or update to a supported RubyGems version."
-  end
 end

--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -275,14 +275,7 @@ module Bundler
     end
 
     def can_install_in_parallel?
-      if Bundler.rubygems.provides?(">= 2.1.0")
-        true
-      else
-        Bundler.ui.warn "RubyGems #{Gem::VERSION} is not threadsafe, so your "\
-          "gems will be installed one at a time. Upgrade to RubyGems 2.1.0 " \
-          "or higher to enable parallel gem installation."
-        false
-      end
+      true
     end
 
     def install_in_parallel(size, standalone, force = false)

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -159,13 +159,9 @@ module Bundler
         next if gemfiles.empty?
         break false if gemfiles.size == 1
       end
-      if multiple_gemfiles && Bundler.bundler_major_version == 1
-        Bundler::SharedHelpers.major_deprecation 2, \
-          "gems.rb and gems.locked will be preferred to Gemfile and Gemfile.lock."
-      end
-
-      return if Bundler.rubygems.provides?(">= 2")
-      major_deprecation(2, "Bundler will only support rubygems >= 2.0, you are running #{Bundler.rubygems.version}")
+      return unless multiple_gemfiles && Bundler.bundler_major_version == 1
+      Bundler::SharedHelpers.major_deprecation 2, \
+        "gems.rb and gems.locked will be preferred to Gemfile and Gemfile.lock."
     end
 
     def trap(signal, override = false, &block)

--- a/lib/bundler/stub_specification.rb
+++ b/lib/bundler/stub_specification.rb
@@ -13,17 +13,13 @@ module Bundler
 
     attr_accessor :stub, :ignored
 
-    # Pre 2.2.0 did not include extension_dir
-    # https://github.com/rubygems/rubygems/commit/9485ca2d101b82a946d6f327f4bdcdea6d4946ea
-    if Bundler.rubygems.provides?(">= 2.2.0")
-      def source=(source)
-        super
-        # Stub has no concept of source, which means that extension_dir may be wrong
-        # This is the case for git-based gems. So, instead manually assign the extension dir
-        return unless source.respond_to?(:extension_dir_name)
-        path = File.join(stub.extensions_dir, source.extension_dir_name)
-        stub.extension_dir = File.expand_path(path)
-      end
+    def source=(source)
+      super
+      # Stub has no concept of source, which means that extension_dir may be wrong
+      # This is the case for git-based gems. So, instead manually assign the extension dir
+      return unless source.respond_to?(:extension_dir_name)
+      path = File.join(stub.extensions_dir, source.extension_dir_name)
+      stub.extension_dir = File.expand_path(path)
     end
 
     def to_yaml
@@ -32,11 +28,9 @@ module Bundler
 
     # @!group Stub Delegates
 
-    if Bundler.rubygems.provides?(">= 2.3")
-      # This is defined directly to avoid having to load every installed spec
-      def missing_extensions?
-        stub.missing_extensions?
-      end
+    # This is defined directly to avoid having to load every installed spec
+    def missing_extensions?
+      stub.missing_extensions?
     end
 
     def activated
@@ -57,16 +51,14 @@ module Bundler
       stub.full_gem_path || method_missing(:full_gem_path)
     end
 
-    if Bundler.rubygems.provides?(">= 2.2.0")
-      def full_require_paths
-        stub.full_require_paths
-      end
+    def full_require_paths
+      stub.full_require_paths
+    end
 
-      # This is what we do in bundler/rubygems_ext
-      # full_require_paths is always implemented in >= 2.2.0
-      def load_paths
-        full_require_paths
-      end
+    # This is what we do in bundler/rubygems_ext
+    # full_require_paths is always implemented
+    def load_paths
+      full_require_paths
     end
 
     def loaded_from

--- a/spec/bundler/friendly_errors_spec.rb
+++ b/spec/bundler/friendly_errors_spec.rb
@@ -16,22 +16,7 @@ RSpec.describe Bundler, "friendly errors" do
       FileUtils.rm(Gem.configuration.config_file_name)
     end
 
-    it "reports a relevant friendly error message", :rubygems => "< 2.5.0" do
-      gemfile <<-G
-        source "file://#{gem_repo1}"
-        gem "rack"
-      G
-
-      bundle :install, :env => { "DEBUG" => true }
-
-      expect(out).to include("Your RubyGems configuration")
-      expect(out).to include("invalid YAML syntax")
-      expect(out).to include("Psych::SyntaxError")
-      expect(out).not_to include("ERROR REPORT TEMPLATE")
-      expect(exitstatus).to eq(25) if exitstatus
-    end
-
-    it "reports a relevant friendly error message", :rubygems => ">= 2.5.0" do
+    it "reports a relevant friendly error message" do
       gemfile <<-G
         source "file://#{gem_repo1}"
         gem "rack"

--- a/spec/bundler/installer/gem_installer_spec.rb
+++ b/spec/bundler/installer/gem_installer_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe Bundler::GemInstaller do
   subject { described_class.new(spec, installer) }
 
   context "spec_settings is nil" do
-    it "invokes install method with empty build_args", :rubygems => ">= 2" do
+    it "invokes install method with empty build_args" do
       allow(spec_source).to receive(:install).with(spec, :force => false, :ensure_builtin_gems_cached => false, :build_args => [])
       subject.install_from_spec
     end
   end
 
   context "spec_settings is build option" do
-    it "invokes install method with build_args", :rubygems => ">= 2" do
+    it "invokes install method with build_args" do
       allow(Bundler.settings).to receive(:[]).with(:bin)
       allow(Bundler.settings).to receive(:[]).with(:inline)
       allow(Bundler.settings).to receive(:[]).with(:forget_cli_options)

--- a/spec/bundler/rubygems_integration_spec.rb
+++ b/spec/bundler/rubygems_integration_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Bundler::RubygemsIntegration do
-  it "uses the same chdir lock as rubygems", :rubygems => "2.1" do
+  it "uses the same chdir lock as rubygems" do
     expect(Bundler.rubygems.ext_lock).to eq(Gem::Ext::Builder::CHDIR_MONITOR)
   end
 
@@ -15,20 +15,9 @@ RSpec.describe Bundler::RubygemsIntegration do
     end
     subject { Bundler.rubygems.validate(spec) }
 
-    it "skips overly-strict gemspec validation", :rubygems => "< 1.7" do
-      expect(spec).to_not receive(:validate)
-      subject
-    end
-
-    it "validates with packaging mode disabled", :rubygems => "1.7" do
+    it "validates with packaging mode disabled" do
       expect(spec).to receive(:validate).with(false)
       subject
-    end
-
-    it "should set a summary to avoid an overly-strict error", :rubygems => "~> 1.7.0" do
-      spec.summary = nil
-      expect { subject }.not_to raise_error
-      expect(spec.summary).to eq("")
     end
 
     context "with an invalid spec" do
@@ -37,8 +26,7 @@ RSpec.describe Bundler::RubygemsIntegration do
           and_raise(Gem::InvalidSpecificationException.new("TODO is not an author"))
       end
 
-      it "should raise a Gem::InvalidSpecificationException and produce a helpful warning message",
-        :rubygems => "1.7" do
+      it "should raise a Gem::InvalidSpecificationException and produce a helpful warning message" do
         expect { subject }.to raise_error(Gem::InvalidSpecificationException,
           "The gemspec at #{__FILE__} is not valid. "\
           "Please fix this gemspec.\nThe validation error was 'TODO is not an author'\n")
@@ -53,7 +41,7 @@ RSpec.describe Bundler::RubygemsIntegration do
     end
   end
 
-  describe "#download_gem", :rubygems => ">= 2.0" do
+  describe "#download_gem" do
     let(:bundler_retry) { double(Bundler::Retry) }
     let(:retry) { double("Bundler::Retry") }
     let(:uri) {  URI.parse("https://foo.bar") }
@@ -78,7 +66,7 @@ RSpec.describe Bundler::RubygemsIntegration do
     end
   end
 
-  describe "#fetch_all_remote_specs", :rubygems => ">= 2.0" do
+  describe "#fetch_all_remote_specs" do
     let(:uri) { URI("https://example.com") }
     let(:fetcher) { double("gem_remote_fetcher") }
     let(:specs_response) { Marshal.dump(["specs"]) }

--- a/spec/bundler/stub_specification_spec.rb
+++ b/spec/bundler/stub_specification_spec.rb
@@ -13,12 +13,10 @@ RSpec.describe Bundler::StubSpecification do
     described_class.from_stub(gemspec)
   end
 
-  if Bundler.rubygems.provides?(">= 2.1")
-    describe "#from_stub" do
-      it "returns the same stub if already a Bundler::StubSpecification" do
-        stub = described_class.from_stub(with_bundler_stub_spec)
-        expect(stub).to be(with_bundler_stub_spec)
-      end
+  describe "#from_stub" do
+    it "returns the same stub if already a Bundler::StubSpecification" do
+      stub = described_class.from_stub(with_bundler_stub_spec)
+      expect(stub).to be(with_bundler_stub_spec)
     end
   end
 end

--- a/spec/commands/clean_spec.rb
+++ b/spec/commands/clean_spec.rb
@@ -714,7 +714,7 @@ RSpec.describe "bundle clean" do
     should_not_have_gems "foo-1.0"
   end
 
-  it "doesn't remove extensions artifacts from bundled git gems after clean", :ruby_repo, :rubygems => "2.2" do
+  it "doesn't remove extensions artifacts from bundled git gems after clean", :ruby_repo do
     build_git "very_simple_git_binary", &:add_c_extension
 
     revision = revision_for(lib_path("very_simple_git_binary-1.0"))
@@ -736,7 +736,7 @@ RSpec.describe "bundle clean" do
     expect(vendored_gems("bundler/gems/very_simple_git_binary-1.0-#{revision[0..11]}")).to exist
   end
 
-  it "removes extension directories", :ruby_repo, :rubygems => "2.2" do
+  it "removes extension directories", :ruby_repo do
     gemfile <<-G
       source "file://#{gem_repo1}"
 

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe "bundle exec" do
     expect(err).to include("bundler: exec needs a command to run")
   end
 
-  it "raises a helpful error when exec'ing to something outside of the bundle", :ruby_repo, :rubygems => ">= 2.5.2" do
+  it "raises a helpful error when exec'ing to something outside of the bundle", :ruby_repo do
     bundle! "config clean false" # want to keep the rackup binstub
     install_gemfile! <<-G
       source "file://#{gem_repo1}"
@@ -234,20 +234,6 @@ RSpec.describe "bundle exec" do
       bundle! "config disable_exec_load #{l}"
       bundle "exec rackup"
       expect(last_command.stderr).to include "can't find executable rackup for gem rack. rack is not currently included in the bundle, perhaps you meant to add it to your Gemfile?"
-    end
-  end
-
-  # Different error message on old RG versions (before activate_bin_path) because they
-  # called `Kernel#gem` directly
-  it "raises a helpful error when exec'ing to something outside of the bundle", :rubygems => "< 2.5.2" do
-    install_gemfile! <<-G
-      source "file://#{gem_repo1}"
-      gem "with_license"
-    G
-    [true, false].each do |l|
-      bundle! "config disable_exec_load #{l}"
-      bundle "exec rackup"
-      expect(last_command.stderr).to include "rack is not part of the bundle. Add it to your Gemfile."
     end
   end
 
@@ -444,7 +430,7 @@ RSpec.describe "bundle exec" do
   end
 
   describe "with gems bundled via :path with invalid gemspecs", :ruby_repo do
-    it "outputs the gemspec validation errors", :rubygems => ">= 1.7.2" do
+    it "outputs the gemspec validation errors" do
       build_lib "foo"
 
       gemspec = lib_path("foo-1.0").join("foo.gemspec").to_s

--- a/spec/commands/help_spec.rb
+++ b/spec/commands/help_spec.rb
@@ -1,15 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe "bundle help" do
-  # RubyGems 1.4+ no longer load gem plugins so this test is no longer needed
-  it "complains if older versions of bundler are installed", :rubygems => "< 1.4" do
-    system_gems "bundler-0.8.1"
-
-    bundle "help"
-    expect(err).to include("older than 0.9")
-    expect(err).to include("running `gem cleanup bundler`.")
-  end
-
   it "uses mann when available" do
     with_fake_man do
       bundle "help gemfile"

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -384,7 +384,7 @@ RSpec.describe "bundle install with gem sources" do
       expect(err).not_to include("file://")
     end
 
-    it "fails gracefully when downloading an invalid specification from the full index", :rubygems => "2.5" do
+    it "fails gracefully when downloading an invalid specification from the full index" do
       build_repo2 do
         build_gem "ajp-rails", "0.0.0", :gemspec => false, :skip_validation => true do |s|
           bad_deps = [["ruby-ajp", ">= 0.2.0"], ["rails", ">= 0.14"]]

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -289,7 +289,7 @@ RSpec.describe "bundle gem" do
       it_should_behave_like "git config is absent"
     end
 
-    it "sets gemspec metadata['allowed_push_host']", :rubygems => "2.0" do
+    it "sets gemspec metadata['allowed_push_host']" do
       expect(generated_gem.gemspec.metadata["allowed_push_host"]).
         to match(/mygemserver\.com/)
     end
@@ -381,7 +381,7 @@ RSpec.describe "bundle gem" do
         expect(bundled_app("test_gem/spec/spec_helper.rb")).to exist
       end
 
-      it "depends on a specific version of rspec", :rubygems => ">= 1.8.1" do
+      it "depends on a specific version of rspec" do
         rspec_dep = generated_gem.gemspec.development_dependencies.find {|d| d.name == "rspec" }
         expect(rspec_dep).to be_specific
       end
@@ -431,7 +431,7 @@ RSpec.describe "bundle gem" do
         bundle "gem #{gem_name} --test=minitest"
       end
 
-      it "depends on a specific version of minitest", :rubygems => ">= 1.8.1" do
+      it "depends on a specific version of minitest" do
         rspec_dep = generated_gem.gemspec.development_dependencies.find {|d| d.name == "minitest" }
         expect(rspec_dep).to be_specific
       end

--- a/spec/commands/show_spec.rb
+++ b/spec/commands/show_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe "bundle show" do
       expect(out).to include("foo (1.0 #{sha[0..6]})")
     end
 
-    it "handles when a version is a '-' prerelease", :rubygems => "2.1" do
+    it "handles when a version is a '-' prerelease" do
       @git = build_git("foo", "1.0.0-beta.1", :path => lib_path("foo"))
       install_gemfile <<-G
         gem "foo", "1.0.0-beta.1", :git => "#{lib_path("foo")}"

--- a/spec/install/gemfile/gemspec_spec.rb
+++ b/spec/install/gemfile/gemspec_spec.rb
@@ -239,7 +239,7 @@ RSpec.describe "bundle install from an existing gemspec" do
     expect(the_bundle).to include_gems "foo 1.0.0"
   end
 
-  it "does not break Gem.finish_resolve with conflicts", :rubygems => ">= 2" do
+  it "does not break Gem.finish_resolve with conflicts" do
     build_lib("foo", :path => tmp.join("foo")) do |s|
       s.version = "1.0.0"
       s.add_dependency "bar", "= 1.0.0"

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -1206,7 +1206,7 @@ In Gemfile:
       expect(out).not_to include("gem install foo")
     end
 
-    it "does not reinstall the extension", :ruby_repo, :rubygems => ">= 2.3.0" do
+    it "does not reinstall the extension", :ruby_repo do
       build_git "foo" do |s|
         s.add_dependency "rake"
         s.extensions << "Rakefile"
@@ -1247,7 +1247,7 @@ In Gemfile:
       expect(out).to eq(installed_time)
     end
 
-    it "does not reinstall the extension when changing another gem", :rubygems => ">= 2.3.0" do
+    it "does not reinstall the extension when changing another gem" do
       build_git "foo" do |s|
         s.add_dependency "rake"
         s.extensions << "Rakefile"
@@ -1290,7 +1290,7 @@ In Gemfile:
       expect(out).to eq(installed_time)
     end
 
-    it "does reinstall the extension when changing refs", :rubygems => ">= 2.3.0" do
+    it "does reinstall the extension when changing refs" do
       build_git "foo" do |s|
         s.add_dependency "rake"
         s.extensions << "Rakefile"

--- a/spec/install/gemfile/path_spec.rb
+++ b/spec/install/gemfile/path_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe "bundle install with explicit source paths" do
     expect(the_bundle).to include_gems "premailer 1.0.0"
   end
 
-  it "warns on invalid specs", :rubygems => "1.7" do
+  it "warns on invalid specs" do
     build_lib "foo"
 
     gemspec = lib_path("foo-1.0").join("foo.gemspec").to_s

--- a/spec/install/gems/compact_index_spec.rb
+++ b/spec/install/gems/compact_index_spec.rb
@@ -863,7 +863,7 @@ The checksum of /versions does not match the checksum provided by the server! So
     E
   end
 
-  describe "checksum validation", :rubygems => ">= 2.3.0" do
+  describe "checksum validation" do
     it "raises when the checksum does not match" do
       install_gemfile <<-G, :artifice => "compact_index_wrong_gem_checksum"
         source "#{source_uri}"

--- a/spec/install/gems/standalone_spec.rb
+++ b/spec/install/gems/standalone_spec.rb
@@ -75,7 +75,7 @@ RSpec.shared_examples "bundle install --standalone" do
       G
     end
 
-    it "generates a bundle/bundler/setup.rb with the proper paths", :rubygems => "2.4" do
+    it "generates a bundle/bundler/setup.rb with the proper paths" do
       expected_path = bundled_app("bundle/bundler/setup.rb")
       extension_line = File.read(expected_path).each_line.find {|line| line.include? "/extensions/" }.strip
       expect(extension_line).to start_with '$:.unshift "#{path}/../#{ruby_engine}/#{ruby_version}/extensions/'

--- a/spec/install/gems/sudo_spec.rb
+++ b/spec/install/gems/sudo_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "when using sudo", :sudo => true do
       expect(the_bundle).to include_gems "rack 1.0"
     end
 
-    it "installs extensions/ compiled by RubyGems 2.2", :rubygems => "2.2" do
+    it "installs extensions/" do
       install_gemfile <<-G
         source "file://#{gem_repo1}"
         gem "very_simple_binary"

--- a/spec/install/global_cache_spec.rb
+++ b/spec/install/global_cache_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe "global gem caching" do
     end
   end
 
-  describe "extension caching", :ruby_repo, :rubygems => "2.2" do
+  describe "extension caching", :ruby_repo do
     it "works" do
       build_git "very_simple_git_binary", &:add_c_extension
       build_lib "very_simple_path_binary", &:add_c_extension

--- a/spec/install/path_spec.rb
+++ b/spec/install/path_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe "bundle install" do
       expect(the_bundle).to include_gems "rack 1.0.0"
     end
 
-    it "re-installs gems whose extensions have been deleted", :ruby_repo, :rubygems => ">= 2.3" do
+    it "re-installs gems whose extensions have been deleted", :ruby_repo do
       build_lib "very_simple_binary", "1.0.0", :to_system => true do |s|
         s.write "lib/very_simple_binary.rb", "raise 'FAIL'"
       end

--- a/spec/other/compatibility_guard_spec.rb
+++ b/spec/other/compatibility_guard_spec.rb
@@ -12,14 +12,5 @@ RSpec.describe "bundler compatibility guard" do
         expect(err).to eq("Bundler 2 requires Ruby 2.3 or later. Either install bundler 1 or update to a supported Ruby version.")
       end
     end
-
-    context "when running on RubyGems < 2.5", :ruby => ">= 2.5" do
-      before { simulate_rubygems_version "1.3.6" }
-
-      it "raises a friendly error" do
-        bundle :version
-        expect(last_command.stderr).to eq("Bundler 2 requires RubyGems 2.5 or later. Either install bundler 1 or update to a supported RubyGems version.")
-      end
-    end
   end
 end

--- a/spec/other/ext_spec.rb
+++ b/spec/other/ext_spec.rb
@@ -54,13 +54,8 @@ RSpec.describe "Gem::SourceIndex#refresh!" do
     G
   end
 
-  it "does not explode when called", :rubygems => "1.7" do
+  it "does not explode when called" do
     run "Gem.source_index.refresh!"
     run "Gem::SourceIndex.new([]).refresh!"
-  end
-
-  it "does not explode when called", :rubygems => "< 1.7" do
-    run "Gem.source_index.refresh!"
-    run "Gem::SourceIndex.from_gems_in([]).refresh!"
   end
 end

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe "major deprecations", :bundler => "< 2" do
   let(:warnings) { last_command.bundler_err } # change to err in 2.0
-  let(:warnings_without_version_messages) { warnings.gsub(/#{Spec::Matchers::MAJOR_DEPRECATION}Bundler will only support ruby(gems)? >= .*/, "") }
+  let(:warnings_without_version_messages) { warnings.gsub(/#{Spec::Matchers::MAJOR_DEPRECATION}Bundler will only support ruby >= .*/, "") }
 
   before do
     create_file "gems.rb", <<-G
@@ -30,27 +30,6 @@ RSpec.describe "major deprecations", :bundler => "< 2" do
         bundle "exec ruby -e #{source.dump}"
         expect(warnings).to have_major_deprecation "Bundler.environment has been removed in favor of Bundler.load"
       end
-    end
-
-    shared_examples_for "environmental deprecations" do |trigger|
-      describe "rubygems version", :rubygems => "< 2.0" do
-        it "requires a newer rubygems version" do
-          instance_eval(&trigger)
-          expect(warnings).to have_major_deprecation "Bundler will only support rubygems >= 2.0, you are running #{Gem::VERSION}"
-        end
-      end
-    end
-
-    describe "-rbundler/setup" do
-      it_behaves_like "environmental deprecations", proc { ruby "require 'bundler/setup'" }
-    end
-
-    describe "Bundler.setup" do
-      it_behaves_like "environmental deprecations", proc { ruby "require 'bundler'; Bundler.setup" }
-    end
-
-    describe "bundle check" do
-      it_behaves_like "environmental deprecations", proc { bundle :check }
     end
 
     describe "bundle update --quiet" do

--- a/spec/other/platform_spec.rb
+++ b/spec/other/platform_spec.rb
@@ -149,7 +149,7 @@ G
       expect(out).to eq("ruby 1.8.7 (rbx 1.2.4)")
     end
 
-    it "handles truffleruby", :rubygems => ">= 2.1.0" do
+    it "handles truffleruby" do
       gemfile <<-G
         source "file://#{gem_repo1}"
         ruby "2.5.1", :engine => 'truffleruby', :engine_version => '1.0.0-rc6'

--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -226,14 +226,10 @@ RSpec.describe "The library itself" do
           gem_command! :build, gemspec
         end
 
-        if Bundler.rubygems.provides?(">= 2.4")
-          # there's no way around this warning
-          last_command.stderr.sub!(/^YAML safe loading.*/, "")
+        # there's no way around this warning
+        last_command.stderr.sub!(/^YAML safe loading.*/, "")
 
-          # older rubygems have weird warnings, and we won't actually be using them
-          # to build the gem for releases anyways
-          expect(last_command.stderr).to be_empty, "bundler should build as a gem without warnings, but\n#{err}"
-        end
+        expect(last_command.stderr).to be_empty, "bundler should build as a gem without warnings, but\n#{err}"
       ensure
         # clean up the .gem generated
         FileUtils.rm("bundler-#{Bundler::VERSION}.gem")

--- a/spec/realworld/gemfile_source_header_spec.rb
+++ b/spec/realworld/gemfile_source_header_spec.rb
@@ -2,7 +2,7 @@
 
 require "thread"
 
-RSpec.describe "fetching dependencies with a mirrored source", :realworld => true, :rubygems => ">= 2.0" do
+RSpec.describe "fetching dependencies with a mirrored source", :realworld => true do
   let(:mirror) { "https://server.example.org" }
   let(:original) { "http://127.0.0.1:#{@port}" }
 

--- a/spec/realworld/parallel_spec.rb
+++ b/spec/realworld/parallel_spec.rb
@@ -11,11 +11,7 @@ RSpec.describe "parallel", :realworld => true, :sometimes => true do
 
     bundle :install, :jobs => 4, :env => { "DEBUG" => "1" }
 
-    if Bundler.rubygems.provides?(">= 2.1.0")
-      expect(out).to match(/[1-3]: /)
-    else
-      expect(out).to include("is not threadsafe")
-    end
+    expect(out).to match(/[1-3]: /)
 
     bundle "info activesupport --path"
     expect(out).to match(/activesupport/)
@@ -40,11 +36,7 @@ RSpec.describe "parallel", :realworld => true, :sometimes => true do
 
     bundle :update, :jobs => 4, :env => { "DEBUG" => "1" }, :all => bundle_update_requires_all?
 
-    if Bundler.rubygems.provides?(">= 2.1.0")
-      expect(out).to match(/[1-3]: /)
-    else
-      expect(out).to include("is not threadsafe")
-    end
+    expect(out).to match(/[1-3]: /)
 
     bundle "info activesupport --path"
     expect(out).to match(/activesupport-3\.2\.\d+/)

--- a/spec/runtime/require_spec.rb
+++ b/spec/runtime/require_spec.rb
@@ -371,7 +371,7 @@ RSpec.describe "Bundler.require" do
     end
   end
 
-  it "does not load rubygems gemspecs that are used", :rubygems => ">= 2.5.2" do
+  it "does not load rubygems gemspecs that are used" do
     install_gemfile! <<-G
       source "file://#{gem_repo1}"
       gem "rack"
@@ -394,7 +394,7 @@ RSpec.describe "Bundler.require" do
     expect(out).to eq("WIN")
   end
 
-  it "does not load git gemspecs that are used", :rubygems => ">= 2.5.2" do
+  it "does not load git gemspecs that are used" do
     build_git "foo"
 
     install_gemfile! <<-G

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -727,7 +727,7 @@ RSpec.describe "Bundler.setup" do
     expect(out).to be_empty
   end
 
-  it "does not load all gemspecs", :rubygems => ">= 2.3" do
+  it "does not load all gemspecs" do
     install_gemfile! <<-G
       source "file://#{gem_repo1}"
       gem "rack"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was there's a lot of unnecessary code, specially in specs, that's never run.

### What was your diagnosis of the problem?

My diagnosis was that since dropping support for old rubygems versions, this code is no longer necessary.

### What is your fix for the problem, implemented in this PR?

My fix is to remove the code.

### Why did you choose this fix out of the possible options?

I chose this fix because red is great on diffs.
