### PR TITLE
Prefer `require_relative` for internal requires

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -1,20 +1,20 @@
 # frozen_string_literal: true
 
-require "bundler/compatibility_guard"
+require_relative "bundler/compatibility_guard"
 
-require "bundler/vendored_fileutils"
+require_relative "bundler/vendored_fileutils"
 require "pathname"
 require "rbconfig"
 
-require "bundler/errors"
-require "bundler/environment_preserver"
-require "bundler/plugin"
-require "bundler/rubygems_ext"
-require "bundler/rubygems_integration"
-require "bundler/version"
-require "bundler/constants"
-require "bundler/current_ruby"
-require "bundler/build_metadata"
+require_relative "bundler/errors"
+require_relative "bundler/environment_preserver"
+require_relative "bundler/plugin"
+require_relative "bundler/rubygems_ext"
+require_relative "bundler/rubygems_integration"
+require_relative "bundler/version"
+require_relative "bundler/constants"
+require_relative "bundler/current_ruby"
+require_relative "bundler/build_metadata"
 
 module Bundler
   environment_preserver = EnvironmentPreserver.new(ENV, EnvironmentPreserver::BUNDLER_KEYS)

--- a/lib/bundler/capistrano.rb
+++ b/lib/bundler/capistrano.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "bundler/shared_helpers"
+require_relative "shared_helpers"
 Bundler::SharedHelpers.major_deprecation 2,
   "The Bundler task for Capistrano. Please use http://github.com/capistrano/bundler"
 
@@ -8,7 +8,7 @@ Bundler::SharedHelpers.major_deprecation 2,
 #
 # Add "require 'bundler/capistrano'" in your Capistrano deploy.rb, and
 # Bundler will be activated after each new deployment.
-require "bundler/deployment"
+require_relative "deployment"
 require "capistrano/version"
 
 if defined?(Capistrano::Version) && Gem::Version.new(Capistrano::Version).release >= Gem::Version.new("3.0")

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "bundler"
 require "bundler/vendored_thor"
 
 module Bundler

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require "bundler/vendored_thor"
+require_relative "vendored_thor"
 
 module Bundler
   class CLI < Thor
-    require "bundler/cli/common"
+    require_relative "cli/common"
 
     package_name "Bundler"
 
@@ -138,7 +138,7 @@ module Bundler
     D
     method_option "gemspec", :type => :string, :banner => "Use the specified .gemspec to create the Gemfile"
     def init
-      require "bundler/cli/init"
+      require_relative "cli/init"
       Init.new(options.dup).run
     end
 
@@ -156,7 +156,7 @@ module Bundler
       "Specify a different path than the system default ($BUNDLE_PATH or $GEM_HOME).#{" Bundler will remember this value for future installs on this machine" unless Bundler.feature_flag.forget_cli_options?}"
     map "c" => "check"
     def check
-      require "bundler/cli/check"
+      require_relative "cli/check"
       Check.new(options).run
     end
 
@@ -167,7 +167,7 @@ module Bundler
     method_option "install", :type => :boolean, :banner =>
       "Runs 'bundle install' after removing the gems from the Gemfile"
     def remove(*gems)
-      require "bundler/cli/remove"
+      require_relative "cli/remove"
       Remove.new(gems, options).run
     end
 
@@ -229,7 +229,7 @@ module Bundler
         remembered_flag_deprecation(option)
       end
 
-      require "bundler/cli/install"
+      require_relative "cli/install"
       Bundler.settings.temporary(:no_install => false) do
         Install.new(options.dup).run
       end
@@ -275,7 +275,7 @@ module Bundler
       "Update everything."
     def update(*gems)
       SharedHelpers.major_deprecation(2, "The `--force` option has been renamed to `--redownload`") if ARGV.include?("--force")
-      require "bundler/cli/update"
+      require_relative "cli/update"
       Bundler.settings.temporary(:no_install => false) do
         Update.new(options, gems).run
       end
