### PR TITLE
Remove old rubygems compatibility code

### DIFF
--- a/lib/bundler/rubygems_ext.rb
+++ b/lib/bundler/rubygems_ext.rb
@@ -4,14 +4,9 @@ require "pathname"
 
 require "rubygems/specification"
 
-begin
-  # Possible use in Gem::Specification#source below and require
-  # shouldn't be deferred.
-  require "rubygems/source"
-rescue LoadError
-  # Not available before RubyGems 2.0.0, ignore
-  nil
-end
+# Possible use in Gem::Specification#source below and require
+# shouldn't be deferred.
+require "rubygems/source"
 
 require "bundler/match_platform"
 

--- a/lib/bundler/rubygems_ext.rb
+++ b/lib/bundler/rubygems_ext.rb
@@ -23,8 +23,6 @@ module Gem
     alias_method :rg_full_gem_path, :full_gem_path
     alias_method :rg_loaded_from,   :loaded_from
 
-    attr_writer :full_gem_path unless instance_methods.include?(:full_gem_path=)
-
     def full_gem_path
       # this cannot check source.is_a?(Bundler::Plugin::API::Source)
       # because that _could_ trip the autoload, and if there are unresolved

--- a/lib/bundler/rubygems_ext.rb
+++ b/lib/bundler/rubygems_ext.rb
@@ -14,16 +14,10 @@ module Gem
   class Specification
     attr_accessor :remote, :location, :relative_loaded_from
 
-    if instance_methods(false).include?(:source)
-      remove_method :source
-      attr_writer :source
-      def source
-        (defined?(@source) && @source) || Gem::Source::Installed.new
-      end
-    else
-      # rubocop:disable Lint/DuplicateMethods
-      attr_accessor :source
-      # rubocop:enable Lint/DuplicateMethods
+    remove_method :source
+    attr_writer :source
+    def source
+      (defined?(@source) && @source) || Gem::Source::Installed.new
     end
 
     alias_method :rg_full_gem_path, :full_gem_path

--- a/lib/bundler/rubygems_ext.rb
+++ b/lib/bundler/rubygems_ext.rb
@@ -11,8 +11,6 @@ require "rubygems/source"
 require "bundler/match_platform"
 
 module Gem
-  @loaded_stacks = Hash.new {|h, k| h[k] = [] }
-
   class Specification
     attr_accessor :remote, :location, :relative_loaded_from
 

--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -546,8 +546,8 @@ module Bundler
       end
     end
 
-    # RubyGems 2.0
-    class Future < RubygemsIntegration
+    # RubyGems 2.1.0
+    class MoreFuture < RubygemsIntegration
       def stub_rubygems(specs)
         Gem::Specification.all = specs
 
@@ -619,10 +619,7 @@ module Bundler
       def path_separator
         Gem.path_separator
       end
-    end
 
-    # RubyGems 2.1.0
-    class MoreFuture < Future
       def initialize
         super
         backport_ext_builder_monitor


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that I was unsure where I needed to add the compatibility layer to #6963, and it took me a bit to scan through the compatibility file and figure it out.

### What was your diagnosis of the problem?

My diagnosis was that all this compatibility code is unused but makes this file harder to understand and scan through.

### What is your fix for the problem, implemented in this PR?

My fix is to remove the code.

### Why did you choose this fix out of the possible options?

I chose this fix because we can do it, I think.