### PR TITLE
Fix all offenses of some easy cops

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -595,16 +595,6 @@ Style/StderrPuts:
 Style/SymbolArray:
   EnforcedStyle: brackets
 
-# Offense count: 3
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyleForMultiline.
-# SupportedStylesForMultiline: comma, consistent_comma, no_comma
-Style/TrailingCommaInArrayLiteral:
-  Exclude:
-    - 'lib/bundler/gem_helpers.rb'
-    - 'lib/bundler/ruby_version.rb'
-    - 'lib/bundler/similarity_detector.rb'
-
 # Offense count: 6
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyleForMultiline.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -70,28 +70,10 @@ Layout/ClosingHeredocIndentation:
     - 'spec/lock/lockfile_spec.rb'
     - 'spec/other/platform_spec.rb'
 
-# Offense count: 5
-# Cop supports --auto-correct.
-Layout/ElseAlignment:
-  Exclude:
-    - 'lib/bundler/dsl.rb'
-    - 'lib/bundler/resolver.rb'
-    - 'lib/bundler/source/path.rb'
-
 # Offense count: 290
 # Cop supports --auto-correct.
 Layout/EmptyLineAfterGuardClause:
   Enabled: false
-
-# Offense count: 4
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyleAlignWith, AutoCorrect, Severity.
-# SupportedStylesAlignWith: keyword, variable, start_of_line
-Layout/EndAlignment:
-  Exclude:
-    - 'lib/bundler/dsl.rb'
-    - 'lib/bundler/resolver.rb'
-    - 'lib/bundler/source/path.rb'
 
 # Offense count: 10
 # Cop supports --auto-correct.
@@ -106,15 +88,6 @@ Layout/IndentArray:
 # SupportedStyles: auto_detection, squiggly, active_support, powerpack, unindent
 Layout/IndentHeredoc:
   Enabled: false
-
-# Offense count: 4
-# Cop supports --auto-correct.
-# Configuration parameters: Width, IgnoredPatterns.
-Layout/IndentationWidth:
-  Exclude:
-    - 'lib/bundler/dsl.rb'
-    - 'lib/bundler/resolver.rb'
-    - 'lib/bundler/source/path.rb'
 
 # Offense count: 3
 # Cop supports --auto-correct.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -595,17 +595,6 @@ Style/StderrPuts:
 Style/SymbolArray:
   EnforcedStyle: brackets
 
-# Offense count: 6
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyleForMultiline.
-# SupportedStylesForMultiline: comma, consistent_comma, no_comma
-Style/TrailingCommaInHashLiteral:
-  Exclude:
-    - 'lib/bundler/cli/gem.rb'
-    - 'lib/bundler/fetcher.rb'
-    - 'lib/bundler/graph.rb'
-    - 'spec/support/artifice/endpoint.rb'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 Style/UnneededCondition:

--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -11,7 +11,7 @@ module Bundler
   class CLI::Gem
     TEST_FRAMEWORK_VERSIONS = {
       "rspec" => "3.0",
-      "minitest" => "5.0"
+      "minitest" => "5.0",
     }.freeze
 
     attr_reader :options, :gem_name, :thor, :name, :target
@@ -57,7 +57,7 @@ module Bundler
         :ext              => options[:ext],
         :exe              => options[:exe],
         :bundler_version  => bundler_dependency_version,
-        :github_username  => github_username.empty? ? "[USERNAME]" : github_username
+        :github_username  => github_username.empty? ? "[USERNAME]" : github_username,
       }
       ensure_safe_gem_name(name, constant_array)
 
@@ -69,7 +69,7 @@ module Bundler
         "Rakefile.tt" => "Rakefile",
         "README.md.tt" => "README.md",
         "bin/console.tt" => "bin/console",
-        "bin/setup.tt" => "bin/setup"
+        "bin/setup.tt" => "bin/setup",
       }
 
       executables = %w[

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -441,10 +441,10 @@ repo_name ||= user_name
       message = String.new
       message << "You passed #{invalid_keys.map {|k| ":" + k }.join(", ")} "
       message << if invalid_keys.size > 1
-                   "as options for #{command}, but they are invalid."
-                 else
-                   "as an option for #{command}, but it is invalid."
-                 end
+        "as options for #{command}, but they are invalid."
+      else
+        "as an option for #{command}, but it is invalid."
+      end
 
       message << " Valid options are: #{valid_keys.join(", ")}."
       message << " You may be able to resolve this by upgrading Bundler to the newest version."

--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -226,7 +226,7 @@ module Bundler
         "GO_SERVER_URL" => "go",
         "SNAP_CI" => "snap",
         "CI_NAME" => ENV["CI_NAME"],
-        "CI" => "ci"
+        "CI" => "ci",
       }
       env_cis.find_all {|env, _| ENV[env] }.map {|_, ci| ci }
     end

