### PR TITLE
Remove `bundle config` deprecations from specs

### DIFF
--- a/spec/cache/gems_spec.rb
+++ b/spec/cache/gems_spec.rb
@@ -74,12 +74,12 @@ RSpec.describe "bundle cache" do
   end
 
   context "using system gems" do
-    before { bundle! "config path.system true" }
+    before { bundle! "config set path.system true" }
     it_behaves_like "when there are only gemsources"
   end
 
   context "installing into a local path" do
-    before { bundle! "config path ./.bundle" }
+    before { bundle! "config set path ./.bundle" }
     it_behaves_like "when there are only gemsources"
   end
 
@@ -97,7 +97,7 @@ RSpec.describe "bundle cache" do
     end
 
     it "uses builtin gems when installing to system gems" do
-      bundle! "config path.system true"
+      bundle! "config set path.system true"
       install_gemfile %(gem 'builtin_gem', '1.0.2')
       expect(the_bundle).to include_gems("builtin_gem 1.0.2")
     end
@@ -129,7 +129,7 @@ RSpec.describe "bundle cache" do
     end
 
     it "errors if the builtin gem isn't available to cache" do
-      bundle! "config path.system true"
+      bundle! "config set path.system true"
 
       install_gemfile <<-G
         gem 'builtin_gem', '1.0.2'

--- a/spec/cache/git_spec.rb
+++ b/spec/cache/git_spec.rb
@@ -127,7 +127,7 @@ end
         gem "foo", :git => '#{lib_path("foo-invalid")}', :branch => :master
       G
 
