### PR TITLE
Review multiple sources deprecation

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -643,7 +643,7 @@ module Bundler
     end
 
     def converge_rubygems_sources
-      return false if Bundler.feature_flag.lockfile_uses_separate_rubygems_sources?
+      return false if Bundler.feature_flag.disable_multisource?
 
       changes = false
 
@@ -915,7 +915,7 @@ module Bundler
       # look for that gemspec (or its dependencies)
       default = sources.default_source
       source_requirements = { :default => default }
-      default = nil unless Bundler.feature_flag.lockfile_uses_separate_rubygems_sources?
+      default = nil unless Bundler.feature_flag.disable_multisource?
       dependencies.each do |dep|
         next unless source = dep.source || default
         source_requirements[dep.name] = source
@@ -929,7 +929,7 @@ module Bundler
 
     def pinned_spec_names(skip = nil)
       pinned_names = []
-      default = Bundler.feature_flag.lockfile_uses_separate_rubygems_sources? && sources.default_source
+      default = Bundler.feature_flag.disable_multisource? && sources.default_source
       @dependencies.each do |dep|
         next unless dep_source = dep.source || default
         next if dep_source == skip

--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -41,7 +41,6 @@ module Bundler
     settings_flag(:global_path_appends_ruby_scope) { bundler_2_mode? }
     settings_flag(:global_gem_cache) { bundler_2_mode? }
     settings_flag(:init_gems_rb) { bundler_2_mode? }
-    settings_flag(:lockfile_uses_separate_rubygems_sources) { bundler_2_mode? }
     settings_flag(:only_update_to_newer_versions) { bundler_2_mode? }
     settings_flag(:path_relative_to_cwd) { bundler_2_mode? }
     settings_flag(:plugins) { @bundler_version >= Gem::Version.new("1.14") }

--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -35,7 +35,7 @@ module Bundler
     settings_flag(:cache_command_is_package) { bundler_2_mode? }
     settings_flag(:default_install_uses_path) { bundler_2_mode? }
     settings_flag(:deployment_means_frozen) { bundler_2_mode? }
-    settings_flag(:disable_multisource) { bundler_2_mode? }
+    settings_flag(:disable_multisource) { bundler_3_mode? }
     settings_flag(:error_on_stderr) { bundler_2_mode? }
     settings_flag(:forget_cli_options) { bundler_3_mode? }
     settings_flag(:global_path_appends_ruby_scope) { bundler_2_mode? }

--- a/lib/bundler/lockfile_parser.rb
+++ b/lib/bundler/lockfile_parser.rb
@@ -88,7 +88,7 @@ module Bundler
           send("parse_#{@state}", line)
         end
       end
-      @sources << @rubygems_aggregate unless Bundler.feature_flag.lockfile_uses_separate_rubygems_sources?
+      @sources << @rubygems_aggregate unless Bundler.feature_flag.disable_multisource?
       @specs = @specs.values.sort_by(&:identifier)
       warn_for_outdated_bundler_version
     rescue ArgumentError => e
@@ -139,7 +139,7 @@ module Bundler
             @sources << @current_source
           end
         when GEM
-          if Bundler.feature_flag.lockfile_uses_separate_rubygems_sources?
+          if Bundler.feature_flag.disable_multisource?
             @opts["remotes"] = @opts.delete("remote")
             @current_source = TYPES[@type].from_lock(@opts)
             @sources << @current_source

--- a/lib/bundler/plugin/installer.rb
+++ b/lib/bundler/plugin/installer.rb
@@ -16,7 +16,7 @@ module Bundler
 
         version = options[:version] || [">= 0"]
 
-        Bundler.settings.temporary(:lockfile_uses_separate_rubygems_sources => false, :disable_multisource => false) do
+        Bundler.settings.temporary(:disable_multisource => false) do
           if options[:git]
             install_git(names, version, options)
           elsif options[:local_git]

--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -39,7 +39,7 @@ module Bundler
       @gem_version_promoter = gem_version_promoter
       @allow_bundler_dependency_conflicts = Bundler.feature_flag.allow_bundler_dependency_conflicts?
       @use_gvp = Bundler.feature_flag.use_gem_version_promoter_for_major_updates? || !@gem_version_promoter.major?
