### PR TITLE
Backport `GemHelper` changes for #7108

### DIFF
--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -2,6 +2,7 @@
 
 require "bundler/vendored_thor" unless defined?(Thor)
 require "bundler"
+require "shellwords"
 
 module Bundler
   class GemHelper
@@ -75,7 +76,7 @@ module Bundler
     def build_gem
       file_name = nil
       gem = ENV["BUNDLE_GEM"] ? ENV["BUNDLE_GEM"] : "gem"
-      sh("#{gem} build -V '#{spec_path}'") do
+      sh(%W[#{gem} build -V #{spec_path}]) do
         file_name = File.basename(built_gem_path)
         SharedHelpers.filesystem_access(File.join(base, "pkg")) {|p| FileUtils.mkdir_p(p) }
         FileUtils.mv(built_gem_path, "pkg")
@@ -87,17 +88,21 @@ module Bundler
     def install_gem(built_gem_path = nil, local = false)
       built_gem_path ||= build_gem
       gem = ENV["BUNDLE_GEM"] ? ENV["BUNDLE_GEM"] : "gem"
-      out, _ = sh_with_code("#{gem} install '#{built_gem_path}'#{" --local" if local}")
-      raise "Couldn't install gem, run `gem install #{built_gem_path}' for more detailed output" unless out[/Successfully installed/]
+      cmd = %W[#{gem} install #{built_gem_path}]
+      cmd << "--local" if local
+      out, status = sh_with_status(cmd)
+      unless status.success? && out[/Successfully installed/]
+        raise "Couldn't install gem, run `gem install #{built_gem_path}' for more detailed output"
+      end
       Bundler.ui.confirm "#{name} (#{version}) installed."
     end
 
   protected
 
     def rubygem_push(path)
-      gem_command = "gem push '#{path}'"
-      gem_command += " --key #{gem_key}" if gem_key
-      gem_command += " --host #{allowed_push_host}" if allowed_push_host
+      gem_command = %W[gem push #{path}]
+      gem_command << "--key" << gem_key if gem_key
+      gem_command << "--host" << allowed_push_host if allowed_push_host
       unless allowed_push_host || Bundler.user_home.join(".gem/credentials").file?
         raise "Your rubygems.org credentials aren't set. Run `gem push` to set them."
       end
@@ -129,12 +134,14 @@ module Bundler
 
     def perform_git_push(options = "")
       cmd = "git push #{options}"
-      out, code = sh_with_code(cmd)
-      raise "Couldn't git push. `#{cmd}' failed with the following output:\n\n#{out}\n" unless code == 0
+      out, status = sh_with_status(cmd)
+      return if status.success?
+      cmd = cmd.shelljoin if cmd.respond_to?(:shelljoin)
+      raise "Couldn't git push. `#{cmd}' failed with the following output:\n\n#{out}\n"
     end
 
     def already_tagged?
-      return false unless sh("git tag").split(/\n/).include?(version_tag)
+      return false unless sh(%w[git tag]).split(/\n/).include?(version_tag)
       Bundler.ui.confirm "Tag #{version_tag} has already been created."
       true
     end
@@ -144,20 +151,20 @@ module Bundler
     end
 
     def clean?
-      sh_with_code("git diff --exit-code")[1] == 0
+      sh_with_status(%w[git diff --exit-code])[1].success?
     end
 
     def committed?
-      sh_with_code("git diff-index --quiet --cached HEAD")[1] == 0
+      sh_with_status(%w[git diff-index --quiet --cached HEAD])[1].success?
     end
 
     def tag_version
-      sh "git tag -m \"Version #{version}\" #{version_tag}"
+      sh %W[git tag -m Version\ #{version} #{version_tag}]
       Bundler.ui.confirm "Tagged #{version_tag}."
       yield if block_given?
     rescue RuntimeError
       Bundler.ui.error "Untagging #{version_tag} due to error."
-      sh_with_code "git tag -d #{version_tag}"
+      sh_with_status %W[git tag -d #{version_tag}]
       raise
     end
 
@@ -174,21 +181,20 @@ module Bundler
     end
 
     def sh(cmd, &block)
-      out, code = sh_with_code(cmd, &block)
-      unless code.zero?
+      out, status = sh_with_status(cmd, &block)
+      unless status.success?
+        cmd = cmd.shelljoin if cmd.respond_to?(:shelljoin)
         raise(out.empty? ? "Running `#{cmd}` failed. Run this command directly for more detailed output." : out)
       end
       out
     end
 
-    def sh_with_code(cmd, &block)
-      cmd += " 2>&1"
-      outbuf = String.new
+    def sh_with_status(cmd, &block)
       Bundler.ui.debug(cmd)
       SharedHelpers.chdir(base) do
-        outbuf = `#{cmd}`
-        status = $?.exitstatus
-        block.call(outbuf) if status.zero? && block
+        outbuf = IO.popen(cmd, :err => [:child, :out], &:read)
+        status = $?
+        block.call(outbuf) if status.success? && block
         [outbuf, status]
       end
     end

--- a/spec/bundler/gem_helper_spec.rb
+++ b/spec/bundler/gem_helper_spec.rb
@@ -181,6 +181,7 @@ RSpec.describe Bundler::GemHelper do
           `git init`
           `git config user.email "you@example.com"`
           `git config user.name "name"`
+          `git config commit.gpgsign false`
           `git config push.default simple`
         end
 
@@ -208,11 +209,12 @@ RSpec.describe Bundler::GemHelper do
       end
 
       context "succeeds" do
+        let(:repo) { build_git("foo", :bare => true) }
+
         before do
-          Dir.chdir(gem_repo1) { `git init --bare` }
           Dir.chdir(app_path) do
-            `git remote add origin file://#{gem_repo1}`
-            `git commit -a -m "initial commit"`
+            sys_exec("git remote add origin file://#{repo.path}")
+            sys_exec('git commit -a -m "initial commit"')
           end
         end
 


### PR DESCRIPTION
I'm working on getting https://github.com/bundler/bundler/pull/7108 into the v2.0.2 release but that code has not been kept up to date over time (i'm not sure why i haven't been doing this). Trying to cherry-pick the changes to `GemHelper` is proving to be not super fun to deal with. Instead, i'm just going to copy/paste the current file & specs into `2-0-stable`

There doesn't seem to be any breaking changes, so this should be ok to perform.
