### PR TITLE
Always pass the `--all` flag when needed

### DIFF
--- a/spec/cache/gems_spec.rb
+++ b/spec/cache/gems_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe "bundle cache" do
 
     it "adds and removes when gems are updated" do
       update_repo2
-      bundle "update", :all => bundle_update_requires_all?
+      bundle "update", :all => true
       expect(cached_gem("rack-1.2")).to exist
       expect(cached_gem("rack-1.0.0")).not_to exist
     end

--- a/spec/cache/git_spec.rb
+++ b/spec/cache/git_spec.rb
@@ -81,7 +81,7 @@ end
       ref = git.ref_for("master", 11)
       expect(ref).not_to eq(old_ref)
 
-      bundle! "update", :all => bundle_update_requires_all?
+      bundle! "update", :all => true
       bundle! "#{cmd}", forgotten_command_line_options([:all, :cache_all] => true)
 
       expect(bundled_app("vendor/cache/foo-1.0-#{ref}")).to exist

--- a/spec/cache/platform_spec.rb
+++ b/spec/cache/platform_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "bundle cache with multiple platforms" do
   end
 
   it "ensures that a successful bundle update does not delete gems for other platforms" do
-    bundle! "update", :all => bundle_update_requires_all?
+    bundle! "update", :all => true
 
     expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
     expect(bundled_app("vendor/cache/activesupport-2.3.5.gem")).to exist

--- a/spec/commands/clean_spec.rb
+++ b/spec/commands/clean_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe "bundle clean" do
     update_git "foo", :path => lib_path("foo-bar")
     revision2 = revision_for(lib_path("foo-bar"))
 
-    bundle! "update", :all => bundle_update_requires_all?
+    bundle! "update", :all => true
     bundle! :clean
 
     expect(out).to include("Removing foo-bar (#{revision[0..11]})")
@@ -378,7 +378,7 @@ RSpec.describe "bundle clean" do
       build_gem "foo", "1.0.1"
     end
 
-    bundle! "update", :all => bundle_update_requires_all?
+    bundle! "update", :all => true
 
     should_have_gems "foo-1.0.1"
     should_not_have_gems "foo-1.0"
@@ -441,7 +441,7 @@ RSpec.describe "bundle clean" do
       build_gem "foo", "1.0.1"
     end
 
-    bundle! :update, :all => bundle_update_requires_all?
+    bundle! :update, :all => true
     should_have_gems "foo-1.0", "foo-1.0.1"
   end
 
@@ -460,7 +460,7 @@ RSpec.describe "bundle clean" do
     update_repo2 do
       build_gem "foo", "1.0.1"
     end
-    bundle! :update, :all => bundle_update_requires_all?
+    bundle! :update, :all => true
 
     gem = ruby_core? ? ENV["BUNDLE_GEM"] : "gem"
     sys_exec! "#{gem} list"

--- a/spec/commands/package_spec.rb
+++ b/spec/commands/package_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe "bundle package" do
       D
 
       bundle! "package --no-install"
-      bundle! "update"
+      bundle! "update --all"
 
       expect(the_bundle).to include_gems "rack 1.0.0"
     end

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "bundle update" do
         gem "rack", "1.0"
       G
 
-      bundle! "update --gemfile OmgFile", :all => bundle_update_requires_all?
+      bundle! "update --gemfile OmgFile", :all => true
 
       expect(bundled_app("OmgFile.lock")).to exist
     end
@@ -167,7 +167,7 @@ RSpec.describe "bundle update" do
           end
         end
 
-        bundle! "update", :all => bundle_update_requires_all?
+        bundle! "update", :all => true
 
         expect(the_bundle).to include_gems("slim 3.0.9", "slim-rails 3.1.3", "slim_lint 0.16.1")
       end
@@ -282,7 +282,7 @@ RSpec.describe "bundle update" do
   describe "in a frozen bundle" do
     it "should fail loudly", :bundler => "< 2" do
       bundle! "install --deployment"
-      bundle "update", :all => bundle_update_requires_all?
+      bundle "update", :all => true
 
       expect(last_command).to be_failure
       expect(out).to match(/You are trying to install in deployment mode after changing.your Gemfile/m)
@@ -291,14 +291,14 @@ RSpec.describe "bundle update" do
 
     it "should suggest different command when frozen is set globally", :bundler => "< 2" do
       bundle! "config set --global frozen 1"
-      bundle "update", :all => bundle_update_requires_all?
+      bundle "update", :all => true
       expect(out).to match(/You are trying to install in deployment mode after changing.your Gemfile/m).
         and match(/freeze \nby running `bundle config unset frozen`./m)
     end
 
     it "should suggest different command when frozen is set globally", :bundler => "2" do
       bundle! "config set --global deployment true"
