### PR TITLE
Strip unknown regexp option line from error format

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -582,7 +582,7 @@ The :#{name} git source is deprecated, and will be removed in the future.#{addit
         description = self.description
         if dsl_path && description =~ /((#{Regexp.quote File.expand_path(dsl_path)}|#{Regexp.quote dsl_path.to_s}):\d+)/
           trace_line = Regexp.last_match[1]
-          description = description.sub(/#{Regexp.quote trace_line}:\s*/, "").sub("\n", " - ")
+          description = description.sub(/\n.*\n(\.\.\.)? *\^~+$/, "").sub(/#{Regexp.quote trace_line}:\s*/, "").sub("\n", " - ")
         end
         [trace_line, description]
       end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

On Gemfile syntax error like `gem 'foo', :path => /unquoted/string/syntax/error`, Ruby 2.7 will show strange error message like:

```
[!] There was an error parsing `Gemfile`: unknown regexp options - trg - ...foo', :path => /unquoted/string/syntax/error
       ...                        ^~~~~~~. Bundler cannot continue.
```

due to recent change in Ruby trunk https://github.com/ruby/ruby/commit/b6468b01f7288789ef2e9bf548d81cdadb8ef053. This caused Bundler's [CI failure on ruby/ruby repository](https://dev.azure.com/rubylang/ruby/_build/results?buildId=180&view=logs&jobId=b6208202-37e9-506d-3aed-7f8fc7b76c87&taskId=a8620f99-3e9e-5782-41a8-f55e2d53059e&lineStart=94&lineEnd=95&colStart=1&colEnd=1).

Bundler's Travis ruby-head has not failed yet because Travis ruby-head is still a little old. It will fail later and this is fixing the future failure.

### What was your diagnosis of the problem?

SyntaxError's message was changed to have an additional message indicating a position of an unknown regexp option like:

```
foo /bar/baz
         ^~~
```

or 

```
...oooooooooooooooooooooo /bar/baz
...                            ^~~
```

### What is your fix for the problem, implemented in this PR?

My fix tries to strip the new message part because the error line is already shown in another part of `DSLError#to_s`.

### Why did you choose this fix out of the possible options?

To keep the best compatibility with older Bundler versions.