-      @lockfile_uses_separate_rubygems_sources = Bundler.feature_flag.lockfile_uses_separate_rubygems_sources?
+      @lockfile_uses_separate_rubygems_sources = Bundler.feature_flag.disable_multisource?
     end
 
     def start(requirements)

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -39,7 +39,6 @@ module Bundler
       global_gem_cache
       ignore_messages
       init_gems_rb
-      lockfile_uses_separate_rubygems_sources
       no_install
       no_prune
       only_update_to_newer_versions

--- a/lib/bundler/source/rubygems.rb
+++ b/lib/bundler/source/rubygems.rb
@@ -51,7 +51,7 @@ module Bundler
       end
 
       def can_lock?(spec)
-        return super if Bundler.feature_flag.lockfile_uses_separate_rubygems_sources?
+        return super if Bundler.feature_flag.disable_multisource?
         spec.source.is_a?(Rubygems)
       end
 

--- a/lib/bundler/source_list.rb
+++ b/lib/bundler/source_list.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "set"
+
 module Bundler
   class SourceList
     attr_reader :path_sources,

--- a/lib/bundler/source_list.rb
+++ b/lib/bundler/source_list.rb
@@ -43,17 +43,14 @@ module Bundler
     end
 
     def global_rubygems_source=(uri)
-      if Bundler.feature_flag.lockfile_uses_separate_rubygems_sources?
+      if Bundler.feature_flag.disable_multisource?
         @global_rubygems_source ||= rubygems_aggregate_class.new("remotes" => uri)
       end
       add_rubygems_remote(uri)
     end
 
     def add_rubygems_remote(uri)
-      if Bundler.feature_flag.lockfile_uses_separate_rubygems_sources?
-        return if Bundler.feature_flag.disable_multisource?
-        raise InvalidOption, "`lockfile_uses_separate_rubygems_sources` cannot be set without `disable_multisource` being set"
-      end
+      return if Bundler.feature_flag.disable_multisource?
       @rubygems_aggregate.add_remote(uri)
       @rubygems_aggregate
     end
@@ -80,7 +77,7 @@ module Bundler
 
     def lock_sources
       lock_sources = (path_sources + git_sources + plugin_sources).sort_by(&:to_s)
-      if Bundler.feature_flag.lockfile_uses_separate_rubygems_sources?
+      if Bundler.feature_flag.disable_multisource?
         lock_sources + rubygems_sources.sort_by(&:to_s)
       else
         lock_sources << combine_rubygems_sources
@@ -97,7 +94,7 @@ module Bundler
         end
       end
 
-      replacement_rubygems = !Bundler.feature_flag.lockfile_uses_separate_rubygems_sources? &&
+      replacement_rubygems = !Bundler.feature_flag.disable_multisource? &&
         replacement_sources.detect {|s| s.is_a?(Source::Rubygems) }
       @rubygems_aggregate = replacement_rubygems if replacement_rubygems
 

--- a/spec/bundler/source_list_spec.rb
+++ b/spec/bundler/source_list_spec.rb
@@ -372,7 +372,7 @@ RSpec.describe Bundler::SourceList do
       source_list.add_git_source("uri" => "git://first-git.org/path.git")
     end
 
-    it "combines the rubygems sources into a single instance, removing duplicate remotes from the end", :bundler => "< 2" do
+    it "combines the rubygems sources into a single instance, removing duplicate remotes from the end", :bundler => "< 3" do
       expect(source_list.lock_sources).to eq [
         Bundler::Source::Git.new("uri" => "git://first-git.org/path.git"),
         Bundler::Source::Git.new("uri" => "git://second-git.org/path.git"),
@@ -391,7 +391,7 @@ RSpec.describe Bundler::SourceList do
       ]
     end
 
