### PR TITLE
Adapt helper path regex to also work with Windows paths

### DIFF
--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -318,7 +318,7 @@ module Spec
             Dir.chdir(root) { gem_command! :build, gemspec.to_s }
           end
           bundler_path = root + "bundler-#{Bundler::VERSION}.gem"
-        elsif g.to_s =~ %r{\A[A-Z]?:/.*\.gem\z}
+        elsif g.to_s =~ %r{\A(?:[A-Z]:)?/.*\.gem\z}
           g
         else
           "#{gem_repo}/gems/#{g}.gem"

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -318,7 +318,7 @@ module Spec
             Dir.chdir(root) { gem_command! :build, gemspec.to_s }
           end
           bundler_path = root + "bundler-#{Bundler::VERSION}.gem"
-        elsif g.to_s =~ %r{\A/.*\.gem\z}
+        elsif g.to_s =~ %r{\A[A-Z]?:/.*\.gem\z}
           g
         else
           "#{gem_repo}/gems/#{g}.gem"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Some tests were failing on Windows with strange paths not existing.

### What was your diagnosis of the problem?

Turns out a regex in the helper for paths didn't fire on Windows paths as they start with something like `C:/`.

### What is your fix for the problem, implemented in this PR?

So I adapted the regex to also match Windows paths.

### Why did you choose this fix out of the possible options?

... which seemed like the right thing to do here.

---

Fixes 21 test failures on Windows.

closes #6892
