### PR TITLE
Allow `update` to install when `--no-install` used

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -277,7 +277,9 @@ module Bundler
     def update(*gems)
       SharedHelpers.major_deprecation(2, "The `--force` option has been renamed to `--redownload`") if ARGV.include?("--force")
       require "bundler/cli/update"
-      Update.new(options, gems).run
+      Bundler.settings.temporary(:no_install => false) do
+        Update.new(options, gems).run
+      end
     end
 
     desc "show GEM [OPTIONS]", "Shows all gems that are part of the bundle, or the path to a given gem"

--- a/spec/commands/package_spec.rb
+++ b/spec/commands/package_spec.rb
@@ -179,6 +179,18 @@ RSpec.describe "bundle package" do
 
       expect(the_bundle).to include_gems "rack 1.0.0"
     end
+
+    it "does not prevent installing gems with bundle update" do
+      gemfile <<-D
+        source "file://#{gem_repo1}"
+        gem "rack", "1.0.0"
+      D
+
+      bundle! "package --no-install"
+      bundle! "update"
+
+      expect(the_bundle).to include_gems "rack 1.0.0"
+    end
   end
 
   context "with --all-platforms" do


### PR DESCRIPTION
Fixes #7077.

### What was the end-user problem that led to this PR?

The problem was #7077. When the `no_install` configuration is activated, this prevents `bundle update` from installing gems, but `no_install` is only meant to affect `bundle package`.

### What was your diagnosis of the problem?

My diagnosis was that `bundle update` needs to ignore this setting.

### What is your fix for the problem, implemented in this PR?

My fix is to the same `bundle install` does to fix this problem.

### Why did you choose this fix out of the possible options?

I chose this fix because it's the most straightforward solution, although the handling of this flag could probably use some refactoring.
