### PR TITLE
Do not prepend ENV vars for sys_exec calls, but use env param of Open3.popen3

### DIFF
--- a/spec/commands/binstubs_spec.rb
+++ b/spec/commands/binstubs_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe "bundle binstubs <gem>" do
 
       context "when BUNDLER_VERSION is set" do
         it "runs the correct version of bundler" do
-          sys_exec "#{bundled_app("bin/bundle")} install", { 'BUNDLER_VERSION' => '999.999.999' }
+          sys_exec "#{bundled_app("bin/bundle")} install", "BUNDLER_VERSION" => "999.999.999"
           expect(exitstatus).to eq(42) if exitstatus
           expect(last_command.stderr).to include("Activating bundler (999.999.999) failed:").
             and include("To install the version of bundler this project requires, run `gem install bundler -v '999.999.999'`")

--- a/spec/commands/binstubs_spec.rb
+++ b/spec/commands/binstubs_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe "bundle binstubs <gem>" do
 
       context "when BUNDLER_VERSION is set" do
         it "runs the correct version of bundler" do
-          sys_exec "BUNDLER_VERSION='999.999.999' #{bundled_app("bin/bundle")} install"
+          sys_exec "#{bundled_app("bin/bundle")} install", { 'BUNDLER_VERSION' => '999.999.999' }
           expect(exitstatus).to eq(42) if exitstatus
           expect(last_command.stderr).to include("Activating bundler (999.999.999) failed:").
             and include("To install the version of bundler this project requires, run `gem install bundler -v '999.999.999'`")

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe "bundle gem" do
       load_paths = [lib, spec]
       load_path_str = "-I#{load_paths.join(File::PATH_SEPARATOR)}"
 
-      sys_exec "PATH=\"\" #{Gem.ruby} #{load_path_str} #{bindir.join("bundle")} gem #{gem_name}"
+      sys_exec "#{Gem.ruby} #{load_path_str} #{bindir.join("bundle")} gem #{gem_name}", { 'PATH' => '' }
     end
 
     it "creates the gem without the need for git" do

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe "bundle gem" do
       load_paths = [lib, spec]
       load_path_str = "-I#{load_paths.join(File::PATH_SEPARATOR)}"
 
-      sys_exec "#{Gem.ruby} #{load_path_str} #{bindir.join("bundle")} gem #{gem_name}", { 'PATH' => '' }
+      sys_exec "#{Gem.ruby} #{load_path_str} #{bindir.join("bundle")} gem #{gem_name}", "PATH" => ""
     end
 
     it "creates the gem without the need for git" do


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Several tests were failing on Windows because of the same problem:

### What was your diagnosis of the problem?

On macOS and Linux you can prepend `ENV_VAR=value` in front of a command to set an environment variable for just this command execution. 

On Windows this construct doesn't exit and such a command fails.

### What is your fix for the problem, implemented in this PR?

`Open3.popen3`, the method used to executed the command in `sys_exec`, also has an optional `env` parameter which you can use to supply a hash of environment variables. Instead of prepending on the command itself, the code now uses that parameter for the env variables. (Suggested by @deivid-rodriguez in https://github.com/bundler/bundler/issues/6886#issuecomment-452010623).

### Why did you choose this fix out of the possible options?

The parameter of `Open3.popen3` perfectly matches our use case.

---

Fixes 35 failing tests on Windows.

closes #6886