-      bundle %(config local.foo #{lib_path("foo-1.0")})
+      bundle %(config set local.foo #{lib_path("foo-1.0")})
       bundle "install"
       bundle "#{cmd}", forgotten_command_line_options([:all, :cache_all] => true)
 

--- a/spec/commands/check_spec.rb
+++ b/spec/commands/check_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe "bundle check" do
   end
 
   it "uses the without setting" do
-    bundle! "config without foo"
+    bundle! "config set without foo"
     install_gemfile! <<-G
       source "file://#{gem_repo1}"
       group :foo do

--- a/spec/commands/clean_spec.rb
+++ b/spec/commands/clean_spec.rb
@@ -276,7 +276,7 @@ RSpec.describe "bundle clean" do
   end
 
   it "displays an error when used without --path" do
-    bundle! "config path.system true"
+    bundle! "config set path.system true"
     install_gemfile <<-G
       source "file://#{gem_repo1}"
 
@@ -320,7 +320,7 @@ RSpec.describe "bundle clean" do
   end
 
   it "does not call clean automatically when using system gems" do
-    bundle! "config path.system true"
+    bundle! "config set path.system true"
 
     bundle! "config list"
 
@@ -446,7 +446,7 @@ RSpec.describe "bundle clean" do
   end
 
   it "does not clean on bundle update when using --system" do
-    bundle! "config path.system true"
+    bundle! "config set path.system true"
 
     build_repo2
 
@@ -468,7 +468,7 @@ RSpec.describe "bundle clean" do
   end
 
   it "cleans system gems when --force is used" do
-    bundle! "config path.system true"
+    bundle! "config set path.system true"
 
     gemfile <<-G
       source "file://#{gem_repo1}"
@@ -560,7 +560,7 @@ RSpec.describe "bundle clean" do
   end
 
   it "when using --force on system gems, it doesn't remove binaries" do
-    bundle! "config path.system true"
+    bundle! "config set path.system true"
 
     build_repo2
     update_repo2 do
@@ -707,7 +707,7 @@ RSpec.describe "bundle clean" do
       gem "weakling"
     G
 
-    bundle! "config auto_install 1"
+    bundle! "config set auto_install 1"
     bundle! :clean
     expect(out).to include("Installing weakling 0.0.3")
     should_have_gems "thin-1.0", "rack-1.0.0", "weakling-0.0.3"

--- a/spec/commands/config_spec.rb
+++ b/spec/commands/config_spec.rb
@@ -488,7 +488,7 @@ RSpec.describe "setting gemfile via config" do
       bundle "config set --local gemfile #{bundled_app("NotGemfile")}"
       expect(File.exist?(".bundle/config")).to eq(true)
 
-      bundle "config"
+      bundle "config list"
       expect(out).to include("NotGemfile")
     end
   end

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -220,13 +220,13 @@ RSpec.describe "bundle exec" do
   end
 
   it "raises a helpful error when exec'ing to something outside of the bundle", :ruby_repo do
-    bundle! "config clean false" # want to keep the rackup binstub
+    bundle! "config set clean false" # want to keep the rackup binstub
     install_gemfile! <<-G
       source "file://#{gem_repo1}"
       gem "with_license"
     G
     [true, false].each do |l|
-      bundle! "config disable_exec_load #{l}"
+      bundle! "config set disable_exec_load #{l}"
       bundle "exec rackup"
       expect(last_command.stderr).to include "can't find executable rackup for gem rack. rack is not currently included in the bundle, perhaps you meant to add it to your Gemfile?"
     end

--- a/spec/commands/inject_spec.rb
+++ b/spec/commands/inject_spec.rb
@@ -80,9 +80,9 @@ Usage: "bundle inject GEM VERSION"
     before do
       bundle "install"
       if Bundler.feature_flag.bundler_2_mode?
-        bundle! "config --local deployment true"
+        bundle! "config set --local deployment true"
       else
-        bundle! "config --local frozen true"
+        bundle! "config set --local frozen true"
       end
     end
 

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe "bundle outdated" do
         build_gem "activesupport", "2.3.4"
       end
 
-      bundle! "config clean false"
+      bundle! "config set clean false"
 
       install_gemfile <<-G
         source "file://#{gem_repo2}"
@@ -414,7 +414,7 @@ RSpec.describe "bundle outdated" do
       gem "foo"
     G
 
-    bundle "config auto_install 1"
+    bundle "config set auto_install 1"
     bundle :outdated
     expect(out).to include("Installing foo 1.0")
   end

--- a/spec/commands/package_spec.rb
+++ b/spec/commands/package_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe "bundle package" do
     subject { bundle :package, forgotten_command_line_options(:frozen => true) }
 
     it "tries to install with frozen" do
-      bundle! "config deployment true"
+      bundle! "config set deployment true"
       gemfile <<-G
         source "file://#{gem_repo1}"
         gem "rack"

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "bundle update" do
   end
 
   context "when update_requires_all_flag is set" do
-    before { bundle! "config update_requires_all_flag true" }
+    before { bundle! "config set update_requires_all_flag true" }
 
     it "errors when passed nothing" do
       install_gemfile! ""
@@ -133,7 +133,7 @@ RSpec.describe "bundle update" do
   describe "when a possible resolve requires an older version of a locked gem" do
     context "and only_update_to_newer_versions is set" do
       before do
-        bundle! "config only_update_to_newer_versions true"
+        bundle! "config set only_update_to_newer_versions true"
       end
 
       it "does not go to an older version" do
@@ -290,14 +290,14 @@ RSpec.describe "bundle update" do
     end
 
     it "should suggest different command when frozen is set globally", :bundler => "< 2" do
-      bundle! "config --global frozen 1"
+      bundle! "config set --global frozen 1"
       bundle "update", :all => bundle_update_requires_all?
       expect(out).to match(/You are trying to install in deployment mode after changing.your Gemfile/m).
         and match(/freeze \nby running `bundle config unset frozen`./m)
     end
 
     it "should suggest different command when frozen is set globally", :bundler => "2" do
-      bundle! "config --global deployment true"
+      bundle! "config set --global deployment true"
       bundle "update", :all => bundle_update_requires_all?
       expect(err).to match(/You are trying to install in deployment mode after changing.your Gemfile/m).
         and match(/freeze \nby running `bundle config unset deployment`./m)
@@ -328,7 +328,7 @@ RSpec.describe "bundle update" do
     end
 
     context "with unlock_source_unlocks_spec set to false" do
-      before { bundle! "config unlock_source_unlocks_spec false" }
+      before { bundle! "config set unlock_source_unlocks_spec false" }
 
       it "should not update gems not included in the source that happen to have the same name" do
         install_gemfile <<-G
@@ -598,7 +598,7 @@ RSpec.describe "bundle update" do
   end
 
   context "with suppress_install_using_messages set" do
-    before { bundle! "config suppress_install_using_messages true" }
+    before { bundle! "config set suppress_install_using_messages true" }
 
     it "only prints `Using` for versions that have changed" do
       build_repo4 do
@@ -811,7 +811,7 @@ RSpec.describe "bundle update conservative" do
 
     context "with patch set as default update level in config" do
       it "should do a patch level update" do
-        bundle! "config --local prefer_patch true"
+        bundle! "config set --local prefer_patch true"
         bundle! "update foo"
 
         expect(the_bundle).to include_gems "foo 1.4.5", "bar 2.1.1", "qux 1.0.0"

--- a/spec/install/allow_offline_install_spec.rb
+++ b/spec/install/allow_offline_install_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "bundle install with :allow_offline_install" do
     it "will install from the compact index" do
       system_gems ["rack-1.0.0"], :path => :bundle_path
 
-      bundle! "config clean false"
+      bundle! "config set clean false"
       install_gemfile! <<-G, :artifice => "compact_index"
         source "http://testgemserver.local"
         gem "rack-obama"

--- a/spec/install/bundler_spec.rb
+++ b/spec/install/bundler_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe "bundle install" do
     end
 
     it "can install dependencies with newer bundler version with system gems" do
-      bundle! "config path.system true"
+      bundle! "config set path.system true"
       install_gemfile! <<-G
         source "file://#{gem_repo2}"
         gem "rails", "3.0"
@@ -139,8 +139,8 @@ RSpec.describe "bundle install" do
     end
 
     it "can install dependencies with newer bundler version with a local path" do
-      bundle! "config path .bundle"
-      bundle! "config global_path_appends_ruby_scope true"
+      bundle! "config set path .bundle"
+      bundle! "config set global_path_appends_ruby_scope true"
       install_gemfile! <<-G
         source "file://#{gem_repo2}"
         gem "rails", "3.0"
@@ -153,7 +153,7 @@ RSpec.describe "bundle install" do
     end
 
     context "with allow_bundler_dependency_conflicts set" do
-      before { bundle! "config allow_bundler_dependency_conflicts true" }
+      before { bundle! "config set allow_bundler_dependency_conflicts true" }
 
       it "are forced to the current bundler version with warnings when no compatible version is found" do
         build_repo4 do

--- a/spec/install/deploy_spec.rb
+++ b/spec/install/deploy_spec.rb
@@ -331,7 +331,7 @@ RSpec.describe "install with --deployment or --frozen" do
       end
 
       context "when allow_deployment_source_credential_changes is true" do
-        before { bundle! "config allow_deployment_source_credential_changes true" }
+        before { bundle! "config set allow_deployment_source_credential_changes true" }
 
         it "allows the replace" do
           bundle :install, forgotten_command_line_options(:deployment => true)
@@ -341,7 +341,7 @@ RSpec.describe "install with --deployment or --frozen" do
       end
 
       context "when allow_deployment_source_credential_changes is false" do
-        before { bundle! "config allow_deployment_source_credential_changes false" }
+        before { bundle! "config set allow_deployment_source_credential_changes false" }
 
         it "prevents the replace" do
           bundle :install, forgotten_command_line_options(:deployment => true)
@@ -374,7 +374,7 @@ RSpec.describe "install with --deployment or --frozen" do
     it "remembers that the bundle is frozen at runtime" do
       bundle! :lock
 
-      bundle! "config deployment true"
+      bundle! "config set deployment true"
 
       gemfile <<-G
         source "file://#{gem_repo1}"

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "bundle install with git sources" do
 
     it "caches the git repo globally" do
       simulate_new_machine
-      bundle! "config global_gem_cache true"
+      bundle! "config set global_gem_cache true"
       bundle! :install
       expect(Dir["#{home}/.bundle/cache/git/foo-1.0-*"]).to have_attributes :size => 1
     end
@@ -285,7 +285,7 @@ RSpec.describe "bundle install with git sources" do
         sys_exec!('git update-ref -m "Bundler Spec!" refs/bundler/1 master~1')
       end
 
-      bundle! "config global_gem_cache true"
+      bundle! "config set global_gem_cache true"
 
       install_gemfile! <<-G
         git "#{lib_path("foo-1.0")}" do
@@ -406,7 +406,7 @@ RSpec.describe "bundle install with git sources" do
         gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
       G
 
-      bundle! %(config local.rack #{lib_path("local-rack")})
+      bundle! %(config set local.rack #{lib_path("local-rack")})
       bundle! :install
 
       run "require 'rack'"
@@ -427,7 +427,7 @@ RSpec.describe "bundle install with git sources" do
         gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
       G
 
-      bundle %(config local.rack #{lib_path("local-rack")})
+      bundle %(config set local.rack #{lib_path("local-rack")})
       run "require 'rack'"
       expect(out).to eq("LOCAL")
     end
@@ -447,7 +447,7 @@ RSpec.describe "bundle install with git sources" do
         gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
       G
 
-      bundle! %(config local.rack #{lib_path("local-rack")})
+      bundle! %(config set local.rack #{lib_path("local-rack")})
       bundle! :install
       run! "require 'rack'"
       expect(out).to eq("LOCAL")
@@ -470,7 +470,7 @@ RSpec.describe "bundle install with git sources" do
         s.add_dependency "nokogiri", "1.4.2"
       end
 
-      bundle %(config local.rack #{lib_path("local-rack")})
+      bundle %(config set local.rack #{lib_path("local-rack")})
       run "require 'rack'"
 
       lockfile1 = File.read(bundled_app("Gemfile.lock"))
@@ -490,7 +490,7 @@ RSpec.describe "bundle install with git sources" do
       FileUtils.cp_r("#{lib_path("rack-0.8")}/.", lib_path("local-rack"))
       update_git "rack", "0.8", :path => lib_path("local-rack")
 
-      bundle %(config local.rack #{lib_path("local-rack")})
+      bundle %(config set local.rack #{lib_path("local-rack")})
       bundle :install
 
       lockfile1 = File.read(bundled_app("Gemfile.lock"))
@@ -505,7 +505,7 @@ RSpec.describe "bundle install with git sources" do
         gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
       G
 
-      bundle %(config local.rack #{lib_path("local-rack")})
+      bundle %(config set local.rack #{lib_path("local-rack")})
       bundle :install
       expect(err).to match(/Cannot use local override for rack-0.8 because #{Regexp.escape(lib_path('local-rack').to_s)} does not exist/)
 
@@ -527,7 +527,7 @@ RSpec.describe "bundle install with git sources" do
         gem "rack", :git => "#{lib_path("rack-0.8")}"
       G
 
-      bundle %(config local.rack #{lib_path("local-rack")})
+      bundle %(config set local.rack #{lib_path("local-rack")})
       bundle :install
       expect(err).to match(/Cannot use local override for rack-0.8 at #{Regexp.escape(lib_path('local-rack').to_s)} because :branch is not specified in Gemfile/)
 
@@ -549,8 +549,8 @@ RSpec.describe "bundle install with git sources" do
         gem "rack", :git => "#{lib_path("rack-0.8")}"
       G
 
-      bundle %(config local.rack #{lib_path("local-rack")})
-      bundle %(config disable_local_branch_check true)
+      bundle %(config set local.rack #{lib_path("local-rack")})
+      bundle %(config set disable_local_branch_check true)
       bundle :install
       expect(out).to match(/Bundle complete!/)
     end
@@ -569,7 +569,7 @@ RSpec.describe "bundle install with git sources" do
         gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
       G
 
-      bundle %(config local.rack #{lib_path("local-rack")})
+      bundle %(config set local.rack #{lib_path("local-rack")})
       bundle :install
       expect(err).to match(/is using branch another but Gemfile specifies master/)
     end
@@ -586,7 +586,7 @@ RSpec.describe "bundle install with git sources" do
         gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
       G
 
-      bundle %(config local.rack #{lib_path("local-rack")})
+      bundle %(config set local.rack #{lib_path("local-rack")})
       bundle :install
       expect(err).to match(/The Gemfile lock is pointing to revision \w+/)
     end
@@ -1402,7 +1402,7 @@ In Gemfile:
 
   describe "when the git source is overridden with a local git repo" do
     before do
-      bundle! "config --global local.foo #{lib_path("foo")}"
+      bundle! "config set --global local.foo #{lib_path("foo")}"
     end
 
     describe "and git output is colorized" do

--- a/spec/install/gemfile/lockfile_spec.rb
+++ b/spec/install/gemfile/lockfile_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "bundle install with a lockfile present" do
 
     context "with plugins disabled" do
       before do
-        bundle! "config plugins false"
+        bundle! "config set plugins false"
         subject
       end
 

--- a/spec/install/gemfile/platform_spec.rb
+++ b/spec/install/gemfile/platform_spec.rb
@@ -391,7 +391,7 @@ The dependency #{Gem::Dependency.new("rack", ">= 0")} will be unused by any of t
   end
 
   context "when disable_platform_warnings is true" do
-    before { bundle! "config disable_platform_warnings true" }
+    before { bundle! "config set disable_platform_warnings true" }
 
     it "does not print the warning when a dependency is unused on any platform" do
       simulate_platform "ruby"

--- a/spec/install/gemfile/sources_spec.rb
+++ b/spec/install/gemfile/sources_spec.rb
@@ -195,8 +195,8 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
           context "when lockfile_uses_separate_rubygems_sources is set" do
             before do
-              bundle! "config lockfile_uses_separate_rubygems_sources true"
-              bundle! "config disable_multisource true"
+              bundle! "config set lockfile_uses_separate_rubygems_sources true"
+              bundle! "config set disable_multisource true"
             end
 
             it "installs from the same source without any warning" do
@@ -306,8 +306,8 @@ RSpec.describe "bundle install with gems on multiple sources" do
     context "when a top-level gem has an indirect dependency" do
       context "when lockfile_uses_separate_rubygems_sources is set" do
         before do
-          bundle! "config lockfile_uses_separate_rubygems_sources true"
-          bundle! "config disable_multisource true"
+          bundle! "config set lockfile_uses_separate_rubygems_sources true"
+          bundle! "config set disable_multisource true"
         end
 
         before do

--- a/spec/install/gemfile_spec.rb
+++ b/spec/install/gemfile_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "bundle install" do
   end
 
   context "with prefer_gems_rb set" do
-    before { bundle! "config prefer_gems_rb true" }
+    before { bundle! "config set prefer_gems_rb true" }
 
     it "prefers gems.rb to Gemfile" do
       create_file("gems.rb", "gem 'bundler'")

--- a/spec/install/gems/compact_index_spec.rb
+++ b/spec/install/gems/compact_index_spec.rb
@@ -255,7 +255,7 @@ The checksum of /versions does not match the checksum provided by the server! So
 
   it "does not double check for gems that are only installed locally" do
     system_gems %w[rack-1.0.0 thin-1.0 net_a-1.0]
-    bundle! "config --local path.system true"
+    bundle! "config set --local path.system true"
     ENV["BUNDLER_SPEC_ALL_REQUESTS"] = strip_whitespace(<<-EOS).strip
       #{source_uri}/versions
       #{source_uri}/info/rack
@@ -894,7 +894,7 @@ The checksum of /versions does not match the checksum provided by the server! So
     end
 
     it "does not raise when disable_checksum_validation is set" do
-      bundle! "config disable_checksum_validation true"
+      bundle! "config set disable_checksum_validation true"
       install_gemfile! <<-G, :artifice => "compact_index_wrong_gem_checksum"
         source "#{source_uri}"
         gem "rack"

--- a/spec/install/gems/native_extensions_spec.rb
+++ b/spec/install/gems/native_extensions_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "installing a gem with native extensions", :ruby_repo do
       C
     end
 
-    bundle! "config build.c_extension --with-c_extension=hello"
+    bundle! "config set build.c_extension --with-c_extension=hello"
 
     install_gemfile! <<-G
       gem "c_extension", :git => #{lib_path("c_extension-1.0").to_s.dump}

--- a/spec/install/gems/sudo_spec.rb
+++ b/spec/install/gems/sudo_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "when using sudo", :sudo => true do
   describe "and BUNDLE_PATH is writable" do
     context "but BUNDLE_PATH/build_info is not writable" do
       before do
-        bundle! "config path.system true"
+        bundle! "config set path.system true"
         subdir = system_gem_path("cache")
         subdir.mkpath
         sudo "chmod u-w #{subdir}"
@@ -25,7 +25,7 @@ RSpec.describe "when using sudo", :sudo => true do
 
   describe "and GEM_HOME is owned by root" do
     before :each do
-      bundle! "config path.system true"
+      bundle! "config set path.system true"
       chown_system_gems_to_root
     end
 
@@ -52,7 +52,7 @@ RSpec.describe "when using sudo", :sudo => true do
     end
 
     it "installs when BUNDLE_PATH is owned by root" do
-      bundle! "config global_path_appends_ruby_scope false" # consistency in tests between 1.x and 2.x modes
+      bundle! "config set global_path_appends_ruby_scope false" # consistency in tests between 1.x and 2.x modes
 
       bundle_path = tmp("owned_by_root")
       FileUtils.mkdir_p bundle_path
@@ -70,7 +70,7 @@ RSpec.describe "when using sudo", :sudo => true do
     end
 
     it "installs when BUNDLE_PATH does not exist" do
-      bundle! "config global_path_appends_ruby_scope false" # consistency in tests between 1.x and 2.x modes
+      bundle! "config set global_path_appends_ruby_scope false" # consistency in tests between 1.x and 2.x modes
 
       root_path = tmp("owned_by_root")
       FileUtils.mkdir_p root_path
@@ -133,7 +133,7 @@ RSpec.describe "when using sudo", :sudo => true do
 
   describe "and GEM_HOME is not writable" do
     it "installs" do
-      bundle! "config path.system true"
+      bundle! "config set path.system true"
       gem_home = tmp("sudo_gem_home")
       sudo "mkdir -p #{gem_home}"
       sudo "chmod ugo-w #{gem_home}"

--- a/spec/install/global_cache_spec.rb
+++ b/spec/install/global_cache_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe "global gem caching" do
-  before { bundle! "config global_gem_cache true" }
+  before { bundle! "config set global_gem_cache true" }
 
   describe "using the cross-application user cache" do
     let(:source)  { "http://localgemserver.test" }
@@ -220,7 +220,7 @@ RSpec.describe "global gem caching" do
       gem_binary_cache.join("very_simple_binary_c.rb").open("w") {|f| f << "puts File.basename(__FILE__)" }
       git_binary_cache.join("very_simple_git_binary_c.rb").open("w") {|f| f << "puts File.basename(__FILE__)" }
 
-      bundle! "config --local path different_path"
+      bundle! "config set --local path different_path"
       bundle! :install
 
       expect(Dir[home(".bundle", "cache", "extensions", "**", "*binary_c*")]).to all(end_with(".rb"))

--- a/spec/install/path_spec.rb
+++ b/spec/install/path_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "bundle install" do
     end
 
     context "with path_relative_to_cwd set to true" do
-      before { bundle! "config path_relative_to_cwd true" }
+      before { bundle! "config set path_relative_to_cwd true" }
 
       it "installs the bundle relatively to current working directory", :bundler => "< 2" do
         Dir.chdir(bundled_app.parent) do
@@ -98,7 +98,7 @@ RSpec.describe "bundle install" do
       if type == :env
         ENV["BUNDLE_PATH"] = location
       elsif type == :global
-        bundle! "config path #{location}", "no-color" => nil
+        bundle! "config set path #{location}", "no-color" => nil
       end
     end
 
@@ -116,7 +116,7 @@ RSpec.describe "bundle install" do
         context "with global_path_appends_ruby_scope set", :bundler => "2" do
           it "installs gems to ." do
             set_bundle_path(type, ".")
-            bundle! "config --global disable_shared_gems true"
+            bundle! "config set --global disable_shared_gems true"
 
             bundle! :install
 
@@ -150,7 +150,7 @@ RSpec.describe "bundle install" do
         context "with global_path_appends_ruby_scope unset", :bundler => "< 2" do
           it "installs gems to ." do
             set_bundle_path(type, ".")
-            bundle! "config --global disable_shared_gems true"
+            bundle! "config set --global disable_shared_gems true"
 
             bundle! :install
 

--- a/spec/other/cli_dispatch_spec.rb
+++ b/spec/other/cli_dispatch_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "bundle command names" do
   end
 
   context "when cache_command_is_package is set" do
-    before { bundle! "config cache_command_is_package true" }
+    before { bundle! "config set cache_command_is_package true" }
 
     it "dispatches `bundle cache` to the package command" do
       bundle "cache --verbose"

--- a/spec/realworld/dependency_api_spec.rb
+++ b/spec/realworld/dependency_api_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "gemcutter's dependency API", :realworld => true do
       @t.run
 
       wait_for_server("127.0.0.1", port)
-      bundle! "config timeout 1"
+      bundle! "config set timeout 1"
     end
 
     after do

--- a/spec/runtime/platform_spec.rb
+++ b/spec/runtime/platform_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
       gem "platform_specific"
     G
 
-    bundle! "config force_ruby_platform true"
+    bundle! "config set force_ruby_platform true"
 
     bundle! "install"
 
@@ -108,7 +108,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
         gem "platform_specific"
       G
 
-      bundle! "config force_ruby_platform true"
+      bundle! "config set force_ruby_platform true"
 
       bundle! "install"
 

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -527,7 +527,7 @@ RSpec.describe "Bundler.setup" do
         gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
       G
 
-      bundle %(config local.rack #{lib_path("local-rack")})
+      bundle %(config set local.rack #{lib_path("local-rack")})
       bundle! :install
 
       FileUtils.rm_rf(lib_path("local-rack"))
@@ -545,7 +545,7 @@ RSpec.describe "Bundler.setup" do
         gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
       G
 
-      bundle %(config local.rack #{lib_path("local-rack")})
+      bundle %(config set local.rack #{lib_path("local-rack")})
       bundle! :install
 
       gemfile <<-G
@@ -567,7 +567,7 @@ RSpec.describe "Bundler.setup" do
         gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
       G
 
-      bundle %(config local.rack #{lib_path("local-rack")})
+      bundle %(config set local.rack #{lib_path("local-rack")})
       bundle! :install
 
       gemfile <<-G
@@ -594,7 +594,7 @@ RSpec.describe "Bundler.setup" do
         gem "rack", :git => "#{lib_path("rack-0.8")}", :ref => "master", :branch => "nonexistant"
       G
 
-      bundle %(config local.rack #{lib_path("local-rack")})
+      bundle %(config set local.rack #{lib_path("local-rack")})
       run "require 'rack'"
       expect(last_command.stderr).to match(/is using branch master but Gemfile specifies nonexistant/)
     end
@@ -980,7 +980,7 @@ end
 
   describe "with system gems in the bundle" do
     before :each do
-      bundle! "config path.system true"
+      bundle! "config set path.system true"
       system_gems "rack-1.0.0"
 
       install_gemfile <<-G

--- a/spec/update/gemfile_spec.rb
+++ b/spec/update/gemfile_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "bundle update" do
   end
 
   context "with prefer_gems_rb set" do
-    before { bundle! "config prefer_gems_rb true" }
+    before { bundle! "config set prefer_gems_rb true" }
 
     it "prefers gems.rb to Gemfile" do
       create_file("gems.rb", "gem 'bundler'")

--- a/spec/update/gems/post_install_spec.rb
+++ b/spec/update/gems/post_install_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "bundle update" do
       gem 'thin'
     G
 
-    bundle! "config #{config}" if config
+    bundle! "config set #{config}" if config
 
     bundle! :install
   end

--- a/spec/update/git_spec.rb
+++ b/spec/update/git_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe "bundle update" do
         gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
       G
 
-      bundle %(config local.rack #{lib_path("local-rack")})
+      bundle %(config set local.rack #{lib_path("local-rack")})
       bundle "update rack"
       expect(out).to include("Bundle updated!")
     end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that some specs still use the deprecated `bundle config interface`

### What is your fix for the problem, implemented in this PR?

My fix is to use the newer interface.