### PR TITLE
Make sure spec fails if gems cannot be installed

### DIFF
--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -435,7 +435,7 @@ module Spec
       ENV["GEM_PATH"] = system_gem_path.to_s
 
       gems.each do |gem|
-        gem_command :install, "--no-document #{gem}"
+        gem_command! :install, "--no-document #{gem}"
       end
       return unless block_given?
       begin


### PR DESCRIPTION

### What was the end-user problem that led to this PR?

The problem was if the installation if system gems failed during specs failed, that was being silently ignored.

### What was your diagnosis of the problem?

My diagnosis was that if this installation fails, the specs that use this helper are not probably testing what they should

### What is your fix for the problem, implemented in this PR?

My fix is to use the bang method instead.