@@ -311,7 +311,7 @@ module Bundler
             Bundler::SharedHelpers.major_deprecation(2, "use `bundle #{new_argv}` instead of `bundle #{old_argv}`")
           end
         end
-        require "bundler/cli/show"
+        require_relative "cli/show"
         Show.new(options, gem_name).run
       end
     end
@@ -322,7 +322,7 @@ module Bundler
     method_option "without-group", :type => :string, :banner => "print all gems except from a group"
     method_option "paths", :type => :boolean, :banner => "print the path to each gem in the bundle"
     def list
-      require "bundler/cli/list"
+      require_relative "cli/list"
       List.new(options).run
     end
 
@@ -331,7 +331,7 @@ module Bundler
     desc "info GEM [OPTIONS]", "Show information for the given gem"
     method_option "path", :type => :boolean, :banner => "Print full path to gem"
     def info(gem_name)
-      require "bundler/cli/info"
+      require_relative "cli/info"
       Info.new(options, gem_name).run
     end
 
@@ -352,7 +352,7 @@ module Bundler
     method_option "all", :type => :boolean, :banner =>
       "Install binstubs for all gems"
     def binstubs(*gems)
-      require "bundler/cli/binstubs"
+      require_relative "cli/binstubs"
       Binstubs.new(options, gems).run
     end
 
@@ -368,7 +368,7 @@ module Bundler
     method_option "optimistic", :type => :boolean, :banner => "Adds optimistic declaration of version to gem"
     method_option "strict", :type => :boolean, :banner => "Adds strict declaration of version to gem"
     def add(*gems)
-      require "bundler/cli/add"
+      require_relative "cli/add"
       Add.new(options.dup, gems).run
     end
 
@@ -404,7 +404,7 @@ module Bundler
     method_option "only-explicit", :type => :boolean, :banner =>
       "Only list gems specified in your Gemfile, not their dependencies"
     def outdated(*gems)
-      require "bundler/cli/outdated"
+      require_relative "cli/outdated"
       Outdated.new(options, gems).run
     end
 
@@ -419,7 +419,7 @@ module Bundler
       method_option "all-platforms", :type => :boolean, :banner => "Include gems for all platforms present in the lockfile, not only the current one"
       method_option "no-prune", :type => :boolean, :banner => "Don't remove stale gems from the cache."
       def cache
-        require "bundler/cli/cache"
+        require_relative "cli/cache"
         Cache.new(options).run
       end
     end
@@ -447,7 +447,7 @@ module Bundler
       bundle without having to download any additional gems.
     D
     def package
-      require "bundler/cli/package"
+      require_relative "cli/package"
       Package.new(options).run
     end
     map %w[pack] => :package
@@ -462,7 +462,7 @@ module Bundler
     D
     map "e" => "exec"
     def exec(*args)
-      require "bundler/cli/exec"
+      require_relative "cli/exec"
       Exec.new(options, args).run
     end
 
@@ -478,19 +478,19 @@ module Bundler
       will show the current value, as well as any superceded values and
       where they were specified.
     D
-    require "bundler/cli/config"
+    require_relative "cli/config"
     subcommand "config", Config
 
     desc "open GEM", "Opens the source directory of the given bundled gem"
     def open(name)
-      require "bundler/cli/open"
+      require_relative "cli/open"
       Open.new(options, name).run
     end
 
     unless Bundler.feature_flag.bundler_3_mode?
       desc "console [GROUP]", "Opens an IRB session with the bundle pre-loaded"
       def console(group = nil)
-        require "bundler/cli/console"
+        require_relative "cli/console"
         Console.new(options, group).run
       end
     end
@@ -538,7 +538,7 @@ module Bundler
       method_option :without, :type => :array, :default => [], :aliases => "-W", :banner => "GROUP[ GROUP...]", :desc => "Exclude gems that are part of the specified named group."
       def viz
         SharedHelpers.major_deprecation 2, "The `viz` command has been moved to the `bundle-viz` gem, see https://github.com/bundler/bundler-viz"
