### PR TITLE
Remove unnecessary ruby filters

### DIFF
--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -164,9 +164,6 @@ module Bundler
           "gems.rb and gems.locked will be preferred to Gemfile and Gemfile.lock."
       end
 
-      if RUBY_VERSION < "2"
-        major_deprecation(2, "Bundler will only support ruby >= 2.0, you are running #{RUBY_VERSION}")
-      end
       return if Bundler.rubygems.provides?(">= 2")
       major_deprecation(2, "Bundler will only support rubygems >= 2.0, you are running #{Bundler.rubygems.version}")
     end

--- a/spec/bundler/fetcher/compact_index_spec.rb
+++ b/spec/bundler/fetcher/compact_index_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Bundler::Fetcher::CompactIndex do
         end
       end
 
-      context "when OpenSSL is FIPS-enabled", :ruby => ">= 2.0.0" do
+      context "when OpenSSL is FIPS-enabled" do
         def remove_cached_md5_availability
           return unless Bundler::SharedHelpers.instance_variable_defined?(:@md5_available)
           Bundler::SharedHelpers.remove_instance_variable(:@md5_available)

--- a/spec/bundler/friendly_errors_spec.rb
+++ b/spec/bundler/friendly_errors_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Bundler, "friendly errors" do
       FileUtils.rm(Gem.configuration.config_file_name)
     end
 
-    it "reports a relevant friendly error message", :ruby => ">= 1.9", :rubygems => "< 2.5.0" do
+    it "reports a relevant friendly error message", :rubygems => "< 2.5.0" do
       gemfile <<-G
         source "file://#{gem_repo1}"
         gem "rack"
@@ -31,7 +31,7 @@ RSpec.describe Bundler, "friendly errors" do
       expect(exitstatus).to eq(25) if exitstatus
     end
 
-    it "reports a relevant friendly error message", :ruby => ">= 1.9", :rubygems => ">= 2.5.0" do
+    it "reports a relevant friendly error message", :rubygems => ">= 2.5.0" do
       gemfile <<-G
         source "file://#{gem_repo1}"
         gem "rack"

--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -288,7 +288,7 @@ RSpec.describe Bundler::SharedHelpers do
       )
     end
 
-    context "with a jruby path_separator regex", :ruby => "1.9" do
+    context "with a jruby path_separator regex" do
       # In versions of jruby that supported ruby 1.8, the path separator was the standard File::PATH_SEPARATOR
       let(:regex) { Regexp.new("(?<!jar:file|jar|file|classpath|uri:classloader|uri|http|https):") }
       it "does not exit if bundle path is the standard uri path" do
@@ -455,7 +455,7 @@ RSpec.describe Bundler::SharedHelpers do
       end
     end
 
-    context "system throws Errno::ENOTSUP", :ruby => "1.9" do
+    context "system throws Errno::ENOTSUP" do
       let(:file_op_block) { proc {|_path| raise Errno::ENOTSUP } }
 
       it "raises a OperationNotSupportedError" do

--- a/spec/bundler/ui_spec.rb
+++ b/spec/bundler/ui_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Bundler::UI do
   describe Bundler::UI::Silent do
-    it "has the same instance methods as Shell", :ruby => ">= 1.9" do
+    it "has the same instance methods as Shell" do
       shell = Bundler::UI::Shell
       methods = proc do |cls|
         cls.instance_methods.map do |i|
@@ -13,7 +13,7 @@ RSpec.describe Bundler::UI do
       expect(methods.call(described_class)).to eq(methods.call(shell))
     end
 
-    it "has the same instance class as Shell", :ruby => ">= 1.9" do
+    it "has the same instance class as Shell" do
       shell = Bundler::UI::Shell
       methods = proc do |cls|
         cls.methods.map do |i|

--- a/spec/cache/gems_spec.rb
+++ b/spec/cache/gems_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "bundle cache" do
     it_behaves_like "when there are only gemsources"
   end
 
-  describe "when there is a built-in gem", :ruby => "2.0" do
+  describe "when there is a built-in gem" do
     before :each do
       build_repo2 do
         build_gem "builtin_gem", "1.0.2"

--- a/spec/commands/config_spec.rb
+++ b/spec/commands/config_spec.rb
@@ -322,7 +322,7 @@ E
       expect(out).to eq("something'")
     end
 
