### PR TITLE
Remove `prefer_gems_rb` setting

### DIFF
--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -44,7 +44,6 @@ module Bundler
     settings_flag(:only_update_to_newer_versions) { bundler_3_mode? }
     settings_flag(:path_relative_to_cwd) { bundler_3_mode? }
     settings_flag(:plugins) { @bundler_version >= Gem::Version.new("1.14") }
-    settings_flag(:prefer_gems_rb) { bundler_3_mode? }
     settings_flag(:print_only_version_number) { bundler_3_mode? }
     settings_flag(:setup_makes_kernel_gem_public) { !bundler_3_mode? }
     settings_flag(:skip_default_git_sources) { bundler_4_mode? }

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -45,7 +45,6 @@ module Bundler
       path_relative_to_cwd
       path.system
       plugins
-      prefer_gems_rb
       prefer_patch
       print_only_version_number
       setup_makes_kernel_gem_public

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -149,13 +149,9 @@ module Bundler
         break gemfiles.size != 1
       end
       return unless multiple_gemfiles
-      diagnosis = "Multiple gemfiles (gems.rb and Gemfile) detected."
-      advice = if Bundler.feature_flag.prefer_gems_rb?
-        "Make sure you remove Gemfile and Gemfile.lock since bundler is ignoring them in favor of gems.rb and gems.rb.locked."
-      else
-        "The gems.rb and gems.rb.locked files are currently ignored, but they will get used as soon as you delete your Gemfile and Gemfile.lock files."
-      end
-      Bundler.ui.warn [diagnosis, advice].join(" ")
+      message = "Multiple gemfiles (gems.rb and Gemfile) detected. " \
+                "Make sure you remove Gemfile and Gemfile.lock since bundler is ignoring them in favor of gems.rb and gems.rb.locked."
+      Bundler.ui.warn message
     end
 
     def trap(signal, override = false, &block)
@@ -235,13 +231,11 @@ module Bundler
     def find_gemfile(order_matters = false)
       given = ENV["BUNDLE_GEMFILE"]
       return given if given && !given.empty?
-      names = gemfile_names
-      names.reverse! if order_matters && Bundler.feature_flag.prefer_gems_rb?
-      find_file(*names)
+      find_file(*gemfile_names)
     end
 
     def gemfile_names
-      ["Gemfile", "gems.rb"]
+      ["gems.rb", "Gemfile"]
     end
 
     def find_file(*names)

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -232,8 +232,6 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
    Makes `--path` relative to the CWD instead of the `Gemfile`.
 * `plugins` (`BUNDLE_PLUGINS`):
    Enable Bundler's experimental plugin system.
-* `prefer_gems_rb` (`BUNDLE_PREFER_GEMS_RB`)
-   Prefer `gems.rb` to `Gemfile` when Bundler is searching for a Gemfile.
 * `prefer_patch` (BUNDLE_PREFER_PATCH):
    Prefer updating only to next patch version during updates. Makes `bundle update` calls equivalent to `bundler update --patch`.
 * `print_only_version_number` (`BUNDLE_PRINT_ONLY_VERSION_NUMBER`)

--- a/spec/install/gemfile_spec.rb
+++ b/spec/install/gemfile_spec.rb
@@ -68,22 +68,6 @@ RSpec.describe "bundle install" do
     end
   end
 
-  context "with prefer_gems_rb set" do
-    before { bundle! "config set prefer_gems_rb true" }
-
-    it "prefers gems.rb to Gemfile" do
-      create_file("gems.rb", "gem 'bundler'")
-      create_file("Gemfile", "raise 'wrong Gemfile!'")
-
-      bundle! :install
-
-      expect(bundled_app("gems.rb")).to be_file
-      expect(bundled_app("Gemfile.lock")).not_to be_file
-
-      expect(the_bundle).to include_gem "bundler #{Bundler::VERSION}"
-    end
-  end
-
   context "with engine specified in symbol" do
     it "does not raise any error parsing Gemfile" do
       simulate_ruby_version "2.3.0" do

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -240,21 +240,7 @@ RSpec.describe "major deprecations" do
       expect(deprecations).to be_empty
     end
 
-    it "should print a proper warning, and use Gemfile", :bundler => "2" do
-      create_file "gems.rb"
-      install_gemfile! <<-G
-        source "file://#{gem_repo1}"
-        gem "rack"
-      G
-
-      expect(warnings).to include(
-        "Multiple gemfiles (gems.rb and Gemfile) detected. The gems.rb and gems.rb.locked files are currently ignored, but they will get used as soon as you delete your Gemfile and Gemfile.lock files."
-      )
-
-      expect(the_bundle).to include_gem "rack 1.0"
-    end
-
-    it "should print a proper warning, and use gems.rb", :bundler => "3" do
+    it "should print a proper warning, and use gems.rb" do
       create_file "gems.rb"
       install_gemfile! <<-G
         source "file://#{gem_repo1}"
@@ -354,13 +340,7 @@ RSpec.describe "major deprecations" do
       RUBY
     end
 
-    it "should print a single deprecation warning", :bundler => "< 3" do
-      expect(warnings).to include(
-        "Multiple gemfiles (gems.rb and Gemfile) detected. The gems.rb and gems.rb.locked files are currently ignored, but they will get used as soon as you delete your Gemfile and Gemfile.lock files."
-      )
-    end
-
-    it "should print a single deprecation warning", :bundler => "3" do
+    it "should print a single deprecation warning" do
       expect(warnings).to include(
         "Multiple gemfiles (gems.rb and Gemfile) detected. Make sure you remove Gemfile and Gemfile.lock since bundler is ignoring them in favor of gems.rb and gems.rb.locked."
       )

--- a/spec/update/gemfile_spec.rb
+++ b/spec/update/gemfile_spec.rb
@@ -46,21 +46,4 @@ RSpec.describe "bundle update" do
       end
     end
   end
-
-  context "with prefer_gems_rb set" do
-    before { bundle! "config set prefer_gems_rb true" }
-
-    it "prefers gems.rb to Gemfile" do
-      create_file("gems.rb", "gem 'bundler'")
-      create_file("Gemfile", "raise 'wrong Gemfile!'")
-
-      bundle! :install
-      bundle! :update, :all => true
-
-      expect(bundled_app("gems.rb")).to be_file
-      expect(bundled_app("Gemfile.lock")).not_to be_file
-
-      expect(the_bundle).to include_gem "bundler #{Bundler::VERSION}"
-    end
-  end
 end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that we currently have a feature flag and setting, `prefer_gems_rb`, that currently does very very little, and it's not worth the maintenance cost in my opinion.

### What was your diagnosis of the problem?

My diagnosis was that the only situation where this setting makes a difference at the moment is when a project has both a `Gemfile` _and_ a `gems.rb` file. In that case, if `prefer_gems_rb` is enabled, the warning will tell the user to remove the `Gemfile` because it's being ignored, whereas if not enabled, it will tell the user to remove the `gems.rb` file because it's being ignored.

I think this setting might've made sense when we actually planned to really deprecate Gemfile's in the short term. Since I think we're not planning to deprecate Gemfile's at the moment, I think it's better to remove the setting.

### What is your fix for the problem, implemented in this PR?

My fix is to remove the setting and keep supporting both names. In the weird case of both types being found in the same project, always prefer `gems.rb` and tell the user to remove the `Gemfile`.