-    it "returns all sources, without combining rubygems sources", :bundler => "2" do
+    it "returns all sources, without combining rubygems sources", :bundler => "3" do
       expect(source_list.lock_sources).to eq [
         Bundler::Source::Git.new("uri" => "git://first-git.org/path.git"),
         Bundler::Source::Git.new("uri" => "git://second-git.org/path.git"),

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -693,6 +693,7 @@ RSpec.describe "bundle exec" do
       end
 
       let(:exit_code) { Bundler::GemNotFound.new.status_code }
+      let(:expected_err) { "" }
       let(:expected) { <<-EOS.strip }
 \e[31mCould not find gem 'rack (= 2)' in any of the gem sources listed in your Gemfile.\e[0m
 \e[33mRun `bundle install` to install missing gems.\e[0m
@@ -702,6 +703,24 @@ RSpec.describe "bundle exec" do
     end
 
     context "when Bundler.setup fails", :bundler => "2" do
+      before do
+        gemfile <<-G
+          gem 'rack', '2'
+        G
+        ENV["BUNDLER_FORCE_TTY"] = "true"
+      end
+
+      let(:exit_code) { Bundler::GemNotFound.new.status_code }
+      let(:expected) { "" }
+      let(:expected_err) { <<-EOS.strip }
+\e[31mCould not find gem 'rack (= 2)' in any of the gem sources listed in your Gemfile.\e[0m
+\e[33mRun `bundle install` to install missing gems.\e[0m
+      EOS
+
+      it_behaves_like "it runs"
+    end
+
+    context "when Bundler.setup fails", :bundler => "3" do
       before do
         gemfile <<-G
           gem 'rack', '2'

--- a/spec/commands/list_spec.rb
+++ b/spec/commands/list_spec.rb
@@ -1,15 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe "bundle list", :bundler => ">= 2" do
-  before do
-    install_gemfile <<-G
-      source "file://#{gem_repo1}"
-
-      gem "rack"
-      gem "rspec", :group => [:test]
-    G
-  end
-
   context "with name-only and paths option" do
     it "raises an error" do
       bundle "list --name-only --paths"
@@ -27,6 +18,15 @@ RSpec.describe "bundle list", :bundler => ">= 2" do
   end
 
   describe "with without-group option" do
+    before do
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+
+        gem "rack"
+        gem "rspec", :group => [:test]
+      G
+    end
+
     context "when group is present" do
       it "prints the gems not in the specified group" do
         bundle! "list --without-group test"
@@ -46,6 +46,15 @@ RSpec.describe "bundle list", :bundler => ">= 2" do
   end
 
   describe "with only-group option" do
+    before do
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+
+        gem "rack"
+        gem "rspec", :group => [:test]
+      G
+    end
+
     context "when group is present" do
       it "prints the gems in the specified group" do
         bundle! "list --only-group default"
@@ -65,6 +74,15 @@ RSpec.describe "bundle list", :bundler => ">= 2" do
   end
 
   context "with name-only option" do
+    before do
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+
+        gem "rack"
+        gem "rspec", :group => [:test]
+      G
+    end
+
     it "prints only the name of the gems in the bundle" do
       bundle "list --name-only"
 
@@ -116,13 +134,35 @@ RSpec.describe "bundle list", :bundler => ">= 2" do
     end
   end
 
-  it "lists gems installed in the bundle" do
-    bundle "list"
-    expect(out).to include("  * rack (1.0.0)")
+  context "without options" do
+    before do
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+
+        gem "rack"
+        gem "rspec", :group => [:test]
+      G
+    end
+
+    it "lists gems installed in the bundle" do
+      bundle "list"
+      expect(out).to include("  * rack (1.0.0)")
+    end
   end
 
-  it "aliases the ls command to list" do
-    bundle "ls"
-    expect(out).to include("Gems included by the bundle")
+  context "when using the ls alias" do
+    before do
+      install_gemfile <<-G
+        source "file://#{gem_repo1}"
+
+        gem "rack"
+        gem "rspec", :group => [:test]
+      G
+    end
+
+    it "runs the list command" do
+      bundle "ls"
+      expect(out).to include("Gems included by the bundle")
+    end
   end
 end

--- a/spec/commands/list_spec.rb
+++ b/spec/commands/list_spec.rb
@@ -93,8 +93,6 @@ RSpec.describe "bundle list", :bundler => ">= 2" do
         gem "git_test", :git => "#{lib_path("git_test")}"
         gemspec :path => "#{tmp.join("gemspec_test")}"
       G
-
-      bundle! "install"
     end
 
     it "prints the path of each gem in the bundle" do

--- a/spec/commands/list_spec.rb
+++ b/spec/commands/list_spec.rb
@@ -82,7 +82,6 @@ RSpec.describe "bundle list", :bundler => ">= 2" do
       build_git "git_test", "1.0.0", :path => lib_path("git_test")
 
       build_lib("gemspec_test", :path => tmp.join("gemspec_test")) do |s|
-        s.write("Gemfile", "source :rubygems\ngemspec")
         s.add_dependency "bar", "=1.0.0"
       end
 

--- a/spec/install/gemfile/sources_spec.rb
+++ b/spec/install/gemfile/sources_spec.rb
@@ -183,9 +183,8 @@ RSpec.describe "bundle install with gems on multiple sources" do
             end
           end
 
-          context "when lockfile_uses_separate_rubygems_sources is set" do
+          context "when disable_multisource is set" do
             before do
-              bundle! "config set lockfile_uses_separate_rubygems_sources true"
               bundle! "config set disable_multisource true"
             end
 
@@ -290,9 +289,8 @@ RSpec.describe "bundle install with gems on multiple sources" do
     end
 
     context "when a top-level gem has an indirect dependency" do
-      context "when lockfile_uses_separate_rubygems_sources is set" do
+      context "when disable_multisource is set" do
         before do
-          bundle! "config set lockfile_uses_separate_rubygems_sources true"
           bundle! "config set disable_multisource true"
         end
 

--- a/spec/install/gemfile/sources_spec.rb
+++ b/spec/install/gemfile/sources_spec.rb
@@ -27,12 +27,6 @@ RSpec.describe "bundle install with gems on multiple sources" do
         G
       end
 
-      xit "shows a deprecation" do
-        bundle :install
-
-        expect(deprecations).to include("Your Gemfile contains multiple primary sources.")
-      end
-
       it "warns about ambiguous gems, but installs anyway, prioritizing sources last to first" do
         bundle :install
 
@@ -61,10 +55,6 @@ RSpec.describe "bundle install with gems on multiple sources" do
         G
 
         bundle :install
-      end
-
-      xit "shows a deprecation" do
-        expect(deprecations).to include("Your Gemfile contains multiple primary sources.")
       end
 
       it "warns about ambiguous gems, but installs anyway" do
@@ -254,10 +244,6 @@ RSpec.describe "bundle install with gems on multiple sources" do
             G
 
             bundle :install
-          end
-
-          xit "shows a deprecation" do
-            expect(deprecations).to include("Your Gemfile contains multiple primary sources.")
           end
 
           it "installs from the other source and warns about ambiguous gems" do

--- a/spec/install/gems/flex_spec.rb
+++ b/spec/install/gems/flex_spec.rb
@@ -244,7 +244,7 @@ RSpec.describe "bundle flex_install" do
   end
 
   describe "when adding a new source" do
-    it "updates the lockfile", :bundler => "< 2" do
+    it "updates the lockfile", :bundler => "< 3" do
       build_repo2
       install_gemfile! <<-G
         source "file://localhost#{gem_repo1}"
@@ -264,7 +264,7 @@ RSpec.describe "bundle flex_install" do
           rack (1.0.0)
 
       PLATFORMS
-        ruby
+        #{lockfile_platforms}
 
       DEPENDENCIES
         rack
@@ -274,7 +274,7 @@ RSpec.describe "bundle flex_install" do
       L
     end
 
-    it "updates the lockfile", :bundler => "2" do
+    it "updates the lockfile", :bundler => "3" do
       build_repo2
       install_gemfile! <<-G
         source "file://localhost#{gem_repo1}"

--- a/spec/install/post_bundle_message_spec.rb
+++ b/spec/install/post_bundle_message_spec.rb
@@ -101,16 +101,16 @@ RSpec.describe "post bundle message" do
     end
 
     describe "with misspelled or non-existent gem name" do
-      it "should report a helpful error message", :bundler => "< 2" do
+      it "should report a helpful error message", :bundler => "< 3" do
         install_gemfile <<-G
           source "file://localhost#{gem_repo1}"
           gem "rack"
           gem "not-a-gem", :group => :development
         G
-        expect(out).to include("Could not find gem 'not-a-gem' in any of the gem sources listed in your Gemfile.")
+        expect(err).to include("Could not find gem 'not-a-gem' in any of the gem sources listed in your Gemfile.")
       end
 
-      it "should report a helpful error message", :bundler => "2" do
+      it "should report a helpful error message", :bundler => "3" do
         install_gemfile <<-G
           source "file://localhost#{gem_repo1}"
           gem "rack"

--- a/spec/lock/lockfile_spec.rb
+++ b/spec/lock/lockfile_spec.rb
@@ -415,7 +415,7 @@ RSpec.describe "the lockfile format" do
     G
   end
 
-  it "generates a lockfile without credentials for a configured source", :bundler => "< 2" do
+  it "generates a lockfile without credentials for a configured source", :bundler => "< 3" do
     bundle "config set http://localgemserver.test/ user:pass"
 
     install_gemfile(<<-G, :artifice => "endpoint_strict_basic_authentication", :quiet => true)
@@ -448,7 +448,7 @@ RSpec.describe "the lockfile format" do
     G
   end
 
-  it "generates a lockfile without credentials for a configured source", :bundler => "2" do
+  it "generates a lockfile without credentials for a configured source", :bundler => "3" do
     bundle "config set http://localgemserver.test/ user:pass"
 
     install_gemfile(<<-G, :artifice => "endpoint_strict_basic_authentication", :quiet => true)

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -358,7 +358,14 @@ RSpec.describe "major deprecations" do
     end
 
     it "shows a deprecation", :bundler => "2" do
-      expect(deprecations).to include(a_string_containing("Your Gemfile contains multiple primary sources."))
+      expect(deprecations).to include(
+        "Your Gemfile contains multiple primary sources. " \
+        "Using `source` more than once without a block is a security risk, and " \
+        "may result in installing unexpected gems. To resolve this warning, use " \
+        "a block to indicate which gems should come from the secondary source. " \
+        "To upgrade this warning to an error, run `bundle config set " \
+        "disable_multisource true`."
+      )
     end
   end
 

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -345,6 +345,23 @@ RSpec.describe "major deprecations" do
     end
   end
 
+  context "bundle install with multiple sources" do
+    before do
+      install_gemfile <<-G
+        source "file://localhost#{gem_repo3}"
+        source "file://localhost#{gem_repo1}"
+      G
+    end
+
+    it "does not print a deprecation warning", :bundler => "< 2" do
+      expect(deprecations).to be_empty
+    end
+
+    xit "shows a deprecation", :bundler => "2" do
+      expect(deprecations).to include("Your Gemfile contains multiple primary sources.")
+    end
+  end
+
   context "when Bundler.setup is run in a ruby script" do
     before do
       create_file "gems.rb"

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -357,8 +357,8 @@ RSpec.describe "major deprecations" do
       expect(deprecations).to be_empty
     end
 
-    xit "shows a deprecation", :bundler => "2" do
-      expect(deprecations).to include("Your Gemfile contains multiple primary sources.")
+    it "shows a deprecation", :bundler => "2" do
+      expect(deprecations).to include(a_string_containing("Your Gemfile contains multiple primary sources."))
     end
   end
 

--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -173,7 +173,6 @@ RSpec.describe "The library itself" do
       gem.mit
       github.https
       inline
-      lockfile_uses_separate_rubygems_sources
       use_gem_version_promoter_for_major_updates
     ]
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that I had not yet reviewed the deprecation about multiple global sources being present on a Gemfile, and thus the specs were skipped.

### What was your diagnosis of the problem?

My diagnosis was that we need to delay the removal of multiple sources support to bundler 3, so that we can show the deprecations in the 2.x series.

I also noticed that part of the deprecation message was inaccurate. In order to upgrade the warning to an error, you would also need to configure the `lockfile_uses_separate_rubygems_sources` setting. Otherwise you will get an error that these two settings depend on each other and can't be enabled separatedly.

### What is your fix for the problem, implemented in this PR?

My fix is to delay these feature flags to bundler 3 so that the deprecation specs pass. Also, since before giving this advice I'd like to study why we have two different settings that can't be enabled separately, and why the can't be merged to a single one, I have removed that part of the message for now.

### Why did you choose this fix out of the possible options?

I chose this fix because it keeps me moving with reviewing all the deprecations for bundler 3 breaking changes, and makes sure that the deprecations for this change of behavior are tested (and passing).