### PR TITLE
Revert the RSpec format in CI back to dots

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -134,7 +134,7 @@ namespace :spec do
     (branches + releases).each do |rg|
       desc "Run specs with RubyGems #{rg}"
       task rg do
-        sh("bin/rspec")
+        sh("bin/rspec --format progress --color")
       end
 
       # Create tasks like spec:rubygems:v1.8.3:sudo to run the sudo specs


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

#7017 made a change that sets the RSpec format to `documentation` in CI. I'm against this change because it now takes _a lot_ more time to scroll to the build errors, and makes the build log have too much information. Maintainers care much more about the failing specs and their errors than the test descriptions in CI.

### What is your fix for the problem, implemented in this PR?

Explicitly set the RSpec format to `progress` in CI.
