### PR TITLE
Fix GemHelper to allow reading Input/Output

### DIFF
--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -192,13 +192,15 @@ module Bundler
     def sh_with_status(cmd, &block)
       Bundler.ui.debug(cmd)
       SharedHelpers.chdir(base) do
-        outbuf = IO.popen(cmd, :err => [:child, :out]) do |io|
-          Thread.new { print io.getc until io.eof? }.join
+        outbuf = StringIO.new
+        IO.popen(cmd, :err => [:child, :out]) do |io|
+          print outbuf.putc(io.getc) until io.eof?
           io.close
         end
         status = $?
-        block.call(outbuf) if status.success? && block
-        [outbuf, status]
+        output = outbuf.string
+        block.call(output) if status.success? && block
+        [output, status]
       end
     end
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Note: This PR is a super seed of #7005.

Currently, users that have enabled 2FA in RubyGems.org with both Web+API are not able to upload their gems via `rake release`, due to a bug in `GemHelper#sh_with_status` not handling input/output correctly.

### What was your diagnosis of the problem?

See https://github.com/bundler/bundler/issues/6854

### What is your fix for the problem, implemented in this PR?

See  https://github.com/bundler/bundler/issues/6854 as this PR is mostly the same.

The major difference here is that i've merged the change into `#sh_with_status` and that i'm using `IO#getc` instead of `IO#gets`. This is because commands could potentially be asking for input on the same line as output, resulting in output that still hasn't been printed.


Example using `passwd`

```
# Using IO#gets
➜ ruby -I lib -rbundler -e 'Bundler::GemHelper.new.send(:sh, "passwd")'
Changing password for colby.
<INPUT>
```

```
# Using IO#getc
$ ruby -I lib -rbundler -e 'Bundler::GemHelper.new.send(:sh, "passwd")'
Changing password for colby.
Old Password:<INPUT>
```


Closes #6854 #7005