### PR TITLE
Make deprecation specs less messy

### DIFF
--- a/spec/commands/show_spec.rb
+++ b/spec/commands/show_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe "bundle show" do
 
     it "does not output git errors" do
       bundle :show
-      expect(last_command.stderr).to eq_err("")
+      expect(err_without_deprecations).to be_empty
     end
   end
 

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -1067,7 +1067,7 @@ RSpec.describe "bundle install with git sources" do
 
       bundle :install,
         :requires => [lib_path("install_hooks.rb")]
-      expect(last_command.stderr).to eq_err("Ran pre-install hook: foo-1.0")
+      expect(err_without_deprecations).to eq("Ran pre-install hook: foo-1.0")
     end
 
     it "runs post-install hooks" do
@@ -1087,7 +1087,7 @@ RSpec.describe "bundle install with git sources" do
 
       bundle :install,
         :requires => [lib_path("install_hooks.rb")]
-      expect(last_command.stderr).to eq_err("Ran post-install hook: foo-1.0")
+      expect(err_without_deprecations).to eq("Ran post-install hook: foo-1.0")
     end
 
     it "complains if the install hook fails" do

--- a/spec/install/gemfile/groups_spec.rb
+++ b/spec/install/gemfile/groups_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "bundle install with groups" do
         puts ACTIVESUPPORT
       R
 
-      expect(last_command.stderr).to eq_err("ZOMG LOAD ERROR")
+      expect(err_without_deprecations).to eq("ZOMG LOAD ERROR")
     end
 
     it "installs gems with inline :groups into those groups" do
@@ -36,7 +36,7 @@ RSpec.describe "bundle install with groups" do
         puts THIN
       R
 
-      expect(last_command.stderr).to eq_err("ZOMG LOAD ERROR")
+      expect(err_without_deprecations).to eq("ZOMG LOAD ERROR")
     end
 
     it "sets up everything if Bundler.setup is used with no groups" do
@@ -57,7 +57,7 @@ RSpec.describe "bundle install with groups" do
         puts THIN
       RUBY
 
-      expect(last_command.stderr).to eq_err("ZOMG LOAD ERROR")
+      expect(err_without_deprecations).to eq("ZOMG LOAD ERROR")
     end
 
     it "sets up old groups when they have previously been removed" do

--- a/spec/install/gemfile/path_spec.rb
+++ b/spec/install/gemfile/path_spec.rb
@@ -575,7 +575,7 @@ RSpec.describe "bundle install with explicit source paths" do
 
       bundle :install,
         :requires => [lib_path("install_hooks.rb")]
-      expect(last_command.stderr).to eq_err("Ran pre-install hook: foo-1.0")
+      expect(err_without_deprecations).to eq("Ran pre-install hook: foo-1.0")
     end
 
     it "runs post-install hooks" do
@@ -595,7 +595,7 @@ RSpec.describe "bundle install with explicit source paths" do
 
       bundle :install,
         :requires => [lib_path("install_hooks.rb")]
-      expect(last_command.stderr).to eq_err("Ran post-install hook: foo-1.0")
+      expect(err_without_deprecations).to eq("Ran post-install hook: foo-1.0")
     end
 
     it "complains if the install hook fails" do

--- a/spec/install/gemfile/sources_spec.rb
+++ b/spec/install/gemfile/sources_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
       xit "shows a deprecation" do
         bundle :install
 
-        expect(err).to have_major_deprecation a_string_including("Your Gemfile contains multiple primary sources.")
+        expect(deprecations).to include("Your Gemfile contains multiple primary sources.")
       end
 
       it "warns about ambiguous gems, but installs anyway, prioritizing sources last to first" do
@@ -64,7 +64,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
       end
 
       xit "shows a deprecation" do
-        expect(err).to have_major_deprecation a_string_including("Your Gemfile contains multiple primary sources.")
+        expect(deprecations).to include("Your Gemfile contains multiple primary sources.")
       end
 
       it "warns about ambiguous gems, but installs anyway" do
