### PR TITLE
Make `bundle clean` clean git extension directories

### DIFF
--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -163,7 +163,7 @@ module Bundler
       gem_dirs             = Dir["#{Gem.dir}/gems/*"]
       gem_files            = Dir["#{Gem.dir}/cache/*.gem"]
       gemspec_files        = Dir["#{Gem.dir}/specifications/*.gemspec"]
-      extension_dirs       = Dir["#{Gem.dir}/extensions/*/*/*"]
+      extension_dirs       = Dir["#{Gem.dir}/extensions/*/*/*"] + Dir["#{Gem.dir}/bundler/gems/extensions/*/*/*"]
       spec_gem_paths       = []
       # need to keep git sources around
       spec_git_paths       = @definition.spec_git_paths


### PR DESCRIPTION
Fixes #7058

This PR fixes it by adding the native extension directories for git gems to the ones for non-git gems.  This is used to get the unused extension directories (`stale_extension_dirs = extension_dirs - spec_extension_paths`) which was already excluding extension directories for git gems.