### PR TITLE
Remove `error_on_stderr` setting

### DIFF
--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -36,7 +36,6 @@ module Bundler
     settings_flag(:default_install_uses_path) { bundler_3_mode? }
     settings_flag(:deployment_means_frozen) { bundler_3_mode? }
     settings_flag(:disable_multisource) { bundler_3_mode? }
-    settings_flag(:error_on_stderr) { bundler_2_mode? }
     settings_flag(:forget_cli_options) { bundler_3_mode? }
     settings_flag(:global_path_appends_ruby_scope) { bundler_3_mode? }
     settings_flag(:global_gem_cache) { bundler_3_mode? }

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -28,7 +28,6 @@ module Bundler
       disable_platform_warnings
       disable_shared_gems
       disable_version_check
-      error_on_stderr
       force_ruby_platform
       forget_cli_options
       frozen

--- a/lib/bundler/ui/shell.rb
+++ b/lib/bundler/ui/shell.rb
@@ -35,14 +35,12 @@ module Bundler
         return if @warning_history.include? msg
         @warning_history << msg
 
-        return tell_err(msg, :yellow, newline) if Bundler.feature_flag.error_on_stderr?
-        tell_me(msg, :yellow, newline)
+        tell_err(msg, :yellow, newline)
       end
 
       def error(msg, newline = nil)
         return unless level("error")
-        return tell_err(msg, :red, newline) if Bundler.feature_flag.error_on_stderr?
-        tell_me(msg, :red, newline)
+        tell_err(msg, :red, newline)
       end
 
       def debug(msg, newline = nil)

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -183,8 +183,6 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
 * `disable_version_check` (`BUNDLE_DISABLE_VERSION_CHECK`):
    Stop Bundler from checking if a newer Bundler version is available on
    rubygems.org.
-* `error_on_stderr` (`BUNDLE_ERROR_ON_STDERR`):
-   Print Bundler errors to stderr.
 * `force_ruby_platform` (`BUNDLE_FORCE_RUBY_PLATFORM`):
    Ignore the current machine's platform and install only `ruby` platform gems.
    As a result, gems with native extensions will be compiled from source.

--- a/spec/bundler/cli_spec.rb
+++ b/spec/bundler/cli_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe "bundle executable" do
       end
     end
 
-    let(:bundler_version) { "1.1" }
+    let(:bundler_version) { "2.1" }
     let(:latest_version) { nil }
     before do
       bundle! "config set --global disable_version_check false"
@@ -125,7 +125,7 @@ RSpec.describe "bundle executable" do
       let(:latest_version) { "222.0" }
       it "prints the version warning" do
         bundle "fail"
-        expect(last_command.stdout).to start_with(<<-EOS.strip)
+        expect(err).to start_with(<<-EOS.strip)
 The latest bundler is #{latest_version}, but you are currently running #{bundler_version}.
 To install the latest version, run `gem install bundler`
         EOS
@@ -150,7 +150,7 @@ To install the latest version, run `gem install bundler`
         let(:latest_version) { "222.0.0.pre.4" }
         it "prints the version warning" do
           bundle "fail"
-          expect(last_command.stdout).to start_with(<<-EOS.strip)
+          expect(err).to start_with(<<-EOS.strip)
 The latest bundler is #{latest_version}, but you are currently running #{bundler_version}.
 To install the latest version, run `gem install bundler --pre`
           EOS

--- a/spec/bundler/ui/shell_spec.rb
+++ b/spec/bundler/ui/shell_spec.rb
@@ -24,13 +24,6 @@ RSpec.describe Bundler::UI::Shell do
     it "prints to stderr" do
       expect { subject.warn("warning") }.to output("warning\n").to_stderr
     end
-
-    context "when stderr flag is enabled" do
-      before { Bundler.settings.temporary(:error_on_stderr => true) }
-      it "prints to stderr" do
-        expect { subject.warn("warning!") }.to output("warning!\n").to_stderr
-      end
-    end
   end
 
   describe "#debug" do
@@ -46,19 +39,12 @@ RSpec.describe Bundler::UI::Shell do
       expect { subject.error("error!!!") }.to output("error!!!\n").to_stderr
     end
 
