### PR TITLE
Remove unnecessary `BUNDLER_SPEC_RUN` env variable

### DIFF
--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -255,19 +255,6 @@ module Bundler
       current  = File.expand_path(SharedHelpers.pwd).untaint
 
       until !File.directory?(current) || current == previous
-        if ENV["BUNDLE_SPEC_RUN"]
-          # avoid stepping above the tmp directory when testing
-          gemspec = if ENV["BUNDLE_RUBY"] && ENV["BUNDLE_GEM"]
-            # for Ruby Core
-            "lib/bundler/bundler.gemspec"
-          else
-            "bundler.gemspec"
-          end
-
-          # avoid stepping above the tmp directory when testing
-          return nil if File.file?(File.join(current, gemspec))
-        end
-
         names.each do |name|
           filename = File.join(current, name)
           yield filename

--- a/spec/bundler/cli_spec.rb
+++ b/spec/bundler/cli_spec.rb
@@ -141,6 +141,7 @@ To install the latest version, run `gem install bundler`
           bundle! "config get --parseable foo"
           expect(last_command.stdboth).to eq ""
 
+          ensure_no_gemfile
           bundle "platform --ruby"
           expect(last_command.stdboth).to eq "Could not locate Gemfile"
         end

--- a/spec/bundler/settings_spec.rb
+++ b/spec/bundler/settings_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Bundler::Settings do
       subject(:settings) { described_class.new(nil) }
 
       it "raises a GemfileNotFound error with explanation" do
+        ensure_no_gemfile
         expect { subject.set_local("foo", "bar") }.
           to raise_error(Bundler::GemfileNotFound, "Could not locate Gemfile")
       end

--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Bundler::SharedHelpers do
       before { ENV["BUNDLE_GEMFILE"] = nil }
 
       it "raises a GemfileNotFound error" do
+        ensure_no_gemfile
         expect { subject.default_gemfile }.to raise_error(
           Bundler::GemfileNotFound, "Could not locate Gemfile"
         )

--- a/spec/commands/check_spec.rb
+++ b/spec/commands/check_spec.rb
@@ -199,6 +199,7 @@ RSpec.describe "bundle check" do
   end
 
   it "outputs an error when the default Gemfile is not found" do
+    ensure_no_gemfile
     bundle :check
     expect(exitstatus).to eq(10) if exitstatus
     expect(err).to include("Could not locate Gemfile")

--- a/spec/commands/config_spec.rb
+++ b/spec/commands/config_spec.rb
@@ -391,10 +391,10 @@ E
   describe "subcommands" do
     it "list", :ruby_repo do
       bundle! "config list"
-      expect(out).to eq "Settings are listed in order of priority. The top value will be used.\nspec_run\nSet via BUNDLE_SPEC_RUN: \"true\""
+      expect(out).to eq "Settings are listed in order of priority. The top value will be used."
 
       bundle! "config list", :parseable => true
-      expect(out).to eq "spec_run=true"
+      expect(out).to be_empty
     end
 
     it "get" do

--- a/spec/other/cli_dispatch_spec.rb
+++ b/spec/other/cli_dispatch_spec.rb
@@ -2,12 +2,14 @@
 
 RSpec.describe "bundle command names" do
   it "work when given fully" do
+    ensure_no_gemfile
     bundle "install"
     expect(err).to eq("Could not locate Gemfile")
     expect(last_command.stdboth).not_to include("Ambiguous command")
   end
 
   it "work when not ambiguous" do
+    ensure_no_gemfile
     bundle "ins"
     expect(err).to eq("Could not locate Gemfile")
     expect(last_command.stdboth).not_to include("Ambiguous command")

--- a/spec/runtime/load_spec.rb
+++ b/spec/runtime/load_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe "Bundler.load" do
 
   describe "without a gemfile" do
     it "raises an exception if the default gemfile is not found" do
+      ensure_no_gemfile
       expect do
         Bundler.load
       end.to raise_error(Bundler::GemfileNotFound, /could not locate gemfile/i)
@@ -55,19 +56,6 @@ RSpec.describe "Bundler.load" do
         ENV["BUNDLE_GEMFILE"] = "omg.rb"
         Bundler.load
       end.to raise_error(Bundler::GemfileNotFound, /omg\.rb/)
-    end
-
-    it "does not find a Gemfile above the testing directory" do
-      bundler_gemfile = tmp.join("../Gemfile")
-      unless File.exist?(bundler_gemfile)
-        FileUtils.touch(bundler_gemfile)
-        @remove_bundler_gemfile = true
-      end
-      begin
-        expect { Bundler.load }.to raise_error(Bundler::GemfileNotFound)
-      ensure
-        bundler_gemfile.rmtree if @remove_bundler_gemfile
-      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,6 @@ $debug = false
 Spec::Manpages.setup unless Gem.win_platform?
 Spec::Rubygems.setup
 ENV["RUBYOPT"] = "#{ENV["RUBYOPT"]} -r#{Spec::Path.spec_dir}/support/hax.rb"
-ENV["BUNDLE_SPEC_RUN"] = "true"
 
 # Don't wrap output in tests
 ENV["THOR_COLUMNS"] = "10000"

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -313,6 +313,12 @@ module Spec
       bundle :lock, opts
     end
 
+    # Makes tests that require absence of any Gemfiles pass, even if the running
+    # system has a Gemfile further up from the specs folder
+    def ensure_no_gemfile
+      allow(Bundler::SharedHelpers).to receive(:search_up).and_return(nil)
+    end
+
     def install_gems(*gems)
       options = gems.last.is_a?(Hash) ? gems.pop : {}
       gem_repo = options.fetch(:gem_repo) { gem_repo1 }


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that our library code contains logic that's only necessary for bundler's specs. I think library code should not contain this kind of code, since it affects end users.

### What is your fix for the problem, implemented in this PR?

My fix is to remove the logic, and instead ensure the specs satisfy what the code wanted to ensure (that specs pass even when there's a Gemfile further up in the directory hierarchy outside of the bundler's development copy).