### PR TITLE
Remove version overwriting hacks

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -22,43 +22,43 @@ module Bundler
   ENV.replace(environment_preserver.backup)
   SUDO_MUTEX = Mutex.new
 
-  autoload :Definition,             "bundler/definition"
-  autoload :Dependency,             "bundler/dependency"
-  autoload :DepProxy,               "bundler/dep_proxy"
-  autoload :Deprecate,              "bundler/deprecate"
-  autoload :Dsl,                    "bundler/dsl"
-  autoload :EndpointSpecification,  "bundler/endpoint_specification"
-  autoload :Env,                    "bundler/env"
-  autoload :Fetcher,                "bundler/fetcher"
-  autoload :FeatureFlag,            "bundler/feature_flag"
-  autoload :GemHelper,              "bundler/gem_helper"
-  autoload :GemHelpers,             "bundler/gem_helpers"
-  autoload :GemRemoteFetcher,       "bundler/gem_remote_fetcher"
-  autoload :GemVersionPromoter,     "bundler/gem_version_promoter"
-  autoload :Graph,                  "bundler/graph"
-  autoload :Index,                  "bundler/index"
-  autoload :Injector,               "bundler/injector"
-  autoload :Installer,              "bundler/installer"
-  autoload :LazySpecification,      "bundler/lazy_specification"
-  autoload :LockfileParser,         "bundler/lockfile_parser"
-  autoload :MatchPlatform,          "bundler/match_platform"
-  autoload :ProcessLock,            "bundler/process_lock"
-  autoload :RemoteSpecification,    "bundler/remote_specification"
-  autoload :Resolver,               "bundler/resolver"
-  autoload :Retry,                  "bundler/retry"
-  autoload :RubyDsl,                "bundler/ruby_dsl"
-  autoload :RubyGemsGemInstaller,   "bundler/rubygems_gem_installer"
-  autoload :RubyVersion,            "bundler/ruby_version"
-  autoload :Runtime,                "bundler/runtime"
-  autoload :Settings,               "bundler/settings"
-  autoload :SharedHelpers,          "bundler/shared_helpers"
-  autoload :Source,                 "bundler/source"
-  autoload :SourceList,             "bundler/source_list"
-  autoload :SpecSet,                "bundler/spec_set"
-  autoload :StubSpecification,      "bundler/stub_specification"
-  autoload :UI,                     "bundler/ui"
-  autoload :URICredentialsFilter,   "bundler/uri_credentials_filter"
-  autoload :VersionRanges,          "bundler/version_ranges"
+  autoload :Definition,             File.expand_path("bundler/definition", __dir__)
+  autoload :Dependency,             File.expand_path("bundler/dependency", __dir__)
+  autoload :DepProxy,               File.expand_path("bundler/dep_proxy", __dir__)
+  autoload :Deprecate,              File.expand_path("bundler/deprecate", __dir__)
+  autoload :Dsl,                    File.expand_path("bundler/dsl", __dir__)
+  autoload :EndpointSpecification,  File.expand_path("bundler/endpoint_specification", __dir__)
+  autoload :Env,                    File.expand_path("bundler/env", __dir__)
+  autoload :Fetcher,                File.expand_path("bundler/fetcher", __dir__)
+  autoload :FeatureFlag,            File.expand_path("bundler/feature_flag", __dir__)
+  autoload :GemHelper,              File.expand_path("bundler/gem_helper", __dir__)
+  autoload :GemHelpers,             File.expand_path("bundler/gem_helpers", __dir__)
+  autoload :GemRemoteFetcher,       File.expand_path("bundler/gem_remote_fetcher", __dir__)
+  autoload :GemVersionPromoter,     File.expand_path("bundler/gem_version_promoter", __dir__)
+  autoload :Graph,                  File.expand_path("bundler/graph", __dir__)
+  autoload :Index,                  File.expand_path("bundler/index", __dir__)
+  autoload :Injector,               File.expand_path("bundler/injector", __dir__)
+  autoload :Installer,              File.expand_path("bundler/installer", __dir__)
+  autoload :LazySpecification,      File.expand_path("bundler/lazy_specification", __dir__)
+  autoload :LockfileParser,         File.expand_path("bundler/lockfile_parser", __dir__)
+  autoload :MatchPlatform,          File.expand_path("bundler/match_platform", __dir__)
+  autoload :ProcessLock,            File.expand_path("bundler/process_lock", __dir__)
+  autoload :RemoteSpecification,    File.expand_path("bundler/remote_specification", __dir__)
+  autoload :Resolver,               File.expand_path("bundler/resolver", __dir__)
+  autoload :Retry,                  File.expand_path("bundler/retry", __dir__)
+  autoload :RubyDsl,                File.expand_path("bundler/ruby_dsl", __dir__)
+  autoload :RubyGemsGemInstaller,   File.expand_path("bundler/rubygems_gem_installer", __dir__)
+  autoload :RubyVersion,            File.expand_path("bundler/ruby_version", __dir__)
+  autoload :Runtime,                File.expand_path("bundler/runtime", __dir__)
+  autoload :Settings,               File.expand_path("bundler/settings", __dir__)
+  autoload :SharedHelpers,          File.expand_path("bundler/shared_helpers", __dir__)
+  autoload :Source,                 File.expand_path("bundler/source", __dir__)
+  autoload :SourceList,             File.expand_path("bundler/source_list", __dir__)
+  autoload :SpecSet,                File.expand_path("bundler/spec_set", __dir__)
+  autoload :StubSpecification,      File.expand_path("bundler/stub_specification", __dir__)
+  autoload :UI,                     File.expand_path("bundler/ui", __dir__)
+  autoload :URICredentialsFilter,   File.expand_path("bundler/uri_credentials_filter", __dir__)
+  autoload :VersionRanges,          File.expand_path("bundler/version_ranges", __dir__)
 
   class << self
     def configure

