### PR TITLE
Development environment cleanup

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -97,7 +97,6 @@ begin
 
   desc "Run specs"
   RSpec::Core::RakeTask.new
-  task :spec => "man:build"
 
   require "rubocop/rake_task"
   rubocop = RuboCop::RakeTask.new

--- a/Rakefile
+++ b/Rakefile
@@ -172,8 +172,7 @@ namespace :spec do
         end
 
         puts "Checked out rubygems '#{rg}' at #{hash}"
-        ENV["RUBYOPT"] = "-I#{File.join(RUBYGEMS_REPO, "lib")} #{rubyopt}"
-        puts "RUBYOPT=#{ENV["RUBYOPT"]}"
+        ENV["RGV"] = rg
       end
 
       task rg => ["clone_rubygems_#{rg}"]

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 $:.unshift File.expand_path("../lib", __FILE__)
-require "shellwords"
 require "benchmark"
 
 NULL_DEVICE = (Gem.win_platform? ? "NUL" : "/dev/null")

--- a/Rakefile
+++ b/Rakefile
@@ -240,7 +240,7 @@ namespace :man do
     require "ronn"
   rescue LoadError
     task(:require) { abort "We couln't activate ronn (#{ronn_requirement}). Try `gem install ronn:'#{ronn_requirement}'` to be able to release!" }
-    task(:build) { warn "We couln't activate ronn (#{ronn_requirement}). Try `gem install ronn:'#{ronn_requirement}'` to be able to build the help pages" }
+    task(:build) { abort "We couln't activate ronn (#{ronn_requirement}). Try `gem install ronn:'#{ronn_requirement}'` to be able to build the help pages" }
   else
     directory "man"
 

--- a/Rakefile
+++ b/Rakefile
@@ -227,10 +227,21 @@ task :rubocop do
   sh("bin/rubocop --parallel")
 end
 
-begin
-  require "ronn"
+namespace :man do
+  ronn_dep = bundler_spec.development_dependencies.find do |dep|
+    dep.name == "ronn"
+  end
 
-  namespace :man do
+  ronn_requirement = ronn_dep.requirement.to_s
+
+  begin
+    gem "ronn", ronn_requirement
+
+    require "ronn"
+  rescue LoadError
+    task(:require) { abort "We couln't activate ronn (#{ronn_requirement}). Try `gem install ronn:'#{ronn_requirement}'` to be able to release!" }
+    task(:build) { warn "We couln't activate ronn (#{ronn_requirement}). Try `gem install ronn:'#{ronn_requirement}'` to be able to build the help pages" }
+  else
     directory "man"
 
     index = []
@@ -283,11 +294,6 @@ begin
     end
 
     task(:require) {}
-  end
-rescue LoadError
-  namespace :man do
-    task(:require) { abort "Install the ronn gem to be able to release!" }
-    task(:build) { warn "Install the ronn gem to build the help pages" }
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -15,13 +15,6 @@ def bundler_spec
   @bundler_spec ||= Gem::Specification.load("bundler.gemspec")
 end
 
-def safe_task(&block)
-  yield
-  true
-rescue StandardError
-  false
-end
-
 # Benchmark task execution
 module Rake
   class Task
@@ -42,6 +35,13 @@ task :spec do
 end
 
 namespace :spec do
