### PR TITLE
Remove explicitly loading thread library

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -5,7 +5,6 @@ require "bundler/compatibility_guard"
 require "bundler/vendored_fileutils"
 require "pathname"
 require "rbconfig"
-require "thread"
 
 require "bundler/errors"
 require "bundler/environment_preserver"

--- a/lib/bundler/worker.rb
+++ b/lib/bundler/worker.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "thread"
-
 module Bundler
   class Worker
     POISON = Object.new

--- a/spec/realworld/dependency_api_spec.rb
+++ b/spec/realworld/dependency_api_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "gemcutter's dependency API", :realworld => true do
       @server_uri = "http://127.0.0.1:#{port}"
 
       require File.expand_path("../../support/artifice/endpoint_timeout", __FILE__)
-      require "thread"
+
       @t = Thread.new do
         server = Rack::Server.start(:app       => EndpointTimeout,
                                     :Host      => "0.0.0.0",

--- a/spec/realworld/gemfile_source_header_spec.rb
+++ b/spec/realworld/gemfile_source_header_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "thread"
-
 RSpec.describe "fetching dependencies with a mirrored source", :realworld => true do
   let(:mirror) { "https://server.example.org" }
   let(:original) { "http://127.0.0.1:#{@port}" }

--- a/spec/realworld/mirror_probe_spec.rb
+++ b/spec/realworld/mirror_probe_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "thread"
-
 RSpec.describe "fetching dependencies with a not available mirror", :realworld => true do
   let(:mirror) { @mirror_uri }
   let(:original) { @server_uri }


### PR DESCRIPTION
### What is your fix for the problem, implemented in this PR?

It's provided by an embedded module in the modern Ruby.
