### PR TITLE
Allow local install on jruby

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -199,68 +199,72 @@ task :rubocop do
 end
 
 namespace :man do
-  ronn_dep = development_dependencies.find do |dep|
-    dep.name == "ronn"
-  end
-
-  ronn_requirement = ronn_dep.requirement.to_s
-
-  begin
-    gem "ronn", ronn_requirement
-
-    require "ronn"
-  rescue LoadError
-    task(:build) { abort "We couln't activate ronn (#{ronn_requirement}). Try `gem install ronn:'#{ronn_requirement}'` to be able to build the help pages" }
+  if RUBY_ENGINE == "jruby"
+    task(:build) {}
   else
-    directory "man"
-
-    index = []
-    sources = Dir["man/*.ronn"].map {|f| File.basename(f, ".ronn") }
-    sources.map do |basename|
-      ronn = "man/#{basename}.ronn"
-      manual_section = ".1" unless basename =~ /\.(\d+)\Z/
-      roff = "man/#{basename}#{manual_section}"
-
-      index << [ronn, File.basename(roff)]
-
-      file roff => ["man", ronn] do
-        sh "#{Gem.ruby} -S ronn --roff --pipe #{ronn} > #{roff}"
-      end
-
-      file "#{roff}.txt" => roff do
-        sh "groff -Wall -mtty-char -mandoc -Tascii #{roff} | col -b > #{roff}.txt"
-      end
-
-      task :build_all_pages => "#{roff}.txt"
+    ronn_dep = development_dependencies.find do |dep|
+      dep.name == "ronn"
     end
 
-    file "index.txt" do
-      index.map! do |(ronn, roff)|
-        [File.read(ronn).split(" ").first, roff]
+    ronn_requirement = ronn_dep.requirement.to_s
+
+    begin
+      gem "ronn", ronn_requirement
+
+      require "ronn"
+    rescue LoadError
+      task(:build) { abort "We couln't activate ronn (#{ronn_requirement}). Try `gem install ronn:'#{ronn_requirement}'` to be able to build the help pages" }
+    else
+      directory "man"
+
+      index = []
+      sources = Dir["man/*.ronn"].map {|f| File.basename(f, ".ronn") }
+      sources.map do |basename|
+        ronn = "man/#{basename}.ronn"
+        manual_section = ".1" unless basename =~ /\.(\d+)\Z/
+        roff = "man/#{basename}#{manual_section}"
+
+        index << [ronn, File.basename(roff)]
+
+        file roff => ["man", ronn] do
+          sh "#{Gem.ruby} -S ronn --roff --pipe #{ronn} > #{roff}"
+        end
+
+        file "#{roff}.txt" => roff do
+          sh "groff -Wall -mtty-char -mandoc -Tascii #{roff} | col -b > #{roff}.txt"
+        end
+
+        task :build_all_pages => "#{roff}.txt"
       end
-      index = index.sort_by(&:first)
-      justification = index.map {|(n, _f)| n.length }.max + 4
-      File.open("man/index.txt", "w") do |f|
-        index.each do |name, filename|
-          f << name.ljust(justification) << filename << "\n"
+
+      file "index.txt" do
+        index.map! do |(ronn, roff)|
+          [File.read(ronn).split(" ").first, roff]
+        end
+        index = index.sort_by(&:first)
+        justification = index.map {|(n, _f)| n.length }.max + 4
+        File.open("man/index.txt", "w") do |f|
+          index.each do |name, filename|
+            f << name.ljust(justification) << filename << "\n"
+          end
         end
       end
-    end
-    task :build_all_pages => "index.txt"
+      task :build_all_pages => "index.txt"
 
-    task :clean do
-      leftovers = Dir["man/*"].reject do |f|
-        File.extname(f) == ".ronn"
+      task :clean do
+        leftovers = Dir["man/*"].reject do |f|
+          File.extname(f) == ".ronn"
+        end
+        rm leftovers if leftovers.any?
       end
-      rm leftovers if leftovers.any?
-    end
 
-    desc "Build the man pages"
-    task :build => ["man:clean", "man:build_all_pages"]
+      desc "Build the man pages"
+      task :build => ["man:clean", "man:build_all_pages"]
 
-    desc "Remove all built man pages"
-    task :clobber do
-      rm_rf "lib/bundler/man"
+      desc "Remove all built man pages"
+      task :clobber do
+        rm_rf "lib/bundler/man"
+      end
     end
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -210,7 +210,6 @@ namespace :man do
 
     require "ronn"
   rescue LoadError
-    task(:require) { abort "We couln't activate ronn (#{ronn_requirement}). Try `gem install ronn:'#{ronn_requirement}'` to be able to release!" }
     task(:build) { abort "We couln't activate ronn (#{ronn_requirement}). Try `gem install ronn:'#{ronn_requirement}'` to be able to build the help pages" }
   else
     directory "man"
@@ -263,8 +262,6 @@ namespace :man do
     task :clobber do
       rm_rf "lib/bundler/man"
     end
-
-    task(:require) {}
   end
 end
 

--- a/task/release.rake
+++ b/task/release.rake
@@ -4,7 +4,7 @@ require "bundler/gem_tasks"
 task :build => ["build_metadata", "man:build", "generate_files"] do
   Rake::Task["build_metadata:clean"].tap(&:reenable).real_invoke
 end
-task :release => ["man:require", "man:build", "release:verify_files", "release:verify_github", "build_metadata"]
+task :release => ["man:build", "release:verify_files", "release:verify_github", "build_metadata"]
 
 namespace :release do
   task :verify_files do


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that `bin/rake install:local` fails on jruby.

### What was your diagnosis of the problem?

My diagnosis was that the `ronn` gem does not support `jruby`. Since the `install:local` task builds docs on the fly, the task crashes.

### What is your fix for the problem, implemented in this PR?

My fix is to make the `man:build` task a noop on jruby, so that `bin/rake install:local` can be run on jruby, so jruby users can easily try out bundler's master.

### Why did you choose this fix out of the possible options?

I chose this fix because it sounds like a good workaround.