### PR TITLE
Fix sticky options deprecation

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -795,7 +795,7 @@ module Bundler
       return unless name_index
 
       value = options[name]
-      value = "#{value.join(" ")}" if option.type == :array
+      value = value.join(" ").to_s if option.type == :array
 
       Bundler::SharedHelpers.major_deprecation 2,\
         "The `#{flag_name}` flag is deprecated because it relied on being " \

--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -38,7 +38,7 @@ module Bundler
     settings_flag(:deployment_means_frozen) { bundler_2_mode? }
     settings_flag(:disable_multisource) { bundler_2_mode? }
     settings_flag(:error_on_stderr) { bundler_2_mode? }
-    settings_flag(:forget_cli_options) { bundler_2_mode? }
+    settings_flag(:forget_cli_options) { bundler_3_mode? }
     settings_flag(:global_path_appends_ruby_scope) { bundler_2_mode? }
     settings_flag(:global_gem_cache) { bundler_2_mode? }
     settings_flag(:init_gems_rb) { bundler_2_mode? }

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -120,7 +120,9 @@ module Bundler
           "flags passed to commands " \
           "will no longer be automatically remembered. Instead please set flags " \
           "you want remembered between commands using `bundle config set " \
-          "<setting name> <setting value>`, i.e. `#{command}`"
+          "<setting name> <setting value>`, i.e. `#{command}`. Once you are " \
+          "ready for the new behavior, use `bundle config set forget_cli_options " \
+          "true` to get rid of this message"
 
         set_local(key, value)
       end

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -117,7 +117,7 @@ module Bundler
         end
 
         unless Bundler.settings[:forget_cli_options] == false
-          Bundler::SharedHelpers.major_deprecation 2,\
+          Bundler::SharedHelpers.major_deprecation 3,\
             "flags passed to commands " \
             "will no longer be automatically remembered. Instead please set flags " \
             "you want remembered between commands using `bundle config set " \

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -116,13 +116,19 @@ module Bundler
           "bundle config set #{key} #{Array(value).join(":")}"
         end
 
-        Bundler::SharedHelpers.major_deprecation 2,\
-          "flags passed to commands " \
-          "will no longer be automatically remembered. Instead please set flags " \
-          "you want remembered between commands using `bundle config set " \
-          "<setting name> <setting value>`, i.e. `#{command}`. Once you are " \
-          "ready for the new behavior, use `bundle config set forget_cli_options " \
-          "true` to get rid of this message"
+        unless Bundler.settings[:forget_cli_options] == false
+          Bundler::SharedHelpers.major_deprecation 2,\
+            "flags passed to commands " \
+            "will no longer be automatically remembered. Instead please set flags " \
+            "you want remembered between commands using `bundle config set " \
+            "<setting name> <setting value>`, i.e. `#{command}`. Once you are " \
+            "ready for the new behavior, use `bundle config set forget_cli_options " \
+            "true` to get rid of this message. Or if you want to get rid of " \
+            "this message and stick with the old behavior for now, run " \
+            "`bundle config set forget_cli_options false`, but keep in mind " \
+            "that this behavior will be fully removed in future versions of " \
+            "bundler."
+        end
 
         set_local(key, value)
       end

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -121,6 +121,42 @@ RSpec.describe "major deprecations" do
           "flags passed to commands will no longer be automatically remembered."
         )
       end
+
+      {
+        :clean => true,
+        :deployment => true,
+        :frozen => true,
+        :"no-cache" => true,
+        :"no-prune" => true,
+        :path => "vendor/bundle",
+        :shebang => "ruby27",
+        :system => true,
+        :without => "development",
+        :with => "development",
+      }.each do |name, value|
+        flag_name = "--#{name}"
+
+        context "with the #{flag_name} flag", :bundler => "2" do
+          it "should print a deprecation warning" do
+            bundle "install #{flag_name} #{value}"
+
+            expect(warnings).to have_major_deprecation(
+              "The `#{flag_name}` flag is deprecated because it relied on " \
+              "being remembered accross bundler invokations, which bundler " \
+              "will no longer do in future versions. Instead please use " \
+              "`bundle config #{name} '#{value}'`, and stop using this flag"
+            )
+          end
+        end
+
+        context "with the #{flag_name} flag", :bundler => "< 2" do
+          it "should not print a deprecation warning" do
+            bundle "install #{flag_name} #{value}"
+
+            expect(warnings).not_to have_major_deprecation
+          end
+        end
+      end
     end
   end
 

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe "major deprecations" do
     end
 
     context "with flags" do
-      xit "should print a deprecation warning about autoremembering flags" do
+      it "should print a deprecation warning about autoremembering flags", :bundler => "3" do
         install_gemfile <<-G, :path => "vendor/bundle"
           source "file://#{gem_repo1}"
           gem "rack"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that deprecating sticky options is currently "useless" since we are removing the flags where the stickyness makes a difference at the same time. So, we don't help users adapt to (and understand) our changes. 

### What was your diagnosis of the problem?

My diagnosis was that we should do this change in two steps, so that first users get a explanation about why we are removing the flags and what is the preferred alternative for them, and once nobody is no longer using these flags, we deprecate sticky options in general, since they are surprising and no longer useful, since we don't depend on them. 

### What is your fix for the problem, implemented in this PR?

My fix is to:

* In bundler 2 (next release, 2.1 for example), print a deprecation message to warn about the removal of all the flags that currently depend on the options being remembered.

* In bundler 3, remove the options and deprecate remembering command line flags.

### Why did you choose this fix out of the possible options?

I chose this fix because it properly and gradually informs our users about the changes that we intend to make and why we intend to make them.