### PR TITLE
Review `bundle show` deprecation

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -320,7 +320,7 @@ module Bundler
     desc "list", "List all gems in the bundle"
     method_option "name-only", :type => :boolean, :banner => "print only the gem names"
     method_option "only-group", :type => :string, :banner => "print gems from a particular group"
-    method_option "without-group", :type => :string, :banner => "print all gems expect from a group"
+    method_option "without-group", :type => :string, :banner => "print all gems except from a group"
     method_option "paths", :type => :boolean, :banner => "print the path to each gem in the bundle"
     def list
       require "bundler/cli/list"

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -282,7 +282,7 @@ module Bundler
       end
     end
 
-    unless Bundler.feature_flag.list_command?
+    unless Bundler.feature_flag.bundler_3_mode?
       desc "show GEM [OPTIONS]", "Shows all gems that are part of the bundle, or the path to a given gem"
       long_desc <<-D
         Show lists the names and versions of all gems that are required by your Gemfile.
@@ -315,23 +315,19 @@ module Bundler
         require "bundler/cli/show"
         Show.new(options, gem_name).run
       end
-
-      map %w[list] => "show"
     end
 
-    if Bundler.feature_flag.list_command?
-      desc "list", "List all gems in the bundle"
-      method_option "name-only", :type => :boolean, :banner => "print only the gem names"
-      method_option "only-group", :type => :string, :banner => "print gems from a particular group"
-      method_option "without-group", :type => :string, :banner => "print all gems expect from a group"
-      method_option "paths", :type => :boolean, :banner => "print the path to each gem in the bundle"
-      def list
-        require "bundler/cli/list"
-        List.new(options).run
-      end
-
-      map %w[ls] => "list"
+    desc "list", "List all gems in the bundle"
+    method_option "name-only", :type => :boolean, :banner => "print only the gem names"
+    method_option "only-group", :type => :string, :banner => "print gems from a particular group"
+    method_option "without-group", :type => :string, :banner => "print all gems expect from a group"
+    method_option "paths", :type => :boolean, :banner => "print the path to each gem in the bundle"
+    def list
+      require "bundler/cli/list"
+      List.new(options).run
     end
+
+    map %w[ls] => "list"
 
     desc "info GEM [OPTIONS]", "Show information for the given gem"
     method_option "path", :type => :boolean, :banner => "Print full path to gem"

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -296,17 +296,21 @@ module Bundler
         if ARGV[0] == "show"
           rest = ARGV[1..-1]
 
-          new_command = rest.find {|arg| !arg.start_with?("--") } ? "info" : "list"
+          if flag = rest.find{|arg| ["--verbose", "--outdated"].include?(arg) }
+            Bundler::SharedHelpers.major_deprecation(2, "the `#{flag}` flag to `bundle show` was undocumented and will be removed without replacement")
+          else
+            new_command = rest.find {|arg| !arg.start_with?("--") } ? "info" : "list"
 
-          new_arguments = rest.map do |arg|
-            next arg if arg != "--paths"
-            next "--path" if new_command == "info"
+            new_arguments = rest.map do |arg|
+              next arg if arg != "--paths"
+              next "--path" if new_command == "info"
+            end
+
+            old_argv = ARGV.join(" ")
+            new_argv = [new_command, *new_arguments.compact].join(" ")
+
+            Bundler::SharedHelpers.major_deprecation(2, "use `bundle #{new_argv}` instead of `bundle #{old_argv}`")
           end
-
-          old_argv = ARGV.join(" ")
-          new_argv = [new_command, *new_arguments.compact].join(" ")
-
-          Bundler::SharedHelpers.major_deprecation(2, "use `bundle #{new_argv}` instead of `bundle #{old_argv}`")
         end
         require "bundler/cli/show"
         Show.new(options, gem_name).run

--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -41,7 +41,7 @@ module Bundler
     settings_flag(:global_path_appends_ruby_scope) { bundler_2_mode? }
     settings_flag(:global_gem_cache) { bundler_2_mode? }
     settings_flag(:init_gems_rb) { bundler_2_mode? }
-    settings_flag(:list_command) { bundler_2_mode? }
+    settings_flag(:list_command) { bundler_3_mode? }
     settings_flag(:lockfile_uses_separate_rubygems_sources) { bundler_2_mode? }
     settings_flag(:only_update_to_newer_versions) { bundler_2_mode? }
     settings_flag(:path_relative_to_cwd) { bundler_2_mode? }

--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -41,7 +41,6 @@ module Bundler
     settings_flag(:global_path_appends_ruby_scope) { bundler_2_mode? }
     settings_flag(:global_gem_cache) { bundler_2_mode? }
     settings_flag(:init_gems_rb) { bundler_2_mode? }
-    settings_flag(:list_command) { bundler_3_mode? }
     settings_flag(:lockfile_uses_separate_rubygems_sources) { bundler_2_mode? }
     settings_flag(:only_update_to_newer_versions) { bundler_2_mode? }
     settings_flag(:path_relative_to_cwd) { bundler_2_mode? }

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -39,7 +39,6 @@ module Bundler
       global_gem_cache
       ignore_messages
       init_gems_rb
