### PR TITLE
Fix offenses for more cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -50,6 +50,9 @@ Style/Alias:
 Style/FrozenStringLiteralComment:
   EnforcedStyle: always
 
+Style/GuardClause:
+  Enabled: false
+
 Style/MultilineBlockChain:
   Enabled: false
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -386,21 +386,6 @@ Style/GlobalVars:
     - 'lib/bundler/cli.rb'
     - 'spec/spec_helper.rb'
 
-# Offense count: 11
-# Configuration parameters: MinBodyLength.
-Style/GuardClause:
-  Exclude:
-    - 'lib/bundler/cli/cache.rb'
-    - 'lib/bundler/cli/install.rb'
-    - 'lib/bundler/cli/outdated.rb'
-    - 'lib/bundler/cli/package.rb'
-    - 'lib/bundler/definition.rb'
-    - 'lib/bundler/installer.rb'
-    - 'lib/bundler/runtime.rb'
-    - 'lib/bundler/source/path/installer.rb'
-    - 'lib/bundler/source_list.rb'
-    - 'spec/support/sometimes.rb'
-
 # Offense count: 108
 # Cop supports --auto-correct.
 Style/IfUnlessModifier:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -370,18 +370,6 @@ Style/EmptyMethod:
     - 'lib/bundler/ui/silent.rb'
     - 'spec/support/artifice/fail.rb'
 
-# Offense count: 7
-# Cop supports --auto-correct.
-Style/Encoding:
-  Exclude:
-    - 'Rakefile'
-    - 'bundler.gemspec'
-    - 'lib/bundler/friendly_errors.rb'
-    - 'spec/bundler/bundler_spec.rb'
-    - 'spec/install/gemfile_spec.rb'
-    - 'spec/install/gemspecs_spec.rb'
-    - 'spec/quality_es_spec.rb'
-
 # Offense count: 2
 Style/EvalWithLocation:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -579,15 +579,6 @@ Style/RescueStandardError:
 Style/SafeNavigation:
   Enabled: false
 
-# Offense count: 4
-# Cop supports --auto-correct.
-Style/StderrPuts:
-  Exclude:
-    - 'bin/rake'
-    - 'lib/bundler/graph.rb'
-    - 'spec/support/artifice/compact_index_api_missing.rb'
-    - 'spec/support/artifice/endpoint_api_missing.rb'
-
 # Offense count: 57
 # Cop supports --auto-correct.
 # Configuration parameters: MinSize.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -473,19 +473,6 @@ Style/MultilineIfModifier:
     - 'lib/bundler/runtime.rb'
     - 'lib/bundler/source/rubygems.rb'
 
-# Offense count: 10
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: literals, strict
-Style/MutableConstant:
-  Exclude:
-    - 'lib/bundler/cli/doctor.rb'
-    - 'lib/bundler/lockfile_parser.rb'
-    - 'lib/bundler/ruby_version.rb'
-    - 'lib/bundler/settings.rb'
-    - 'lib/bundler/yaml_serializer.rb'
-    - 'spec/support/matchers.rb'
-
 # Offense count: 3
 # Cop supports --auto-correct.
 # Configuration parameters: AutoCorrect, EnforcedStyle, IgnoredMethods.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -545,21 +545,6 @@ Style/RedundantReturn:
   Exclude:
     - 'lib/bundler/installer/gem_installer.rb'
 
-# Offense count: 13
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: implicit, explicit
-Style/RescueStandardError:
-  Exclude:
-    - 'Rakefile'
-    - 'lib/bundler/friendly_errors.rb'
-    - 'lib/bundler/resolver.rb'
-    - 'lib/bundler/retry.rb'
-    - 'lib/bundler/source/rubygems.rb'
-    - 'spec/support/artifice/compact_index.rb'
-    - 'spec/support/helpers.rb'
-    - 'spec/support/matchers.rb'
-
 # Offense count: 35
 # Cop supports --auto-correct.
 # Configuration parameters: ConvertCodeThatCanStartToReturnNil, Whitelist.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -162,15 +162,6 @@ Lint/NestedMethodDefinition:
     - 'lib/bundler/inline.rb'
     - 'spec/support/builders.rb'
 
-# Offense count: 5
-Lint/RescueException:
-  Exclude:
-    - 'lib/bundler/cli.rb'
-    - 'lib/bundler/dsl.rb'
-    - 'lib/bundler/friendly_errors.rb'
-    - 'lib/bundler/rubygems_integration.rb'
-    - 'lib/bundler/worker.rb'
-
 # Offense count: 2
 Lint/ShadowedException:
   Exclude:

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 # frozen_string_literal: true
 
 $:.unshift File.expand_path("../lib", __FILE__)

