### PR TITLE
Add missing `bundle info` feature, bug fix, and specs

### DIFF
--- a/lib/bundler/cli/common.rb
+++ b/lib/bundler/cli/common.rb
@@ -49,10 +49,6 @@ module Bundler
     end
 
     def self.ask_for_spec_from(specs)
-      if !$stdout.tty? && ENV["BUNDLE_SPEC_RUN"].nil?
-        raise GemNotFound, gem_not_found_message(name, Bundler.definition.dependencies)
-      end
-
       specs.each_with_index do |spec, index|
         Bundler.ui.info "#{index.succ} : #{spec.name}", true
       end

--- a/lib/bundler/cli/info.rb
+++ b/lib/bundler/cli/info.rb
@@ -9,6 +9,11 @@ module Bundler
     end
 
     def run
+      Bundler.ui.silence do
+        Bundler.definition.validate_runtime!
+        Bundler.load.lock
+      end
+
       spec = spec_for_gem(gem_name)
 
       spec_not_found(gem_name) unless spec

--- a/lib/bundler/cli/info.rb
+++ b/lib/bundler/cli/info.rb
@@ -25,7 +25,7 @@ module Bundler
 
     def spec_for_gem(gem_name)
       spec = Bundler.definition.specs.find {|s| s.name == gem_name }
-      spec || default_gem_spec(gem_name)
+      spec || default_gem_spec(gem_name) || Bundler::CLI::Common.select_spec(gem_name, :regex_match)
     end
 
     def default_gem_spec(gem_name)

--- a/lib/bundler/cli/info.rb
+++ b/lib/bundler/cli/info.rb
@@ -16,9 +16,10 @@ module Bundler
 
       spec = spec_for_gem(gem_name)
 
-      spec_not_found(gem_name) unless spec
-      return print_gem_path(spec) if @options[:path]
-      print_gem_info(spec)
+      if spec
+        return print_gem_path(spec) if @options[:path]
+        print_gem_info(spec)
+      end
     end
 
   private

--- a/lib/bundler/cli/info.rb
+++ b/lib/bundler/cli/info.rb
@@ -39,7 +39,13 @@ module Bundler
     end
 
     def print_gem_path(spec)
-      Bundler.ui.info spec.full_gem_path
+      path = if spec.name == "bundler"
+        File.expand_path("../../../..", __FILE__)
+      else
+        spec.full_gem_path
+      end
+
+      Bundler.ui.info path
     end
 
     def print_gem_info(spec)

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -10,8 +10,6 @@ RSpec.describe "bundle info" do
     end
 
     it "creates a Gemfile.lock when invoked with a gem name" do
-      skip "'bundle info rails' does not create a lock file automatically like 'bundle show rails' does"
-
       FileUtils.rm("Gemfile.lock")
 
       bundle "info rails"

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -116,6 +116,19 @@ RSpec.describe "bundle info" do
     end
   end
 
+  context "with a valid regexp for gem name" do
+    it "presents alternatives" do
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem "rack"
+        gem "rack-obama"
+      G
+
+      bundle "info rac"
+      expect(out).to eq "1 : rack\n2 : rack-obama\n0 : - exit -\n>"
+    end
+  end
+
   context "with an invalid regexp for gem name" do
     it "does not find the gem" do
       install_gemfile <<-G

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe "bundle info" do
     end
 
     it "prints the path to the running bundler" do
-      skip "'bundle info bundler --path' currently prints a different (incorrect) path from the old alternative 'bundle show rails'"
       bundle "info bundler --path"
       expect(out).to eq(root.to_s)
     end

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -1,12 +1,22 @@
 # frozen_string_literal: true
 
 RSpec.describe "bundle info" do
-  context "info from specific gem in gemfile" do
+  context "with a standard Gemfile" do
     before do
       install_gemfile <<-G
         source "file://#{gem_repo1}"
         gem "rails"
       G
+    end
+
+    it "creates a Gemfile.lock when invoked with a gem name" do
+      skip "'bundle info rails' does not create a lock file automatically like 'bundle show rails' does"
+
+      FileUtils.rm("Gemfile.lock")
+
+      bundle "info rails"
+
+      expect(bundled_app("Gemfile.lock")).to exist
     end
 
     it "prints information if gem exists in bundle" do
@@ -15,6 +25,17 @@ RSpec.describe "bundle info" do
 \tSummary: This is just a fake gem for testing
 \tHomepage: http://example.com
 \tPath: #{default_bundle_path("gems", "rails-2.3.2")}"
+    end
+
+    it "prints path if gem exists in bundle" do
+      bundle "info rails --path"
+      expect(out).to eq(default_bundle_path("gems", "rails-2.3.2").to_s)
+    end
+
+    it "prints the path to the running bundler" do
+      skip "'bundle info bundler --path' currently prints a different (incorrect) path from the old alternative 'bundle show rails'"
+      bundle "info bundler --path"
+      expect(out).to eq(root.to_s)
     end
 
     it "complains if gem not in bundle" do
@@ -43,6 +64,72 @@ RSpec.describe "bundle info" do
       it "excludes the homepage field from the output" do
         expect(out).to_not include("Homepage:")
       end