-      bundle "update", :all => bundle_update_requires_all?
+      bundle "update", :all => true
       expect(err).to match(/You are trying to install in deployment mode after changing.your Gemfile/m).
         and match(/freeze \nby running `bundle config unset deployment`./m)
     end
@@ -542,7 +542,7 @@ RSpec.describe "bundle update without a Gemfile.lock" do
       gem "rack", "1.0"
     G
 
-    bundle "update", :all => bundle_update_requires_all?
+    bundle "update", :all => true
 
     expect(the_bundle).to include_gems "rack 1.0.0"
   end
@@ -563,7 +563,7 @@ RSpec.describe "bundle update when a gem depends on a newer version of bundler" 
   end
 
   it "should explain that bundler conflicted", :bundler => "< 2" do
-    bundle "update", :all => bundle_update_requires_all?
+    bundle "update", :all => true
     expect(last_command.stdboth).not_to match(/in snapshot/i)
     expect(last_command.bundler_err).to match(/current Bundler version/i).
       and match(/perhaps you need to update bundler/i)
@@ -586,14 +586,14 @@ RSpec.describe "bundle update" do
       gem "activesupport"
     G
 
-    bundle "update", :all => bundle_update_requires_all?
+    bundle "update", :all => true
     expect(out).to include("Using activesupport 2.3.5")
 
     update_repo2 do
       build_gem "activesupport", "3.0"
     end
 
-    bundle "update", :all => bundle_update_requires_all?
+    bundle "update", :all => true
     expect(out).to include("Installing activesupport 3.0 (was 2.3.5)")
   end
 
@@ -612,7 +612,7 @@ RSpec.describe "bundle update" do
         gem "foo"
       G
 
-      bundle! "update", :all => bundle_update_requires_all?
+      bundle! "update", :all => true
       out.gsub!(/RubyGems [\d\.]+ is not threadsafe.*\n?/, "")
       expect(out).to include "Resolving dependencies...\nBundle updated!"
 
@@ -620,7 +620,7 @@ RSpec.describe "bundle update" do
         build_gem "foo", "2.0"
       end
 
-      bundle! "update", :all => bundle_update_requires_all?
+      bundle! "update", :all => true
       out.sub!("Removing foo (1.0)\n", "")
       out.gsub!(/RubyGems [\d\.]+ is not threadsafe.*\n?/, "")
       expect(out).to include strip_whitespace(<<-EOS).strip
@@ -826,7 +826,7 @@ RSpec.describe "bundle update conservative" do
       end
 
       it "update all" do
-        bundle! "update --patch", :all => bundle_update_requires_all?
+        bundle! "update --patch", :all => true
 
         expect(the_bundle).to include_gems "foo 1.4.5", "bar 2.1.1", "qux 1.0.1"
       end
@@ -848,7 +848,7 @@ RSpec.describe "bundle update conservative" do
       end
 
       it "minor preferred" do
-        bundle! "update --minor --strict", :all => bundle_update_requires_all?
+        bundle! "update --minor --strict", :all => true
 
         expect(the_bundle).to include_gems "foo 1.5.0", "bar 2.1.1", "qux 1.1.0"
       end
@@ -945,7 +945,7 @@ RSpec.describe "bundle update conservative" do
     end
 
     it "raises if too many flags are provided" do
-      bundle "update --patch --minor", :all => bundle_update_requires_all?
+      bundle "update --patch --minor", :all => true
 
       expect(last_command.bundler_err).to eq "Provide only one of the following options: minor, patch"
     end

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -294,7 +294,7 @@ RSpec.describe "bundle install with git sources" do
       G
 
       # ensure we also git fetch after cloning
-      bundle! :update, :all => bundle_update_requires_all?
+      bundle! :update, :all => true
 
       Dir.chdir(Dir[home(".bundle/cache/git/foo-*")].first) do
         sys_exec("git ls-remote .")
@@ -814,14 +814,14 @@ RSpec.describe "bundle install with git sources" do
       s.write "lib/forced.rb", "FORCED = '1.1'"
     end
 
-    bundle "update", :all => bundle_update_requires_all?
+    bundle "update", :all => true
     expect(the_bundle).to include_gems "forced 1.1"
 
     Dir.chdir(lib_path("forced-1.0")) do
       `git reset --hard HEAD^`
     end
 
-    bundle "update", :all => bundle_update_requires_all?
+    bundle "update", :all => true
     expect(the_bundle).to include_gems "forced 1.0"
   end
 
@@ -1378,7 +1378,7 @@ In Gemfile:
       G
 
       with_path_as("") do
-        bundle "update", :all => bundle_update_requires_all?
+        bundle "update", :all => true
       end
       expect(last_command.bundler_err).
         to include("You need to install git to be able to use gems from git repositories. For help installing git, please refer to GitHub's tutorial at https://help.github.com/articles/set-up-git")