--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,7 @@ end
 def safe_task(&block)
   yield
   true
-rescue
+rescue StandardError
   false
 end
 

--- a/bin/rake
+++ b/bin/rake
@@ -11,7 +11,7 @@ unless ARGV[0] == "spec:deps"
     begin
       gem dep.name, dep.requirement
     rescue Gem::LoadError => e
-      $stderr.puts "#{e.message} (#{e.class})"
+      warn "#{e.message} (#{e.class})"
     end
   end
 

--- a/bundler.gemspec
+++ b/bundler.gemspec
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 begin

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -16,7 +16,7 @@ module Bundler
 
     def self.start(*)
       super
-    rescue Exception => e
+    rescue Exception => e # rubocop:disable Lint/RescueException
       Bundler.ui = UI::Shell.new
       raise e
     ensure

--- a/lib/bundler/cli/doctor.rb
+++ b/lib/bundler/cli/doctor.rb
@@ -4,8 +4,8 @@ require "rbconfig"
 
 module Bundler
   class CLI::Doctor
-    DARWIN_REGEX = /\s+(.+) \(compatibility /
-    LDD_REGEX = /\t\S+ => (\S+) \(\S+\)/
+    DARWIN_REGEX = /\s+(.+) \(compatibility /.freeze
+    LDD_REGEX = /\t\S+ => (\S+) \(\S+\)/.freeze
 
     attr_reader :options
 

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -45,7 +45,7 @@ module Bundler
       @gemfiles << expanded_gemfile_path
       contents ||= Bundler.read_file(@gemfile.to_s)
       instance_eval(contents.dup.untaint, gemfile.to_s, 1)
-    rescue Exception => e
+    rescue Exception => e # rubocop:disable Lint/RescueException
       message = "There was an error " \
         "#{e.is_a?(GemfileEvalError) ? "evaluating" : "parsing"} " \
         "`#{File.basename gemfile.to_s}`: #{e.message}"

--- a/lib/bundler/friendly_errors.rb
+++ b/lib/bundler/friendly_errors.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 require "cgi"

--- a/lib/bundler/friendly_errors.rb
+++ b/lib/bundler/friendly_errors.rb
@@ -123,7 +123,7 @@ module Bundler
     yield
   rescue SignalException
     raise
-  rescue Exception => e
+  rescue Exception => e # rubocop:disable Lint/RescueException
     FriendlyErrors.log_error(e)
     exit FriendlyErrors.exit_status(e)
   end

--- a/lib/bundler/friendly_errors.rb
+++ b/lib/bundler/friendly_errors.rb
@@ -44,7 +44,7 @@ module Bundler
           "Alternatively, you can increase the amount of memory the JVM is able to use by running Bundler with jruby -J-Xmx1024m -S bundle (JRuby defaults to 500MB)."
       else request_issue_report_for(error)
       end
-    rescue
+    rescue StandardError
       raise error
     end
 

--- a/lib/bundler/graph.rb
+++ b/lib/bundler/graph.rb
@@ -142,7 +142,7 @@ module Bundler
             g.output @output_format.to_sym => "#{@output_file}.#{@output_format}"
             Bundler.ui.info "#{@output_file}.#{@output_format}"
           rescue ArgumentError => e
-            $stderr.puts "Unsupported output format. See Ruby-Graphviz/lib/graphviz/constants.rb"
+            warn "Unsupported output format. See Ruby-Graphviz/lib/graphviz/constants.rb"
             raise e
           end
         end

--- a/lib/bundler/lockfile_parser.rb
+++ b/lib/bundler/lockfile_parser.rb
@@ -23,7 +23,7 @@ module Bundler
     PATH         = "PATH".freeze
     PLUGIN       = "PLUGIN SOURCE".freeze
     SPECS        = "  specs:".freeze
-    OPTIONS      = /^  ([a-z]+): (.*)$/i
+    OPTIONS      = /^  ([a-z]+): (.*)$/i.freeze
     SOURCE       = [GIT, GEM, PATH, PLUGIN].freeze
 
     SECTIONS_BY_VERSION_INTRODUCED = {
@@ -183,7 +183,7 @@ module Bundler
       (?:-(.*))?\))?                                     # Optional platform
       (!)?                                               # Optional pinned marker
       $                                                  # Line end
-    /xo
+    /xo.freeze
 
     def parse_dependency(line)
       return unless line =~ NAME_VERSION

--- a/lib/bundler/plugin/installer.rb
+++ b/lib/bundler/plugin/installer.rb
@@ -43,16 +43,11 @@ module Bundler
 
     private
 
-      # Rubocop misunderstands the semantics of this method, assuming an `else` code block
-      # that doesn't exist. See https://github.com/bbatsov/rubocop/issues/5702.
-      #
-      # rubocop:disable Style/GuardClause
       def check_sources_consistency!(options)
         if options.key?(:git) && options.key?(:local_git)
           raise InvalidOption, "Remote and local plugin git sources can't be both specified"
         end
       end
-      # rubocop:enable Style/GuardClause
 
       def install_git(names, version, options)
         uri = options.delete(:git)

--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -172,13 +172,13 @@ module Bundler
 
     def name_for_explicit_dependency_source
       Bundler.default_gemfile.basename.to_s
-    rescue
+    rescue StandardError
       "Gemfile"
     end
 
     def name_for_locking_dependency_source
       Bundler.default_lockfile.basename.to_s
-    rescue
+    rescue StandardError
       "Gemfile.lock"
     end
 

--- a/lib/bundler/retry.rb
+++ b/lib/bundler/retry.rb
@@ -38,7 +38,7 @@ module Bundler
       @failed = false
       @current_run += 1
       @result = block.call
-    rescue => e
+    rescue StandardError => e
       fail_attempt(e)
     end
 

--- a/lib/bundler/ruby_version.rb
+++ b/lib/bundler/ruby_version.rb
@@ -49,7 +49,7 @@ module Bundler
       ([\d.]+) # ruby version
       (?:p(-?\d+))? # optional patchlevel
       (?:\s\((\S+)\s(.+)\))? # optional engine info
-    /xo
+    /xo.freeze
 
     # Returns a RubyVersion from the given string.
     # @param [String] the version string to match.

--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -307,7 +307,7 @@ module Bundler
       gem_from_path(path, security_policies[policy]).spec
     rescue Gem::Package::FormatError
       raise GemspecError, "Could not read gem at #{path}. It may be corrupted."
-    rescue Exception, Gem::Exception, Gem::Security::Exception => e
+    rescue Exception, Gem::Exception, Gem::Security::Exception => e # rubocop:disable Lint/RescueException
       if e.is_a?(Gem::Security::Exception) ||
           e.message =~ /unknown trust policy|unsigned gem/i ||
           e.message =~ /couldn't verify (meta)?data signature/i

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -421,7 +421,7 @@ module Bundler
       )
       \2 # matching closing quote
       $