--- a/lib/bundler/gem_helpers.rb
+++ b/lib/bundler/gem_helpers.rb
@@ -10,7 +10,7 @@ module Bundler
       [Gem::Platform.new("universal-mingw32"), Gem::Platform.new("universal-mingw32")],
       [Gem::Platform.new("x64-mingw32"), Gem::Platform.new("x64-mingw32")],
       [Gem::Platform.new("x86_64-mingw32"), Gem::Platform.new("x64-mingw32")],
-      [Gem::Platform.new("mingw32"), Gem::Platform.new("x86-mingw32")]
+      [Gem::Platform.new("mingw32"), Gem::Platform.new("x86-mingw32")],
     ].freeze
 
     def generic(p)

--- a/lib/bundler/graph.rb
+++ b/lib/bundler/graph.rb
@@ -117,7 +117,7 @@ module Bundler
               :style     => "filled",
               :fillcolor => "#B9B9D5",
               :shape     => "box3d",
-              :fontsize  => 16
+              :fontsize  => 16,
             }.merge(@node_options[group])
           )
         end

--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -279,10 +279,10 @@ module Bundler
           versions_with_platforms = specs.map {|s| [s.version, s.platform] }
           message = String.new("Could not find gem '#{SharedHelpers.pretty_dependency(requirement)}' in #{source}#{cache_message}.\n")
           message << if versions_with_platforms.any?
-                       "The source contains '#{name}' at: #{formatted_versions_with_platforms(versions_with_platforms)}"
-                     else
-                       "The source does not contain any versions of '#{name}'"
-                     end
+            "The source contains '#{name}' at: #{formatted_versions_with_platforms(versions_with_platforms)}"
+          else
+            "The source does not contain any versions of '#{name}'"
+          end
         else
           message = "Could not find gem '#{requirement}' in any of the gem sources " \
             "listed in your Gemfile#{cache_message}."
@@ -375,12 +375,12 @@ module Bundler
             o << " "
 
             o << if relevant_sources.empty?
-                   "in any of the sources.\n"
-                 elsif metadata_requirement
-                   "is not available in #{relevant_sources.join(" or ")}"
-                 else
-                   "in any of the relevant sources:\n  #{relevant_sources * "\n  "}\n"
-                 end
+              "in any of the sources.\n"
+            elsif metadata_requirement
+              "is not available in #{relevant_sources.join(" or ")}"
+            else
+              "in any of the relevant sources:\n  #{relevant_sources * "\n  "}\n"
+            end
           end
         end,
         :version_for_spec => lambda {|spec| spec.version },

--- a/lib/bundler/ruby_version.rb
+++ b/lib/bundler/ruby_version.rb
@@ -74,7 +74,7 @@ module Bundler
       @host ||= [
         RbConfig::CONFIG["host_cpu"],
         RbConfig::CONFIG["host_vendor"],
-        RbConfig::CONFIG["host_os"]
+        RbConfig::CONFIG["host_os"],
       ].join("-")
     end
 

--- a/lib/bundler/similarity_detector.rb
+++ b/lib/bundler/similarity_detector.rb
@@ -51,7 +51,7 @@ module Bundler
           dm[i][j] = [
             dm[i - 1][j - 1] + (this[j - 1] == that[i - 1] ? 0 : sub),
             dm[i][j - 1] + ins,
-            dm[i - 1][j] + del
+            dm[i - 1][j] + del,
           ].min
         end
       end

--- a/lib/bundler/source/path.rb
+++ b/lib/bundler/source/path.rb
@@ -191,10 +191,10 @@ module Bundler
         else
           message = String.new("The path `#{expanded_path}` ")
           message << if File.exist?(expanded_path)
-                       "is not a directory."
-                     else
-                       "does not exist."
-                     end
+            "is not a directory."
+          else
+            "does not exist."
+          end
           raise PathError, message
         end
 

--- a/spec/support/artifice/endpoint.rb
+++ b/spec/support/artifice/endpoint.rb
@@ -59,7 +59,7 @@ class Endpoint < Sinatra::Base
             :platform     => spec.platform.to_s,
             :dependencies => spec.dependencies.select {|dep| dep.type == :runtime }.map do |dep|
               [dep.name, dep.requirement.requirements.map {|a| a.join(" ") }.join(", ")]
-            end
+            end,
           }
         end.compact
       end


### PR DESCRIPTION
References https://github.com/bundler/bundler/pull/7009/files#r261892716.

### What was the end-user problem that led to this PR?

The problem was just some leftover consistency offenses.

### What was your diagnosis of the problem?

My diagnosis was that we can easily fix these globally.

### What is your fix for the problem, implemented in this PR?

My fix is to enable the three cops and run `rubocop --auto-correct`.

### Why did you choose this fix out of the possible options?

I chose this fix because these cops depend on each other, so enabling just one of them leaves weird indented code behind. 
