### PR TITLE
Unskip `--binstubs` flag deprecation

### DIFF
--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -74,9 +74,16 @@ RSpec.describe "major deprecations" do
     end
 
     describe "bundle install --binstubs" do
-      xit "should output a deprecation warning" do
+      before do
         bundle :install, :binstubs => true
-        expect(deprecations).to include("The --binstubs option will be removed")
+      end
+
+      it "should print no deprecations", :bundler => "< 2" do
+        expect(deprecations).to be_empty
+      end
+
+      it "should output a deprecation warning", :bundler => "2" do
+        expect(deprecations).to include("The --binstubs option will be removed in favor of `bundle binstubs`")
       end
     end
   end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that some deprecation specs were still skipped.

### What was your diagnosis of the problem?

My diagnosis was that I should get all of them passing.

### What is your fix for the problem, implemented in this PR?

My fix is to uncomment the spec and get it passing. The only fix was to include the full deprecation message so that it matches the assertion.

### Why did you choose this fix out of the possible options?

I could've regexp-matched the existing message but I preferred to use the full message in the assertion instead. I chose this fix because although it makes it more brittle since changing the message _will_ break the test, having the whole messages inside the deprecation specs makes it easier to get a quick view and understand the stuff that we are deprecating and the quality of the existing deprecation messages.