-    }xo
+    }xo.freeze
 
     def load_config(config_file)
       return {} if !config_file || ignore_config?
@@ -444,7 +444,7 @@ module Bundler
         (https?.*?) # URI
         (\.#{Regexp.union(PER_URI_OPTIONS)})? # optional suffix key
         \z
-      /ix
+      /ix.freeze
 
     # TODO: duplicates Rubygems#normalize_uri
     # TODO: is this the correct place to validate mirror URIs?

--- a/lib/bundler/source/rubygems.rb
+++ b/lib/bundler/source/rubygems.rb
@@ -124,7 +124,7 @@ module Bundler
           begin
             s = Bundler.rubygems.spec_from_gem(path, Bundler.settings["trust-policy"])
             spec.__swap__(s)
-          rescue
+          rescue StandardError
             Bundler.rm_rf(path)
             raise
           end

--- a/lib/bundler/worker.rb
+++ b/lib/bundler/worker.rb
@@ -62,7 +62,7 @@ module Bundler
 
     def apply_func(obj, i)
       @func.call(obj, i)
-    rescue Exception => e
+    rescue Exception => e # rubocop:disable Lint/RescueException
       WrappedException.new(e)
     end
 

--- a/lib/bundler/yaml_serializer.rb
+++ b/lib/bundler/yaml_serializer.rb
@@ -32,7 +32,7 @@ module Bundler
       (.*) # value
       \1 # matching closing quote
       $
-    /xo
+    /xo.freeze
 
     HASH_REGEX = /
       ^
@@ -45,7 +45,7 @@ module Bundler
       (.*) # value
       \3 # matching closing quote
       $
-    /xo
+    /xo.freeze
 
     def load(str)
       res = {}

--- a/spec/bundler/bundler_spec.rb
+++ b/spec/bundler/bundler_spec.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 require "bundler"

--- a/spec/install/gemfile_spec.rb
+++ b/spec/install/gemfile_spec.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 RSpec.describe "bundle install" do

--- a/spec/install/gemspecs_spec.rb
+++ b/spec/install/gemspecs_spec.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 RSpec.describe "bundle install" do

--- a/spec/quality_es_spec.rb
+++ b/spec/quality_es_spec.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 if defined?(Encoding) && Encoding.default_external.name != "UTF-8"

--- a/spec/support/artifice/compact_index.rb
+++ b/spec/support/artifice/compact_index.rb
@@ -21,7 +21,7 @@ class CompactIndexAPI < Endpoint
       headers "Surrogate-Control" => "max-age=2592000, stale-while-revalidate=60"
       content_type "text/plain"
       requested_range_for(response_body)
-    rescue => e
+    rescue StandardError => e
       puts e
       puts e.backtrace
       raise
@@ -83,7 +83,7 @@ class CompactIndexAPI < Endpoint
             end
             checksum = begin
                          Digest(:SHA256).file("#{GEM_REPO}/gems/#{spec.original_name}.gem").base64digest
-                       rescue
+                       rescue StandardError
                          nil
                        end
             CompactIndex::GemVersion.new(spec.version.version, spec.platform.to_s, checksum, nil,

--- a/spec/support/artifice/compact_index_api_missing.rb
+++ b/spec/support/artifice/compact_index_api_missing.rb
@@ -6,7 +6,7 @@ Artifice.deactivate
 
 class CompactIndexApiMissing < CompactIndexAPI
   get "/fetch/actual/gem/:id" do
-    $stderr.puts params[:id]
+    warn params[:id]
     if params[:id] == "rack-1.0.gemspec.rz"
       halt 404
     else

--- a/spec/support/artifice/endpoint_api_missing.rb
+++ b/spec/support/artifice/endpoint_api_missing.rb
@@ -6,7 +6,7 @@ Artifice.deactivate
 
 class EndpointApiMissing < Endpoint
   get "/fetch/actual/gem/:id" do
-    $stderr.puts params[:id]
+    warn params[:id]
     if params[:id] == "rack-1.0.gemspec.rz"
       halt 404
     else

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -569,7 +569,7 @@ module Spec
       tries = 0
       sleep 0.5
       TCPSocket.new(host, port)
-    rescue => e
+    rescue StandardError => e
       raise(e) if tries > (seconds * 2)
       tries += 1
       retry
@@ -579,7 +579,7 @@ module Spec
       port = 21_453
       begin
         port += 1 while TCPSocket.new("127.0.0.1", port)
-      rescue
+      rescue StandardError
         false
       end
       port

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -60,7 +60,7 @@ module Spec
       end
     end
 
-    MAJOR_DEPRECATION = /^\[DEPRECATED\]\s*/
+    MAJOR_DEPRECATION = /^\[DEPRECATED\]\s*/.freeze
 
     RSpec::Matchers.define :eq_err do |expected|
       diffable

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -152,7 +152,7 @@ module Spec
           version_const = name == "bundler" ? "Bundler::VERSION" : Spec::Builders.constantize(name)
           begin
             run! "require '#{name}.rb'; puts #{version_const}", *groups
-          rescue => e
+          rescue StandardError => e
             next "#{name} is not installed:\n#{indent(e)}"
           end
           last_command.stdout.gsub!(/#{MAJOR_DEPRECATION}.*$/, "")
@@ -167,7 +167,7 @@ module Spec
           begin
             source_const = "#{Spec::Builders.constantize(name)}_SOURCE"
             run! "require '#{name}/source'; puts #{source_const}", *groups
-          rescue
+          rescue StandardError
             next "#{name} does not have a source defined:\n#{indent(e)}"
           end
           last_command.stdout.gsub!(/#{MAJOR_DEPRECATION}.*$/, "")
@@ -193,7 +193,7 @@ module Spec
                 puts "WIN"
               end
             R
-          rescue => e
+          rescue StandardError => e
             next "checking for #{name} failed:\n#{e}"
           end
           next if last_command.stdout == "WIN"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that a few cops with exceptions in the TODO file have been bothering me recently when moving files around.

### What was your diagnosis of the problem?

My diagnosis was that we can just fix these offenses once and for all, or alternatively disable them inline, or moving them to the permanent config.

### What is your fix for the problem, implemented in this PR?

My fix is to:
* Auto-correct a few simple cops.
* Permanently disable `Style/GuardClause`, because I don't think it always leads to better code, and sometimes it forces artificial refactorings when making changes to methods, making the intention of the changes more obscure.
* Move `rescue Exception` disabling inline, so that when moving that code around, rubocop doesn't complain.

### Why did you choose this fix out of the possible options?

I chose this fix because this is my opinionated approach to this. :)
