### PR TITLE
Skip platform warnings in inline mode

### DIFF
--- a/lib/bundler/inline.rb
+++ b/lib/bundler/inline.rb
@@ -60,7 +60,7 @@ def gemfile(install = false, options = {}, &gemfile)
 
     Bundler.ui = ui if install
     if install || missing_specs.call
-      Bundler.settings.temporary(:inline => true) do
+      Bundler.settings.temporary(:inline => true, :disable_platform_warnings => true) do
         installer = Bundler::Installer.install(Bundler.root, definition, :system => true)
         installer.post_install_messages.each do |name, message|
           Bundler.ui.info "Post-install message from #{name}:\n#{message}"

--- a/spec/runtime/inline_spec.rb
+++ b/spec/runtime/inline_spec.rb
@@ -290,4 +290,17 @@ RSpec.describe "bundler/inline#gemfile" do
     expect(last_command).to be_success
     expect(out).to eq "1.0.0"
   end
+
+  it "skips platform warnings" do
+    simulate_platform "ruby"
+
+    script <<-RUBY
+      gemfile(true) do
+        source "file://#{gem_repo1}"
+        gem "rack", platform: :jruby
+      end
+    RUBY
+
+    expect(err).to be_empty
+  end
 end


### PR DESCRIPTION
Fixes #6822.

### What was the end-user problem that led to this PR?

The problem was that inline mode prints platform warnings recommending to run `bundle lock` commands.

### What was your diagnosis of the problem?

My diagnosis was that the platform is always missing in the lock file since there's no lock file here.

### What is your fix for the problem, implemented in this PR?

My fix is to skip platform warnings in this case.

### Why did you choose this fix out of the possible options?

I chose this fix because it's simple.