### PR TITLE
Remove --no-hardlinks and see what happens

### DIFF
--- a/lib/bundler/source/git/git_proxy.rb
+++ b/lib/bundler/source/git/git_proxy.rb
@@ -114,7 +114,11 @@ module Bundler
           end
 
           in_path do
-            git_retry %(fetch --force --quiet --tags #{uri_escaped_with_configured_credentials} "refs/heads/*:refs/heads/*" #{extra_ref})
+            if remote?(uri)
+              git_retry %(fetch --force --quiet --depth 1 --tags #{uri_escaped_with_configured_credentials} "refs/heads/*:refs/heads/*" #{extra_ref})
+            else
+              git_retry %(fetch --force --quiet --tags #{uri_escaped_with_configured_credentials} "refs/heads/*:refs/heads/*" #{extra_ref})
+            end
           end
         end
 

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -876,7 +876,7 @@ RSpec.describe "bundle install with git sources" do
     update_git "foo"
     update_git "foo"
 
-    install_gemfile <<-G
+    install_gemfile! <<-G
       git "#{lib_path("foo-1.0")}", :ref => "#{git.ref_for("HEAD^")}" do
         gem "foo"
       end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that cloning bit git repos can be very slow.

### What was your diagnosis of the problem?

My diagnosis was that we are cloning the full history of the repo.

### What is your fix for the problem, implemented in this PR?

My fix is to use `--depth 1` for remote clones to only download what's necessary.

### Why did you choose this fix out of the possible options?

I chose this fix because it is much faster, according to my tests.