@@ -257,7 +257,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
           end
 
           xit "shows a deprecation" do
-            expect(err).to have_major_deprecation a_string_including("Your Gemfile contains multiple primary sources.")
+            expect(deprecations).to include("Your Gemfile contains multiple primary sources.")
           end
 
           it "installs from the other source and warns about ambiguous gems" do

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -20,11 +20,11 @@ RSpec.describe "major deprecations" do
       end
 
       it "is not deprecated", :bundler => "< 2" do
-        expect(warnings).not_to have_major_deprecation
+        expect(deprecations).to be_empty
       end
 
       it "is deprecated in favor of .unbundled_env", :bundler => "2" do
-        expect(warnings).to have_major_deprecation \
+        expect(deprecations).to include \
           "`Bundler.clean_env` has been deprecated in favor of `Bundler.unbundled_env`. " \
           "If you instead want the environment before bundler was originally loaded, use `Bundler.original_env`"
       end
@@ -37,18 +37,18 @@ RSpec.describe "major deprecations" do
       end
 
       it "is not deprecated", :bundler => "< 2" do
-        expect(warnings).not_to have_major_deprecation
+        expect(deprecations).to be_empty
       end
 
       it "is deprecated in favor of .load", :bundler => "2" do
-        expect(warnings).to have_major_deprecation "Bundler.environment has been removed in favor of Bundler.load"
+        expect(deprecations).to include "Bundler.environment has been removed in favor of Bundler.load"
       end
     end
 
     describe "bundle update --quiet" do
       it "does not print any deprecations" do
         bundle :update, :quiet => true
-        expect(warnings).not_to have_major_deprecation
+        expect(deprecations).to be_empty
       end
     end
 
@@ -59,24 +59,24 @@ RSpec.describe "major deprecations" do
 
       it "does not warn when no options are given", :bundler => "< 2" do
         bundle! "update"
-        expect(warnings).not_to have_major_deprecation
+        expect(deprecations).to be_empty
       end
 
       it "warns when no options are given", :bundler => "2" do
         bundle! "update"
-        expect(warnings).to have_major_deprecation a_string_including("Pass --all to `bundle update` to update everything")
+        expect(deprecations).to include("Pass --all to `bundle update` to update everything")
       end
 
       it "does not warn when --all is passed" do
         bundle! "update --all"
-        expect(warnings).not_to have_major_deprecation
+        expect(deprecations).to be_empty
       end
     end
 
     describe "bundle install --binstubs" do
       xit "should output a deprecation warning" do
         bundle :install, :binstubs => true
-        expect(warnings).to have_major_deprecation a_string_including("The --binstubs option will be removed")
+        expect(deprecations).to include("The --binstubs option will be removed")
       end
     end
   end
@@ -89,7 +89,7 @@ RSpec.describe "major deprecations" do
       G
 
       bundle :install
-      expect(warnings).not_to have_major_deprecation
+      expect(deprecations).to be_empty
     end
 
     it "should print a proper warning when both gems.rb and Gemfile present, and use Gemfile", :bundler => "< 2" do
@@ -129,7 +129,7 @@ RSpec.describe "major deprecations" do
       end
 
       it "should print a deprecation warning about autoremembering flags", :bundler => "3" do