-    context "when stderr flag is enabled" do
-      before { Bundler.settings.temporary(:error_on_stderr => true) }
-      it "prints to stderr" do
-        expect { subject.error("error!!!") }.to output("error!!!\n").to_stderr
-      end
-
-      context "when stderr is closed" do
-        it "doesn't report anything" do
-          output = capture(:stderr, :closed => true) do
-            subject.error("Something went wrong")
-          end
-          expect(output).to_not eq("Something went wrong\n")
+    context "when stderr is closed" do
+      it "doesn't report anything" do
+        output = capture(:stderr, :closed => true) do
+          subject.error("Something went wrong")
         end
+        expect(output).to_not eq("Something went wrong\n")
       end
     end
   end

--- a/spec/commands/add_spec.rb
+++ b/spec/commands/add_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "bundle add" do
     it "shows error" do
       bundle "add"
 
-      expect(last_command.bundler_err).to include("Please specify gems to add")
+      expect(err).to include("Please specify gems to add")
     end
   end
 

--- a/spec/commands/binstubs_spec.rb
+++ b/spec/commands/binstubs_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe "bundle binstubs <gem>" do
 
       bundle "binstubs rack", :all => true
       expect(last_command).to be_failure
-      expect(last_command.bundler_err).to include("Cannot specify --all with specific gems")
+      expect(err).to include("Cannot specify --all with specific gems")
     end
 
     context "when generating bundle binstub outside bundler" do

--- a/spec/commands/check_spec.rb
+++ b/spec/commands/check_spec.rb
@@ -338,7 +338,7 @@ RSpec.describe "bundle check" do
       it "does not change the lock but warns" do
         lockfile lock_with(Bundler::VERSION.succ)
         bundle! :check
-        expect(last_command.bundler_err).to include("the running version of Bundler (#{Bundler::VERSION}) is older than the version that created the lockfile (#{Bundler::VERSION.succ})")
+        expect(err).to include("the running version of Bundler (#{Bundler::VERSION}) is older than the version that created the lockfile (#{Bundler::VERSION.succ})")
         lockfile_should_be lock_with(Bundler::VERSION.succ)
       end
     end

--- a/spec/commands/config_spec.rb
+++ b/spec/commands/config_spec.rb
@@ -430,7 +430,7 @@ E
 
       bundle "config set --global --local foo 5"
       expect(last_command).to be_failure
-      expect(last_command.bundler_err).to eq "The options global and local were specified. Please only use one of the switches at a time."
+      expect(err).to eq "The options global and local were specified. Please only use one of the switches at a time."
     end
 
     it "unset" do
@@ -470,7 +470,7 @@ E
 
       bundle "config unset foo --local --global"
       expect(last_command).to be_failure
-      expect(last_command.bundler_err).to eq "The options global and local were specified. Please only use one of the switches at a time."
+      expect(err).to eq "The options global and local were specified. Please only use one of the switches at a time."
     end
   end
 end

--- a/spec/commands/init_spec.rb
+++ b/spec/commands/init_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe "bundle init" do
         end
 
         bundle :init, :gemspec => spec_file
-        expect(last_command.bundler_err).to include("There was an error while loading `test.gemspec`")
+        expect(err).to include("There was an error while loading `test.gemspec`")
       end
     end
   end

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "bundle install with gem sources" do
         raise StandardError, "FAIL"
       G
 
-      expect(last_command.bundler_err).to include('StandardError, "FAIL"')
+      expect(err).to include('StandardError, "FAIL"')
       expect(bundled_app("Gemfile.lock")).not_to exist
     end
 
@@ -404,7 +404,7 @@ RSpec.describe "bundle install with gem sources" do
       G
 
       expect(last_command.stdboth).not_to match(/Error Report/i)
-      expect(last_command.bundler_err).to include("An error occurred while installing ajp-rails (0.0.0), and Bundler cannot continue.").
+      expect(err).to include("An error occurred while installing ajp-rails (0.0.0), and Bundler cannot continue.").
         and include(normalize_uri_file("Make sure that `gem install ajp-rails -v '0.0.0' --source 'file://localhost#{gem_repo2}/'` succeeds before bundling."))
     end
 

--- a/spec/commands/lock_spec.rb
+++ b/spec/commands/lock_spec.rb
@@ -242,7 +242,7 @@ RSpec.describe "bundle lock" do
 
   it "errors when removing all platforms" do
     bundle "lock --remove-platform #{local_platforms.join(" ")}"
