### PR TITLE
Expand comparison path for Windows compat

### DIFF
--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Bundler::SharedHelpers do
     before { ENV["BUNDLE_GEMFILE"] = "/path/Gemfile" }
 
     context "Gemfile is present" do
-      let(:expected_gemfile_path) { Pathname.new("/path/Gemfile") }
+      let(:expected_gemfile_path) { Pathname.new("/path/Gemfile").expand_path }
 
       it "returns the Gemfile path" do
         expect(subject.default_gemfile).to eq(expected_gemfile_path)


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

A specific test (#6890) was failing...

### What was your diagnosis of the problem?

... because the comparison was missing the drive letter on Windows. 

### What is your fix for the problem, implemented in this PR?

I added expansion of the path that was already present in the implementation but not the test.

### Why did you choose this fix out of the possible options?

Makes the test pass and looks right.

---

closes #6890 

fixes 1 failing test on Windows