--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -9,10 +9,10 @@ require "rubygems/request"
 module Bundler
   # Handles all the fetching with the rubygems server
   class Fetcher
-    autoload :CompactIndex, "bundler/fetcher/compact_index"
-    autoload :Downloader, "bundler/fetcher/downloader"
-    autoload :Dependency, "bundler/fetcher/dependency"
-    autoload :Index, "bundler/fetcher/index"
+    autoload :CompactIndex, File.expand_path("fetcher/compact_index", __dir__)
+    autoload :Downloader, File.expand_path("fetcher/downloader", __dir__)
+    autoload :Dependency, File.expand_path("fetcher/dependency", __dir__)
+    autoload :Index, File.expand_path("fetcher/index", __dir__)
 
     # This error is raised when it looks like the network is down
     class NetworkDownError < HTTPError; end

--- a/lib/bundler/fetcher/compact_index.rb
+++ b/lib/bundler/fetcher/compact_index.rb
@@ -4,7 +4,7 @@ require_relative "base"
 require_relative "../worker"
 
 module Bundler
-  autoload :CompactIndexClient, "bundler/compact_index_client"
+  autoload :CompactIndexClient, File.expand_path("../compact_index_client", __dir__)
 
   class Fetcher
     class CompactIndex < Base

--- a/lib/bundler/plugin/api.rb
+++ b/lib/bundler/plugin/api.rb
@@ -23,7 +23,7 @@ module Bundler
   # and hooks).
   module Plugin
     class API
-      autoload :Source, "bundler/plugin/api/source"
+      autoload :Source, File.expand_path("api/source", __dir__)
 
       # The plugins should declare that they handle a command through this helper.
       #

--- a/lib/bundler/plugin/installer.rb
+++ b/lib/bundler/plugin/installer.rb
@@ -8,8 +8,8 @@ module Bundler
   # are heavily dependent on the Gemfile.
   module Plugin
     class Installer
-      autoload :Rubygems, "bundler/plugin/installer/rubygems"
-      autoload :Git,      "bundler/plugin/installer/git"
+      autoload :Rubygems, File.expand_path("installer/rubygems", __dir__)
+      autoload :Git,      File.expand_path("installer/git", __dir__)
 
       def install(names, options)
         check_sources_consistency!(options)

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -4,9 +4,9 @@ require "uri"
 
 module Bundler
   class Settings