-    expect(last_command.bundler_err).to include("Removing all platforms from the bundle is not allowed")
+    expect(err).to include("Removing all platforms from the bundle is not allowed")
   end
 
   # from https://github.com/bundler/bundler/issues/4896

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -770,22 +770,22 @@ RSpec.describe "bundle gem" do
 
     it "fails gracefully with a ." do
       bundle "gem foo.gemspec"
-      expect(last_command.bundler_err).to end_with("Invalid gem name foo.gemspec -- `Foo.gemspec` is an invalid constant name")
+      expect(err).to end_with("Invalid gem name foo.gemspec -- `Foo.gemspec` is an invalid constant name")
     end
 
     it "fails gracefully with a ^" do
       bundle "gem ^"
-      expect(last_command.bundler_err).to end_with("Invalid gem name ^ -- `^` is an invalid constant name")
+      expect(err).to end_with("Invalid gem name ^ -- `^` is an invalid constant name")
     end
 
     it "fails gracefully with a space" do
       bundle "gem 'foo bar'"
-      expect(last_command.bundler_err).to end_with("Invalid gem name foo bar -- `Foo bar` is an invalid constant name")
+      expect(err).to end_with("Invalid gem name foo bar -- `Foo bar` is an invalid constant name")
     end
 
     it "fails gracefully when multiple names are passed" do
       bundle "gem foo bar baz"
-      expect(last_command.bundler_err).to eq(<<-E.strip)
+      expect(err).to eq(<<-E.strip)
 ERROR: "bundle gem" was called with arguments ["foo", "bar", "baz"]
 Usage: "bundle gem NAME [OPTIONS]"
       E
@@ -876,7 +876,7 @@ Usage: "bundle gem NAME [OPTIONS]"
         FileUtils.touch("conflict-foobar")
       end
       bundle "gem conflict-foobar"
-      expect(last_command.bundler_err).to include("Errno::ENOTDIR")
+      expect(err).to include("Errno::ENOTDIR")
       expect(exitstatus).to eql(32) if exitstatus
     end
   end

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -565,13 +565,13 @@ RSpec.describe "bundle update when a gem depends on a newer version of bundler" 
   it "should explain that bundler conflicted", :bundler => "< 3" do
     bundle "update", :all => true
     expect(last_command.stdboth).not_to match(/in snapshot/i)
-    expect(last_command.bundler_err).to match(/current Bundler version/i).
+    expect(err).to match(/current Bundler version/i).
       and match(/perhaps you need to update bundler/i)
   end
 
   it "should warn that the newer version of Bundler would conflict", :bundler => "3" do
     bundle! "update", :all => true
-    expect(last_command.bundler_err).to include("rails (3.0.1) has dependency bundler").
+    expect(err).to include("rails (3.0.1) has dependency bundler").
       and include("so the dependency is being ignored")
     expect(the_bundle).to include_gem "rails 3.0.1"
   end
@@ -947,7 +947,7 @@ RSpec.describe "bundle update conservative" do
     it "raises if too many flags are provided" do
       bundle "update --patch --minor", :all => true
 
-      expect(last_command.bundler_err).to eq "Provide only one of the following options: minor, patch"
+      expect(err).to eq "Provide only one of the following options: minor, patch"
     end
   end
 end

--- a/spec/install/bundler_spec.rb
+++ b/spec/install/bundler_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "bundle install" do
 
         Could not find gem 'bundler (= 0.9.2)' in any
         E
-      expect(last_command.bundler_err).to include(nice_error)
+      expect(err).to include(nice_error)
     end
 
     it "works for gems with multiple versions in its dependencies" do
@@ -104,7 +104,7 @@ RSpec.describe "bundle install" do
             rails_fail was resolved to 1.0, which depends on
               activesupport (= 1.2.3)
       E
-      expect(last_command.bundler_err).to include(nice_error)
+      expect(err).to include(nice_error)
     end
 
     it "causes a conflict if a child dependency conflicts with the Gemfile" do
@@ -122,7 +122,7 @@ RSpec.describe "bundle install" do
             rails_fail was resolved to 1.0, which depends on
               activesupport (= 1.2.3)
       E