-      list_command
       lockfile_uses_separate_rubygems_sources
       no_install
       no_prune

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -214,8 +214,6 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
    Generate a `gems.rb` instead of a `Gemfile` when running `bundle init`.
 * `jobs` (`BUNDLE_JOBS`):
    The number of gems Bundler can install in parallel. Defaults to 1.
-* `list_command` (`BUNDLE_LIST_COMMAND`)
-   Enable new list command feature
 * `no_install` (`BUNDLE_NO_INSTALL`):
    Whether `bundle package` should skip installing gems.
 * `no_prune` (`BUNDLE_NO_PRUNE`):

--- a/spec/commands/list_spec.rb
+++ b/spec/commands/list_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "bundle list", :bundler => "2" do
+RSpec.describe "bundle list", :bundler => "3" do
   before do
     install_gemfile <<-G
       source "file://#{gem_repo1}"

--- a/spec/commands/list_spec.rb
+++ b/spec/commands/list_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "bundle list", :bundler => "3" do
+RSpec.describe "bundle list", :bundler => ">= 2" do
   before do
     install_gemfile <<-G
       source "file://#{gem_repo1}"

--- a/spec/commands/show_spec.rb
+++ b/spec/commands/show_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "bundle show" do
+RSpec.describe "bundle show", :bundler => "< 3" do
   context "with a standard Gemfile" do
     before :each do
       install_gemfile <<-G

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -486,6 +486,34 @@ The :gist git source is deprecated, and will be removed in the future. Add this 
       end
     end
 
+    context "with --outdated flag" do
+      before do
+        bundle! "show --outdated"
+      end
+
+      it "does not print a deprecation warning", :bundler => "< 2" do
+        expect(deprecations).to be_empty
+      end
+
+      it "prints a deprecation warning informing about its removal", :bundler => "2" do
+        expect(deprecations).to include("the `--outdated` flag to `bundle show` was undocumented and will be removed without replacement")
+      end
+    end
+
+    context "with --verbose flag" do
+      before do
+        bundle! "show --verbose"
+      end
+
+      it "does not print a deprecation warning", :bundler => "< 2" do
+        expect(deprecations).to be_empty
+      end
+
+      it "prints a deprecation warning informing about its removal", :bundler => "2" do
+        expect(deprecations).to include("the `--verbose` flag to `bundle show` was undocumented and will be removed without replacement")
+      end
+    end
+
     context "with a gem argument" do
       before do
         bundle! "show rack"

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -470,16 +470,34 @@ The :gist git source is deprecated, and will be removed in the future. Add this 
         source "file://#{gem_repo1}"
         gem "rack"
       G
-
-      bundle! :show
     end
 
-    it "does not print a deprecation warning", :bundler => "< 2" do
-      expect(deprecations).to be_empty
+    context "without flags" do
+      before do
+        bundle! :show
+      end
+
+      it "does not print a deprecation warning", :bundler => "< 2" do
+        expect(deprecations).to be_empty
+      end
+
+      it "prints a deprecation warning recommending `bundle list`", :bundler => "2" do
+        expect(deprecations).to include("use `bundle list` instead of `bundle show`")
+      end
     end
 
-    it "prints a deprecation warning", :bundler => "2" do
-      expect(deprecations).to include("use `bundle list` instead of `bundle show`")
+    context "with a gem argument" do
+      before do
+        bundle! "show rack"
+      end
+
+      it "does not print a deprecation warning", :bundler => "< 2" do
+        expect(deprecations).to be_empty
+      end
+
+      it "prints a deprecation warning recommending `bundle info`", :bundler => "2" do
+        expect(deprecations).to include("use `bundle info rack` instead of `bundle show rack`")
+      end
     end
   end
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was there was some work to do regarding the deprecation of `bundle show` and the `bundle list` introduction.

### What was your diagnosis of the problem?

* The command should error out in bundler 3 and was still there.
* The command would print erroneous deprecation messages for the `--verbose` and `--outdated` flags. These flags to `bundle show` are undocumented and will be removed in bundler 3.
* The `bundle list` help would show the help for the new `list` command that lists groups of (or all) gems in the Gemfile, but its implementation would just be an alias to `bundle show`.

### What is your fix for the problem, implemented in this PR?

My fix is to remove the command in bundler 3, to show a different deprecation message when `--outdated` or `--verbose` are used to inform about their removal without replacement, and the inconditionally introduce the new list command without any feature flag. 

### Why did you choose this fix out of the possible options?

I chose this fix because:

* The `--outdated` and `--verbse` options are undocumented, so nobody should be using them. Still, I give a correct deprecation message for any users they might have used them.
* The `list` command was super confusing because it was an alias to `show` but that was not documented anywhere. So, I consider find to introduce the new `bundle list` now to match the documentation.