-    autoload :Mirror,  "bundler/mirror"
-    autoload :Mirrors, "bundler/mirror"
-    autoload :Validator, "bundler/settings/validator"
+    autoload :Mirror,  File.expand_path("mirror", __dir__)
+    autoload :Mirrors, File.expand_path("mirror", __dir__)
+    autoload :Validator, File.expand_path("settings/validator", __dir__)
 
     BOOL_KEYS = %w[
       allow_bundler_dependency_conflicts

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -291,8 +291,9 @@ module Bundler
 
     def set_rubyopt
       rubyopt = [ENV["RUBYOPT"]].compact
-      return if !rubyopt.empty? && rubyopt.first =~ %r{-rbundler/setup}
-      rubyopt.unshift %(-rbundler/setup)
+      setup_require = "-r#{File.expand_path("setup", __dir__)}"
+      return if !rubyopt.empty? && rubyopt.first =~ /#{setup_require}/
+      rubyopt.unshift %(#{setup_require})
       Bundler::SharedHelpers.set_env "RUBYOPT", rubyopt.join(" ")
     end
 

--- a/lib/bundler/source.rb
+++ b/lib/bundler/source.rb
@@ -2,11 +2,11 @@
 
 module Bundler
   class Source
-    autoload :Gemspec,  "bundler/source/gemspec"
-    autoload :Git,      "bundler/source/git"
-    autoload :Metadata, "bundler/source/metadata"
-    autoload :Path,     "bundler/source/path"
-    autoload :Rubygems, "bundler/source/rubygems"
+    autoload :Gemspec,  File.expand_path("source/gemspec", __dir__)
+    autoload :Git,      File.expand_path("source/git", __dir__)
+    autoload :Metadata, File.expand_path("source/metadata", __dir__)
+    autoload :Path,     File.expand_path("source/path", __dir__)
+    autoload :Rubygems, File.expand_path("source/rubygems", __dir__)
 
     attr_accessor :dependency_names
 

--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -6,7 +6,7 @@ require "uri"
 module Bundler
   class Source
     class Git < Path
-      autoload :GitProxy, "bundler/source/git/git_proxy"
+      autoload :GitProxy, File.expand_path("git/git_proxy", __dir__)
 
       attr_reader :uri, :ref, :branch, :options, :submodules
 

--- a/lib/bundler/source/path.rb
+++ b/lib/bundler/source/path.rb
@@ -3,7 +3,7 @@
 module Bundler
   class Source
     class Path < Source
-      autoload :Installer, "bundler/source/path/installer"
+      autoload :Installer, File.expand_path("path/installer", __dir__)
 
       attr_reader :path, :options, :root_path, :original_path
       attr_writer :name

--- a/lib/bundler/source/rubygems.rb
+++ b/lib/bundler/source/rubygems.rb
@@ -6,7 +6,7 @@ require "rubygems/user_interaction"
 module Bundler
   class Source
     class Rubygems < Source
-      autoload :Remote, "bundler/source/rubygems/remote"
+      autoload :Remote, File.expand_path("rubygems/remote", __dir__)
 
       # Use the API when installing less than X gems
       API_REQUEST_LIMIT = 500

--- a/lib/bundler/ui.rb
+++ b/lib/bundler/ui.rb
@@ -2,8 +2,8 @@
 
 module Bundler
   module UI
-    autoload :RGProxy, "bundler/ui/rg_proxy"
-    autoload :Shell,   "bundler/ui/shell"
-    autoload :Silent,  "bundler/ui/silent"
+    autoload :RGProxy, File.expand_path("ui/rg_proxy", __dir__)
+    autoload :Shell,   File.expand_path("ui/shell", __dir__)
+    autoload :Silent,  File.expand_path("ui/silent", __dir__)
   end
 end

--- a/lib/bundler/vendor/molinillo/lib/molinillo.rb
+++ b/lib/bundler/vendor/molinillo/lib/molinillo.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require 'bundler/vendor/molinillo/lib/molinillo/compatibility'
-require 'bundler/vendor/molinillo/lib/molinillo/gem_metadata'
-require 'bundler/vendor/molinillo/lib/molinillo/errors'
-require 'bundler/vendor/molinillo/lib/molinillo/resolver'
-require 'bundler/vendor/molinillo/lib/molinillo/modules/ui'
-require 'bundler/vendor/molinillo/lib/molinillo/modules/specification_provider'
+require_relative 'molinillo/compatibility'
+require_relative 'molinillo/gem_metadata'
+require_relative 'molinillo/errors'
+require_relative 'molinillo/resolver'
+require_relative 'molinillo/modules/ui'
+require_relative 'molinillo/modules/specification_provider'
 
 # Bundler::Molinillo is a generic dependency resolution algorithm.
 module Bundler::Molinillo

--- a/lib/bundler/vendor/molinillo/lib/molinillo/dependency_graph.rb
+++ b/lib/bundler/vendor/molinillo/lib/molinillo/dependency_graph.rb
@@ -3,8 +3,8 @@
 require 'set'
 require 'tsort'
 
-require 'bundler/vendor/molinillo/lib/molinillo/dependency_graph/log'
-require 'bundler/vendor/molinillo/lib/molinillo/dependency_graph/vertex'
+require_relative 'dependency_graph/log'
+require_relative 'dependency_graph/vertex'
 
 module Bundler::Molinillo
   # A directed acyclic graph that is tuned to hold named dependencies

--- a/lib/bundler/vendor/molinillo/lib/molinillo/dependency_graph/add_edge_no_circular.rb
+++ b/lib/bundler/vendor/molinillo/lib/molinillo/dependency_graph/add_edge_no_circular.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'bundler/vendor/molinillo/lib/molinillo/dependency_graph/action'
+require_relative 'action'
 module Bundler::Molinillo
   class DependencyGraph
     # @!visibility private

--- a/lib/bundler/vendor/molinillo/lib/molinillo/dependency_graph/add_vertex.rb
+++ b/lib/bundler/vendor/molinillo/lib/molinillo/dependency_graph/add_vertex.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'bundler/vendor/molinillo/lib/molinillo/dependency_graph/action'
+require_relative 'action'
 module Bundler::Molinillo
   class DependencyGraph
     # @!visibility private

--- a/lib/bundler/vendor/molinillo/lib/molinillo/dependency_graph/delete_edge.rb
+++ b/lib/bundler/vendor/molinillo/lib/molinillo/dependency_graph/delete_edge.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'bundler/vendor/molinillo/lib/molinillo/dependency_graph/action'
+require_relative 'action'
 module Bundler::Molinillo
   class DependencyGraph
     # @!visibility private

--- a/lib/bundler/vendor/molinillo/lib/molinillo/dependency_graph/detach_vertex_named.rb
+++ b/lib/bundler/vendor/molinillo/lib/molinillo/dependency_graph/detach_vertex_named.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'bundler/vendor/molinillo/lib/molinillo/dependency_graph/action'
+require_relative 'action'
 module Bundler::Molinillo
   class DependencyGraph
     # @!visibility private

--- a/lib/bundler/vendor/molinillo/lib/molinillo/dependency_graph/log.rb
+++ b/lib/bundler/vendor/molinillo/lib/molinillo/dependency_graph/log.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require 'bundler/vendor/molinillo/lib/molinillo/dependency_graph/add_edge_no_circular'
-require 'bundler/vendor/molinillo/lib/molinillo/dependency_graph/add_vertex'
-require 'bundler/vendor/molinillo/lib/molinillo/dependency_graph/delete_edge'
-require 'bundler/vendor/molinillo/lib/molinillo/dependency_graph/detach_vertex_named'
-require 'bundler/vendor/molinillo/lib/molinillo/dependency_graph/set_payload'
-require 'bundler/vendor/molinillo/lib/molinillo/dependency_graph/tag'
+require_relative 'add_edge_no_circular'
+require_relative 'add_vertex'
+require_relative 'delete_edge'
+require_relative 'detach_vertex_named'
+require_relative 'set_payload'
+require_relative 'tag'
 
 module Bundler::Molinillo
   class DependencyGraph

--- a/lib/bundler/vendor/molinillo/lib/molinillo/dependency_graph/set_payload.rb
+++ b/lib/bundler/vendor/molinillo/lib/molinillo/dependency_graph/set_payload.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'bundler/vendor/molinillo/lib/molinillo/dependency_graph/action'
+require_relative 'action'
 module Bundler::Molinillo
   class DependencyGraph
     # @!visibility private

--- a/lib/bundler/vendor/molinillo/lib/molinillo/dependency_graph/tag.rb
+++ b/lib/bundler/vendor/molinillo/lib/molinillo/dependency_graph/tag.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'bundler/vendor/molinillo/lib/molinillo/dependency_graph/action'
+require_relative 'action'
 module Bundler::Molinillo
   class DependencyGraph
     # @!visibility private

--- a/lib/bundler/vendor/molinillo/lib/molinillo/errors.rb
+++ b/lib/bundler/vendor/molinillo/lib/molinillo/errors.rb
@@ -80,7 +80,7 @@ module Bundler::Molinillo
       @specification_provider = specification_provider
     end
 
-    require 'bundler/vendor/molinillo/lib/molinillo/delegates/specification_provider'
+    require_relative 'delegates/specification_provider'
     include Delegates::SpecificationProvider
 
     # @return [String] An error message that includes requirement trees,

--- a/lib/bundler/vendor/molinillo/lib/molinillo/resolution.rb
+++ b/lib/bundler/vendor/molinillo/lib/molinillo/resolution.rb
@@ -238,11 +238,11 @@ module Bundler::Molinillo
         debug { 'Activated: ' + Hash[activated.vertices.select { |_n, v| v.payload }].keys.join(', ') } if state
       end
 
-      require 'bundler/vendor/molinillo/lib/molinillo/state'
-      require 'bundler/vendor/molinillo/lib/molinillo/modules/specification_provider'
+      require_relative 'state'
+      require_relative 'modules/specification_provider'
 
-      require 'bundler/vendor/molinillo/lib/molinillo/delegates/resolution_state'
-      require 'bundler/vendor/molinillo/lib/molinillo/delegates/specification_provider'
+      require_relative 'delegates/resolution_state'
+      require_relative 'delegates/specification_provider'
 
       include Bundler::Molinillo::Delegates::ResolutionState
       include Bundler::Molinillo::Delegates::SpecificationProvider

--- a/lib/bundler/vendor/molinillo/lib/molinillo/resolver.rb
+++ b/lib/bundler/vendor/molinillo/lib/molinillo/resolver.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'bundler/vendor/molinillo/lib/molinillo/dependency_graph'
+require_relative 'dependency_graph'
 
 module Bundler::Molinillo
   # This class encapsulates a dependency resolver.
@@ -9,7 +9,7 @@ module Bundler::Molinillo
   #
   #
   class Resolver
-    require 'bundler/vendor/molinillo/lib/molinillo/resolution'
+    require_relative 'resolution'
 
     # @return [SpecificationProvider] the specification provider used
     #   in the resolution process

--- a/lib/bundler/vendor/thor/lib/thor/base.rb
+++ b/lib/bundler/vendor/thor/lib/thor/base.rb
@@ -9,9 +9,9 @@ require "bundler/vendor/thor/lib/thor/line_editor"
 require "bundler/vendor/thor/lib/thor/util"
 
 class Bundler::Thor
-  autoload :Actions,    "bundler/vendor/thor/lib/thor/actions"
-  autoload :RakeCompat, "bundler/vendor/thor/lib/thor/rake_compat"
-  autoload :Group,      "bundler/vendor/thor/lib/thor/group"
+  autoload :Actions,    File.expand_path("actions", __dir__)
+  autoload :RakeCompat, File.expand_path("rake_compat", __dir__)
+  autoload :Group,      File.expand_path("group", __dir__)
 
   # Shortcuts for help.
   HELP_MAPPINGS       = %w(-h -? --help -D)

--- a/lib/bundler/vendor/thor/lib/thor/shell.rb
+++ b/lib/bundler/vendor/thor/lib/thor/shell.rb
@@ -24,9 +24,9 @@ class Bundler::Thor
     SHELL_DELEGATED_METHODS = [:ask, :error, :set_color, :yes?, :no?, :say, :say_status, :print_in_columns, :print_table, :print_wrapped, :file_collision, :terminal_width]
     attr_writer :shell
 
-    autoload :Basic, "bundler/vendor/thor/lib/thor/shell/basic"
-    autoload :Color, "bundler/vendor/thor/lib/thor/shell/color"
-    autoload :HTML,  "bundler/vendor/thor/lib/thor/shell/html"
+    autoload :Basic, File.expand_path("shell/basic", __dir__)
+    autoload :Color, File.expand_path("shell/color", __dir__)
+    autoload :HTML,  File.expand_path("shell/html", __dir__)
 
     # Add shell to initialize config values.
     #

--- a/lib/bundler/version.rb
+++ b/lib/bundler/version.rb
@@ -1,23 +1,7 @@
 # frozen_string_literal: false
 
 module Bundler
-  # We're doing this because we might write tests that deal
-  # with other versions of bundler and we are unsure how to
-  # handle this better.
-  VERSION = "2.1.0.pre.1".freeze unless defined?(::Bundler::VERSION)
-
-  def self.overwrite_loaded_gem_version
-    begin
-      require "rubygems"
-    rescue LoadError
-      return
-    end
-    return unless bundler_spec = Gem.loaded_specs["bundler"]
-    return if bundler_spec.version == VERSION
-    bundler_spec.version = Bundler::VERSION
-  end
-  private_class_method :overwrite_loaded_gem_version
-  overwrite_loaded_gem_version
+  VERSION = "2.1.0.pre.1".freeze
 
   def self.bundler_major_version
     @bundler_major_version ||= VERSION.split(".").first.to_i

--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe Bundler::SharedHelpers do
     shared_examples_for "ENV['RUBYOPT'] gets set correctly" do
       it "ensures -rbundler/setup is at the beginning of ENV['RUBYOPT']" do
         subject.set_bundle_environment
-        expect(ENV["RUBYOPT"].split(" ")).to start_with("-rbundler/setup")
+        expect(ENV["RUBYOPT"].split(" ")).to start_with("-r#{File.expand_path("../../lib/bundler/setup", __dir__)}")
       end
     end
 

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -279,7 +279,7 @@ RSpec.describe "bundle exec" do
     G
 
     rubyopt = ENV["RUBYOPT"]
-    rubyopt = "-rbundler/setup #{rubyopt}"
+    rubyopt = "-r#{File.expand_path("../../lib/bundler/setup", __dir__)} #{rubyopt}"
 
     bundle "exec 'echo $RUBYOPT'"
     expect(out).to have_rubyopts(rubyopt)

--- a/spec/support/hax.rb
+++ b/spec/support/hax.rb
@@ -21,6 +21,8 @@ module Gem
 end
 
 if ENV["BUNDLER_SPEC_VERSION"]
+  require "bundler/version"
+
   module Bundler
     remove_const(:VERSION) if const_defined?(:VERSION)
     VERSION = ENV["BUNDLER_SPEC_VERSION"].dup


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that we are doing some hacks in our version file that are... dangerous. At very least they cause "circular problems" like #6927, but I also have bad feelings about it.

### What was your diagnosis of the problem?

My diagnosis was we're overwriting the version of the currently loaded bundler :grimacing:. This hack is _almost_ unnecessary (see the spec run here with the hack fully removed: https://travis-ci.org/bundler/bundler/builds/509497021. Only three jobs failed, and for old rubies/rubygems/bundler). 

### What is your fix for the problem, implemented in this PR?

My fix is to limit the hack to `bundler`'s spec run, since it's only needed there.

### Why did you choose this fix out of the possible options?

I chose this fix because fully getting the build green with the hack fully removed is a bit of work. I dedicated a bit of time to investigate one of the failures and it all comes down to the priority of loading default gems vs `-I`. So I think something like https://github.com/rubygems/rubygems/pull/1868 should fix it. But that's out of the scope of this PR.

Closes #6927.