+    end
+  end
+
+  context "with a git repo in the Gemfile" do
+    before :each do
+      @git = build_git "foo", "1.0"
+    end
+
+    it "prints out git info" do
+      install_gemfile <<-G
+        gem "foo", :git => "#{lib_path("foo-1.0")}"
+      G
+      expect(the_bundle).to include_gems "foo 1.0"
+
+      bundle "info foo"
+      expect(out).to include("foo (1.0 #{@git.ref_for("master", 6)}")
+    end
+
+    it "prints out branch names other than master" do
+      update_git "foo", :branch => "omg" do |s|
+        s.write "lib/foo.rb", "FOO = '1.0.omg'"
+      end
+      @revision = revision_for(lib_path("foo-1.0"))[0...6]
+
+      install_gemfile <<-G
+        gem "foo", :git => "#{lib_path("foo-1.0")}", :branch => "omg"
+      G
+      expect(the_bundle).to include_gems "foo 1.0.omg"
+
+      bundle "info foo"
+      expect(out).to include("foo (1.0 #{@git.ref_for("omg", 6)}")
+    end
+
+    it "doesn't print the branch when tied to a ref" do
+      sha = revision_for(lib_path("foo-1.0"))
+      install_gemfile <<-G
+        gem "foo", :git => "#{lib_path("foo-1.0")}", :ref => "#{sha}"
+      G
+
+      bundle "info foo"
+      expect(out).to include("foo (1.0 #{sha[0..6]})")
+    end
+
+    it "handles when a version is a '-' prerelease", :rubygems => "2.1" do
+      @git = build_git("foo", "1.0.0-beta.1", :path => lib_path("foo"))
+      install_gemfile <<-G
+        gem "foo", "1.0.0-beta.1", :git => "#{lib_path("foo")}"
+      G
+      expect(the_bundle).to include_gems "foo 1.0.0.pre.beta.1"
+
+      bundle! "info foo"
+      expect(out).to include("foo (1.0.0.pre.beta.1")
+    end
+  end
+
+  context "with an invalid regexp for gem name" do
+    it "does not find the gem" do
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem "rails"
+      G
+
+      invalid_regexp = "[]"
+
+      bundle "show #{invalid_regexp}"
+      expect(err).to include("Could not find gem '#{invalid_regexp}'.")
     end
   end
 end

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "bundle info" do
       G
     end
 
-    it "prints information about the current gem" do
+    it "prints information if gem exists in bundle" do
       bundle "info rails"
       expect(out).to include "* rails (2.3.2)
 \tSummary: This is just a fake gem for testing
@@ -17,11 +17,9 @@ RSpec.describe "bundle info" do
 \tPath: #{default_bundle_path("gems", "rails-2.3.2")}"
     end
 
-    context "given a gem that is not installed" do
-      it "prints missing gem error" do
-        bundle "info foo"
-        expect(err).to eq "Could not find gem 'foo'."
-      end
+    it "complains if gem not in bundle" do
+      bundle "info missing"
+      expect(err).to eq("Could not find gem 'missing'.")
     end
 
     context "given a default gem shippped in ruby", :ruby_repo do

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -46,12 +46,5 @@ RSpec.describe "bundle info" do
         expect(out).to_not include("Homepage:")
       end
     end
-
-    context "given --path option" do
-      it "prints the path to the gem" do
-        bundle "info rails"
-        expect(out).to eq(default_bundle_path("gems", "rails-2.3.2").to_s)
-      end
-    end
   end
 end

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe "bundle info" do
       bundle "info rails"
       expect(out).to include "* rails (2.3.2)
 \tSummary: This is just a fake gem for testing
-\tHomepage: http://example.com"
-      expect(out).to match(%r{Path\: .*\/rails\-2\.3\.2})
+\tHomepage: http://example.com
+\tPath: #{default_bundle_path("gems", "rails-2.3.2")}"
     end
 
     context "given a gem that is not installed" do
@@ -50,7 +50,7 @@ RSpec.describe "bundle info" do
     context "given --path option" do
       it "prints the path to the gem" do
         bundle "info rails"
-        expect(out).to match(%r{.*\/rails\-2\.3\.2})
+        expect(out).to eq(default_bundle_path("gems", "rails-2.3.2").to_s)
       end
     end
   end

--- a/spec/commands/show_spec.rb
+++ b/spec/commands/show_spec.rb
@@ -172,6 +172,19 @@ RSpec.describe "bundle show" do
     expect(out).to include("Installing foo 1.0")
   end
 
+  context "with a valid regexp for gem name" do
+    it "presents alternatives" do
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+        gem "rack"
+        gem "rack-obama"
+      G
+
+      bundle "show rac"
+      expect(out).to eq "1 : rack\n2 : rack-obama\n0 : - exit -\n>"
+    end
+  end
+
   context "with an invalid regexp for gem name" do
     it "does not find the gem" do
       install_gemfile <<-G


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that `bundler info GEM` did not have feature parity with `bundle show GEM`, and it should because it's the recommended alternative. Also, `bundle info bundler` was showing an incorrect path while `bundle show bundler` was correct.

### What was your diagnosis of the problem?

My diagnosis was that some code should be pulled from `bundle show`.

### What is your fix for the problem, implemented in this PR?

My fix is to port the missing feature, bug fix, and specs to `bundle info` from `bundle show`.

### Why did you choose this fix out of the possible options?

I chose this fix because it guarantees that the recommended alternative will work similarly to the current show command.