+  def safe_task(&block)
+    yield
+    true
+  rescue StandardError
+    false
+  end
+
   desc "Ensure spec dependencies are installed"
   task :deps do
     deps = Hash[bundler_spec.development_dependencies.map do |d|

--- a/Rakefile
+++ b/Rakefile
@@ -90,14 +90,12 @@ namespace :spec do
   end
 end
 
+desc "Run specs"
+task :spec do
+  sh("bin/rspec")
+end
+
 begin
-  rspec = bundler_spec.development_dependencies.find {|d| d.name == "rspec" }
-  gem "rspec", rspec.requirement.to_s
-  require "rspec/core/rake_task"
-
-  desc "Run specs"
-  RSpec::Core::RakeTask.new
-
   require "rubocop/rake_task"
   rubocop = RuboCop::RakeTask.new
   rubocop.options = ["--parallel"]
@@ -143,9 +141,8 @@ begin
       releases = %w[v2.5.2 v2.6.14 v2.7.9 v3.0.3]
       (branches + releases).each do |rg|
         desc "Run specs with RubyGems #{rg}"
-        RSpec::Core::RakeTask.new(rg) do |t|
-          t.rspec_opts = %w[--format progress --color]
-          t.ruby_opts  = %w[-w]
+        task rg do
+          sh("bin/rspec")
         end
 
         # Create tasks like spec:rubygems:v1.8.3:sudo to run the sudo specs
@@ -184,9 +181,8 @@ begin
       end
 
       desc "Run specs under a RubyGems checkout (set RG=path)"
-      RSpec::Core::RakeTask.new("co") do |t|
-        t.rspec_opts = %w[--format documentation --color]
-        t.ruby_opts  = %w[-w]
+      task "co" do
+        sh("bin/rspec")
       end
 
       task "setup_co" do
@@ -235,10 +231,6 @@ begin
     end
   end
 rescue LoadError
-  task :spec do
-    abort "Run `rake spec:deps` to be able to run the specs"
-  end
-
   task :rubocop do
     abort "Run `rake spec:deps` to be able to run rubocop"
   end

--- a/Rakefile
+++ b/Rakefile
@@ -95,11 +95,12 @@ task :spec do
   sh("bin/rspec")
 end
 
-begin
-  require "rubocop/rake_task"
-  rubocop = RuboCop::RakeTask.new
-  rubocop.options = ["--parallel"]
+desc "Run RuboCop"
+task :rubocop do
+  sh("bin/rubocop --parallel")
+end
 
+begin
   namespace :spec do
     task :clean do
       rm_rf "tmp"
@@ -231,9 +232,7 @@ begin
     end
   end
 rescue LoadError
-  task :rubocop do
-    abort "Run `rake spec:deps` to be able to run rubocop"
-  end
+  nil
 end
 
 begin

--- a/Rakefile
+++ b/Rakefile
@@ -358,6 +358,6 @@ end
 
 task :default => :spec
 
-Dir["task/*.{rb,rake}"].each(&method(:load))
+Dir["task/*.rake"].each(&method(:load))
 
 task :generate_files => Rake::Task.tasks.select {|t| t.name.start_with?("lib/bundler/generated") }

--- a/Rakefile
+++ b/Rakefile
@@ -176,7 +176,7 @@ begin
           puts "RUBYOPT=#{ENV["RUBYOPT"]}"
         end
 
-        task rg => ["man:build", "clone_rubygems_#{rg}"]
+        task rg => ["clone_rubygems_#{rg}"]
         task "rubygems:all" => rg
       end
 

--- a/Rakefile
+++ b/Rakefile
@@ -36,6 +36,11 @@ module Rake
   end
 end
 
+desc "Run specs"
+task :spec do
+  sh("bin/rspec")
+end
+
 namespace :spec do
   desc "Ensure spec dependencies are installed"
   task :deps do
@@ -88,19 +93,7 @@ namespace :spec do
       Rake::Task["spec:deps"].invoke
     end
   end
-end
 
-desc "Run specs"
-task :spec do
-  sh("bin/rspec")
-end
-
-desc "Run RuboCop"
-task :rubocop do
-  sh("bin/rubocop --parallel")
-end
-
-namespace :spec do
   task :clean do
     rm_rf "tmp"
   end
@@ -228,6 +221,11 @@ namespace :spec do
       raise "Spec run failed, please review the log for more information"
     end
   end
+end
+
+desc "Run RuboCop"
+task :rubocop do
+  sh("bin/rubocop --parallel")
 end
 
 begin

--- a/bin/rake
+++ b/bin/rake
@@ -5,17 +5,18 @@ load File.expand_path("../with_rubygems", __FILE__) if ENV["RGV"]
 
 require "rubygems"
 
-unless ARGV[0] == "spec:deps"
-  bundler_spec = Gem::Specification.load(File.expand_path("../../bundler.gemspec", __FILE__))
-  bundler_spec.dependencies.each do |dep|
-    begin
-      gem dep.name, dep.requirement
-    rescue Gem::LoadError => e
-      warn "#{e.message} (#{e.class})"
-    end
-  end
-
-  Gem.finish_resolve if Gem.respond_to?(:finish_resolve)
+bundler_spec = Gem::Specification.load(File.expand_path("../../bundler.gemspec", __FILE__))
+rake = bundler_spec.development_dependencies.find do |dep|
+  dep.name == "rake"
 end
 
-load Gem.bin_path("rake", "rake")
+rake_requirement = rake.requirement.to_s
+
+begin
+  gem "rake", rake_requirement
+  Gem.finish_resolve if Gem.respond_to?(:finish_resolve)
+
+  load Gem.bin_path("rake", "rake")
+rescue Gem::LoadError
+  warn "We couln't activate rake (#{rake_requirement}). Run `gem install rake:'#{rake_requirement}'`"
+end

--- a/bin/rake
+++ b/bin/rake
@@ -14,8 +14,6 @@ rake_requirement = rake.requirement.to_s
 
 begin
   gem "rake", rake_requirement
-  Gem.finish_resolve if Gem.respond_to?(:finish_resolve)
-
   load Gem.bin_path("rake", "rake")
 rescue Gem::LoadError
   warn "We couln't activate rake (#{rake_requirement}). Run `gem install rake:'#{rake_requirement}'`"

--- a/bin/rspec
+++ b/bin/rspec
@@ -6,10 +6,17 @@ load File.expand_path("../with_rubygems", __FILE__) if ENV["RGV"]
 require "rubygems"
 
 bundler_spec = Gem::Specification.load(File.expand_path("../../bundler.gemspec", __FILE__))
-bundler_spec.dependencies.each do |dep|
-  gem dep.name, dep.requirement
+rspec = bundler_spec.development_dependencies.find do |dep|
+  dep.name == "rspec"
 end
 
-Gem.finish_resolve if Gem.respond_to?(:finish_resolve)
+rspec_requirement = rspec.requirement.to_s
 
-load Gem.bin_path("rspec-core", "rspec")
+begin
+  gem "rspec", rspec_requirement
+  Gem.finish_resolve if Gem.respond_to?(:finish_resolve)
+
+  load Gem.bin_path("rspec-core", "rspec")
+rescue Gem::LoadError
+  warn "We couln't activate rspec (#{rspec_requirement}). Try `gem install rspec:'#{rspec_requirement}'`"
+end

--- a/bin/rspec
+++ b/bin/rspec
@@ -14,8 +14,6 @@ rspec_requirement = rspec.requirement.to_s
 
 begin
   gem "rspec", rspec_requirement
-  Gem.finish_resolve if Gem.respond_to?(:finish_resolve)
-
   load Gem.bin_path("rspec-core", "rspec")
 rescue Gem::LoadError
   warn "We couln't activate rspec (#{rspec_requirement}). Try `gem install rspec:'#{rspec_requirement}'`"

--- a/bin/rubocop
+++ b/bin/rubocop
@@ -14,8 +14,6 @@ rubocop_requirement = rubocop.requirement.to_s
 
 begin
   gem "rubocop", rubocop_requirement
-  Gem.finish_resolve if Gem.respond_to?(:finish_resolve)
-
   load Gem.bin_path("rubocop", "rubocop")
 rescue Gem::LoadError
   warn "We couln't activate rubocop (#{rubocop_requirement}). Try `gem install rubocop:'#{rubocop_requirement}'`"

--- a/bin/rubocop
+++ b/bin/rubocop
@@ -6,12 +6,17 @@ load File.expand_path("../with_rubygems", __FILE__) if ENV["RGV"]
 require "rubygems"
 
 bundler_spec = Gem::Specification.load(File.expand_path("../../bundler.gemspec", __FILE__))
-bundler_spec.dependencies.each do |dep|
-  gem dep.name, dep.requirement
+rubocop = bundler_spec.dependencies.find do |dep|
+  dep.name == "rubocop"
 end
 
-gem "rubocop", "= 0.65.0"
+rubocop_requirement = rubocop.requirement.to_s
 
-Gem.finish_resolve if Gem.respond_to?(:finish_resolve)
+begin
+  gem "rubocop", rubocop_requirement
+  Gem.finish_resolve if Gem.respond_to?(:finish_resolve)
 
-load Gem.bin_path("rubocop", "rubocop")
+  load Gem.bin_path("rubocop", "rubocop")
+rescue Gem::LoadError
+  warn "We couln't activate rubocop (#{rubocop_requirement}). Try `gem install rubocop:'#{rubocop_requirement}'`"
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,19 +3,6 @@
 $:.unshift File.expand_path("..", __FILE__)
 $:.unshift File.expand_path("../../lib", __FILE__)
 
-require "rubygems"
-
-begin
-  require File.expand_path("../support/path.rb", __FILE__)
-  spec = Gem::Specification.load(Spec::Path.gemspec.to_s)
-  rspec = spec.dependencies.find {|d| d.name == "rspec" }
-  gem "rspec", rspec.requirement.to_s
-  require "rspec"
-  require "diff/lcs"
-rescue LoadError
-  abort "Run rake spec:deps to install development dependencies"
-end
-
 require "bundler/psyched_yaml"
 require "bundler/vendored_fileutils"
 require "uri"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was making changes in the development setup was brittle and led to hard to debug errors. For example, the ones in #6980. Also, it was hard to reproduce exactly what's going on in the current CI environment. Which is useful to setup other CI, or run the specs under a docker image.

### What was your diagnosis of the problem?

My diagnosis was that we can simplify a lot of this stuff.

### What is your fix for the problem, implemented in this PR?

My fix is... a lot of simplifications, but the most important ones being:

* Now each binstub activates only its own dependency, not every development dependency. That means a contributor can perfectly work on manual pages installing only `rake` and `ronn` without having to install all development dependencies. Same with styling (`rubocop`), or with specs (`rspec`).
* Error messages are better now.
* The rake tasks for each main `Rakefile` section (man / spec / vendor) have been extracted to their own files.
* Rake tasks now shell out to the proper binstub, so gem activation is only needed there.

### Why did you choose this fix out of the possible options?

I chose this fix because it simplifies a lot the development environment in my opinion. Also, specs now pass under a docker image!
