### PR TITLE
Complete some missing specs

### DIFF
--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -48,6 +48,42 @@ RSpec.describe "major deprecations" do
       end
     end
 
+    describe ".clean_system" do
+      before do
+        source = "Bundler.clean_system('ls')"
+        bundle "exec ruby -e #{source.dump}"
+      end
+
+      it "is not deprecated", :bundler => "< 2" do
+        expect(deprecations).to be_empty
+      end
+
+      it "is deprecated in favor of .unbundled_system", :bundler => "2" do
+        expect(deprecations).to include(
+          "`Bundler.clean_system` has been deprecated in favor of `Bundler.unbundled_system`. " \
+          "If you instead want to run the command in the environment before bundler was originally loaded, use `Bundler.original_system`"
+        )
+      end
+    end
+
+    describe ".clean_exec" do
+      before do
+        source = "Bundler.clean_exec('ls')"
+        bundle "exec ruby -e #{source.dump}"
+      end
+
+      it "is not deprecated", :bundler => "< 2" do
+        expect(deprecations).to be_empty
+      end
+
+      it "is deprecated in favor of .unbundled_exec", :bundler => "2" do
+        expect(deprecations).to include(
+          "`Bundler.clean_exec` has been deprecated in favor of `Bundler.unbundled_exec`. " \
+          "If you instead want to exec to a command in the environment before bundler was originally loaded, use `Bundler.original_exec`"
+        )
+      end
+    end
+
     describe ".environment" do
       before do
         source = "Bundler.environment"

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -30,6 +30,24 @@ RSpec.describe "major deprecations" do
       end
     end
 
+    describe ".with_clean_env" do
+      before do
+        source = "Bundler.with_clean_env {}"
+        bundle "exec ruby -e #{source.dump}"
+      end
+
+      it "is not deprecated", :bundler => "< 2" do
+        expect(deprecations).to be_empty
+      end
+
+      it "is deprecated in favor of .unbundled_env", :bundler => "2" do
+        expect(deprecations).to include(
+          "`Bundler.with_clean_env` has been deprecated in favor of `Bundler.with_unbundled_env`. " \
+          "If you instead want the environment before bundler was originally loaded, use `Bundler.with_original_env`"
+        )
+      end
+    end
+
     describe ".environment" do
       before do
         source = "Bundler.environment"

--- a/spec/runtime/with_unbundled_env_spec.rb
+++ b/spec/runtime/with_unbundled_env_spec.rb
@@ -102,24 +102,6 @@ RSpec.describe "Bundler.with_env helpers" do
     let(:modified_env) { "Bundler.clean_env" }
 
     it_behaves_like "an unbundling helper"
-
-    it "prints a deprecation", :bundler => 2 do
-      code = "Bundler.clean_env"
-      bundle_exec_ruby! code.dump
-      expect(err).to include(
-        "[DEPRECATED] `Bundler.clean_env` has been deprecated in favor of `Bundler.unbundled_env`. " \
-        "If you instead want the environment before bundler was originally loaded, use `Bundler.original_env`"
-      )
-    end
-
-    it "does not print a deprecation", :bundler => "< 2" do
-      code = "Bundler.clean_env"
-      bundle_exec_ruby! code.dump
-      expect(out).not_to include(
-        "[DEPRECATED] `Bundler.clean_env` has been deprecated in favor of `Bundler.unbundled_env`. " \
-        "If you instead want the environment before bundler was originally loaded, use `Bundler.original_env`"
-      )
-    end
   end
 
   describe "Bundler.with_original_env" do
@@ -151,24 +133,6 @@ RSpec.describe "Bundler.with_env helpers" do
       end
 
       expect(ENV).not_to have_key("FOO")
-    end
-
-    it "prints a deprecation", :bundler => 2 do
-      code = "Bundler.with_clean_env {}"
-      bundle_exec_ruby! code.dump
-      expect(err).to include(
-        "[DEPRECATED] `Bundler.with_clean_env` has been deprecated in favor of `Bundler.with_unbundled_env`. " \
-        "If you instead want the environment before bundler was originally loaded, use `Bundler.with_original_env`"
-      )
-    end
-
-    it "does not print a deprecation", :bundler => "< 2" do
-      code = "Bundler.with_clean_env {}"
-      bundle_exec_ruby! code.dump
-      expect(out).not_to include(
-        "[DEPRECATED] `Bundler.with_clean_env` has been deprecated in favor of `Bundler.with_unbundled_env`. " \
-        "If you instead want the environment before bundler was originally loaded, use `Bundler.with_original_env`"
-      )
     end
   end
 


### PR DESCRIPTION
This is a follow up to #7052.

### What was the end-user problem that led to this PR?

The problem was that the `Bundle.with_clean_env` & `Bundle.with_original_env` family was missing some deprecation specs, and also the specs were spread out across different files.

### What is your fix for the problem, implemented in this PR?

My fix is to add the missing specs, and centralize them in the deprecation specs file.