-        expect(warnings).to have_major_deprecation a_string_including(
+        expect(deprecations).to include(
           "flags passed to commands will no longer be automatically remembered."
         )
       end
@@ -152,7 +152,7 @@ RSpec.describe "major deprecations" do
           it "should print a deprecation warning" do
             bundle "install #{flag_name} #{value}"
 
-            expect(warnings).to have_major_deprecation(
+            expect(deprecations).to include(
               "The `#{flag_name}` flag is deprecated because it relied on " \
               "being remembered accross bundler invokations, which bundler " \
               "will no longer do in future versions. Instead please use " \
@@ -165,7 +165,7 @@ RSpec.describe "major deprecations" do
           it "should not print a deprecation warning" do
             bundle "install #{flag_name} #{value}"
 
-            expect(warnings).not_to have_major_deprecation
+            expect(deprecations).to be_empty
           end
         end
       end
@@ -212,11 +212,11 @@ RSpec.describe "major deprecations" do
     end
 
     it "should not print a capistrano deprecation warning", :bundler => "< 2" do
-      expect(warnings).not_to have_major_deprecation
+      expect(deprecations).to be_empty
     end
 
     it "should print a capistrano deprecation warning", :bundler => "2" do
-      expect(warnings).to have_major_deprecation("Bundler no longer integrates " \
+      expect(deprecations).to include("Bundler no longer integrates " \
                              "with Capistrano, but Capistrano provides " \
                              "its own integration with Bundler via the " \
                              "capistrano-bundler gem. Use it instead.")
@@ -306,11 +306,11 @@ The :gist git source is deprecated, and will be removed in the future. Add this 
     end
 
     it "does not print a deprecation warning", :bundler => "< 2" do
-      expect(warnings).not_to have_major_deprecation
+      expect(deprecations).to be_empty
     end
 
     it "prints a deprecation warning", :bundler => "2" do
-      expect(warnings).to have_major_deprecation a_string_including("use `bundle list` instead of `bundle show`")
+      expect(deprecations).to include("use `bundle list` instead of `bundle show`")
     end
   end
 
@@ -320,12 +320,12 @@ The :gist git source is deprecated, and will be removed in the future. Add this 
     end
 
     it "does not print a deprecation warning", :bundler => "< 2" do
-      expect(warnings).not_to have_major_deprecation
+      expect(deprecations).to be_empty
     end
 
     it "prints a deprecation warning", :bundler => "2" do
-      expect(warnings).to have_major_deprecation \
-        a_string_including("bundle console will be replaced by `bin/console` generated by `bundle gem <name>`")
+      expect(deprecations).to include \
+        "bundle console will be replaced by `bin/console` generated by `bundle gem <name>`"
     end
   end
 end

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -14,9 +14,16 @@ RSpec.describe "major deprecations" do
     end
 
     describe ".clean_env" do
-      it "is deprecated in favor of .unbundled_env" do
+      before do
         source = "Bundler.clean_env"
         bundle "exec ruby -e #{source.dump}"
+      end
+
+      it "is not deprecated", :bundler => "< 2" do
+        expect(warnings).not_to have_major_deprecation
+      end
+
+      it "is deprecated in favor of .unbundled_env", :bundler => "2" do
         expect(warnings).to have_major_deprecation \
           "`Bundler.clean_env` has been deprecated in favor of `Bundler.unbundled_env`. " \
           "If you instead want the environment before bundler was originally loaded, use `Bundler.original_env`"
@@ -24,9 +31,16 @@ RSpec.describe "major deprecations" do
     end
 
     describe ".environment" do
-      it "is deprecated in favor of .load" do
+      before do
         source = "Bundler.environment"
         bundle "exec ruby -e #{source.dump}"
+      end
+
+      it "is not deprecated", :bundler => "< 2" do
+        expect(warnings).not_to have_major_deprecation
+      end
+
+      it "is deprecated in favor of .load", :bundler => "2" do
         expect(warnings).to have_major_deprecation "Bundler.environment has been removed in favor of Bundler.load"
       end
     end
@@ -191,11 +205,17 @@ RSpec.describe "major deprecations" do
   end
 
   context "when `bundler/deployment` is required in a ruby script" do
-    it "should print a capistrano deprecation warning" do
+    before do
       ruby(<<-RUBY)
         require 'bundler/deployment'
       RUBY
+    end
 
+    it "should not print a capistrano deprecation warning", :bundler => "< 2" do
+      expect(warnings).not_to have_major_deprecation
+    end
+
+    it "should print a capistrano deprecation warning", :bundler => "2" do
       expect(warnings).to have_major_deprecation("Bundler no longer integrates " \
                              "with Capistrano, but Capistrano provides " \
                              "its own integration with Bundler via the " \

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -3,16 +3,16 @@
 RSpec.describe "major deprecations" do
   let(:warnings) { err }
 
-  before do
-    create_file "gems.rb", <<-G
-      source "file:#{gem_repo1}"
-      ruby #{RUBY_VERSION.dump}
-      gem "rack"
-    G
-    bundle! "install"
-  end
-
   describe "Bundler" do
+    before do
+      create_file "gems.rb", <<-G
+        source "file:#{gem_repo1}"
+        ruby #{RUBY_VERSION.dump}
+        gem "rack"
+      G
+      bundle! "install"
+    end
+
     describe ".clean_env" do
       it "is deprecated in favor of .unbundled_env" do
         source = "Bundler.clean_env"
@@ -61,10 +61,6 @@ RSpec.describe "major deprecations" do
 
     describe "bundle install --binstubs" do
       xit "should output a deprecation warning" do
-        gemfile <<-G
-          gem 'rack'
-        G
-
         bundle :install, :binstubs => true
         expect(warnings).to have_major_deprecation a_string_including("The --binstubs option will be removed")
       end
@@ -111,12 +107,14 @@ RSpec.describe "major deprecations" do
     end
 
     context "with flags" do
-      it "should print a deprecation warning about autoremembering flags", :bundler => "3" do
+      before do
         install_gemfile <<-G, :path => "vendor/bundle"
           source "file://#{gem_repo1}"
           gem "rack"
         G
+      end
 
+      it "should print a deprecation warning about autoremembering flags", :bundler => "3" do
         expect(warnings).to have_major_deprecation a_string_including(
           "flags passed to commands will no longer be automatically remembered."
         )

--- a/spec/runtime/require_spec.rb
+++ b/spec/runtime/require_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe "Bundler.require" do
       Bundler.require
     R
 
-    expect(last_command.stderr).to eq_err("ZOMG LOAD ERROR")
+    expect(err_without_deprecations).to eq("ZOMG LOAD ERROR")
   end
 
   it "displays a helpful message if the required gem throws an error" do
@@ -160,7 +160,7 @@ RSpec.describe "Bundler.require" do
     RUBY
     run(cmd)
 
-    expect(last_command.stderr).to eq_err("ZOMG LOAD ERROR: cannot load such file -- load-bar")
+    expect(err_without_deprecations).to eq("ZOMG LOAD ERROR: cannot load such file -- load-bar")
   end
 
   describe "with namespaced gems" do
@@ -211,7 +211,7 @@ RSpec.describe "Bundler.require" do
       load_error_run <<-R, "jquery-rails"
         Bundler.require
       R
-      expect(last_command.stderr).to eq_err("ZOMG LOAD ERROR")
+      expect(err_without_deprecations).to eq("ZOMG LOAD ERROR")
     end
 
     it "handles the case where regex fails" do
@@ -234,7 +234,7 @@ RSpec.describe "Bundler.require" do
       RUBY
       run(cmd)
 
-      expect(last_command.stderr).to eq_err("ZOMG LOAD ERROR")
+      expect(err_without_deprecations).to eq("ZOMG LOAD ERROR")
     end
 
     it "doesn't swallow the error when the library has an unrelated error" do
@@ -258,7 +258,7 @@ RSpec.describe "Bundler.require" do
       RUBY
       run(cmd)
 
-      expect(last_command.stderr).to eq_err("ZOMG LOAD ERROR: cannot load such file -- load-bar")
+      expect(err_without_deprecations).to eq("ZOMG LOAD ERROR: cannot load such file -- load-bar")
     end
   end
 
@@ -366,7 +366,7 @@ RSpec.describe "Bundler.require" do
         load_error_run <<-R, "no_such_file_omg"
           Bundler.require
         R
-        expect(last_command.stderr).to eq_err("ZOMG LOAD ERROR")
+        expect(err_without_deprecations).to eq("ZOMG LOAD ERROR")
       end
     end
   end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -48,6 +48,12 @@ module Spec
       Bundler.feature_flag.error_on_stderr? ? last_command.stderr : last_command.stdout
     end
 
+    MAJOR_DEPRECATION = /^\[DEPRECATED\]\s*/.freeze
+
+    def err_without_deprecations
+      last_command.stderr.gsub(/#{MAJOR_DEPRECATION}.+[\n]?/, "")
+    end
+
     def exitstatus
       last_command.exitstatus
     end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -54,6 +54,10 @@ module Spec
       last_command.stderr.gsub(/#{MAJOR_DEPRECATION}.+[\n]?/, "")
     end
 
+    def deprecations
+      err.split("\n").select {|l| l =~ MAJOR_DEPRECATION }.join("\n").split(MAJOR_DEPRECATION)
+    end
+
     def exitstatus
       last_command.exitstatus
     end

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -62,19 +62,6 @@ module Spec
 
     MAJOR_DEPRECATION = /^\[DEPRECATED\]\s*/.freeze
 
-    RSpec::Matchers.define :have_major_deprecation do |expected|
-      diffable
-      match do |actual|
-        deprecations = actual.split(MAJOR_DEPRECATION)
-
-        return !expected.nil? if deprecations.empty?
-
-        deprecations.any? do |d|
-          !d.empty? && values_match?(expected, d.strip)
-        end
-      end
-    end
-
     RSpec::Matchers.define :have_dep do |*args|
       dep = Bundler::Dependency.new(*args)
 

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -62,13 +62,6 @@ module Spec
 
     MAJOR_DEPRECATION = /^\[DEPRECATED\]\s*/.freeze
 
-    RSpec::Matchers.define :eq_err do |expected|
-      diffable
-      match do |actual|
-        actual.gsub(/#{MAJOR_DEPRECATION}.+[\n]?/, "") == expected
-      end
-    end
-
     RSpec::Matchers.define :have_major_deprecation do |expected|
       diffable
       match do |actual|

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -60,8 +60,6 @@ module Spec
       end
     end
 
-    MAJOR_DEPRECATION = /^\[DEPRECATED\]\s*/.freeze
-
     RSpec::Matchers.define :have_dep do |*args|
       dep = Bundler::Dependency.new(*args)
 
@@ -135,7 +133,6 @@ module Spec
           rescue StandardError => e
             next "#{name} is not installed:\n#{indent(e)}"
           end
-          last_command.stdout.gsub!(/#{MAJOR_DEPRECATION}.*$/, "")
           actual_version, actual_platform = last_command.stdout.strip.split(/\s+/, 2)
           unless Gem::Version.new(actual_version) == Gem::Version.new(version)
             next "#{name} was expected to be at version #{version} but was #{actual_version}"
@@ -150,7 +147,6 @@ module Spec
           rescue StandardError
             next "#{name} does not have a source defined:\n#{indent(e)}"
           end
-          last_command.stdout.gsub!(/#{MAJOR_DEPRECATION}.*$/, "")
           unless last_command.stdout.strip == source
             next "Expected #{name} (#{version}) to be installed from `#{source}`, was actually from `#{out}`"
           end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that deprecation specs, even though they are now passing, are very brittle. This is because most of them create multiple gem files (`gems.rb` and `Gemfile`), and thus display deprecation messages by default about that.

### What was your diagnosis of the problem?

My diagnosis was that each deprecation should test its own message, instead of having the same deprecation printed by most specs.

### What is your fix for the problem, implemented in this PR?

My fix is to make the specs create a single gem file, except for the ones that test the deprecation about multiple gem files.

### Why did you choose this fix out of the possible options?

I chose this fix because it makes the tests less brittle and do less unnecessary things. 
