### PR TITLE
Remove `RUBY_VERSION` leftovers

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -545,7 +545,7 @@ EOF
     rescue ScriptError, StandardError => e
       msg = "There was an error while loading `#{path.basename}`: #{e.message}"
 
-      if e.is_a?(LoadError) && RUBY_VERSION >= "1.9"
+      if e.is_a?(LoadError)
         msg += "\nDoes it try to require a relative path? That's been removed in Ruby 1.9"
       end
 

--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -1,10 +1,4 @@
-<%- if RUBY_VERSION < "2.0.0" -%>
-# coding: utf-8
-
-lib = File.expand_path("../lib", __FILE__)
-<%- else -%>
 lib = File.expand_path("lib", __dir__)
-<%- end -%>
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "<%= config[:namespaced_path] %>/version"
 

--- a/lib/bundler/templates/newgem/test/test_helper.rb.tt
+++ b/lib/bundler/templates/newgem/test/test_helper.rb.tt
@@ -1,8 +1,4 @@
-<%- if RUBY_VERSION < "2.0.0" -%>
-$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
-<%- else -%>
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
-<%- end -%>
 require "<%= config[:namespaced_path] %>"
 
 require "minitest/autorun"

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "bundle exec" do
         require 'tempfile'
         io = Tempfile.new("io-test-fd")
         args = %W[#{Gem.ruby} -I#{lib} #{bindir.join("bundle")} exec --keep-file-descriptors #{Gem.ruby} #{command.path} \#{io.to_i}]
-        args << { io.to_i => io } if RUBY_VERSION >= "2.0"
+        args << { io.to_i => io }
         exec(*args)
       end
     G
@@ -87,12 +87,7 @@ RSpec.describe "bundle exec" do
     install_gemfile ""
     sys_exec "#{Gem.ruby} #{command.path}"
 
-    if Bundler.current_ruby.ruby_2?
-      expect(out).to eq("")
-    else
-      expect(out).to eq("Ruby version #{RUBY_VERSION} defaults to keeping non-standard file descriptors on Kernel#exec.")
-    end
-
+    expect(out).to eq("")
     expect(last_command.stderr).to be_empty
   end
 
@@ -500,7 +495,7 @@ RSpec.describe "bundle exec" do
     let(:rack) { "RACK: 1.0.0" }
     let(:process) do
       title = "PROCESS: #{path}"
-      title += " arg1 arg2" if RUBY_VERSION >= "2.1"
+      title += " arg1 arg2"
       title
     end
     let(:exit_code) { 0 }

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "bundle info" do
     end
 
     context "given a default gem shippped in ruby", :ruby_repo do
-      it "prints information about the default gem", :if => (RUBY_VERSION >= "2.0") do
+      it "prints information about the default gem" do
         bundle "info rdoc"
         expect(out).to include("* rdoc")
         expect(out).to include("Default Gem: yes")

--- a/spec/install/gemfile_spec.rb
+++ b/spec/install/gemfile_spec.rb
@@ -115,8 +115,6 @@ RSpec.describe "bundle install" do
 
   context "with a Gemfile containing non-US-ASCII characters" do
     it "reads the Gemfile with the UTF-8 encoding by default" do
-      skip "Ruby 1.8 has no encodings" if RUBY_VERSION < "1.9"
-
       install_gemfile <<-G
         str = "Il était une fois ..."
         puts "The source encoding is: " + str.encoding.name
@@ -128,8 +126,6 @@ RSpec.describe "bundle install" do
     end
 
     it "respects the magic encoding comment" do
-      skip "Ruby 1.8 has no encodings" if RUBY_VERSION < "1.9"
-
       # NOTE: This works thanks to #eval interpreting the magic encoding comment
       install_gemfile <<-G
         # encoding: iso-8859-1

--- a/spec/install/gemspecs_spec.rb
+++ b/spec/install/gemspecs_spec.rb
@@ -64,8 +64,6 @@ RSpec.describe "bundle install" do
   end
 
   it "reads gemspecs respecting their encoding" do
-    skip "Unicode is not supported on Ruby 1.x without extra work" if RUBY_VERSION < "2.0"
-
     create_file "version.rb", <<-RUBY
       module Persistent💎
         VERSION = "0.0.1"

--- a/spec/plugins/list_spec.rb
+++ b/spec/plugins/list_spec.rb
@@ -53,18 +53,8 @@ RSpec.describe "bundler plugin list" do
       plugin_should_be_installed("foo", "bar")
       bundle "plugin list"
 
-      if RUBY_VERSION < "1.9"
-        # Bundler::Plugin::Index#installed_plugins is keys of Hash,
-        # and Hash is not ordered in prior to Ruby 1.9.
-        # So, foo and bar plugins are not always listed in that order.
-        expected_output1 = "foo\n-----\n  shout"
-        expect(out).to include(expected_output1)
-        expected_output2 = "bar\n-----\n  scream"
-        expect(out).to include(expected_output2)
-      else
-        expected_output = "foo\n-----\n  shout\n\nbar\n-----\n  scream"
-        expect(out).to include(expected_output)
-      end
+      expected_output = "foo\n-----\n  shout\n\nbar\n-----\n  scream"
+      expect(out).to include(expected_output)
     end
   end
 end

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -650,62 +650,6 @@ RSpec.describe "Bundler.setup" do
     end
   end
 
-  # Unfortunately, gem_prelude does not record the information about
-  # activated gems, so this test cannot work on 1.9 :(
-  if RUBY_VERSION < "1.9"
-    describe "preactivated gems" do
-      it "raises an exception if a pre activated gem conflicts with the bundle" do
-        system_gems "thin-1.0", "rack-1.0.0"
-        build_gem "thin", "1.1", :to_system => true do |s|
-          s.add_dependency "rack"
-        end
-
-        gemfile <<-G
-          gem "thin", "1.0"
-        G
-
-        ruby <<-R
-          require 'rubygems'
-          gem "thin"
-          require 'bundler'
-          begin
-            Bundler.setup
-            puts "FAIL"
-          rescue Gem::LoadError => e
-            puts e.message
-          end
-        R
-
-        expect(out).to eq("You have already activated thin 1.1, but your Gemfile requires thin 1.0. Prepending `bundle exec` to your command may solve this.")
-      end
-
-      it "version_requirement is now deprecated in rubygems 1.4.0+" do
-        system_gems "thin-1.0", "rack-1.0.0"
-        build_gem "thin", "1.1", :to_system => true do |s|
-          s.add_dependency "rack"
-        end
-
-        gemfile <<-G
-          gem "thin", "1.0"
-        G
-
-        ruby <<-R
-          require 'rubygems'
-          gem "thin"
-          require 'bundler'
-          begin
-            Bundler.setup
-            puts "FAIL"
-          rescue Gem::LoadError => e
-            puts e.message
-          end
-        R
-
-        expect(last_command.stderr).to be_empty
-      end
-    end
-  end
-
   # RubyGems returns loaded_from as a string
   it "has loaded_from as a string on all specs" do
     build_git "foo"
@@ -1091,7 +1035,7 @@ end
 
       expect(err.lines.map(&:chomp)).to include(
         a_string_starting_with("[!] There was an error while loading `bar.gemspec`:"),
-        RUBY_VERSION >= "1.9" ? a_string_starting_with("Does it try to require a relative path? That's been removed in Ruby 1.9.") : "",
+        a_string_starting_with("Does it try to require a relative path? That's been removed in Ruby 1.9."),
         " #  from #{default_bundle_path "bundler", "gems", "bar-1.0-#{ref[0, 12]}", "bar.gemspec"}:1",
         " >  require 'foobarbaz'"
       )

--- a/spec/support/artifice/vcr.rb
+++ b/spec/support/artifice/vcr.rb
@@ -1,13 +1,6 @@
 # frozen_string_literal: true
 
 require "net/http"
-if RUBY_VERSION < "1.9"
-  begin
-    require "net/https"
-  rescue LoadError
-    nil # net/https or openssl
-  end
-end # but only for 1.8
 
 CASSETTE_PATH = File.expand_path("../vcr_cassettes", __FILE__)
 CASSETTE_NAME = ENV.fetch("BUNDLER_SPEC_VCR_CASSETTE_NAME") { "realworld" }


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that find old ruby compatibility code can confuse contributors into thinking those versions are still supported.

### What was your diagnosis of the problem?

My diagnosis was that we can remove this code, since we no longer support those versions.

### What is your fix for the problem, implemented in this PR?

My fix is to remove the code.

### Why did you choose this fix out of the possible options?

I chose this fix because we can do it :)