--- a/spec/install/gems/compact_index_spec.rb
+++ b/spec/install/gems/compact_index_spec.rb
@@ -247,7 +247,7 @@ The checksum of /versions does not match the checksum provided by the server! So
         gem "rack"
       G
 
-      bundle! "update --full-index", :artifice => "compact_index", :all => bundle_update_requires_all?
+      bundle! "update --full-index", :artifice => "compact_index", :all => true
       expect(out).to include("Fetching source index from #{source_uri}")
       expect(the_bundle).to include_gems "rack 1.0.0"
     end

--- a/spec/install/gems/dependency_api_spec.rb
+++ b/spec/install/gems/dependency_api_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe "gemcutter's dependency API" do
         gem "rack"
       G
 
-      bundle! "update --full-index", :artifice => "endpoint", :all => bundle_update_requires_all?
+      bundle! "update --full-index", :artifice => "endpoint", :all => true
       expect(out).to include("Fetching source index from #{source_uri}")
       expect(the_bundle).to include_gems "rack 1.0.0"
     end

--- a/spec/install/git_spec.rb
+++ b/spec/install/git_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "bundle install" do
 
       update_git "foo", "4.0", :path => lib_path("foo"), :gemspec => true
 
-      bundle! :update, :all => bundle_update_requires_all?
+      bundle! :update, :all => true
       expect(out).to include("Using foo 2.0 (was 1.0) from #{lib_path("foo")} (at master~2@#{rev2})")
       expect(the_bundle).to include_gems "foo 2.0", :source => "git@#{lib_path("foo")}"
     end

--- a/spec/install/post_bundle_message_spec.rb
+++ b/spec/install/post_bundle_message_spec.rb
@@ -177,28 +177,28 @@ The source does not contain any versions of 'not-a-gem'
 
   describe "for bundle update" do
     it "without any options" do
-      bundle! :update, :all => bundle_update_requires_all?
+      bundle! :update, :all => true
       expect(out).not_to include("Gems in the groups")
       expect(out).to include(bundle_updated_message)
     end
 
     it "with --without one group" do
       bundle! :install, forgotten_command_line_options(:without => "emo")
-      bundle! :update, :all => bundle_update_requires_all?
+      bundle! :update, :all => true
       expect(out).to include("Gems in the group emo were not installed")
       expect(out).to include(bundle_updated_message)
     end
 
     it "with --without two groups" do
       bundle! :install, forgotten_command_line_options(:without => "emo test")
-      bundle! :update, :all => bundle_update_requires_all?
+      bundle! :update, :all => true
       expect(out).to include("Gems in the groups emo and test were not installed")
       expect(out).to include(bundle_updated_message)
     end
 
     it "with --without more groups" do
       bundle! :install, forgotten_command_line_options(:without => "emo obama test")
-      bundle! :update, :all => bundle_update_requires_all?
+      bundle! :update, :all => true
       expect(out).to include("Gems in the groups emo, obama and test were not installed")
       expect(out).to include(bundle_updated_message)
     end

--- a/spec/other/platform_spec.rb
+++ b/spec/other/platform_spec.rb
@@ -511,7 +511,7 @@ G
         build_gem "activesupport", "3.0"
       end
 
-      bundle "update", :all => bundle_update_requires_all?
+      bundle "update", :all => true
       expect(the_bundle).to include_gems "rack 1.2", "rack-obama 1.0", "activesupport 3.0"
     end
 
@@ -528,7 +528,7 @@ G
           build_gem "activesupport", "3.0"
         end
 
-        bundle "update", :all => bundle_update_requires_all?
+        bundle "update", :all => true
         expect(the_bundle).to include_gems "rack 1.2", "rack-obama 1.0", "activesupport 3.0"
       end
     end
@@ -545,7 +545,7 @@ G
         build_gem "activesupport", "3.0"
       end
 
-      bundle :update, :all => bundle_update_requires_all?
+      bundle :update, :all => true
       should_be_ruby_version_incorrect
     end
 
@@ -561,7 +561,7 @@ G
         build_gem "activesupport", "3.0"
       end
 
-      bundle :update, :all => bundle_update_requires_all?
+      bundle :update, :all => true
       should_be_engine_incorrect
     end
 
@@ -578,7 +578,7 @@ G
           build_gem "activesupport", "3.0"
         end
 
-        bundle :update, :all => bundle_update_requires_all?
+        bundle :update, :all => true
         should_be_engine_version_incorrect
       end
     end
@@ -594,7 +594,7 @@ G
         build_gem "activesupport", "3.0"
       end
 
