### PR TITLE
Small fix with plural.

### DIFF
--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -133,7 +133,7 @@ module Bundler
 
             unless options[:parseable]
               if groups
-                Bundler.ui.info "===== Group #{groups} ====="
+                Bundler.ui.info "===== #{groups_text("Group", groups)} ====="
               else
                 Bundler.ui.info "===== Without group ====="
               end
@@ -166,6 +166,10 @@ module Bundler
     end
 
   private
+
+    def groups_text(group_text, groups)
+      "#{group_text}#{groups.split(",").size > 1 ? "s" : ""} \"#{groups}\""
+    end
 
     def retrieve_active_spec(strict, definition, current_spec)
       if strict
@@ -212,7 +216,7 @@ module Bundler
       elsif options_include_groups || !groups
         "  * #{spec_outdated_info}"
       else
-        "  * #{spec_outdated_info} in groups \"#{groups}\""
+        "  * #{spec_outdated_info} in #{groups_text("group", groups)}"
       end
 
       Bundler.ui.info output_message.rstrip

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -59,15 +59,19 @@ RSpec.describe "bundle outdated" do
       install_gemfile <<-G
         source "file://#{gem_repo2}"
 
+        gem "terranova", '8'
+
         group :development, :test do
           gem 'activesupport', '2.3.5'
         end
       G
 
       update_repo2 { build_gem "activesupport", "3.0" }
+      update_repo2 { build_gem "terranova", "9" }
 
       bundle "outdated --verbose"
       expect(out).to include("activesupport (newest 3.0, installed 2.3.5, requested = 2.3.5) in groups \"development, test\"")
+      expect(out).to include("terranova (newest 9, installed 8, requested = 8) in group \"default\"")
     end
   end
 
@@ -117,10 +121,10 @@ RSpec.describe "bundle outdated" do
     it "returns a sorted list of outdated gems from one group => 'default'" do
       test_group_option("default")
 
-      expect(out).to include("===== Group default =====")
+      expect(out).to include("===== Group \"default\" =====")
       expect(out).to include("terranova (")
 
-      expect(out).not_to include("===== Group development, test =====")
+      expect(out).not_to include("===== Groups \"development, test\" =====")
       expect(out).not_to include("activesupport")
       expect(out).not_to include("duradura")
     end
@@ -128,10 +132,10 @@ RSpec.describe "bundle outdated" do
     it "returns a sorted list of outdated gems from one group => 'development'" do
       test_group_option("development", 2)
 
-      expect(out).not_to include("===== Group default =====")
+      expect(out).not_to include("===== Group \"default\" =====")
       expect(out).not_to include("terranova (")
 
-      expect(out).to include("===== Group development, test =====")
+      expect(out).to include("===== Groups \"development, test\" =====")
       expect(out).to include("activesupport")
       expect(out).to include("duradura")
     end
@@ -139,10 +143,10 @@ RSpec.describe "bundle outdated" do
     it "returns a sorted list of outdated gems from one group => 'test'" do
       test_group_option("test", 2)
 
-      expect(out).not_to include("===== Group default =====")
+      expect(out).not_to include("===== Group \"default\" =====")
       expect(out).not_to include("terranova (")
 
-      expect(out).to include("===== Group development, test =====")
+      expect(out).to include("===== Groups \"development, test\" =====")
       expect(out).to include("activesupport")
       expect(out).to include("duradura")
     end
@@ -184,9 +188,9 @@ RSpec.describe "bundle outdated" do
       end
 
       bundle "outdated --groups"
-      expect(out).to include("===== Group default =====")
+      expect(out).to include("===== Group \"default\" =====")
       expect(out).to include("terranova (newest 9, installed 8, requested = 8)")
-      expect(out).to include("===== Group development, test =====")
+      expect(out).to include("===== Groups \"development, test\" =====")
       expect(out).to include("activesupport (newest 3.0, installed 2.3.5, requested = 2.3.5)")
       expect(out).to include("duradura (newest 8.0, installed 7.0, requested = 7.0)")
 


### PR DESCRIPTION
**The problem was** when is outdated is ran always if the gem belongs to one group or more always show "groups" in plural.

**My diagnosis is** if the gem belongs to one group it's incorrect to show "groups" in plural.

**My fix was** if the gem belongs to one group it should show "group" in singular.
