### PR TITLE
Backport to workaround from ruby core.

### DIFF
--- a/spec/bundler/gem_helper_spec.rb
+++ b/spec/bundler/gem_helper_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Bundler::GemHelper do
     end
   end
 
-  context "gem management" do
+  context "gem management", :ruby_repo do
     def mock_confirm_message(message)
       expect(Bundler.ui).to receive(:confirm).with(message)
     end

--- a/spec/commands/binstubs_spec.rb
+++ b/spec/commands/binstubs_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe "bundle binstubs <gem>" do
         context "when requesting a different bundler version" do
           before { lockfile lockfile.gsub(Bundler::VERSION, "999.999.999") }
 
-          it "attempts to load that version", :ruby_repo do
+          it "attempts to load that version" do
             sys_exec bundled_app("bin/rackup").to_s
             expect(exitstatus).to eq(42) if exitstatus
             expect(last_command.stderr).to include("Activating bundler (999.999.999) failed:").

--- a/spec/commands/config_spec.rb
+++ b/spec/commands/config_spec.rb
@@ -389,7 +389,7 @@ E
   end
 
   describe "subcommands" do
-    it "list" do
+    it "list", :ruby_repo do
       bundle! "config list"
       expect(last_command.stdout).to eq "Settings are listed in order of priority. The top value will be used.\nspec_run\nSet via BUNDLE_SPEC_RUN: \"true\""
 

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -530,7 +530,7 @@ RSpec.describe "bundle exec" do
     expect(out).to include("Installing foo 1.0")
   end
 
-  describe "with gems bundled via :path with invalid gemspecs", :ruby_repo do
+  describe "with gems bundled via :path with invalid gemspecs" do
     it "outputs the gemspec validation errors" do
       build_lib "foo"
 
@@ -836,7 +836,7 @@ __FILE__: #{path.to_s.inspect}
         bundle :install, :system_bundler => true, :path => "vendor/bundler"
       end
 
-      it "overrides disable_shared_gems so bundler can be found", :rubygems => ">= 2.6.2" do
+      it "overrides disable_shared_gems so bundler can be found", :ruby_repo, :rubygems => ">= 2.6.2" do
         system_gems :bundler
         file = bundled_app("file_that_bundle_execs.rb")
         create_file(file, <<-RB)

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe "bundle info" do
     end
   end
 
-  context "with a valid regexp for gem name" do
+  context "with a valid regexp for gem name", :ruby_repo do
     it "presents alternatives" do
       install_gemfile <<-G
         source "file://#{gem_repo1}"

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe "bundle gem" do
     end
   end
 
-  it "generates a valid gemspec" do
+  it "generates a valid gemspec", :ruby_repo do
     in_app_root
     bundle! "gem newgem --bin"
 

--- a/spec/commands/show_spec.rb
+++ b/spec/commands/show_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
   end
 
   context "with a valid regexp for gem name" do
-    it "presents alternatives" do
+    it "presents alternatives", :ruby_repo do
       install_gemfile <<-G
         source "file://#{gem_repo1}"
         gem "rack"

--- a/spec/install/deploy_spec.rb
+++ b/spec/install/deploy_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "install with --deployment or --frozen" do
     bundle! :install, forgotten_command_line_options(:deployment => true, :without => "test")
   end
 
-  it "works when you bundle exec bundle", :ruby_repo do
+  it "works when you bundle exec bundle" do
     bundle :install
     bundle "install --deployment"
     bundle! "exec bundle check"

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -1247,7 +1247,7 @@ In Gemfile:
       expect(out).to eq(installed_time)
     end
 
-    it "does not reinstall the extension when changing another gem" do
+    it "does not reinstall the extension when changing another gem", :ruby_repo do
       build_git "foo" do |s|
         s.add_dependency "rake"
         s.extensions << "Rakefile"
@@ -1290,7 +1290,7 @@ In Gemfile:
       expect(out).to eq(installed_time)
     end
 
-    it "does reinstall the extension when changing refs" do
+    it "does reinstall the extension when changing refs", :ruby_repo do
       build_git "foo" do |s|
         s.add_dependency "rake"
         s.extensions << "Rakefile"

--- a/spec/quality_es_spec.rb
+++ b/spec/quality_es_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "La biblioteca si misma" do
     expect(error_messages.compact).to be_well_formed
   end
 
-  it "mantiene la calidad de lenguaje de oraciones usadas en el código fuente" do
+  it "mantiene la calidad de lenguaje de oraciones usadas en el código fuente", :ruby_repo do
     error_messages = []
     exempt = /vendor/
     Dir.chdir(root) do

--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -235,7 +235,7 @@ RSpec.describe "The library itself" do
     end
   end
 
-  it "ships the correct set of files" do
+  it "ships the correct set of files", :ruby_repo do
     Dir.chdir(root) do
       git_list = IO.popen("git ls-files -z", &:read).split("\x0").select {|f| f.match(%r{^(lib|exe)/}) }
       git_list += %w[CHANGELOG.md LICENSE.md README.md bundler.gemspec]

--- a/spec/runtime/gem_tasks_spec.rb
+++ b/spec/runtime/gem_tasks_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "require 'bundler/gem_tasks'", :ruby_repo do
+RSpec.describe "require 'bundler/gem_tasks'" do
   before :each do
     bundled_app("foo.gemspec").open("w") do |f|
       f.write <<-GEMSPEC

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,7 @@ if File.expand_path(__FILE__) =~ %r{([^\w/\.:\-])}
 end
 
 require "bundler"
+require "rspec"
 
 Dir["#{File.expand_path("../support", __FILE__)}/*.rb"].each do |file|
   file = file.gsub(%r{\A#{Regexp.escape File.expand_path("..", __FILE__)}/}, "")


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The current master branch couldn't invoke with the ruby core repository.

### What was your diagnosis of the problem?

1. We need to add explicitly declare `rspec` in spec_helper.rb
2. Some examples were failed on ruby core repository.

### What is your fix for the problem, implemented in this PR?

1. simply added.
2. update the `ruby_repo` labels for skipping to run.
