### PR TITLE
Remove remembered options deprecation message

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -798,7 +798,7 @@ module Bundler
       value = value.join(" ").to_s if option.type == :array
 
       Bundler::SharedHelpers.major_deprecation 2,\
-        "The `#{flag_name}` flag is deprecated because it relied on being " \
+        "The `#{flag_name}` flag is deprecated because it relies on being " \
         "remembered accross bundler invokations, which bundler will no longer " \
         "do in future versions. Instead please use `bundle config #{name} " \
         "'#{value}'`, and stop using this flag"

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -110,26 +110,6 @@ module Bundler
         temporary(key => value)
         value
       else
-        command = if value.nil?
-          "bundle config unset #{key}"
-        else
-          "bundle config set #{key} #{Array(value).join(":")}"
-        end
-
-        unless Bundler.settings[:forget_cli_options] == false
-          Bundler::SharedHelpers.major_deprecation 3,\
-            "flags passed to commands " \
-            "will no longer be automatically remembered. Instead please set flags " \
-            "you want remembered between commands using `bundle config set " \
-            "<setting name> <setting value>`, i.e. `#{command}`. Once you are " \
-            "ready for the new behavior, use `bundle config set forget_cli_options " \
-            "true` to get rid of this message. Or if you want to get rid of " \
-            "this message and stick with the old behavior for now, run " \
-            "`bundle config set forget_cli_options false`, but keep in mind " \
-            "that this behavior will be fully removed in future versions of " \
-            "bundler."
-        end
-
         set_local(key, value)
       end
     end

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe "major deprecations" do
             bundle "install #{flag_name} #{value}"
 
             expect(deprecations).to include(
-              "The `#{flag_name}` flag is deprecated because it relied on " \
+              "The `#{flag_name}` flag is deprecated because it relies on " \
               "being remembered accross bundler invokations, which bundler " \
               "will no longer do in future versions. Instead please use " \
               "`bundle config #{name} '#{value}'`, and stop using this flag"

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -128,12 +128,6 @@ RSpec.describe "major deprecations" do
         G
       end
 
-      it "should print a deprecation warning about autoremembering flags", :bundler => "3" do
-        expect(deprecations).to include(
-          "flags passed to commands will no longer be automatically remembered."
-        )
-      end
-
       {
         :clean => true,
         :deployment => true,


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that this deprecation message is almost always a false positive. I realized about this when being bitten by this deprecation message during on our own specs (see https://travis-ci.org/bundler/bundler/builds/506776354 for example).

### What was your diagnosis of the problem?

My diagnosis was that people running things like `bundle install --retry 3` will be annoyed by this deprecation message, because they're not doing anything wrong, really. They have the option to set the flag permanently through configuration, but passing it per command is fine too. The fact that the flag will no longer be remembered is unlikely to cause any problems in my opinion.

### What is your fix for the problem, implemented in this PR?

My fix is to remove this message altogether. We already print deprecation messages for the flags that we are removing because they only are guaranteed to work when remembering options (`--with`, `--without`, and friends). For the rest of the flags not being removed from `bundle install`, printing a deprecation message is just annoying since users are not doing anything wrong by using them.

### Why did you choose this fix out of the possible options?

I chose this fix because we shouldn't overwhelm users with deprecation messages unless we really need to.