### PR TITLE
Add missing method to rake file

### DIFF
--- a/task/build_metadata.rake
+++ b/task/build_metadata.rake
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+def bundler_spec
+  Gem::Specification.load("bundler.gemspec")
+end
+
 def write_build_metadata(build_metadata)
   build_metadata_file = "lib/bundler/build_metadata.rb"
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was any Rake task depending on the `:build_metadata` task is currently failing with  ``NameError: undefined local variable or method `bundler_spec' for main:Object``. For example, the release or build tasks.

### What was your diagnosis of the problem?

My diagnosis was that I probably broke this during the development environment refactoring.

### What is your fix for the problem, implemented in this PR?

My fix is to add the missing method to the file that needs it.

### Why did you choose this fix out of the possible options?

I chose this fix because it works and it restores working tasks.
