### PR TITLE
Remove unnecessary test stuff

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -54,11 +54,6 @@ namespace :spec do
       "'#{name}:#{version}'"
     end.join(" ")
     sh %(#{Gem.ruby} -S gem #{gem_install_command})
-
-    # Download and install gems used inside tests
-    $LOAD_PATH.unshift("./spec")
-    require "support/rubygems_ext"
-    Spec::Rubygems.setup
   end
 
   namespace :travis do

--- a/spec/support/rubygems_ext.rb
+++ b/spec/support/rubygems_ext.rb
@@ -2,6 +2,7 @@
 
 require "rubygems/user_interaction"
 require "support/path"
+require "fileutils"
 
 module Spec
   module Rubygems


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that our test setup could be simpler.

### What was your diagnosis of the problem?

My diagnosis was that some lines installing test gem dependencies could be removed from the Rakefile, because the tests already detect this situation and auto-install test gems appropriately.

### What is your fix for the problem, implemented in this PR?

My fix is to remove the lines. However, removing the lines led to a single test failure that can be explained becase `FileUtils` ends up being required too late, thus skipping one call to `Gem.clear_paths` done in the tests setup so that stuff memoized by `rubygems` is cleared and tests can assume is not loaded yet. The situation is very intricate but I tried to explain it in the commit message.

### Why did you choose this fix out of the possible options?

I chose this fix because it fixes the test failure, but I also plan to propose to eliminate the `autoload` calls in rubygems that also contributed to this issue.