### PR TITLE
Use double quotes for `git commit -m`

### DIFF
--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -221,7 +221,7 @@ RSpec.describe "bundle install with git sources" do
       end
 
       Dir.chdir(lib_path("foo-1.0")) do
-        `git update-ref -m 'Bundler Spec!' refs/bundler/1 master~1`
+        `git update-ref -m "Bundler Spec!" refs/bundler/1 master~1`
       end
 
       # want to ensure we don't fallback to HEAD
@@ -257,7 +257,7 @@ RSpec.describe "bundle install with git sources" do
       end
 
       Dir.chdir(lib_path("foo-1.0")) do
-        `git update-ref -m 'Bundler Spec!' refs/bundler/1 master~1`
+        `git update-ref -m "Bundler Spec!" refs/bundler/1 master~1`
       end
 
       # want to ensure we don't fallback to HEAD
@@ -282,7 +282,7 @@ RSpec.describe "bundle install with git sources" do
 
     it "does not download random non-head refs" do
       Dir.chdir(lib_path("foo-1.0")) do
-        sys_exec!("git update-ref -m 'Bundler Spec!' refs/bundler/1 master~1")
+        sys_exec!('git update-ref -m "Bundler Spec!" refs/bundler/1 master~1')
       end
 
       bundle! "config global_gem_cache true"
@@ -1163,7 +1163,7 @@ RSpec.describe "bundle install with git sources" do
               void Init_foo() { rb_define_global_function("foo", &foo, 0); }
             C
           end
-          `git commit -m 'commit for iteration #{i}' ext/foo.c`
+          `git commit -m "commit for iteration #{i}" ext/foo.c`
         end
         git_commit_sha = git_reader.ref_for("HEAD")
 

--- a/spec/support/builders.rb
+++ b/spec/support/builders.rb
@@ -649,7 +649,7 @@ module Spec
           `git config user.email "lol@wut.com"`
           `git config user.name "lolwut"`
           `git config commit.gpgsign false`
-          `git commit -m 'OMG INITIAL COMMIT'`
+          `git commit -m "OMG INITIAL COMMIT"`
         end
       end
     end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that Azure logs are full of "error: pathspec 'COMMIT'' did not match any file(s) known to git." and other similar ones.

### What was your diagnosis of the problem?

My diagnosis was that Windows' doesn't like single quotes.

### What is your fix for the problem, implemented in this PR?

My fix is to use double quotes, which is also consistent with our global style.

### Why did you choose this fix out of the possible options?

I chose this fix because it brings the number of spec failures on Windows from 657 to 474! :tada: 
