### PR TITLE
`bundle update` shows help instead of raising

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -101,29 +101,10 @@ module Bundler
                              :desc => "Specify the number of times you wish to attempt network commands"
     class_option "verbose", :type => :boolean, :desc => "Enable verbose output mode", :aliases => "-V"
 
-    def help(topic = nil)
-      case topic
-      when "gemfile" then command = "gemfile"
-      when nil       then command = "bundle"
-      else command = "bundle-#{topic}"
-      end
-
-      man_path  = File.expand_path("../../../man", __FILE__)
-      man_pages = Hash[Dir.glob(File.join(man_path, "*")).grep(/.*\.\d*\Z/).collect do |f|
-        [File.basename(f, ".*"), f]
-      end]
-
-      if man_pages.include?(command)
-        if Bundler.which("man") && man_path !~ %r{^file:/.+!/META-INF/jruby.home/.+}
-          Kernel.exec "man #{man_pages[command]}"
-        else
-          puts File.read("#{man_path}/#{File.basename(man_pages[command])}.txt")
-        end
-      elsif command_path = Bundler.which("bundler-#{topic}")
-        Kernel.exec(command_path, "--help")
-      else
-        super
-      end
+    def help(topic = nil, plain = nil)
+      return super if plain
+      require "bundler/cli/help"
+      Help.new(topic, self).run
     end
 
     def self.handle_no_command_error(command, has_namespace = $thor_runner)

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -101,11 +101,11 @@ module Bundler
                              :desc => "Specify the number of times you wish to attempt network commands"
     class_option "verbose", :type => :boolean, :desc => "Enable verbose output mode", :aliases => "-V"
 
-    def help(cli = nil)
-      case cli
+    def help(topic = nil)
+      case topic
       when "gemfile" then command = "gemfile"
       when nil       then command = "bundle"
-      else command = "bundle-#{cli}"
+      else command = "bundle-#{topic}"
       end
 
       man_path  = File.expand_path("../../../man", __FILE__)
@@ -119,7 +119,7 @@ module Bundler
         else
           puts File.read("#{man_path}/#{File.basename(man_pages[command])}.txt")
         end
-      elsif command_path = Bundler.which("bundler-#{cli}")
+      elsif command_path = Bundler.which("bundler-#{topic}")
         Kernel.exec(command_path, "--help")
       else
         super

--- a/lib/bundler/cli/help.rb
+++ b/lib/bundler/cli/help.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Bundler
+  class CLI::Help
+    attr_reader :topic, :cli
+    def initialize(topic = nil, cli = nil)
+      @topic = topic
+      @cli = cli
+    end
+
+    def run
+      case topic
+      when "gemfile" then command = "gemfile"
+      when nil       then command = "bundle"
+      else command = "bundle-#{topic}"
+      end
+
+      man_path  = File.expand_path("../../../../man", __FILE__)
+      man_pages = Hash[Dir.glob(File.join(man_path, "*")).grep(/.*\.\d*\Z/).collect do |f|
+        [File.basename(f, ".*"), f]
+      end]
+
+      if man_pages.include?(command)
+        if Bundler.which("man") && man_path !~ %r{^file:/.+!/META-INF/jruby.home/.+}
+          Kernel.exec "man #{man_pages[command]}"
+        else
+          puts File.read("#{man_path}/#{File.basename(man_pages[command])}.txt")
+        end
+      elsif command_path = Bundler.which("bundler-#{topic}")
+        Kernel.exec(command_path, "--help")
+      else
+        cli.help(topic, true)
+      end
+    end
+  end
+end

--- a/lib/bundler/cli/update.rb
+++ b/lib/bundler/cli/update.rb
@@ -18,18 +18,18 @@ module Bundler
 
       no_specific_gems = gems.empty? && sources.empty? && groups.empty? && !options[:ruby] && !options[:bundler]
 
-      if no_specific_gems && !options[:all]
-        if Bundler.feature_flag.update_requires_all_flag?
-          raise InvalidOption, "To update everything, pass the `--all` flag."
-        end
-        SharedHelpers.major_deprecation 2, "Pass --all to `bundle update` to update everything"
-      elsif !no_specific_gems && options[:all]
-        raise InvalidOption, "Cannot specify --all along with specific options."
-      end
-
       if no_specific_gems
+        if !options[:all] && Bundler.feature_flag.update_requires_all_flag?
+          require "bundler/cli/help"
+          Bundler::CLI::Help.new("update").run
+        elsif !options[:all]
+          SharedHelpers.major_deprecation 2, "Pass --all to `bundle update` to update everything"
+        end
+
         # We're doing a full update
         Bundler.definition(true)
