### PR TITLE
Remove standard output from `with_rubygems`

### DIFF
--- a/bin/with_rubygems
+++ b/bin/with_rubygems
@@ -4,7 +4,7 @@
 require "pathname"
 
 def run(*cmd)
-  return if system(*cmd)
+  return if system(*cmd, :out => IO::NULL)
   raise "Running `#{cmd.join(" ")}` failed"
 end
 
@@ -20,8 +20,6 @@ unless rubygems_path.directory?
     run("git remote update")
     version = "v#{version}" if version =~ /\A\d/
     run("git", "checkout", version, "--quiet")
-    hash = `git rev-parse HEAD`.chomp
-    puts "Checked out rubygems '#{version}' at #{hash}"
   end
 end
 


### PR DESCRIPTION
This PR might be very specific to my setup, but it would certainly help me.

### What was the end-user problem that led to this PR?

The problem was that sometimes I don't find out early about rubocop issues, so I have to push extra commits to fix them, and that means time and CI resources.

### What was your diagnosis of the problem?

My diagnosis was that:

* I run rubocop automatically on save from `vim using [ale](https://github.com/w0rp/ale).
* I set `ENV["RGV"] = master`, so that I always run the latest rubygems.

Because of setting `ENV["RGV"]`, the `with_rubygems` script is run everytime a binstub is loaded (including `rubocop`). This script prints some git information to the standard output. Since ALE expects a very specific output from `rubocop`, the fact that the `with_rubygems` script prints stuff to the standard output means that ALE no longer works, and I don't get to early fix style issues.

### What is your fix for the problem, implemented in this PR?

My fix is to make the `with_rubygems` script be silent.

### Why did you choose this fix out of the possible options?

I could've removed loading the `with_rubygems` script from the `rubocop` binstub, but I chose this fix because other subcommands in the script already seemed to try to be silent, like the `--quiet` flag passed to `git checkout`.