-      bundle :update, :all => bundle_update_requires_all?
+      bundle :update, :all => true
       should_be_patchlevel_incorrect
     end
   end

--- a/spec/realworld/parallel_spec.rb
+++ b/spec/realworld/parallel_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "parallel", :realworld => true, :sometimes => true do
       gem 'i18n', '~> 0.6.0' # Because 0.7+ requires Ruby 1.9.3+
     G
 
-    bundle :update, :jobs => 4, :env => { "DEBUG" => "1" }, :all => bundle_update_requires_all?
+    bundle :update, :jobs => 4, :env => { "DEBUG" => "1" }, :all => true
 
     expect(out).to match(/[1-3]: /)
 

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -62,10 +62,6 @@ module Spec
       last_command.exitstatus
     end
 
-    def bundle_update_requires_all?
-      Bundler::VERSION.start_with?("1.") ? nil : true
-    end
-
     def in_app_root(&blk)
       Dir.chdir(bundled_app, &blk)
     end

--- a/spec/update/gemfile_spec.rb
+++ b/spec/update/gemfile_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "bundle update" do
       G
 
       bundle! :install, :gemfile => bundled_app("NotGemfile")
-      bundle! :update, :gemfile => bundled_app("NotGemfile"), :all => bundle_update_requires_all?
+      bundle! :update, :gemfile => bundled_app("NotGemfile"), :all => true
 
       # Specify BUNDLE_GEMFILE for `the_bundle`
       # to retrieve the proper Gemfile
@@ -30,7 +30,7 @@ RSpec.describe "bundle update" do
     end
 
     it "uses the gemfile to update" do
-      bundle! "update", :all => bundle_update_requires_all?
+      bundle! "update", :all => true
       bundle "list"
 
       expect(out).to include("rack (1.0.0)")
@@ -39,7 +39,7 @@ RSpec.describe "bundle update" do
     it "uses the gemfile while in a subdirectory" do
       bundled_app("subdir").mkpath
       Dir.chdir(bundled_app("subdir")) do
-        bundle! "update", :all => bundle_update_requires_all?
+        bundle! "update", :all => true
         bundle "list"
 
         expect(out).to include("rack (1.0.0)")
@@ -55,7 +55,7 @@ RSpec.describe "bundle update" do
       create_file("Gemfile", "raise 'wrong Gemfile!'")
 
       bundle! :install
-      bundle! :update, :all => bundle_update_requires_all?
+      bundle! :update, :all => true
 
       expect(bundled_app("gems.rb")).to be_file
       expect(bundled_app("Gemfile.lock")).not_to be_file

--- a/spec/update/gems/post_install_spec.rb
+++ b/spec/update/gems/post_install_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "bundle update" do
         gem 'thin'
       G
 
-      bundle! :update, :all => bundle_update_requires_all?
+      bundle! :update, :all => true
     end
 
     it_behaves_like "a post-install message outputter"
@@ -67,7 +67,7 @@ RSpec.describe "bundle update" do
         gem 'thin'
       G
 
-      bundle! :update, :all => bundle_update_requires_all?
+      bundle! :update, :all => true
     end
 
     it_behaves_like "a post-install message outputter"

--- a/spec/update/git_spec.rb
+++ b/spec/update/git_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "bundle update" do
         s.write "lib/foo.rb", "FOO = '1.1'"
       end
 
-      bundle "update", :all => bundle_update_requires_all?
+      bundle "update", :all => true
 
       expect(the_bundle).to include_gems "foo 1.1"
     end
@@ -111,7 +111,7 @@ RSpec.describe "bundle update" do
         gem 'foo', :git => "#{@remote.path}", :tag => "fubar"
       G
 
-      bundle "update", :all => bundle_update_requires_all?
+      bundle "update", :all => true
       expect(exitstatus).to eq(0) if exitstatus
     end
 
@@ -191,7 +191,7 @@ RSpec.describe "bundle update" do
 
       lib_path("foo-1.0").join(".git").rmtree
 
-      bundle :update, :all => bundle_update_requires_all?
+      bundle :update, :all => true
       expect(last_command.bundler_err).to include(lib_path("foo-1.0").to_s).
         and match(/Git error: command `git fetch.+has failed/)
     end
@@ -233,7 +233,7 @@ RSpec.describe "bundle update" do
           rails!
       G
 
-      bundle "update", :all => bundle_update_requires_all?
+      bundle "update", :all => true
       expect(out).to include("Using rails 3.0 (was 2.3.2) from #{lib_path("rails")} (at master@#{revision_for(lib_path("rails"))[0..6]})")
     end
   end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that some specs were still using `bundle update` to update all gems, which is deprecated.

### What is your fix for the problem, implemented in this PR?

My fix is to update all specs to use the new preferred command, namely, `bundle update --all`.