-        require "bundler/cli/viz"
+        require_relative "cli/viz"
         Viz.new(options.dup).run
       end
     end
@@ -562,7 +562,7 @@ module Bundler
       def gem_command.run(instance, args = [])
         arity = 1 # name
 
-        require "bundler/cli/gem"
+        require_relative "cli/gem"
         cmd_args = args + [instance]
         cmd_args.unshift(instance.options)
 
@@ -590,7 +590,7 @@ module Bundler
     method_option "force", :type => :boolean, :default => false, :banner =>
       "Forces clean even if --path is not set"
     def clean
-      require "bundler/cli/clean"
+      require_relative "cli/clean"
       Clean.new(options.dup).run
     end
 
@@ -598,7 +598,7 @@ module Bundler
     method_option "ruby", :type => :boolean, :default => false, :banner =>
       "only display ruby related platform information"
     def platform
-      require "bundler/cli/platform"
+      require_relative "cli/platform"
       Platform.new(options).run
     end
 
@@ -609,7 +609,7 @@ module Bundler
      "Install gem into a bundler group"
     def inject(name, version)
       SharedHelpers.major_deprecation 2, "The `inject` command has been replaced by the `add` command"
-      require "bundler/cli/inject"
+      require_relative "cli/inject"
       Inject.new(options.dup, name, version).run
     end
 
@@ -641,7 +641,7 @@ module Bundler
     method_option "conservative", :type => :boolean, :banner =>
       "If updating, use bundle install conservative update behavior and do not allow shared dependencies to be updated"
     def lock
-      require "bundler/cli/lock"
+      require_relative "cli/lock"
       Lock.new(options).run
     end
 
@@ -661,13 +661,13 @@ module Bundler
     method_option "quiet", :type => :boolean, :banner =>
         "Only output warnings and errors."
     def doctor
-      require "bundler/cli/doctor"
+      require_relative "cli/doctor"
       Doctor.new(options).run
     end
 
     desc "issue", "Learn how to report an issue in Bundler"
     def issue
-      require "bundler/cli/issue"
+      require_relative "cli/issue"
       Issue.new.run
     end
 
