### PR TITLE
Correction to : bundle outdated --source not working as expected

### DIFF
--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -792,3 +792,13 @@ RSpec.describe "bundle outdated" do
     end
   end
 end
+
+
+describe "with --source" do
+      bundle "outdated --source #{source}"
+      expect(out).to include("Bundle source !")
+      # Gem names are one per-line, between "*" and their parenthesized version.
+      gem_list = out.split("\n").map {|g| g[/\* (.*) \(/, 1] }.compact
+      expect(gem_list).to eq(gem_list.sort)
+      expect(gem_list.size).to eq gems_list_size
+end  

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -765,6 +765,14 @@ RSpec.describe "bundle outdated" do
     end
   end
 
+  describe "with --source" do
+    bundle "outdated --source #{source}"
+    expect(out).to include("Bundle source !")
+    gem_list = out.split("\n").map {|g| g[/\* (.*) \(/, 1] }.compact
+    expect(gem_list).to eq(gem_list.sort)
+    expect(gem_list.size).to eq gems_list_size
+  end  
+
   describe "with --only-explicit" do
     it "does not report outdated dependent gems" do
       build_repo4 do
@@ -792,13 +800,3 @@ RSpec.describe "bundle outdated" do
     end
   end
 end
-
-
-describe "with --source" do
-      bundle "outdated --source #{source}"
-      expect(out).to include("Bundle source !")
-      # Gem names are one per-line, between "*" and their parenthesized version.
-      gem_list = out.split("\n").map {|g| g[/\* (.*) \(/, 1] }.compact
-      expect(gem_list).to eq(gem_list.sort)
-      expect(gem_list.size).to eq gems_list_size
-end  

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -771,7 +771,7 @@ RSpec.describe "bundle outdated" do
     gem_list = out.split("\n").map {|g| g[/\* (.*) \(/, 1] }.compact
     expect(gem_list).to eq(gem_list.sort)
     expect(gem_list.size).to eq gems_list_size
-  end  
+  end
 
   describe "with --only-explicit" do
     it "does not report outdated dependent gems" do


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was bundle outdated --source not working as expected.

### What was your diagnosis of the problem?

My diagnosis was to add --source in the directory of spec/commands/outdated_spec.rb and add a basic spec to it, I'm a beginner at work, trying to learn.

### What is your fix for the problem, implemented in this PR?

My fix was to add the basic spec for outdated, I need guidance on the same to enhance and correct it.

### Why did you choose this fix out of the possible options?

I chose this fix because it was needed for the issue, I guess.

Closes #4881.