### PR TITLE
Don't consider default gems on `bundle info`

### DIFF
--- a/lib/bundler/cli/info.rb
+++ b/lib/bundler/cli/info.rb
@@ -26,13 +26,7 @@ module Bundler
 
     def spec_for_gem(gem_name)
       spec = Bundler.definition.specs.find {|s| s.name == gem_name }
-      spec || default_gem_spec(gem_name) || Bundler::CLI::Common.select_spec(gem_name, :regex_match)
-    end
-
-    def default_gem_spec(gem_name)
-      return unless Gem::Specification.respond_to?(:find_all_by_name)
-      gem_spec = Gem::Specification.find_all_by_name(gem_name).last
-      return gem_spec if gem_spec && gem_spec.respond_to?(:default_gem?) && gem_spec.default_gem?
+      spec || Bundler::CLI::Common.select_spec(gem_name, :regex_match)
     end
 
     def spec_not_found(gem_name)

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -41,10 +41,30 @@ RSpec.describe "bundle info" do
     end
 
     context "given a default gem shippped in ruby", :ruby_repo do
-      it "prints information about the default gem" do
-        bundle "info rdoc"
-        expect(out).to include("* rdoc")
-        expect(out).to include("Default Gem: yes")
+      context "when included in the bundle" do
+        before do
+          install_gemfile <<-G
+            gem "rdoc"
+          G
+        end
+
+        it "prints information about the default gem" do
+          bundle "info rdoc"
+          expect(out).to include("* rdoc")
+          expect(out).to include("Default Gem: yes")
+        end
+      end
+
+      context "when not included in the bundle" do
+        before do
+          install_gemfile <<-G
+          G
+        end
+
+        it "does not print information about the default gem" do
+          bundle "info rdoc"
+          expect(err).to include("Could not find gem 'rdoc'")
+        end
       end
     end
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that while old `bundle show` did not consider default gems, the new `bundle info` does.

### What was your diagnosis of the problem?

My diagnosis was that we should keep the same behavior as `bundle show`.

### What is your fix for the problem, implemented in this PR?

My fix is remove the default gems specific code from the command.

### Why did you choose this fix out of the possible options?

I chose this fix because it's consistent with other commands. If users want this in the feature, we can always add it under a command flag or whatever.