### PR TITLE
Tweak rubygems integration

### DIFF
--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -304,27 +304,17 @@ module Bundler
       end
     end
 
-    if provides?(">= 2.5.2")
-      # RubyGems-generated binstubs call Kernel#gem
-      def binstubs_call_gem?
-        false
-      end
+    # RubyGems-generated binstubs call Kernel#gem
+    def binstubs_call_gem?
+      !provides?(">= 2.5.2")
+    end
 
-      # only 2.5.2+ has all of the stub methods we want to use, and since this
-      # is a performance optimization _only_,
-      # we'll restrict ourselves to the most
-      # recent RG versions instead of all versions that have stubs
-      def stubs_provide_full_functionality?
-        true
-      end
-    else
-      def binstubs_call_gem?
-        true
-      end
-
-      def stubs_provide_full_functionality?
-        false
-      end
+    # only 2.5.2+ has all of the stub methods we want to use, and since this
+    # is a performance optimization _only_,
+    # we'll restrict ourselves to the most
+    # recent RG versions instead of all versions that have stubs
+    def stubs_provide_full_functionality?
+      provides?(">= 2.5.2")
     end
 
     def replace_gem(specs, specs_by_name)

--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require "monitor"
-
 module Bundler
   class RubygemsIntegration
     if defined?(Gem::Ext::Builder::CHDIR_MONITOR)
       EXT_LOCK = Gem::Ext::Builder::CHDIR_MONITOR
     else
+      require "monitor"
+
       EXT_LOCK = Monitor.new
     end
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that the rubygems integration file could be more consistent.

### What is your fix for the problem, implemented in this PR?

My fix is to lazily require `monitor`, just like it's done with the other requires in the file, and to define the methods that check the rubygems version a single time, just like the rest of the methods in the file. 