### PR TITLE
Respect color option when instantiating shells

### DIFF
--- a/lib/bundler/ui/shell.rb
+++ b/lib/bundler/ui/shell.rb
@@ -10,7 +10,7 @@ module Bundler
       attr_writer :shell
 
       def initialize(options = {})
-        if options["no-color"] || !$stdout.tty?
+        if options["no-color"]
           Thor::Base.shell = Thor::Shell::Basic
         end
         @shell = Thor::Base.shell.new

--- a/lib/bundler/ui/shell.rb
+++ b/lib/bundler/ui/shell.rb
@@ -10,9 +10,7 @@ module Bundler
       attr_writer :shell
 
       def initialize(options = {})
-        if options["no-color"]
-          Thor::Base.shell = Thor::Shell::Basic
-        end
+        Thor::Base.shell = options["no-color"] ? Thor::Shell::Basic : nil
         @shell = Thor::Base.shell.new
         @level = ENV["DEBUG"] ? "debug" : "info"
         @warning_history = []

--- a/spec/bundler/source_spec.rb
+++ b/spec/bundler/source_spec.rb
@@ -65,6 +65,8 @@ RSpec.describe Bundler::Source do
           end
 
           context "without color" do
+            before { Bundler.ui = Bundler::UI::Shell.new("no-color" => true) }
+
             it "should return a string with the spec name and version and locked spec version" do
               expect(subject.version_message(spec)).to eq("nokogiri >= 1.6 (was < 1.5)")
             end

--- a/spec/bundler/source_spec.rb
+++ b/spec/bundler/source_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Bundler::Source do
         context "with a different version" do
           let(:locked_gem) { double(:locked_gem, :name => "nokogiri", :version => "< 1.5") }
 
-          context "with color" do
+          context "with color", :non_windows do
             before { Bundler.ui = Bundler::UI::Shell.new }
 
             it "should return a string with the spec name and version and locked spec version" do
@@ -77,7 +77,7 @@ RSpec.describe Bundler::Source do
           let(:spec) { double(:spec, :name => "nokogiri", :version => "1.6.1", :platform => rb) }
           let(:locked_gem) { double(:locked_gem, :name => "nokogiri", :version => "1.7.0") }
 
-          context "with color" do
+          context "with color", :non_windows do
             before { Bundler.ui = Bundler::UI::Shell.new }
 
             it "should return a string with the locked spec version in yellow" do
@@ -98,7 +98,7 @@ RSpec.describe Bundler::Source do
           let(:spec) { double(:spec, :name => "nokogiri", :version => "1.7.1", :platform => rb) }
           let(:locked_gem) { double(:locked_gem, :name => "nokogiri", :version => "1.7.0") }
 
-          context "with color" do
+          context "with color", :non_windows do
             before { Bundler.ui = Bundler::UI::Shell.new }
 
             it "should return a string with the locked spec version in green" do

--- a/spec/bundler/source_spec.rb
+++ b/spec/bundler/source_spec.rb
@@ -60,10 +60,6 @@ RSpec.describe Bundler::Source do
             before { Bundler.ui = Bundler::UI::Shell.new }
 
             it "should return a string with the spec name and version and locked spec version" do
-              if Bundler.ui.instance_variable_get(:@shell).is_a?(Bundler::Thor::Shell::Basic)
-                skip "tty color is not supported with Thor::Shell::Basic environment."
-              end
-
               expect(subject.version_message(spec)).to eq("nokogiri >= 1.6\e[32m (was < 1.5)\e[0m")
             end
           end
@@ -83,10 +79,6 @@ RSpec.describe Bundler::Source do
             before { Bundler.ui = Bundler::UI::Shell.new }
 
             it "should return a string with the locked spec version in yellow" do
-              if Bundler.ui.instance_variable_get(:@shell).is_a?(Bundler::Thor::Shell::Basic)
-                skip "tty color is not supported with Thor::Shell::Basic environment."
-              end
-
               expect(subject.version_message(spec)).to eq("nokogiri 1.6.1\e[33m (was 1.7.0)\e[0m")
             end
           end
@@ -100,10 +92,6 @@ RSpec.describe Bundler::Source do
             before { Bundler.ui = Bundler::UI::Shell.new }
 
             it "should return a string with the locked spec version in green" do
-              if Bundler.ui.instance_variable_get(:@shell).is_a?(Bundler::Thor::Shell::Basic)
-                skip "tty color is not supported with Thor::Shell::Basic environment."
-              end
-
               expect(subject.version_message(spec)).to eq("nokogiri 1.7.1\e[32m (was 1.7.0)\e[0m")
             end
           end

--- a/spec/bundler/source_spec.rb
+++ b/spec/bundler/source_spec.rb
@@ -84,6 +84,14 @@ RSpec.describe Bundler::Source do
               expect(subject.version_message(spec)).to eq("nokogiri 1.6.1\e[33m (was 1.7.0)\e[0m")
             end
           end
+
+          context "without color" do
+            before { Bundler.ui = Bundler::UI::Shell.new("no-color" => true) }
+
+            it "should return a string with the locked spec version in yellow" do
+              expect(subject.version_message(spec)).to eq("nokogiri 1.6.1 (was 1.7.0)")
+            end
+          end
         end
 
         context "with an older version" do
@@ -95,6 +103,14 @@ RSpec.describe Bundler::Source do
 
             it "should return a string with the locked spec version in green" do
               expect(subject.version_message(spec)).to eq("nokogiri 1.7.1\e[32m (was 1.7.0)\e[0m")
+            end
+          end
+
+          context "without color" do
+            before { Bundler.ui = Bundler::UI::Shell.new("no-color" => true) }
+
+            it "should return a string with the locked spec version in yellow" do
+              expect(subject.version_message(spec)).to eq("nokogiri 1.7.1 (was 1.7.0)")
             end
           end
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -78,6 +78,7 @@ RSpec.configure do |config|
   config.filter_run_excluding :rubygems_master => (ENV["RGV"] != "master")
   config.filter_run_excluding :bundler => RequirementChecker.against(Bundler::VERSION.split(".")[0])
   config.filter_run_excluding :ruby_repo => !(ENV["BUNDLE_RUBY"] && ENV["BUNDLE_GEM"]).nil?
+  config.filter_run_excluding :non_windows => Gem.win_platform?
 
   config.filter_run_when_matching :focus unless ENV["CI"]
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that some specs have started to fail randomly in several unrelated PRs. See for example, https://travis-ci.org/bundler/bundler/jobs/500322731. Note that currently bundler specs always run in the same order ( :crying_cat_face: ), but enabling or disabling specs can still affect the final set of specs, and thus make this issue manifest.

### What was your diagnosis of the problem?

My diagnosis was that the base thor's shell is being memoized the first time bundler instantiates a shell. That means further instantiations will not respect the "--no-color" option.

### What is your fix for the problem, implemented in this PR?

My fix is to reset the base thor's shell the proper color / non-color one, every time we instantiate a new shell, not only when "--color" is given. 

### Why did you choose this fix out of the possible options?

I chose this fix because it felt like a real issue that should be fixed in lib/, and not only with some state resetting hack inside the specs. 
