### PR TITLE
Try fix azure flakyness

### DIFF
--- a/.azure-pipelines/steps.yml
+++ b/.azure-pipelines/steps.yml
@@ -22,7 +22,7 @@ steps:
 - script: |
     ruby bin/rake spec:deps
   displayName: 'ruby bin/rake spec:deps'
-  
+
 - script: |
     gem install --no-document --conservative rspec_junit_formatter
   displayName: 'gem install rspec_junit_formatter'

--- a/.azure-pipelines/steps.yml
+++ b/.azure-pipelines/steps.yml
@@ -28,7 +28,7 @@ steps:
   displayName: 'gem install rspec_junit_formatter'
 
 - script: |
-    ruby -r rspec_junit_formatter bin/rspec --format progress --format RspecJunitFormatter -o rspec/bundler-junit-results.xml || exit 0
+    timeout 50m bash -c 'ruby -r rspec_junit_formatter bin/rspec --format progress --format RspecJunitFormatter -o rspec/bundler-junit-results.xml' || exit 0
   displayName: 'ruby bin/rspec'
 
 - task: PublishTestResults@2


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that sometimes Azure is timing out. My guess is that this is not Azure slowness, but the big amount of failures currently present on the Windows build making it very slow.

### What was your diagnosis of the problem?

My diagnosis was that we don't want red Azure builds for now, since we don't yet really fully support Windows.

### What is your fix for the problem, implemented in this PR?

My fix is to wrap the job that runs the specs with a [bash timeout](https://linux.die.net/man/1/timeout) with a limit under Azure's one hour limit. 

### Why did you choose this fix out of the possible options?

I chose this fix because I think it should prevent Azure statuses from getting in the middle for now.