-    it "doesn't return quotes around values", :ruby => "1.9" do
+    it "doesn't return quotes around values" do
       bundle "config set foo '1'"
       run "puts Bundler.settings.send(:global_config_file).read"
       expect(out).to include('"1"')
@@ -330,7 +330,7 @@ E
       expect(out).to eq("1")
     end
 
-    it "doesn't duplicate quotes around values", :if => (RUBY_VERSION >= "2.1") do
+    it "doesn't duplicate quotes around values" do
       bundled_app(".bundle").mkpath
       File.open(bundled_app(".bundle/config"), "w") do |f|
         f.write 'BUNDLE_FOO: "$BUILD_DIR"'

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -750,7 +750,7 @@ __FILE__: #{path.to_s.inspect}
           end
         RUBY
 
-        it "receives the signal", :ruby => ">= 1.9.3" do
+        it "receives the signal" do
           bundle!("exec #{path}") do |_, o, thr|
             o.gets # Consumes 'Started' and ensures that thread has started
             Process.kill("INT", thr.pid)

--- a/spec/commands/package_spec.rb
+++ b/spec/commands/package_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe "bundle package" do
   end
 
   context "with --all-platforms" do
-    it "puts the gems in vendor/cache even for other rubies", :ruby => "2.1" do
+    it "puts the gems in vendor/cache even for other rubies" do
       gemfile <<-D
         source "file://#{gem_repo1}"
         gem 'rack', :platforms => :ruby_19

--- a/spec/commands/viz_spec.rb
+++ b/spec/commands/viz_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "bundle viz", :ruby => "1.9.3", :bundler => "< 2", :if => Bundler.which("dot") do
+RSpec.describe "bundle viz", :bundler => "< 2", :if => Bundler.which("dot") do
   let(:ruby_graphviz) do
     graphviz_glob = base_system_gems.join("cache/ruby-graphviz*")
     Pathname.glob(graphviz_glob).first

--- a/spec/install/bundler_spec.rb
+++ b/spec/install/bundler_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe "bundle install" do
       expect(last_command.bundler_err).to include(nice_error)
     end
 
-    it "can install dependencies with newer bundler version with system gems", :ruby => "> 2" do
+    it "can install dependencies with newer bundler version with system gems" do
       bundle! "config path.system true"
       install_gemfile! <<-G
         source "file://#{gem_repo2}"
@@ -138,7 +138,7 @@ RSpec.describe "bundle install" do
       expect(out).to include("The Gemfile's dependencies are satisfied")
     end
 
-    it "can install dependencies with newer bundler version with a local path", :ruby => "> 2" do
+    it "can install dependencies with newer bundler version with a local path" do
       bundle! "config path .bundle"
       bundle! "config global_path_appends_ruby_scope true"
       install_gemfile! <<-G

--- a/spec/install/process_lock_spec.rb
+++ b/spec/install/process_lock_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "process lock spec" do
       expect(the_bundle).to include_gems "rack 1.0"
     end
 
-    context "when creating a lock raises Errno::ENOTSUP", :ruby => ">= 1.9" do
+    context "when creating a lock raises Errno::ENOTSUP" do
       before { allow(File).to receive(:open).and_raise(Errno::ENOTSUP) }
 
       it "skips creating the lock file and yields" do

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -33,13 +33,6 @@ RSpec.describe "major deprecations", :bundler => "< 2" do
     end
 
     shared_examples_for "environmental deprecations" do |trigger|
-      describe "ruby version", :ruby => "< 2.0" do
-        it "requires a newer ruby version" do
-          instance_eval(&trigger)
-          expect(warnings).to have_major_deprecation "Bundler will only support ruby >= 2.0, you are running #{RUBY_VERSION}"
-        end
-      end
-
       describe "rubygems version", :rubygems => "< 2.0" do
         it "requires a newer rubygems version" do
           instance_eval(&trigger)

--- a/spec/realworld/double_check_spec.rb
+++ b/spec/realworld/double_check_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe "double checking sources", :realworld => true do
-  it "finds already-installed gems", :ruby => ">= 2.2" do
+  it "finds already-installed gems" do
     create_file("rails.gemspec", <<-RUBY)
       Gem::Specification.new do |s|
         s.name        = "rails"

--- a/spec/realworld/edgecases_spec.rb
+++ b/spec/realworld/edgecases_spec.rb
@@ -19,45 +19,7 @@ RSpec.describe "real world edgecases", :realworld => true, :sometimes => true do
     RUBY
   end
 