+      elsif options[:all]
+        raise InvalidOption, "Cannot specify --all along with specific options."
       else
         unless Bundler.default_lockfile.exist?
           raise GemfileLockNotFound, "This Bundle hasn't been installed yet. " \

--- a/lib/bundler/cli/update.rb
+++ b/lib/bundler/cli/update.rb
@@ -16,18 +16,18 @@ module Bundler
       sources = Array(options[:source])
       groups  = Array(options[:group]).map(&:to_sym)
 
-      full_update = gems.empty? && sources.empty? && groups.empty? && !options[:ruby] && !options[:bundler]
+      no_specific_gems = gems.empty? && sources.empty? && groups.empty? && !options[:ruby] && !options[:bundler]
 
-      if full_update && !options[:all]
+      if no_specific_gems && !options[:all]
         if Bundler.feature_flag.update_requires_all_flag?
           raise InvalidOption, "To update everything, pass the `--all` flag."
         end
         SharedHelpers.major_deprecation 2, "Pass --all to `bundle update` to update everything"
-      elsif !full_update && options[:all]
+      elsif !no_specific_gems && options[:all]
         raise InvalidOption, "Cannot specify --all along with specific options."
       end
 
-      if full_update
+      if no_specific_gems
         # We're doing a full update
         Bundler.definition(true)
       else

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -74,10 +74,11 @@ RSpec.describe "bundle update" do
   context "when update_requires_all_flag is set" do
     before { bundle! "config update_requires_all_flag true" }
 
-    it "errors when passed nothing" do
+    it "shows usage instructions when passed nothing" do
       install_gemfile! ""
       bundle :update
-      expect(err).to eq("To update everything, pass the `--all` flag.")
+      expect(out).to include("bundle-update - Update your gems to the latest available versions")
+      expect(err).to be_empty
     end
 
     it "errors when passed --all and another option" do

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "bundle update" do
     G
   end
 
-  describe "with no arguments", :bundler => "< 2" do
+  describe "with no arguments", :bundler => "< 3" do
     it "updates the entire bundle" do
       update_repo2 do
         build_gem "activesupport", "3.0"
@@ -32,6 +32,18 @@ RSpec.describe "bundle update" do
       G
       bundle "update"
       expect(bundled_app("Gemfile.lock")).to exist
+    end
+  end
+
+  describe "with no arguments", :bundler => "3" do
+    it "does not update the entire bundle" do
+      update_repo2 do
+        build_gem "activesupport", "3.0"
+      end
+
+      bundle "update"
+      expect(out).not_to include("Bundle updated!")
+      expect(the_bundle).not_to include_gems "rack 1.2", "activesupport 3.0"
     end
   end
 

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -565,13 +565,13 @@ RSpec.describe "bundle update when a gem depends on a newer version of bundler" 
   it "should explain that bundler conflicted", :bundler => "< 2" do
     bundle "update", :all => bundle_update_requires_all?
     expect(last_command.stdboth).not_to match(/in snapshot/i)
-    expect(last_command.bundler_err).to match(/current Bundler version/i).
+    expect(err).to match(/current Bundler version/i).
       and match(/perhaps you need to update bundler/i)
   end
 
   it "should warn that the newer version of Bundler would conflict", :bundler => "2" do
     bundle! "update", :all => true
-    expect(last_command.bundler_err).to include("rails (3.0.1) has dependency bundler").
+    expect(err).to include("rails (3.0.1) has dependency bundler").
       and include("so the dependency is being ignored")
     expect(the_bundle).to include_gem "rails 3.0.1"
   end
@@ -947,7 +947,7 @@ RSpec.describe "bundle update conservative" do
     it "raises if too many flags are provided" do
       bundle "update --patch --minor", :all => bundle_update_requires_all?
 
-      expect(last_command.bundler_err).to eq "Provide only one of the following options: minor, patch"
+      expect(err).to eq "Provide only one of the following options: minor, patch"
     end
   end
 end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that after we change the behavior of `bundle update` to require the `--all` flag to update the whole bundle, it will start raising with the message "To update everything, pass the \`--all\` flag.". In my opinion, this is not very user friendly because it makes the simplest version of the command an error.

### What was your diagnosis of the problem?

My diagnosis was that we should instead teach users how to use `bundle update` when they run `bundle  update`. This is the same rationale as showing `bundle` help instead of running `bundle install` when `bundle` is run. It's more user friendly than just saying "To install gems, use `bundle install`".

### What is your fix for the problem, implemented in this PR?

My fix is to delegate to `bundle help update` when `bundle update` is run.

### Why did you choose this fix out of the possible options?

I chose this fix because it makes sense from the end user point of view as I explained above.