### PR TITLE
Bump version to 2.1.0.pre.1.

### DIFF
--- a/lib/bundler/version.rb
+++ b/lib/bundler/version.rb
@@ -7,7 +7,7 @@ module Bundler
   # We're doing this because we might write tests that deal
   # with other versions of bundler and we are unsure how to
   # handle this better.
-  VERSION = "2.1.0.beta1" unless defined?(::Bundler::VERSION)
+  VERSION = "2.1.0.pre.1" unless defined?(::Bundler::VERSION)
 
   def self.overwrite_loaded_gem_version
     begin

--- a/lib/bundler/version.rb
+++ b/lib/bundler/version.rb
@@ -7,7 +7,7 @@ module Bundler
   # We're doing this because we might write tests that deal
   # with other versions of bundler and we are unsure how to
   # handle this better.
-  VERSION = "2.0.0.dev" unless defined?(::Bundler::VERSION)
+  VERSION = "2.1.0.beta1" unless defined?(::Bundler::VERSION)
 
   def self.overwrite_loaded_gem_version
     begin


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

When we released the new version, We got the test failure or an error with a version number like 2.0.0.

### What was your diagnosis of the problem?

We didn't test with new version number until release time.

### What is your fix for the problem, implemented in this PR?

I did bump to the minor version in the master branch.

### Why did you choose this fix out of the possible options?

We should develop with a new version number like 2.1.0.