@@ -678,12 +678,12 @@ module Bundler
       checkout --force`.
     D
     def pristine(*gems)
-      require "bundler/cli/pristine"
+      require_relative "cli/pristine"
       Pristine.new(gems).run
     end
 
     if Bundler.feature_flag.plugins?
-      require "bundler/cli/plugin"
+      require_relative "cli/plugin"
       desc "plugin", "Manage the bundler plugins"
       subcommand "plugin", Plugin
     end

--- a/lib/bundler/cli/common.rb
+++ b/lib/bundler/cli/common.rb
@@ -59,7 +59,7 @@ module Bundler
     end
 
     def self.gem_not_found_message(missing_gem_name, alternatives)
-      require "bundler/similarity_detector"
+      require_relative "../similarity_detector"
       message = "Could not find gem '#{missing_gem_name}'."
       alternate_names = alternatives.map {|a| a.respond_to?(:name) ? a.name : a }
       suggestions = SimilarityDetector.new(alternate_names).similar_word_list(missing_gem_name)

--- a/lib/bundler/cli/doctor.rb
+++ b/lib/bundler/cli/doctor.rb
@@ -56,7 +56,7 @@ module Bundler
     end
 
     def check!
-      require "bundler/cli/check"
+      require_relative "check"
       Bundler::CLI::Check.new({}).run
     end
 

--- a/lib/bundler/cli/exec.rb
+++ b/lib/bundler/cli/exec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "bundler/current_ruby"
+require_relative "../current_ruby"
 
 module Bundler
   class CLI::Exec
@@ -69,7 +69,7 @@ module Bundler
       Process.setproctitle(process_title(file, args)) if Process.respond_to?(:setproctitle)
       ui = Bundler.ui
       Bundler.ui = nil
-      require "bundler/setup"
+      require_relative "../setup"
       TRAPPED_SIGNALS.each {|s| trap(s, "DEFAULT") }
       Kernel.load(file)
     rescue SystemExit, SignalException

--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -80,7 +80,7 @@ module Bundler
       warn_ambiguous_gems
 
       if CLI::Common.clean_after_install?
-        require "bundler/cli/clean"
+        require_relative "clean"
         Bundler::CLI::Clean.new(options).run
       end
     rescue GemNotFound, VersionConflict => e

--- a/lib/bundler/cli/issue.rb
+++ b/lib/bundler/cli/issue.rb
@@ -33,7 +33,7 @@ module Bundler
     end
 
     def doctor
-      require "bundler/cli/doctor"
+      require_relative "doctor"
       Bundler::CLI::Doctor.new({}).run
     end
   end

--- a/lib/bundler/cli/package.rb
+++ b/lib/bundler/cli/package.rb
@@ -25,7 +25,7 @@ module Bundler
   private
 
     def install
-      require "bundler/cli/install"
+      require_relative "install"
       options = self.options.dup
       if Bundler.settings[:cache_all_platforms]
         options["local"] = false

--- a/lib/bundler/cli/plugin.rb
+++ b/lib/bundler/cli/plugin.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "bundler/vendored_thor"
+require_relative "../vendored_thor"
 module Bundler
   class CLI::Plugin < Thor
     desc "install PLUGINS", "Install the plugin from the source"

--- a/lib/bundler/cli/update.rb
+++ b/lib/bundler/cli/update.rb
@@ -62,7 +62,7 @@ module Bundler
       Bundler.load.cache if Bundler.app_cache.exist?
 
       if CLI::Common.clean_after_install?
-        require "bundler/cli/clean"
+        require_relative "clean"
         Bundler::CLI::Clean.new(options).run
       end
 

--- a/lib/bundler/compact_index_client.rb
+++ b/lib/bundler/compact_index_client.rb
@@ -13,8 +13,8 @@ module Bundler
 
     class Error < StandardError; end
 
-    require "bundler/compact_index_client/cache"
-    require "bundler/compact_index_client/updater"
+    require_relative "compact_index_client/cache"
+    require_relative "compact_index_client/updater"
 
     attr_reader :directory
 

--- a/lib/bundler/compact_index_client/updater.rb
+++ b/lib/bundler/compact_index_client/updater.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "bundler/vendored_fileutils"
+require_relative "../vendored_fileutils"
 require "stringio"
 require "zlib"
 

--- a/lib/bundler/compatibility_guard.rb
+++ b/lib/bundler/compatibility_guard.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: false
 
-require "bundler/version"
+require_relative "version"
 
 if Bundler::VERSION.split(".").first.to_i >= 2
   if Gem::Version.new(Object::RUBY_VERSION.dup) < Gem::Version.new("2.3")

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "bundler/lockfile_parser"
+require_relative "lockfile_parser"
 require "set"
 
 module Bundler
@@ -385,7 +385,7 @@ module Bundler
     end
 
     def to_lock
-      require "bundler/lockfile_generator"
+      require_relative "lockfile_generator"
       LockfileGenerator.generate(self)
     end
 

--- a/lib/bundler/dependency.rb
+++ b/lib/bundler/dependency.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 require "rubygems/dependency"
-require "bundler/shared_helpers"
-require "bundler/rubygems_ext"
+require_relative "shared_helpers"
+require_relative "rubygems_ext"
 
 module Bundler
   class Dependency < Gem::Dependency

--- a/lib/bundler/deployment.rb
+++ b/lib/bundler/deployment.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "bundler/shared_helpers"
+require_relative "shared_helpers"
 Bundler::SharedHelpers.major_deprecation 2, "Bundler no longer integrates with " \
   "Capistrano, but Capistrano provides its own integration with " \
   "Bundler via the capistrano-bundler gem. Use it instead."

--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require "bundler/dependency"
-require "bundler/ruby_dsl"
+require_relative "dependency"
+require_relative "ruby_dsl"
 
 module Bundler
   class Dsl

--- a/lib/bundler/env.rb
+++ b/lib/bundler/env.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require "bundler/rubygems_integration"
-require "bundler/source/git/git_proxy"
+require_relative "rubygems_integration"
+require_relative "source/git/git_proxy"
 
 module Bundler
   class Env

--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "bundler/vendored_persistent"
+require_relative "vendored_persistent"
 require "cgi"
 require "securerandom"
 require "zlib"

--- a/lib/bundler/fetcher/compact_index.rb
+++ b/lib/bundler/fetcher/compact_index.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require "bundler/fetcher/base"
-require "bundler/worker"
+require_relative "base"
+require_relative "../worker"
 
 module Bundler
   autoload :CompactIndexClient, "bundler/compact_index_client"

--- a/lib/bundler/fetcher/dependency.rb
+++ b/lib/bundler/fetcher/dependency.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "bundler/fetcher/base"
+require_relative "base"
 require "cgi"
 
 module Bundler

--- a/lib/bundler/fetcher/index.rb
+++ b/lib/bundler/fetcher/index.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "bundler/fetcher/base"
+require_relative "base"
 require "rubygems/remote_fetcher"
 
 module Bundler

--- a/lib/bundler/friendly_errors.rb
+++ b/lib/bundler/friendly_errors.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "cgi"
-require "bundler/vendored_thor"
+require_relative "vendored_thor"
 
 module Bundler
   module FriendlyErrors

--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require "bundler/vendored_thor" unless defined?(Thor)
-require "bundler"
+require_relative "vendored_thor" unless defined?(Thor)
+require_relative "../bundler"
 require "shellwords"
 
 module Bundler

--- a/lib/bundler/gem_tasks.rb
+++ b/lib/bundler/gem_tasks.rb
@@ -3,5 +3,5 @@
 require "rake/clean"
 CLOBBER.include "pkg"
 
-require "bundler/gem_helper"
+require_relative "gem_helper"
 Bundler::GemHelper.install_tasks

--- a/lib/bundler/inline.rb
+++ b/lib/bundler/inline.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "bundler/compatibility_guard"
+require_relative "compatibility_guard"
 
 # Allows for declaring a Gemfile inline in a ruby script, optionally installing
 # any gems that aren't already installed on the user's system.
@@ -32,7 +32,7 @@ require "bundler/compatibility_guard"
 #          puts Pod::VERSION # => "0.34.4"
 #
 def gemfile(install = false, options = {}, &gemfile)
-  require "bundler"
+  require_relative "../bundler"
 
   opts = options.dup
   ui = opts.delete(:ui) { Bundler::UI::Shell.new }

--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -2,10 +2,10 @@
 
 require "erb"
 require "rubygems/dependency_installer"
-require "bundler/worker"
-require "bundler/installer/parallel_installer"
-require "bundler/installer/standalone"
-require "bundler/installer/gem_installer"
+require_relative "worker"
+require_relative "installer/parallel_installer"
+require_relative "installer/standalone"
+require_relative "installer/gem_installer"
 
 module Bundler
   class Installer

--- a/lib/bundler/installer/parallel_installer.rb
+++ b/lib/bundler/installer/parallel_installer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require "bundler/worker"
-require "bundler/installer/gem_installer"
+require_relative "../worker"
+require_relative "gem_installer"
 
 module Bundler
   class ParallelInstaller

--- a/lib/bundler/lazy_specification.rb
+++ b/lib/bundler/lazy_specification.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "uri"
-require "bundler/match_platform"
+require_relative "match_platform"
 
 module Bundler
   class LazySpecification

--- a/lib/bundler/match_platform.rb
+++ b/lib/bundler/match_platform.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "bundler/gem_helpers"
+require_relative "gem_helpers"
 
 module Bundler
   module MatchPlatform

--- a/lib/bundler/plugin.rb
+++ b/lib/bundler/plugin.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "bundler/plugin/api"
+require_relative "plugin/api"
 
 module Bundler
   module Plugin

--- a/lib/bundler/plugin/index.rb
+++ b/lib/bundler/plugin/index.rb
@@ -139,7 +139,7 @@ module Bundler
 
           data = index_f.read
 
-          require "bundler/yaml_serializer"
+          require_relative "../yaml_serializer"
           index = YAMLSerializer.load(data)
 
           @commands.merge!(index["commands"])
@@ -162,7 +162,7 @@ module Bundler
           "sources"      => @sources,
         }
 
-        require "bundler/yaml_serializer"
+        require_relative "../yaml_serializer"
         SharedHelpers.filesystem_access(index_file) do |index_f|
           FileUtils.mkdir_p(index_f.dirname)
           File.open(index_f, "w") {|f| f.puts YAMLSerializer.dump(index) }

--- a/lib/bundler/psyched_yaml.rb
+++ b/lib/bundler/psyched_yaml.rb
@@ -27,7 +27,7 @@ module Bundler
   end
 end
 
-require "bundler/deprecate"
+require_relative "deprecate"
 begin
   Bundler::Deprecate.skip_during do
     require "rubygems/safe_yaml"

--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -2,8 +2,8 @@
 
 module Bundler
   class Resolver
-    require "bundler/vendored_molinillo"
-    require "bundler/resolver/spec_group"
+    require_relative "vendored_molinillo"
+    require_relative "resolver/spec_group"
 
     # Figures out the best possible configuration of gems that satisfies
     # the list of passed dependencies and any child dependencies without

--- a/lib/bundler/rubygems_ext.rb
+++ b/lib/bundler/rubygems_ext.rb
@@ -8,7 +8,7 @@ require "rubygems/specification"
 # shouldn't be deferred.
 require "rubygems/source"
 
-require "bundler/match_platform"
+require_relative "match_platform"
 
 module Gem
   class Specification

--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -637,7 +637,7 @@ module Bundler
     end
 
     def all_specs
-      require "bundler/remote_specification"
+      require_relative "remote_specification"
       Gem::Specification.stubs.map do |stub|
         StubSpecification.from_stub(stub)
       end

--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -111,7 +111,7 @@ module Bundler
     end
 
     def configuration
-      require "bundler/psyched_yaml"
+      require_relative "psyched_yaml"
       Gem.configuration
     rescue Gem::SystemExitException, LoadError => e
       Bundler.ui.error "#{e.class}: #{e.message}"
@@ -261,7 +261,7 @@ module Bundler
 
     def spec_from_gem(path, policy = nil)
       require "rubygems/security"
-      require "bundler/psyched_yaml"
+      require_relative "psyched_yaml"
       gem_from_path(path, security_policies[policy]).spec
     rescue Gem::Package::FormatError
       raise GemspecError, "Could not read gem at #{path}. It may be corrupted."
@@ -686,7 +686,7 @@ module Bundler
 
     def use_gemdeps(gemfile)
       ENV["BUNDLE_GEMFILE"] ||= File.expand_path(gemfile)
-      require "bundler/gemdeps"
+      require_relative "gemdeps"
       runtime = Bundler.setup
       Bundler.ui = nil
       activated_spec_names = runtime.requested_specs.map(&:to_spec).sort_by(&:name)

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -357,7 +357,7 @@ module Bundler
       return unless file
       SharedHelpers.filesystem_access(file) do |p|
         FileUtils.mkdir_p(p.dirname)
-        require "bundler/yaml_serializer"
+        require_relative "yaml_serializer"
         p.open("w") {|f| f.write(YAMLSerializer.dump(hash)) }
       end
     end
@@ -397,7 +397,7 @@ module Bundler
       SharedHelpers.filesystem_access(config_file, :read) do |file|
         valid_file = file.exist? && !file.size.zero?
         return {} unless valid_file
-        require "bundler/yaml_serializer"
+        require_relative "yaml_serializer"
         YAMLSerializer.load file.read
       end
     end

--- a/lib/bundler/setup.rb
+++ b/lib/bundler/setup.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "bundler/shared_helpers"
+require_relative "shared_helpers"
 
 if Bundler::SharedHelpers.in_bundle?
   require "bundler"

--- a/lib/bundler/setup.rb
+++ b/lib/bundler/setup.rb
@@ -3,7 +3,7 @@
 require_relative "shared_helpers"
 
 if Bundler::SharedHelpers.in_bundle?
-  require "bundler"
+  require_relative "../bundler"
 
   if STDOUT.tty? || ENV["BUNDLER_FORCE_TTY"]
     Bundler.ui = Bundler::UI::Shell.new

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -293,8 +293,6 @@ module Bundler
       # for Ruby core repository
       exe_file = File.expand_path("../../../../bin/bundle", __FILE__) unless File.exist?(exe_file)
       Bundler::SharedHelpers.set_env "BUNDLE_BIN_PATH", exe_file
-
-      # Set BUNDLE_GEMFILE
       Bundler::SharedHelpers.set_env "BUNDLE_GEMFILE", find_gemfile(:order_matters).to_s
       Bundler::SharedHelpers.set_env "BUNDLER_VERSION", Bundler::VERSION
     end

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-require "bundler/compatibility_guard"
+require_relative "compatibility_guard"
 
 require "pathname"
 require "rbconfig"
 require "rubygems"
 
-require "bundler/version"
-require "bundler/constants"
-require "bundler/rubygems_integration"
-require "bundler/current_ruby"
+require_relative "version"
+require_relative "constants"
+require_relative "rubygems_integration"
+require_relative "current_ruby"
 
 module Bundler
   module SharedHelpers
@@ -132,7 +132,7 @@ module Bundler
     def major_deprecation(major_version, message)
       bundler_major_version = Bundler.bundler_major_version
       if bundler_major_version > major_version
-        require "bundler/errors"
+        require_relative "errors"
         raise DeprecatedError, "[REMOVED] #{message}"
       end
 
@@ -351,9 +351,9 @@ module Bundler
     end
 
     def prints_major_deprecations?
-      require "bundler"
+      require_relative "../bundler"
       return false if Bundler.settings[:silence_deprecations]
-      require "bundler/deprecate"
+      require_relative "deprecate"
       return false if Bundler::Deprecate.skip
       true
     end

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -289,18 +289,10 @@ module Bundler
     public :set_env
 
     def set_bundle_variables
-      begin
-        exe_file = Bundler.rubygems.bin_path("bundler", "bundle", VERSION)
-        unless File.exist?(exe_file)
-          exe_file = File.expand_path("../../../exe/bundle", __FILE__)
-        end
-        Bundler::SharedHelpers.set_env "BUNDLE_BIN_PATH", exe_file
-      rescue Gem::GemNotFoundException
-        exe_file = File.expand_path("../../../exe/bundle", __FILE__)
-        # for Ruby core repository
-        exe_file = File.expand_path("../../../../bin/bundle", __FILE__) unless File.exist?(exe_file)
-        Bundler::SharedHelpers.set_env "BUNDLE_BIN_PATH", exe_file
-      end
+      exe_file = File.expand_path("../../../exe/bundle", __FILE__)
+      # for Ruby core repository
+      exe_file = File.expand_path("../../../../bin/bundle", __FILE__) unless File.exist?(exe_file)
+      Bundler::SharedHelpers.set_env "BUNDLE_BIN_PATH", exe_file
 
       # Set BUNDLE_GEMFILE
       Bundler::SharedHelpers.set_env "BUNDLE_GEMFILE", find_gemfile(:order_matters).to_s

--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "bundler/vendored_fileutils"
+require_relative "../vendored_fileutils"
 require "uri"
 
 module Bundler

--- a/lib/bundler/stub_specification.rb
+++ b/lib/bundler/stub_specification.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "bundler/remote_specification"
+require_relative "remote_specification"
 
 module Bundler
   class StubSpecification < RemoteSpecification

--- a/lib/bundler/ui/rg_proxy.rb
+++ b/lib/bundler/ui/rg_proxy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "bundler/ui"
+require_relative "../ui"
 require "rubygems/user_interaction"
 
 module Bundler

--- a/lib/bundler/ui/shell.rb
+++ b/lib/bundler/ui/shell.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "bundler/vendored_thor"
+require_relative "../vendored_thor"
 
 module Bundler
   module UI

--- a/lib/bundler/vendored_fileutils.rb
+++ b/lib/bundler/vendored_fileutils.rb
@@ -2,7 +2,7 @@
 
 module Bundler; end
 if RUBY_VERSION >= "2.4"
-  require "bundler/vendor/fileutils/lib/fileutils"
+  require_relative "vendor/fileutils/lib/fileutils"
 else
   # the version we vendor is 2.4+
   require "fileutils"

--- a/lib/bundler/vendored_molinillo.rb
+++ b/lib/bundler/vendored_molinillo.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
 module Bundler; end
-require "bundler/vendor/molinillo/lib/molinillo"
+require_relative "vendor/molinillo/lib/molinillo"

--- a/lib/bundler/vendored_persistent.rb
+++ b/lib/bundler/vendored_persistent.rb
@@ -15,7 +15,7 @@ module Bundler
     end
   end
 end
-require "bundler/vendor/net-http-persistent/lib/net/http/persistent"
+require_relative "vendor/net-http-persistent/lib/net/http/persistent"
 
 module Bundler
   class PersistentHTTP < Persistent::Net::HTTP::Persistent

--- a/lib/bundler/vendored_thor.rb
+++ b/lib/bundler/vendored_thor.rb
@@ -5,4 +5,4 @@ module Bundler
     Kernel.send(:require, "bundler/vendor/thor/lib/thor/actions")
   end
 end
-require "bundler/vendor/thor/lib/thor"
+require_relative "vendor/thor/lib/thor"

--- a/lib/bundler/vlad.rb
+++ b/lib/bundler/vlad.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "bundler/shared_helpers"
+require_relative "shared_helpers"
 Bundler::SharedHelpers.major_deprecation 2,
   "The Bundler task for Vlad"
 
@@ -8,7 +8,7 @@ Bundler::SharedHelpers.major_deprecation 2,
 #
 # Add "require 'bundler/vlad'" in your Vlad deploy.rb, and
 # include the vlad:bundle:install task in your vlad:deploy task.
-require "bundler/deployment"
+require_relative "deployment"
 
 include Rake::DSL if defined? Rake::DSL
 

--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "set"
+
 if defined?(Encoding) && Encoding.default_external.name != "UTF-8"
   # An approximation of ruby -E UTF-8, since it works on 1.8.7
   Encoding.default_external = Encoding.find("UTF-8")


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that `bundler` seems to, in some very rare cases, leak to the copy of itself installed as a default gem. I have been able to reproduce this only for stuff that we have already fixed. For example: https://github.com/bundler/bundler/pull/6502. However, I have the gut feeling that this can still happen under some conditions, because sometimes we still get reports from people using bundler 2, and getting the error "You must user Bundler 2 or greater with this Gemfile". 

### What was your diagnosis of the problem?

My diagnosis was that somehow, due to the complicated LOAD_PATH manipulation bundler does, we may endup requiring bundler files in another copy of bundler.

### What is your fix for the problem, implemented in this PR?

My fix is not really a fix, although it _might_ prevent the potential issue from happening. As @colby-swandale would say, we should fix the real culprit instead. However, I think using `require_relative` is a better practice anyways, because it makes it clear that you are requiring "internal" files and not files from some dependencies. And it should also be faster because it does not search the LOAD_PATH. And it skips the rubygems monkeypatches to `require`, which seems also good.

### Why did you choose this fix out of the possible options?

I chose this fix because I think it's a good practice.