### PR TITLE
Spec simplifications

### DIFF
--- a/spec/bundler/gem_helper_spec.rb
+++ b/spec/bundler/gem_helper_spec.rb
@@ -210,10 +210,10 @@ RSpec.describe Bundler::GemHelper do
 
       context "succeeds" do
         before do
-          Dir.chdir(gem_repo1) { `git init --bare` }
+          Dir.chdir(gem_repo1) { sys_exec("git init --bare") }
           Dir.chdir(app_path) do
-            `git remote add origin file://#{gem_repo1}`
-            `git commit -a -m "initial commit"`
+            sys_exec("git remote add origin file://#{gem_repo1}")
+            sys_exec('git commit -a -m "initial commit"')
           end
         end
 

--- a/spec/bundler/gem_helper_spec.rb
+++ b/spec/bundler/gem_helper_spec.rb
@@ -209,10 +209,11 @@ RSpec.describe Bundler::GemHelper do
       end
 
       context "succeeds" do
+        let(:repo) { build_git("foo", :bare => true) }
+
         before do
-          Dir.chdir(gem_repo1) { sys_exec("git init --bare") }
           Dir.chdir(app_path) do
-            sys_exec("git remote add origin file://#{gem_repo1}")
+            sys_exec("git remote add origin file://#{repo.path}")
             sys_exec('git commit -a -m "initial commit"')
           end
         end

--- a/spec/bundler/mirror_spec.rb
+++ b/spec/bundler/mirror_spec.rb
@@ -298,8 +298,8 @@ RSpec.describe Bundler::Settings::TCPSocketProbe do
 
   context "with a listening TCP Server" do
     def with_server_and_mirror
-      server = TCPServer.new("127.0.0.1", 0)
-      mirror = Bundler::Settings::Mirror.new("http://localhost:#{server.addr[1]}", 1)
+      server = TCPServer.new("0.0.0.0", 0)
+      mirror = Bundler::Settings::Mirror.new("http://0.0.0.0:#{server.addr[1]}", 1)
       yield server, mirror
       server.close unless server.closed?
     end

--- a/spec/bundler/vendored_persistent_spec.rb
+++ b/spec/bundler/vendored_persistent_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
 require "bundler/vendored_persistent"
 
 RSpec.describe Bundler::PersistentHTTP do

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "bundle info" do
 
     context "when gem does not have homepage" do
       before do
-        build_repo1 do
+        build_repo2 do
           build_gem "rails", "2.3.2" do |s|
             s.executables = "rails"
             s.summary = "Just another test gem"

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -374,13 +374,13 @@ RSpec.describe "bundle install with gem sources" do
     it "gracefully handles error when rubygems server is unavailable" do
       install_gemfile <<-G, :artifice => nil
         source "file://#{gem_repo1}"
-        source "http://localhost:9384" do
+        source "http://0.0.0.0:9384" do
           gem 'foo'
         end
       G
 
       bundle :install, :artifice => nil
-      expect(err).to include("Could not fetch specs from http://localhost:9384/")
+      expect(err).to include("Could not fetch specs from http://0.0.0.0:9384/")
       expect(err).not_to include("file://")
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,7 +36,6 @@ $debug = false
 
 Spec::Manpages.setup unless Gem.win_platform?
 Spec::Rubygems.setup
-FileUtils.rm_rf(Spec::Path.gem_repo1)
 ENV["RUBYOPT"] = "#{ENV["RUBYOPT"]} -r#{Spec::Path.spec_dir}/support/hax.rb"
 ENV["BUNDLE_SPEC_RUN"] = "true"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,13 +4,6 @@ $:.unshift File.expand_path("..", __FILE__)
 $:.unshift File.expand_path("../../lib", __FILE__)
 
 require "rubygems"
-module Gem
-  if defined?(@path_to_default_spec_map)
-    @path_to_default_spec_map.delete_if do |_path, spec|
-      spec.name == "bundler"
-    end
-  end
-end
 
 begin
   require File.expand_path("../support/path.rb", __FILE__)

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -429,7 +429,7 @@ module Spec
       ENV["GEM_PATH"] = system_gem_path.to_s
 
       gems.each do |gem|
-        gem_command :install, "--no-rdoc --no-ri #{gem}"
+        gem_command :install, "--no-document #{gem}"
       end
       return unless block_given?
       begin

--- a/spec/support/rubygems_ext.rb
+++ b/spec/support/rubygems_ext.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "rubygems/user_interaction"
-require "support/path" unless defined?(Spec::Path)
+require "support/path"
 
 module Spec
   module Rubygems


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that the current specs don't pass under docker.

### What was your diagnosis of the problem?

My diagnosis was that we should use 0.0.0.0 instead of 127.0.0.1 for mirror specs, since docker likes it better and the change doesn't affect the intention of the specs.

### What is your fix for the problem, implemented in this PR?

My fix is to do that change, but also add a few extra simplifications that I created while setting up the specs to run inside a docker image.

### Why did you choose this fix out of the possible options?

I chose this fix because it works and makes the test setup simpler.