-      expect(last_command.bundler_err).to include(nice_error)
+      expect(err).to include(nice_error)
     end
 
     it "can install dependencies with newer bundler version with system gems" do

--- a/spec/install/failure_spec.rb
+++ b/spec/install/failure_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "bundle install" do
         source "file:\/\/localhost#{gem_repo2}"
         gem "rails"
       G
-      expect(last_command.bundler_err).to end_with(normalize_uri_file(<<-M.strip))
+      expect(err).to end_with(normalize_uri_file(<<-M.strip))
 An error occurred while installing activesupport (2.3.2), and Bundler cannot continue.
 Make sure that `gem install activesupport -v '2.3.2' --source 'file://localhost#{gem_repo2}/'` succeeds before bundling.
 
@@ -46,7 +46,7 @@ In Gemfile:
           gem "activesupport", :git => "#{lib_path("activesupport")}"
         G
 
-        expect(last_command.bundler_err).to end_with(<<-M.strip)
+        expect(err).to end_with(<<-M.strip)
 An error occurred while installing activesupport (2.3.2), and Bundler cannot continue.
 
 In Gemfile:
@@ -77,7 +77,7 @@ In Gemfile:
           end
         G
 
-        expect(last_command.bundler_err).to end_with(<<-M.strip)
+        expect(err).to end_with(<<-M.strip)
 An error occurred while installing activesupport (2.3.2), and Bundler cannot continue.
 
 
@@ -111,7 +111,7 @@ In Gemfile:
           gem "rails"
         end
       G
-      expect(last_command.bundler_err).to end_with(normalize_uri_file(<<-M.strip))
+      expect(err).to end_with(normalize_uri_file(<<-M.strip))
 An error occurred while installing activesupport (2.3.2), and Bundler cannot continue.
 Make sure that `gem install activesupport -v '2.3.2' --source 'file://localhost#{gem_repo2}/'` succeeds before bundling.
 

--- a/spec/install/gemfile/gemspec_spec.rb
+++ b/spec/install/gemfile/gemspec_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "bundle install from an existing gemspec" do
       source "file://#{gem_repo2}"
       gemspec :path => '#{tmp.join("foo")}'
     G
