### PR TITLE
Ignore `frozen` setting in inline mode

### DIFF
--- a/spec/runtime/inline_spec.rb
+++ b/spec/runtime/inline_spec.rb
@@ -244,6 +244,20 @@ RSpec.describe "bundler/inline#gemfile" do
     expect(exitstatus).to be_zero if exitstatus
   end
 
+  it "installs inline gems when frozen is set" do
+    script <<-RUBY, :env => { "BUNDLE_FROZEN" => "true" }
+      gemfile do
+        source "file://#{gem_repo1}"
+        gem "rack"
+      end
+
+      puts RACK
+    RUBY
+
+    expect(last_command.stderr).to be_empty
+    expect(exitstatus).to be_zero if exitstatus
+  end
+
   it "installs inline gems when BUNDLE_GEMFILE is set to an empty string" do
     ENV["BUNDLE_GEMFILE"] = ""
 


### PR DESCRIPTION
Fixes #7114.

### What was the end-user problem that led to this PR?

The problem was that the inline mode wouldn't work if `BUNDLE_FROZEN` is set.

### What was your diagnosis of the problem?

My diagnosis was that since we're in frozen mode, the current platform doesn't get added to the definition, and thus platform validation fails.

### What is your fix for the problem, implemented in this PR?

My fix is to temporary ignore `BUNDLE_FROZEN` for the inline mode. The inline mode can't really be frozen since it has no lock file.