### PR TITLE
Normalize file URIs in spec's lockfiles

### DIFF
--- a/spec/lock/lockfile_spec.rb
+++ b/spec/lock/lockfile_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "the lockfile format", :bundler => "2" do
   end
 
   it "does not update the lockfile's bundler version if nothing changed during bundle install" do
-    version = "#{Bundler::VERSION.split(".").first}.0.0.0.a"
+    version = "#{Bundler::VERSION.split(".").first}.0.0.a"
 
     lockfile <<-L
       GEM

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -283,7 +283,7 @@ module Spec
       if contents.nil?
         File.open("Gemfile.lock", "r", &:read)
       else
-        create_file("Gemfile.lock", contents, *args)
+        create_file("Gemfile.lock", normalize_uri_file(contents), *args)
       end
     end
 

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -268,18 +268,22 @@ module Spec
     end
 
     def gemfile(*args)
-      if args.empty?
+      contents = args.shift
+
+      if contents.nil?
         File.open("Gemfile", "r", &:read)
       else
-        create_file("Gemfile", *args)
+        create_file("Gemfile", contents, *args)
       end
     end
 
     def lockfile(*args)
-      if args.empty?
+      contents = args.shift
+
+      if contents.nil?
         File.open("Gemfile.lock", "r", &:read)
       else
-        create_file("Gemfile.lock", *args)
+        create_file("Gemfile.lock", contents, *args)
       end
     end
 

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -194,7 +194,7 @@ module Spec
     RSpec::Matchers.alias_matcher :include_gem, :include_gems
 
     def have_lockfile(expected)
-      read_as(strip_whitespace(expected))
+      read_as(normalize_uri_file(strip_whitespace(expected)))
     end
 
     def plugin_should_be_installed(*names)
@@ -212,7 +212,7 @@ module Spec
     end
 
     def lockfile_should_be(expected)
-      expect(bundled_app("Gemfile.lock")).to read_as(normalize_uri_file(strip_whitespace(expected)))
+      expect(bundled_app("Gemfile.lock")).to have_lockfile(expected)
     end
 
     def gemfile_should_be(expected)


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that bumping bundler's version in #7088 made a lockfile spec fail.

### What was your diagnosis of the problem?

My diagnosis was that there was a combination of bugs that was making this spec pass, but the spec was incorrect.

### What is your fix for the problem, implemented in this PR?

My fix is to change the test version the spec uses to not hit https://github.com/rubygems/rubygems/issues/2595, and thus reproduce the failure. And then fix the spec that was incorrect because the lockfile written had different URLs (`file://localhost/<stuff>`) from the lockfile we were checking against (`file://<stuff>`), thus tricking `bundle install` into thinking something had changed, and thus making it rewrite it with an incorrect bundler version.

### Why did you choose this fix out of the possible options?

I chose this fix because it makes #7088 pass and it reduces surprises.