-    expect(last_command.bundler_err).to match(/There are no gemspecs at #{tmp.join('foo')}/)
+    expect(err).to match(/There are no gemspecs at #{tmp.join('foo')}/)
   end
 
   it "should raise if there are too many gemspecs available" do
@@ -77,7 +77,7 @@ RSpec.describe "bundle install from an existing gemspec" do
       source "file://#{gem_repo2}"
       gemspec :path => '#{tmp.join("foo")}'
     G
-    expect(last_command.bundler_err).to match(/There are multiple gemspecs at #{tmp.join('foo')}/)
+    expect(err).to match(/There are multiple gemspecs at #{tmp.join('foo')}/)
   end
 
   it "should pick a specific gemspec" do

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -1197,7 +1197,7 @@ RSpec.describe "bundle install with git sources" do
         gem "foo", :git => "#{lib_path("foo-1.0")}"
       G
 
-      expect(last_command.bundler_err).to end_with(<<-M.strip)
+      expect(err).to end_with(<<-M.strip)
 An error occurred while installing foo (1.0), and Bundler cannot continue.
 
 In Gemfile:
@@ -1380,7 +1380,7 @@ In Gemfile:
       with_path_as("") do
         bundle "update", :all => true
       end
-      expect(last_command.bundler_err).
+      expect(err).
         to include("You need to install git to be able to use gems from git repositories. For help installing git, please refer to GitHub's tutorial at https://help.github.com/articles/set-up-git")
     end
 

--- a/spec/install/gems/flex_spec.rb
+++ b/spec/install/gems/flex_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe "bundle flex_install" do
       E
 
       bundle :install, :retry => 0
-      expect(last_command.bundler_err).to end_with(nice_error)
+      expect(err).to end_with(nice_error)
     end
   end
 

--- a/spec/install/gems/resolving_spec.rb
+++ b/spec/install/gems/resolving_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe "bundle install with install-time dependencies" do
 
             Ruby\0 (> 9000), which is required by gem 'require_ruby', is not available in the local ruby installation
           E
-          expect(last_command.bundler_err).to end_with(nice_error)
+          expect(err).to end_with(nice_error)
         end
       end
 

--- a/spec/lock/lockfile_spec.rb
+++ b/spec/lock/lockfile_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe "the lockfile format" do
     G
 
     expect(last_command).to be_failure
-    expect(last_command.bundler_err).to include("You must use Bundler 9999999 or greater with this lockfile.")
+    expect(err).to include("You must use Bundler 9999999 or greater with this lockfile.")
   end
 
   it "shows a friendly error when running with a new bundler 2 lockfile" do
@@ -1579,7 +1579,7 @@ RSpec.describe "the lockfile format" do
       gem "rack"
     G
 
-    expect(last_command.bundler_err).to match(/your Gemfile.lock contains merge conflicts/i)
-    expect(last_command.bundler_err).to match(/git checkout HEAD -- Gemfile.lock/i)
+    expect(err).to match(/your Gemfile.lock contains merge conflicts/i)
+    expect(err).to match(/git checkout HEAD -- Gemfile.lock/i)
   end
 end

--- a/spec/other/cli_dispatch_spec.rb
+++ b/spec/other/cli_dispatch_spec.rb
@@ -3,19 +3,19 @@
 RSpec.describe "bundle command names" do
   it "work when given fully" do
     bundle "install"
-    expect(last_command.bundler_err).to eq("Could not locate Gemfile")
+    expect(err).to eq("Could not locate Gemfile")
     expect(last_command.stdboth).not_to include("Ambiguous command")
   end
 
   it "work when not ambiguous" do
     bundle "ins"
-    expect(last_command.bundler_err).to eq("Could not locate Gemfile")
+    expect(err).to eq("Could not locate Gemfile")
     expect(last_command.stdboth).not_to include("Ambiguous command")
   end
 
   it "print a friendly error when ambiguous" do
     bundle "in"
-    expect(last_command.bundler_err).to eq("Ambiguous command in matches [info, init, inject, install]")
+    expect(err).to eq("Ambiguous command in matches [info, init, inject, install]")
   end
 
   context "when cache_command_is_package is set" do

--- a/spec/realworld/mirror_probe_spec.rb
+++ b/spec/realworld/mirror_probe_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe "fetching dependencies with a not available mirror", :realworld =
       bundle :install, :artifice => nil
 
       expect(last_command.stdout).to include "Fetching source index from #{mirror}/"
-      expect(last_command.bundler_err).to include <<-EOS.strip
+      expect(err).to include <<-EOS.strip
 Retrying fetcher due to error (2/4): Bundler::HTTPError Could not fetch specs from #{mirror}/
 Retrying fetcher due to error (3/4): Bundler::HTTPError Could not fetch specs from #{mirror}/
 Retrying fetcher due to error (4/4): Bundler::HTTPError Could not fetch specs from #{mirror}/

--- a/spec/support/command_execution.rb
+++ b/spec/support/command_execution.rb
@@ -27,14 +27,6 @@ module Spec
       @stdboth ||= [stderr, stdout].join("\n").strip
     end
 
-    def bundler_err
-      if Bundler::VERSION.start_with?("1.")
-        stdout
-      else
-        stderr
-      end
-    end
-
     def to_s_verbose
       [
         to_s,

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -45,7 +45,7 @@ module Spec
     end
 
     def err
-      Bundler.feature_flag.error_on_stderr? ? last_command.stderr : last_command.stdout
+      last_command.stderr
     end
 
     MAJOR_DEPRECATION = /^\[DEPRECATED\]\s*/.freeze

--- a/spec/update/git_spec.rb
+++ b/spec/update/git_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe "bundle update" do
       lib_path("foo-1.0").join(".git").rmtree
 
       bundle :update, :all => true
-      expect(last_command.bundler_err).to include(lib_path("foo-1.0").to_s).
+      expect(err).to include(lib_path("foo-1.0").to_s).
         and match(/Git error: command `git fetch.+has failed/)
     end
 


### PR DESCRIPTION
Closes #6730 (supersedes it).

### What was the end-user problem that led to this PR?

The problem was that this is not a good fit for a feature flag nor a setting since it was just a bug fix.

### What was your diagnosis of the problem?

My diagnosis was that we can remove the setting, specially since the behavior has already changed.

### What is your fix for the problem, implemented in this PR?

My fix is to remove the setting.
