### PR TITLE
Fix circular require warnings

### DIFF
--- a/lib/bundler/compatibility_guard.rb
+++ b/lib/bundler/compatibility_guard.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: false
 
-require "rubygems"
 require "bundler/version"
 
 if Bundler::VERSION.split(".").first.to_i >= 2

--- a/lib/bundler/rubygems_ext.rb
+++ b/lib/bundler/rubygems_ext.rb
@@ -7,7 +7,6 @@ if defined?(Gem::QuickLoader)
   Gem::QuickLoader.load_full_rubygems_library
 end
 
-require "rubygems"
 require "rubygems/specification"
 
 begin

--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "monitor"
-require "rubygems"
 require "rubygems/config_file"
 
 module Bundler


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that testing rubygems in ruby-core with warnings enabled prints a lot of ruby warnings.

### What was your diagnosis of the problem?

My diagnosis was that while requiring `rubygems`, bundler is required [here](https://github.com/rubygems/rubygems/blob/dad8d252f2b1562c4517fa6d73eb39dfbd0c4f37/lib/rubygems.rb#L1184), and then while requiring `bundler`, `rubygems` is required in several places. Thus the circular require warnings are printed.

### What is your fix for the problem, implemented in this PR?

My fix is to not require `rubygems` from `bundler`. Rubygems is made available by default by `ruby` anyways unless you use the `--disable-gems` option. And if you use that option, requiring `bundler` makes no sense.

### Why did you choose this fix out of the possible options?

I chose this fix because it's cleaner than #6862, in my opinion. This PR closes #6862 by superseding it.
