### PR TITLE
Gemspec require relative

### DIFF
--- a/bundler.gemspec
+++ b/bundler.gemspec
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 begin
-  require File.expand_path("../lib/bundler/version", __FILE__)
+  require_relative "lib/bundler/version"
 rescue LoadError
   # for Ruby core repository
-  require File.expand_path("../version", __FILE__)
+  require_relative "version"
 end
 
 Gem::Specification.new do |s|

--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -1,6 +1,4 @@
-lib = File.expand_path("lib", __dir__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "<%= config[:namespaced_path] %>/version"
+require_relative 'lib/<%=config[:namespaced_path]%>/version'
 
 Gem::Specification.new do |spec|
   spec.name          = <%= config[:name].inspect %>


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

This is a follow up to #7100. Gemspec is another place where `require_relative` sounds like a win.

### What is your fix for the problem, implemented in this PR?

My fix changes bundler's gemspec to use `require_relative`, and extracts the relevant change from #4397 to also change the generated gemspec from `bundle gem`.