### PR TITLE
Fix multiple gem files deprecation

### DIFF
--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -157,11 +157,16 @@ module Bundler
       multiple_gemfiles = search_up(".") do |dir|
         gemfiles = gemfile_names.select {|gf| File.file? File.expand_path(gf, dir) }
         next if gemfiles.empty?
-        break false if gemfiles.size == 1
+        break gemfiles.size != 1
       end
-      return unless multiple_gemfiles && Bundler.bundler_major_version == 1
-      Bundler::SharedHelpers.major_deprecation 2, \
-        "gems.rb and gems.locked will be preferred to Gemfile and Gemfile.lock."
+      return unless multiple_gemfiles
+      diagnosis = "Multiple gemfiles (gems.rb and Gemfile) detected."
+      advice = if Bundler.feature_flag.prefer_gems_rb?
+        "Make sure you remove Gemfile and Gemfile.lock since bundler is ignoring them in favor of gems.rb and gems.rb.locked."
+      else
+        "The gems.rb and gems.rb.locked files are currently ignored, but they will get used as soon as you delete your Gemfile and Gemfile.lock files."
+      end
+      Bundler.ui.warn [diagnosis, advice].join(" ")
     end
 
     def trap(signal, override = false, &block)

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe "major deprecations" do
   end
 
   context "when Bundler.setup is run in a ruby script" do
-    it "should print a single deprecation warning" do
+    before do
       create_file "gems.rb"
       install_gemfile! <<-G
         source "file://#{gem_repo1}"
@@ -124,7 +124,9 @@ RSpec.describe "major deprecations" do
         Bundler.setup
         Bundler.setup
       RUBY
+    end
 
+    it "should print a single deprecation warning" do
       expect(warnings).to have_major_deprecation("gems.rb and gems.locked will be preferred to Gemfile and Gemfile.lock.")
     end
   end

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "major deprecations" do
     end
   end
 
-  context "when bundle is run" do
+  context "when bundle install is run" do
     it "should not warn about gems.rb" do
       create_file "gems.rb", <<-G
         source "file://#{gem_repo1}"

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -82,15 +82,32 @@ RSpec.describe "major deprecations" do
       expect(warnings).not_to have_major_deprecation
     end
 
-    xit "should print a Gemfile deprecation warning" do
+    it "should print a proper warning when both gems.rb and Gemfile present, and use Gemfile", :bundler => "< 2" do
       create_file "gems.rb"
       install_gemfile! <<-G
         source "file://#{gem_repo1}"
         gem "rack"
       G
-      expect(the_bundle).to include_gem "rack 1.0"
 
-      expect(warnings).to have_major_deprecation a_string_including("gems.rb and gems.locked will be preferred to Gemfile and Gemfile.lock.")
+      expect(warnings).to include(
+        "Multiple gemfiles (gems.rb and Gemfile) detected. The gems.rb and gems.rb.locked files are currently ignored, but they will get used as soon as you delete your Gemfile and Gemfile.lock files."
+      )
+
+      expect(the_bundle).to include_gem "rack 1.0"
+    end
+
+    it "should print a proper warning when both gems.rb and Gemfile present, and use gems.rb", :bundler => "2" do
+      create_file "gems.rb"
+      install_gemfile! <<-G
+        source "file://#{gem_repo1}"
+        gem "rack"
+      G
+
+      expect(warnings).to include(
+        "Multiple gemfiles (gems.rb and Gemfile) detected. Make sure you remove Gemfile and Gemfile.lock since bundler is ignoring them in favor of gems.rb and gems.rb.locked."
+      )
+
+      expect(the_bundle).not_to include_gem "rack 1.0"
     end
 
     context "with flags" do
@@ -126,8 +143,16 @@ RSpec.describe "major deprecations" do
       RUBY
     end
 
-    it "should print a single deprecation warning" do
-      expect(warnings).to have_major_deprecation("gems.rb and gems.locked will be preferred to Gemfile and Gemfile.lock.")
+    it "should print a single deprecation warning", :bundler => "< 2" do
+      expect(warnings).to include(
+        "Multiple gemfiles (gems.rb and Gemfile) detected. The gems.rb and gems.rb.locked files are currently ignored, but they will get used as soon as you delete your Gemfile and Gemfile.lock files."
+      )
+    end
+
+    it "should print a single deprecation warning", :bundler => "2" do
+      expect(warnings).to include(
+        "Multiple gemfiles (gems.rb and Gemfile) detected. Make sure you remove Gemfile and Gemfile.lock since bundler is ignoring them in favor of gems.rb and gems.rb.locked."
+      )
     end
   end
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was the current message about deprecating `Gemfile` in favor of `gems.rb` was incorrect, and this I'm not sure when it was supposed to be displayed. Its corresponding test was also failing.

### What was your diagnosis of the problem?

My diagnosis was that the intention was not to deprecate Gemfile's for the time being, but only warn if the user opts in to `gems.rb` but does not remove the old `Gemfile`.

### What is your fix for the problem, implemented in this PR?

My fix is to properly detect the situation where both `Gemfile` and `gems.rb` files are present, and show proper messages guiding the user to properly make the switch.

### Why did you choose this fix out of the possible options?

I chose this fix because I think it works and doesn't take this migration too far, since the ecosystem is not yet ready for this at all.
