### PR TITLE
Make `init_gems_rb` a regular setting

### DIFF
--- a/lib/bundler/cli/init.rb
+++ b/lib/bundler/cli/init.rb
@@ -41,7 +41,7 @@ module Bundler
   private
 
     def gemfile
-      @gemfile ||= Bundler.feature_flag.init_gems_rb? ? "gems.rb" : "Gemfile"
+      @gemfile ||= Bundler.settings[:init_gems_rb] ? "gems.rb" : "Gemfile"
     end
   end
 end

--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -40,7 +40,6 @@ module Bundler
     settings_flag(:forget_cli_options) { bundler_3_mode? }
     settings_flag(:global_path_appends_ruby_scope) { bundler_3_mode? }
     settings_flag(:global_gem_cache) { bundler_3_mode? }
-    settings_flag(:init_gems_rb) { bundler_3_mode? }
     settings_flag(:only_update_to_newer_versions) { bundler_3_mode? }
     settings_flag(:path_relative_to_cwd) { bundler_3_mode? }
     settings_flag(:plugins) { @bundler_version >= Gem::Version.new("1.14") }

--- a/spec/commands/init_spec.rb
+++ b/spec/commands/init_spec.rb
@@ -1,19 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.describe "bundle init" do
-  it "generates a Gemfile", :bundler => "< 3" do
+  it "generates a Gemfile" do
     bundle! :init
     expect(out).to include("Writing new Gemfile")
     expect(bundled_app("Gemfile")).to be_file
   end
 
-  it "generates a gems.rb", :bundler => "3" do
-    bundle! :init
-    expect(out).to include("Writing new gems.rb")
-    expect(bundled_app("gems.rb")).to be_file
-  end
-
-  context "when a Gemfile already exists", :bundler => "< 3" do
+  context "when a Gemfile already exists" do
     before do
       create_file "Gemfile", <<-G
         gem "rails"
@@ -30,24 +24,7 @@ RSpec.describe "bundle init" do
     end
   end
 
-  context "when gems.rb already exists", :bundler => ">= 3" do
-    before do
-      create_file("gems.rb", <<-G)
-        gem "rails"
-      G
-    end
-
-    it "does not change existing Gemfiles" do
-      expect { bundle :init }.not_to change { File.read(bundled_app("gems.rb")) }
-    end
-
-    it "notifies the user that an existing gems.rb already exists" do
-      bundle :init
-      expect(err).to include("gems.rb already exists")
-    end
-  end
-
-  context "when a Gemfile exists in a parent directory", :bundler => "< 3" do
+  context "when a Gemfile exists in a parent directory" do
     let(:subdir) { "child_dir" }
 
     it "lets users generate a Gemfile in a child directory" do
@@ -82,24 +59,7 @@ RSpec.describe "bundle init" do
     end
   end
 
-  context "when a gems.rb file exists in a parent directory", :bundler => ">= 3" do
-    let(:subdir) { "child_dir" }
-
-    it "lets users generate a Gemfile in a child directory" do
-      bundle! :init
-
-      FileUtils.mkdir bundled_app(subdir)
-
-      Dir.chdir bundled_app(subdir) do
-        bundle! :init
-      end
-
-      expect(out).to include("Writing new gems.rb")
-      expect(bundled_app("#{subdir}/gems.rb")).to be_file
-    end
-  end
-
-  context "given --gemspec option", :bundler => "< 3" do
+  context "given --gemspec option" do
     let(:spec_file) { tmp.join("test.gemspec") }
 
     it "should generate from an existing gemspec" do
@@ -115,11 +75,7 @@ RSpec.describe "bundle init" do
 
       bundle :init, :gemspec => spec_file
 
-      gemfile = if Bundler::VERSION[0, 2] == "2."
-        bundled_app("Gemfile").read
-      else
-        bundled_app("gems.rb").read
-      end
+      gemfile = bundled_app("Gemfile").read
       expect(gemfile).to match(%r{source 'https://rubygems.org'})
       expect(gemfile.scan(/gem "rack", "= 1.0.1"/).size).to eq(1)
       expect(gemfile.scan(/gem "rspec", "= 1.2"/).size).to eq(1)
@@ -146,7 +102,47 @@ RSpec.describe "bundle init" do
   context "when init_gems_rb setting is enabled" do
     before { bundle "config set init_gems_rb true" }
 
-    context "given --gemspec option", :bundler => "< 3" do
+    it "generates a gems.rb" do
+      bundle! :init
+      expect(out).to include("Writing new gems.rb")
+      expect(bundled_app("gems.rb")).to be_file
+    end
+
+    context "when gems.rb already exists" do
+      before do
+        create_file("gems.rb", <<-G)
+          gem "rails"
+        G
+      end
+
+      it "does not change existing Gemfiles" do
+        expect { bundle :init }.not_to change { File.read(bundled_app("gems.rb")) }
+      end
+
+      it "notifies the user that an existing gems.rb already exists" do
+        bundle :init
+        expect(err).to include("gems.rb already exists")
+      end
+    end
+
+    context "when a gems.rb file exists in a parent directory" do
+      let(:subdir) { "child_dir" }
+
+      it "lets users generate a Gemfile in a child directory" do
+        bundle! :init
+
+        FileUtils.mkdir bundled_app(subdir)
+
+        Dir.chdir bundled_app(subdir) do
+          bundle! :init
+        end
+
+        expect(out).to include("Writing new gems.rb")
+        expect(bundled_app("#{subdir}/gems.rb")).to be_file
+      end
+    end
+
+    context "given --gemspec option" do
       let(:spec_file) { tmp.join("test.gemspec") }
 
       before do


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that we have a feature flag to change the file name of the file where gems are defined from `Gemfile` to `gems.rb`, and it is unclear whether we will actually do this, and when.

### What was your diagnosis of the problem?

My diagnosis was that a feature flag is not a good fit here. It's perfectly fine to configure this and allow users to use `gems.rb` by default for their gems, but we don't know when/if we will actually change the default so a plain setting feels better than a feature flag.

### What is your fix for the problem, implemented in this PR?

My fix is to convert the `init_gems_rb` feature flag into a plain setting.
