### PR TITLE
Remove command removal settings

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -487,7 +487,7 @@ module Bundler
       Open.new(options, name).run
     end
 
-    if Bundler.feature_flag.console_command?
+    unless Bundler.feature_flag.bundler_3_mode?
       desc "console [GROUP]", "Opens an IRB session with the bundle pre-loaded"
       def console(group = nil)
         require "bundler/cli/console"

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -524,7 +524,7 @@ module Bundler
       end
     end
 
-    if Bundler.feature_flag.viz_command?
+    unless Bundler.feature_flag.bundler_3_mode?
       desc "viz [OPTIONS]", "Generates a visual dependency graph", :hide => true
       long_desc <<-D
         Viz generates a PNG file of the current Gemfile as a dependency graph.

--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -56,7 +56,6 @@ module Bundler
     settings_flag(:unlock_source_unlocks_spec) { !bundler_2_mode? }
     settings_flag(:update_requires_all_flag) { bundler_3_mode? }
     settings_flag(:use_gem_version_promoter_for_major_updates) { bundler_2_mode? }
-    settings_flag(:viz_command) { !bundler_3_mode? }
 
     settings_option(:default_cli_command) { bundler_2_mode? ? :cli_help : :install }
 

--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -33,7 +33,6 @@ module Bundler
     settings_flag(:auto_config_jobs) { bundler_2_mode? }
     settings_flag(:cache_all) { bundler_2_mode? }
     settings_flag(:cache_command_is_package) { bundler_2_mode? }
-    settings_flag(:console_command) { !bundler_3_mode? }
     settings_flag(:default_install_uses_path) { bundler_2_mode? }
     settings_flag(:deployment_means_frozen) { bundler_2_mode? }
     settings_flag(:disable_multisource) { bundler_2_mode? }

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -60,7 +60,6 @@ module Bundler
       unlock_source_unlocks_spec
       update_requires_all_flag
       use_gem_version_promoter_for_major_updates
-      viz_command
     ].freeze
 
     NUMBER_KEYS = %w[

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -18,7 +18,6 @@ module Bundler
       cache_all
       cache_all_platforms
       cache_command_is_package
-      console_command
       default_install_uses_path
       deployment
       deployment_means_frozen

--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -167,7 +167,6 @@ RSpec.describe "The library itself" do
     exemptions = %w[
       auto_config_jobs
       cache_command_is_package
-      console_command
       deployment_means_frozen
       forget_cli_options
       gem.coc

--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -176,7 +176,6 @@ RSpec.describe "The library itself" do
       inline
       lockfile_uses_separate_rubygems_sources
       use_gem_version_promoter_for_major_updates
-      viz_command
     ]
 
     all_settings = Hash.new {|h, k| h[k] = [] }


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that the `viz_command` and `console_command` settings are not meant to be something configured by users. These commands are going away, we don't want to support optionally keeping them.

### What was your diagnosis of the problem?

My diagnosis was that we are using settings for two different things:

* Different supported behaviors that are configurable by users.
* Feature flags that allow us developers to easily maintain a single branch of code and making breaking changes more easily, and users to opt-in/out of certain new features/changes. 

The second case is valid but it's complicated because we need to commit to provide a proper life cycle for the setting:
* Allow opting in through the setting.
* Toggle the setting's default value.
* Deprecate the value for the setting enabling the old behavior.
* Deprecate the setting altogether making it a no-op.
* Finally removing the setting.

I plan to work on that, but I didn't start yet.

Instead, what we've been doing to workaround this is to try to not expose these settings to users by, for example, not documenting them.

However, in my opinion, in this particular case it's best to instead not provide a setting at all, and check for the bundler version directly for whether we should be providing the command. The only extra benefit of providing a feature flag, namely, allowing opting in early to the new behavior, is not necessary here because users can "opt in" anyways by simply not using the deprecated commands.

### What is your fix for the problem, implemented in this PR?

My fix is to remove the settings and check for `Bundler.feature_flag.bundler_3_mode?` instead.

### Why did you choose this fix out of the possible options?

I chose this fix because it's simple and it makes it clear that keeping these commands is not something we want to support. They are going away for good.
