### PR TITLE
Smaller ci matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ jobs:
       stage: test
     # 1.x mode (we want to keep stuff passing in 1.x mode for now)
     - rvm: 2.6.1
-      env: RGV=v2.7.8 BUNDLER_SPEC_SUB_VERSION=1.98
+      env: RGV=v3.0.2 BUNDLER_SPEC_SUB_VERSION=1.98
       stage: test
 
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,26 +50,17 @@ jobs:
     - rvm: 2.6.1
       script: rake rubocop
       stage: linting
-    # Ruby 2.5, Rubygems 2.7 and up
+    # Ruby 2.5, Rubygems 2.7
     - rvm: 2.5.3
       env: RGV=v2.7.8
       stage: test
-    # Ruby 2.4, Rubygems 2.6 and up
+    # Ruby 2.4, Rubygems 2.6
     - rvm: 2.4.5
       env: RGV=v2.6.14
       stage: test
-    - rvm: 2.4.5
-      env: RGV=v2.7.8
-      stage: test
-    # Ruby 2.3, Rubygems 2.5 and up
+    # Ruby 2.3, Rubygems 2.5
     - rvm: 2.3.8
       env: RGV=v2.5.2
-      stage: test
-    - rvm: 2.3.8
-      env: RGV=v2.6.14
-      stage: test
-    - rvm: 2.3.8
-      env: RGV=v2.7.8
       stage: test
     # Ruby-head (we want to know how we're doing, but not fail the build)
     - rvm: ruby-head


### PR DESCRIPTION
Fixes #6956.

### What was the end-user problem that led to this PR?

The problem was that we have a very slow CI

### What was your diagnosis of the problem?

My diagnosis was that the CI matrix is very big, and that old rubies use more resources than new rubies.

### What is your fix for the problem, implemented in this PR?

My fix is to remove some entries and when it comes to testing old rubygems version, test only the rubygems version each tested MRI version shipped with.

### Why did you choose this fix out of the possible options?

I chose this fix because it saves us some time, and it gives all rubies the same amount of CI resources.