### PR TITLE
Bump vendored fileutils to 1.2.0

### DIFF
--- a/lib/bundler/vendor/fileutils/lib/fileutils/version.rb
+++ b/lib/bundler/vendor/fileutils/lib/fileutils/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Bundler::FileUtils
+  VERSION = "1.2.0"
+end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was we manually updated some code in the vendored fileutils instead of using a released version.

### What was your diagnosis of the problem?

My diagnosis was that we should use the recently released fileutils 1.2.0.

### What is your fix for the problem, implemented in this PR?

My fix is to vendor it through `bin/rake vendor:fileutils[v1.2.0]`.

### Why did you choose this fix out of the possible options?

I chose this fix because it properly upgrades the vendored code to match what's last released.