### PR TITLE
Change info command spec to use `bundle info` instead of `bundle show`

### DIFF
--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe "bundle info" do
 
       invalid_regexp = "[]"
 
-      bundle "show #{invalid_regexp}"
+      bundle "info #{invalid_regexp}"
       expect(err).to include("Could not find gem '#{invalid_regexp}'.")
     end
   end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

A test in the info command spec was using `bundle show` instead of `bundle info`.

This is causing specs in Bundler 3 to fail. See https://travis-ci.org/bundler/bundler/jobs/514507744

### What is your fix for the problem, implemented in this PR?

Change the test to use `bundle info` instead.
