### PR TITLE
Review old `bundle config` interface deprecation

### DIFF
--- a/lib/bundler/cli/config.rb
+++ b/lib/bundler/cli/config.rb
@@ -14,8 +14,20 @@ module Bundler
     scope_options
     method_option :delete, :type => :boolean, :banner => "delete"
     def base(name = nil, *value)
+      new_args =
+        if ARGV.size == 1
+          ["config", "list"]
+        elsif ARGV.include?("--delete")
+          ARGV.map {|arg| arg == "--delete" ? "unset" : arg }
+        elsif ARGV.include?("--global") || ARGV.include?("--local") || ARGV.size == 3
+          ["config", "set", *ARGV[1..-1]]
+        else
+          ["config", "get", ARGV[1]]
+        end
+
       SharedHelpers.major_deprecation 2,
-        "Using the `config` command without a subcommand [list, get, set, unset]"
+        "Using the `config` command without a subcommand [list, get, set, unset] is deprecated and will be removed in the future. Use `bundle #{new_args.join(" ")}` instead."
+
       Base.new(options, name, value, self).run
     end
 

--- a/lib/bundler/cli/config.rb
+++ b/lib/bundler/cli/config.rb
@@ -14,7 +14,7 @@ module Bundler
     scope_options
     method_option :delete, :type => :boolean, :banner => "delete"
     def base(name = nil, *value)
-      SharedHelpers.major_deprecation 3,
+      SharedHelpers.major_deprecation 2,
         "Using the `config` command without a subcommand [list, get, set, unset]"
       Base.new(options, name, value, self).run
     end

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -34,7 +34,13 @@ Executing `bundle config set --local <name> <value>` will set that configuration
 the local application. The configuration will be stored in `app/.bundle/config`.
 
 Executing `bundle config unset <name>` will delete the configuration in both
-local and global sources. Not compatible with --global or --local flag.
+local and global sources.
+
+Executing `bundle config unset --global <name>` will delete the configuration
+only from the user configuration.
+
+Executing `bundle config unset --local <name> <value>` will delete the
+configuration only from the local application.
 
 Executing bundle with the `BUNDLE_IGNORE_CONFIG` environment variable set will
 cause it to ignore all configuration.

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -52,6 +52,20 @@ RSpec.describe "major deprecations" do
       end
     end
 
+    describe "bundle config" do
+      before do
+        bundle! "config"
+      end
+
+      it "does not warn when no options are given", :bundler => "< 2" do
+        expect(deprecations).to be_empty
+      end
+
+      it "warns when no options are given", :bundler => "2" do
+        expect(deprecations).to include("Using the `config` command without a subcommand [list, get, set, unset]")
+      end
+    end
+
     describe "bundle update" do
       before do
         bundle! "install"

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -53,16 +53,116 @@ RSpec.describe "major deprecations" do
     end
 
     describe "bundle config" do
-      before do
-        bundle! "config"
+      describe "old list interface" do
+        before do
+          bundle! "config"
+        end
+
+        it "does not warn", :bundler => "< 2" do
+          expect(deprecations).to be_empty
+        end
+
+        it "warns", :bundler => "2" do
+          expect(deprecations).to include("Using the `config` command without a subcommand [list, get, set, unset] is deprecated and will be removed in the future. Use `bundle config list` instead.")
+        end
       end
 
-      it "does not warn when no options are given", :bundler => "< 2" do
-        expect(deprecations).to be_empty
+      describe "old get interface" do
+        before do
+          bundle! "config waka"
+        end
+
+        it "does not warn", :bundler => "< 2" do
+          expect(deprecations).to be_empty
+        end
+
+        it "warns", :bundler => "2" do
+          expect(deprecations).to include("Using the `config` command without a subcommand [list, get, set, unset] is deprecated and will be removed in the future. Use `bundle config get waka` instead.")
+        end
       end
 
-      it "warns when no options are given", :bundler => "2" do
-        expect(deprecations).to include("Using the `config` command without a subcommand [list, get, set, unset]")
+      describe "old set interface" do
+        before do
+          bundle! "config waka wakapun"
+        end
+
+        it "does not warn", :bundler => "< 2" do
+          expect(deprecations).to be_empty
+        end
+
+        it "warns", :bundler => "2" do
+          expect(deprecations).to include("Using the `config` command without a subcommand [list, get, set, unset] is deprecated and will be removed in the future. Use `bundle config set waka wakapun` instead.")
+        end
+      end
+
+      describe "old set interface with --local" do
+        before do
+          bundle! "config --local waka wakapun"
+        end
+
+        it "does not warn", :bundler => "< 2" do
+          expect(deprecations).to be_empty
+        end
+
+        it "warns", :bundler => "2" do
+          expect(deprecations).to include("Using the `config` command without a subcommand [list, get, set, unset] is deprecated and will be removed in the future. Use `bundle config set --local waka wakapun` instead.")
+        end
+      end
+
+      describe "old set interface with --global" do
+        before do
+          bundle! "config --global waka wakapun"
+        end
+
+        it "does not warn", :bundler => "< 2" do
+          expect(deprecations).to be_empty
+        end
+
+        it "warns", :bundler => "2" do
+          expect(deprecations).to include("Using the `config` command without a subcommand [list, get, set, unset] is deprecated and will be removed in the future. Use `bundle config set --global waka wakapun` instead.")
+        end
+      end
+
+      describe "old unset interface" do
+        before do
+          bundle! "config --delete waka"
+        end
+
+        it "does not warn", :bundler => "< 2" do
+          expect(deprecations).to be_empty
+        end
+
+        it "warns", :bundler => "2" do
+          expect(deprecations).to include("Using the `config` command without a subcommand [list, get, set, unset] is deprecated and will be removed in the future. Use `bundle config unset waka` instead.")
+        end
+      end
+
+      describe "old unset interface with --local" do
+        before do
+          bundle! "config --delete --local waka"
+        end
+
+        it "does not warn", :bundler => "< 2" do
+          expect(deprecations).to be_empty
+        end
+
+        it "warns", :bundler => "2" do
+          expect(deprecations).to include("Using the `config` command without a subcommand [list, get, set, unset] is deprecated and will be removed in the future. Use `bundle config unset --local waka` instead.")
+        end
+      end
+
+      describe "old unset interface with --global" do
+        before do
+          bundle! "config --delete --global waka"
+        end
+
+        it "does not warn", :bundler => "< 2" do
+          expect(deprecations).to be_empty
+        end
+
+        it "warns", :bundler => "2" do
+          expect(deprecations).to include("Using the `config` command without a subcommand [list, get, set, unset] is deprecated and will be removed in the future. Use `bundle config unset --global waka` instead.")
+        end
       end
     end
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that the `bundle config` command interface changes needed a few tweaks.

### What was your diagnosis of the problem?

My diagnosis was that:

* `bundle config` deprecation was not getting enabled until bundler 3.
* `bundle config` documentation was incorrect about `unset` not supporting `--global` or `--local`.
* `bundle config` deprecation didn't give actionable suggestions.

### What is your fix for the problem, implemented in this PR?

My fix is to move the version to deprecate the old interface to `bundler 2`, to fix the documentation, and to improve the deprecation messages to give actionable suggestions.

### Why did you choose this fix out of the possible options?

I chose this fix because it makes `bundle config` better.
