### PR TITLE
Cache rubocop in travis-ci

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,8 @@ AllCops:
     - tmp/**/*
     - lib/bundler/vendor/**/*
   DisplayCopNames: true
+  CacheRootDirectory: tmp/rubocop
+  MaxFilesInCache: 5000
 
 # Bundler
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ branches:
     - /.+-dev$/
     - /.+-stable$/
 
+cache:
+  directories:
+    - tmp/rubocop
+
 notifications:
   slack:
     on_success: change


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

We run rubocop on every build that goes through every file looking for any breaking rules. Currently this takes about ~30s to execute. We also have the linting step required to pass before any other steps are executed, so having this step execute as fast as possible is important to developers.

I think there is a small optimize we can make to the build time by caching rubocop between builds.

### What is your fix for the problem, implemented in this PR?

Have travis cache the results from rubocop between builds to speed up build times