-  # there is no rbx-relative-require gem that will install on 1.9
-  it "ignores extra gems with bad platforms", :ruby => "~> 1.8.7" do
-    gemfile <<-G
-      source "https://rubygems.org"
-      gem "linecache", "0.46"
-    G
-    bundle :lock
-    expect(last_command.stderr).to be_empty
-    expect(exitstatus).to eq(0) if exitstatus
-  end
-
-  # https://github.com/bundler/bundler/issues/1202
-  it "bundle cache works with rubygems 1.3.7 and pre gems",
-    :ruby => "~> 1.8.7", :rubygems => "~> 1.3.7" do
-    install_gemfile <<-G
-      source "https://rubygems.org"
-      gem "rack",          "1.3.0.beta2"
-      gem "will_paginate", "3.0.pre2"
-    G
-    bundle :cache
-    expect(out).not_to include("Removing outdated .gem files from vendor/cache")
-  end
-
-  # https://github.com/bundler/bundler/issues/1486
-  # this is a hash collision that only manifests on 1.8.7
-  it "finds the correct child versions", :ruby => "~> 1.8.7" do
-    gemfile <<-G
-      source "https://rubygems.org"
-
-      gem 'i18n', '~> 0.6.0'
-      gem 'activesupport', '~> 3.0.5'
-      gem 'activerecord', '~> 3.0.5'
-      gem 'builder', '~> 2.1.2'
-    G
-    bundle :lock
-    expect(lockfile).to include("activemodel (3.0.5)")
-  end
-
-  it "resolves dependencies correctly", :ruby => "1.9.3" do
+  it "resolves dependencies correctly" do
     gemfile <<-G
       source "https://rubygems.org"
 
@@ -70,7 +32,7 @@ RSpec.describe "real world edgecases", :realworld => true, :sometimes => true do
     expect(lockfile).to include("capybara (2.2.1)")
   end
 
-  it "installs the latest version of gxapi_rails", :ruby => "1.9.3" do
+  it "installs the latest version of gxapi_rails" do
     gemfile <<-G
       source "https://rubygems.org"
 
@@ -97,7 +59,7 @@ RSpec.describe "real world edgecases", :realworld => true, :sometimes => true do
     expect(lockfile).to include(rubygems_version("activesupport", "~> 3.0"))
   end
 
-  it "is able to update a top-level dependency when there is a conflict on a shared transitive child", :ruby => "2.1" do
+  it "is able to update a top-level dependency when there is a conflict on a shared transitive child" do
     # from https://github.com/bundler/bundler/issues/5031
 
     gemfile <<-G

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -1243,7 +1243,7 @@ end
   end
 
   describe "with gemified standard libraries" do
-    it "does not load Psych", :ruby => "~> 2.2" do
+    it "does not load Psych" do
       gemfile ""
       ruby <<-RUBY
         require 'bundler/setup'

--- a/spec/runtime/with_unbundled_env_spec.rb
+++ b/spec/runtime/with_unbundled_env_spec.rb
@@ -188,14 +188,14 @@ RSpec.describe "Bundler.with_env helpers" do
     end
   end
 
-  describe "Bundler.clean_system", :ruby => ">= 1.9", :bundler => "< 2" do
+  describe "Bundler.clean_system", :bundler => "< 2" do
     it "runs system inside with_clean_env" do
       Bundler.clean_system(%(echo 'if [ "$BUNDLE_PATH" = "" ]; then exit 42; else exit 1; fi' | /bin/sh))
       expect($?.exitstatus).to eq(42)
     end
   end
 
-  describe "Bundler.clean_exec", :ruby => ">= 1.9", :bundler => "< 2" do
+  describe "Bundler.clean_exec", :bundler => "< 2" do
     it "runs exec inside with_clean_env" do
       pid = Kernel.fork do
         Bundler.clean_exec(%(echo 'if [ "$BUNDLE_PATH" = "" ]; then exit 42; else exit 1; fi' | /bin/sh))


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was there's a lot of unnecessary code, specially in specs, that's never run.

### What was your diagnosis of the problem?

My diagnosis was that since dropping support for old ruby versions, this code is no longer necessary.

### What is your fix for the problem, implemented in this PR?

My fix is to remove the code.

### Why did you choose this fix out of the possible options?

I chose this fix because red is great on diffs.
