### PR TITLE
Add git and branch options to `bundle add`

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -363,6 +363,8 @@ module Bundler
     method_option "version", :aliases => "-v", :type => :string
     method_option "group", :aliases => "-g", :type => :string
     method_option "source", :aliases => "-s", :type => :string
+    method_option "git", :type => :string
+    method_option "branch", :type => :string
     method_option "skip-install", :type => :boolean, :banner =>
       "Adds gem to the Gemfile but does not install it"
     method_option "optimistic", :type => :boolean, :banner => "Adds optimistic declaration of version to gem"

--- a/lib/bundler/dependency.rb
+++ b/lib/bundler/dependency.rb
@@ -7,7 +7,7 @@ require "bundler/rubygems_ext"
 module Bundler
   class Dependency < Gem::Dependency
     attr_reader :autorequire
-    attr_reader :groups, :platforms, :gemfile
+    attr_reader :groups, :platforms, :gemfile, :git, :branch
 
     PLATFORM_MAP = {
       :ruby     => Gem::Platform::RUBY,
@@ -84,6 +84,8 @@ module Bundler
       @autorequire    = nil
       @groups         = Array(options["group"] || :default).map(&:to_sym)
       @source         = options["source"]
+      @git            = options["git"]
+      @branch         = options["branch"]
       @platforms      = Array(options["platforms"])
       @env            = options["env"]
       @should_include = options.fetch("should_include", true)

--- a/lib/bundler/injector.rb
+++ b/lib/bundler/injector.rb
@@ -111,8 +111,10 @@ module Bundler
         end
 
         source = ", :source => \"#{d.source}\"" unless d.source.nil?
+        git = ", :git => \"#{d.git}\"" unless d.git.nil?
+        branch = ", :branch => \"#{d.branch}\"" unless d.branch.nil?
 
-        %(gem #{name}#{requirement}#{group}#{source})
+        %(gem #{name}#{requirement}#{group}#{source}#{git}#{branch})
       end.join("\n")
     end
 

--- a/man/bundle-add.ronn
+++ b/man/bundle-add.ronn
@@ -3,7 +3,7 @@ bundle-add(1) -- Add gem to the Gemfile and run bundle install
 
 ## SYNOPSIS
 
-`bundle add` <GEM_NAME> [--group=GROUP] [--version=VERSION] [--source=SOURCE] [--skip-install] [--strict] [--optimistic]
+`bundle add` <GEM_NAME> [--group=GROUP] [--version=VERSION] [--source=SOURCE] [--git=GIT] [--branch=BRANCH] [--skip-install] [--strict] [--optimistic]
 
 ## DESCRIPTION
 Adds the named gem to the Gemfile and run `bundle install`. `bundle install` can be avoided by using the flag `--skip-install`.
@@ -29,6 +29,12 @@ bundle add rails --group "development, test"
 
 * `--source`, , `-s`:
   Specify the source for the added gem.
+
+* `--git`:
+  Specify the git source for the added gem.
+
+* `--branch`:
+  Specify the git branch for the added gem.
 
 * `--skip-install`:
   Adds the gem to the Gemfile but does not install it.

--- a/spec/commands/add_spec.rb
+++ b/spec/commands/add_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe "bundle add" do
       build_gem "dog", "1.1.3.pre"
     end
 
+    build_git "foo", "2.0"
+
     install_gemfile <<-G
       source "file://#{gem_repo2}"
       gem "weakling", "~> 0.0.1"
@@ -85,6 +87,28 @@ RSpec.describe "bundle add" do
       bundle "add 'foo' --source='file://#{gem_repo2}'"
 
       expect(bundled_app("Gemfile").read).to match(%r{gem "foo", "~> 2.0", :source => "file:\/\/#{gem_repo2}"})
+      expect(the_bundle).to include_gems "foo 2.0"
+    end
+  end
+
+  describe "with --git" do
+    it "adds dependency with specified github source" do
+      bundle "add foo --git=#{lib_path("foo-2.0")}"
+
+      expect(bundled_app("Gemfile").read).to match(/gem "foo", "~> 2.0", :git => "#{lib_path("foo-2.0")}"/)
+      expect(the_bundle).to include_gems "foo 2.0"
+    end
+  end
+
+  describe "with --git and --branch" do
+    before do
+      update_git "foo", "2.0", :branch => "test"
+    end
+
+    it "adds dependency with specified github source and branch" do
+      bundle "add foo --git=#{lib_path("foo-2.0")} --branch=test"
+
+      expect(bundled_app("Gemfile").read).to match(/gem "foo", "~> 2.0", :git => "#{lib_path("foo-2.0")}", :branch => "test"/)
       expect(the_bundle).to include_gems "foo 2.0"
     end
   end


### PR DESCRIPTION
Closes #6841 These changes will allow to add a gem with the git or branch options.

```
bundle add redis --git "https://github.com/redis/redis-rb" --branch "staging"
```

The result in Gemfile will be: 
```
gem "redis", "~> 4.0", :git => "https://github.com/redis/redis-rb", :branch => "staging"
```