### PR TITLE
Downgrade version mismatches to warnings

### DIFF
--- a/lib/bundler/lockfile_parser.rb
+++ b/lib/bundler/lockfile_parser.rb
@@ -101,9 +101,6 @@ module Bundler
       return unless bundler_version
       prerelease_text = bundler_version.prerelease? ? " --pre" : ""
       current_version = Gem::Version.create(Bundler::VERSION)
-      if current_version.segments.first < bundler_version.segments.first
-        raise LockfileError, "You must use Bundler #{bundler_version.segments.first} or greater with this lockfile."
-      end
       return unless current_version < bundler_version
       Bundler.ui.warn "Warning: the running version of Bundler (#{current_version}) is older " \
            "than the version that created the lockfile (#{bundler_version}). We suggest you to " \

--- a/lib/bundler/lockfile_parser.rb
+++ b/lib/bundler/lockfile_parser.rb
@@ -101,17 +101,14 @@ module Bundler
       return unless bundler_version
       prerelease_text = bundler_version.prerelease? ? " --pre" : ""
       current_version = Gem::Version.create(Bundler::VERSION)
-      case current_version.segments.first <=> bundler_version.segments.first
-      when -1
+      if current_version.segments.first < bundler_version.segments.first
         raise LockfileError, "You must use Bundler #{bundler_version.segments.first} or greater with this lockfile."
-      when 0
-        if current_version < bundler_version
-          Bundler.ui.warn "Warning: the running version of Bundler (#{current_version}) is older " \
-               "than the version that created the lockfile (#{bundler_version}). We suggest you to " \
-               "upgrade to the version that created the lockfile by running `gem install " \
-               "bundler:#{bundler_version}#{prerelease_text}`.\n"
-        end
       end
+      return unless current_version < bundler_version
+      Bundler.ui.warn "Warning: the running version of Bundler (#{current_version}) is older " \
+           "than the version that created the lockfile (#{bundler_version}). We suggest you to " \
+           "upgrade to the version that created the lockfile by running `gem install " \
+           "bundler:#{bundler_version}#{prerelease_text}`.\n"
     end
 
   private

--- a/spec/lock/lockfile_spec.rb
+++ b/spec/lock/lockfile_spec.rb
@@ -230,7 +230,7 @@ RSpec.describe "the lockfile format" do
     expect(err).to include("You must use Bundler 9999999 or greater with this lockfile.")
   end
 
-  it "warns when updating bundler major version", :bundler => "< 3" do
+  it "warns when updating bundler major version" do
     lockfile <<-L
       GEM
         remote: file://localhost#{gem_repo1}/
@@ -239,54 +239,6 @@ RSpec.describe "the lockfile format" do
 
       PLATFORMS
         #{generic_local_platform}
-
-      DEPENDENCIES
-        rack
-
-      BUNDLED WITH
-         1.10.0
-    L
-
-    simulate_bundler_version "9999999.0.0" do
-      install_gemfile <<-G
-        source "file://localhost#{gem_repo1}/"
-
-        gem "rack"
-      G
-    end
-
-    expect(err).to include(
-      "Warning: the lockfile is being updated to Bundler " \
-      "9999999, after which you will be unable to return to Bundler 1."
-    )
-
-    lockfile_should_be <<-G
-      GEM
-        remote: file://localhost#{gem_repo1}/
-        specs:
-          rack (1.0.0)
-
-      PLATFORMS
-        #{generic_local_platform}
-        #{specific_local_platform}
-
-      DEPENDENCIES
-        rack
-
-      BUNDLED WITH
-         9999999.0.0
-    G
-  end
-
-  it "warns when updating bundler major version", :bundler => "3" do
-    lockfile <<-L
-      GEM
-        remote: file://localhost#{gem_repo1}/
-        specs:
-          rack (1.0.0)
-
-      PLATFORMS
-        #{lockfile_platforms}
 
       DEPENDENCIES
         rack

