### PR TITLE
Fix spec calling incorrect helper

### DIFF
--- a/spec/runtime/with_unbundled_env_spec.rb
+++ b/spec/runtime/with_unbundled_env_spec.rb
@@ -153,29 +153,50 @@ RSpec.describe "Bundler.with_env helpers" do
   end
 
   describe "Bundler.original_system" do
+    let(:code) do
+      <<~RUBY
+        Bundler.original_system(%([ "\$BUNDLE_FOO" = "bar" ] && exit 42))
+
+        exit $?.exitstatus
+      RUBY
+    end
+
     it "runs system inside with_original_env" do
-      code = 'exit Bundler.original_system(%(test "\$BUNDLE_FOO" = "bar"))'
       lib = File.expand_path("../../lib", __dir__)
       system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib} -rbundler -e '#{code}'")
-      expect($?.exitstatus).to eq(0)
+      expect($?.exitstatus).to eq(42)
     end
   end
 
   describe "Bundler.clean_system", :bundler => 2 do
+    let(:code) do
+      <<~RUBY
+        Bundler.clean_system(%([ "\$BUNDLE_FOO" = "bar" ] || exit 42))
+
+        exit $?.exitstatus
+      RUBY
+    end
+
     it "runs system inside with_clean_env" do
-      code = 'exit Bundler.clean_system(%(test "\$BUNDLE_FOO" = "bar"))'
       lib = File.expand_path("../../lib", __dir__)
       system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib} -rbundler -e '#{code}'")
-      expect($?.exitstatus).to eq(1)
+      expect($?.exitstatus).to eq(42)
     end
   end
 
   describe "Bundler.unbundled_system" do
+    let(:code) do
+      <<~RUBY
+        Bundler.unbundled_system(%([ "\$BUNDLE_FOO" = "bar" ] || exit 42))
+
+        exit $?.exitstatus
+      RUBY
+    end
+
     it "runs system inside with_unbundled_env" do
-      code = 'exit Bundler.clean_system(%(test "\$BUNDLE_FOO" = "bar"))'
       lib = File.expand_path("../../lib", __dir__)
       system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib} -rbundler -e '#{code}'")
-      expect($?.exitstatus).to eq(1)
+      expect($?.exitstatus).to eq(42)
     end
   end
 


### PR DESCRIPTION


Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was the subprocess spawed by one spec was crashing, but that was not making the spec fail.

### What was your diagnosis of the problem?

My diagnosis was that since the spec was checking for a failure status of the subprocess, that was not specific enough to detect the particular bug in this spec (it was calling `clean_system`, removed from bundler 3, instead of `unbundled_system`).

### What is your fix for the problem, implemented in this PR?

My fix is to restore the previous strategy for these specs, namely, check for a more specific status than 0
or 1.