### PR TITLE
Shellsplit build config

### DIFF
--- a/lib/bundler/installer/gem_installer.rb
+++ b/lib/bundler/installer/gem_installer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "shellwords"
+
 module Bundler
   class GemInstaller
     attr_reader :spec, :standalone, :worker, :force, :installer
@@ -56,7 +58,9 @@ module Bundler
 
     def spec_settings
       # Fetch the build settings, if there are any
-      Bundler.settings["build.#{spec.name}"]
+      if settings = Bundler.settings["build.#{spec.name}"]
+        Shellwords.shellsplit(settings)
+      end
     end
 
     def install

--- a/spec/bundler/installer/gem_installer_spec.rb
+++ b/spec/bundler/installer/gem_installer_spec.rb
@@ -26,4 +26,15 @@ RSpec.describe Bundler::GemInstaller do
       subject.install_from_spec
     end
   end
+
+  context "spec_settings is build option with spaces" do
+    it "invokes install method with build_args" do
+      allow(Bundler.settings).to receive(:[]).with(:bin)
+      allow(Bundler.settings).to receive(:[]).with(:inline)
+      allow(Bundler.settings).to receive(:[]).with(:forget_cli_options)
+      allow(Bundler.settings).to receive(:[]).with("build.dummy").and_return("--with-dummy-config=dummy --with-another-dummy-config")
+      expect(spec_source).to receive(:install).with(spec, :force => false, :ensure_builtin_gems_cached => false, :build_args => ["--with-dummy-config=dummy", "--with-another-dummy-config"])
+      subject.install_from_spec
+    end
+  end
 end

--- a/spec/install/gems/native_extensions_spec.rb
+++ b/spec/install/gems/native_extensions_spec.rb
@@ -87,4 +87,45 @@ RSpec.describe "installing a gem with native extensions", :ruby_repo do
     run! "Bundler.require; puts CExtension.new.its_true"
     expect(out).to eq("true")
   end
+
+  it "install with multiple build flags" do
+    build_git "c_extension" do |s|
+      s.extensions = ["ext/extconf.rb"]
+      s.write "ext/extconf.rb", <<-E
+        require "mkmf"
+        name = "c_extension_bundle"
+        dir_config(name)
+        raise "OMG" unless with_config("c_extension") == "hello" && with_config("c_extension_bundle-dir") == "hola"
+        create_makefile(name)
+      E
+
+      s.write "ext/c_extension.c", <<-C
+        #include "ruby.h"
+
+        VALUE c_extension_true(VALUE self) {
+          return Qtrue;
+        }
+
+        void Init_c_extension_bundle() {
+          VALUE c_Extension = rb_define_class("CExtension", rb_cObject);
+          rb_define_method(c_Extension, "its_true", c_extension_true, 0);
+        }
+      C
+
+      s.write "lib/c_extension.rb", <<-C
+        require "c_extension_bundle"
+      C
+    end
+
+    bundle! "config build.c_extension --with-c_extension=hello --with-c_extension_bundle-dir=hola"
+
+    install_gemfile! <<-G
+      gem "c_extension", :git => #{lib_path("c_extension-1.0").to_s.dump}
+    G
+
+    expect(out).not_to include("extconf.rb failed")
+
+    run! "Bundler.require; puts CExtension.new.its_true"
+    expect(out).to eq("true")
+  end
 end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was #6940. Build configurations with multiple whitepaced parameter are no longer properly handled.

### What was your diagnosis of the problem?

My diagnosis was not mine, was @jeremy's: Since [shellscaping / shelljoining build arguments to the rubygems gem installer](https://github.com/bundler/bundler/issues/6940), these are no longer properly passed

### What is your fix for the problem, implemented in this PR?

My fix is not mine, it's @jeremy's: shellsplit settings before passing them.

### Why did you choose this fix out of the possible options?

I chose this fix because it works and it sounds like the proper followup to https://github.com/rubygems/rubygems/pull/2441.

Fixes #6940.