--- a/spec/lock/lockfile_spec.rb
+++ b/spec/lock/lockfile_spec.rb
@@ -230,44 +230,6 @@ RSpec.describe "the lockfile format" do
     expect(err).to include("You must use Bundler 9999999 or greater with this lockfile.")
   end
 
-  it "shows a friendly error when running with a new bundler 2 lockfile" do
-    lockfile <<-L
-      GEM
-        remote: https://rails-assets.org/
-        specs:
-         rails-assets-bootstrap (3.3.4)
-           rails-assets-jquery (>= 1.9.1)
-         rails-assets-jquery (2.1.4)
-
-      GEM
-        remote: https://rubygems.org/
-        specs:
-         rake (10.4.2)
-
-      PLATFORMS
-        ruby
-
-      DEPENDENCIES
-        rails-assets-bootstrap!
-        rake
-
-      BUNDLED WITH
-         9999999.0.0
-    L
-
-    install_gemfile <<-G
-      source 'https://rubygems.org'
-      gem 'rake'
-
-      source 'https://rails-assets.org' do
-        gem 'rails-assets-bootstrap'
-      end
-    G
-
-    expect(last_command).to be_failure
-    expect(err).to include("You must use Bundler 9999999 or greater with this lockfile.")
-  end
-
   it "warns when updating bundler major version", :bundler => "< 3" do
     lockfile <<-L
       GEM

--- a/spec/lock/lockfile_spec.rb
+++ b/spec/lock/lockfile_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe "the lockfile format" do
     G
   end
 
-  it "outputs a warning if the current is older than lockfile's bundler version" do
+  it "warns if the current is older than lockfile's bundler version" do
     current_version = Bundler::VERSION
     newer_minor = bump_minor(current_version)
 

--- a/spec/lock/lockfile_spec.rb
+++ b/spec/lock/lockfile_spec.rb
@@ -203,33 +203,6 @@ RSpec.describe "the lockfile format" do
     G
   end
 
-  it "errors if the current is a major version older than lockfile's bundler version", :bundler => "3" do
-    lockfile <<-L
-      GEM
-        remote: file://localhost#{gem_repo1}/
-        specs:
-          rack (1.0.0)
-
-      PLATFORMS
-        #{lockfile_platforms}
-
-      DEPENDENCIES
-        rack
-
-      BUNDLED WITH
-         9999999.0.0
-    L
-
-    install_gemfile <<-G
-      source "file://localhost#{gem_repo1}/"
-
-      gem "rack"
-    G
-
-    expect(last_command).to be_failure
-    expect(err).to include("You must use Bundler 9999999 or greater with this lockfile.")
-  end
-
   it "warns when updating bundler major version" do
     lockfile <<-L
       GEM

--- a/spec/support/platforms.rb
+++ b/spec/support/platforms.rb
@@ -105,7 +105,7 @@ module Spec
     end
 
     def local_platforms
-      if Bundler::VERSION.split(".").first.to_i > 2
+      if Bundler.feature_flag.specific_platform?
         [local, specific_local_platform]
       else
         [local]


### PR DESCRIPTION
Closes #6993.
Complements rubygems/rubygems#2621.

### What was the end-user problem that led to this PR?

The problem was that bundler 2 has become too unfriendly because it errors out when the running version does not match the version in the BUNDLED WITH section in the lockfile.

### What was your diagnosis of the problem?

My diagnosis is that we still believe that making sure the exact same bundler version is always run for a specific application is a good thing, because it ensures resolution is always the same because it's resolved by the exact same code that generated the lockfile.

BUT, we need to ensure this in a more user friendly way, for example by auto-switching and auto-installing the right bundler version without any user intervention.

### What is your fix for the problem, implemented in this PR?

My fix is to downgrade this hard error to a warning that does not prevent bundler from running.



### Why did you choose this fix out of the possible options?

I chose this fix because it still shows the mismatch but allows bundler to run, thus being a bit friendlier. Hopefully this won't be needed once bundler is smart enough to autoswitch and autoinstall.
