### PR TITLE
Get `bundle exec` respecting proc titles

### DIFF
--- a/lib/bundler/cli/exec.rb
+++ b/lib/bundler/cli/exec.rb
@@ -27,12 +27,7 @@ module Bundler
         if !Bundler.settings[:disable_exec_load] && ruby_shebang?(bin_path)
           return kernel_load(bin_path, *args)
         end
-        # First, try to exec directly to something in PATH
-        if Bundler.current_ruby.jruby_18?
-          kernel_exec(bin_path, *args)
-        else
-          kernel_exec([bin_path, cmd], *args)
-        end
+        kernel_exec(bin_path, *args)
       else
         # exec using the given command
         kernel_exec(cmd, *args)

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -55,6 +55,17 @@ RSpec.describe "bundle exec" do
     expect(out).to eq("hi")
   end
 
+  it "respects custom process title when loading through ruby" do
+    script_that_changes_its_own_title_and_checks_if_picked_up_by_ps_unix_utility = <<~RUBY
+      Process.setproctitle("1-2-3-4-5-6-7-8-9-10-11-12-13-14-15-16")
+      puts `ps -eo args | grep [1]-2-3-4-5-6-7-8-9-10-11-12-13-14-15-16`
+    RUBY
+    create_file "Gemfile"
+    create_file "a.rb", script_that_changes_its_own_title_and_checks_if_picked_up_by_ps_unix_utility
+    bundle "exec ruby a.rb"
+    expect(out).to eq("1-2-3-4-5-6-7-8-9-10-11-12-13-14-15-16")
+  end
+
   it "accepts --verbose" do
     install_gemfile 'gem "rack"'
     bundle "exec --verbose echo foobar"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that `bundle exec` would not respect custom proctitles inside scripts.

### What was your diagnosis of the problem?

My diagnosis was that the previous code was using the third form of `Kernel.exec`, documented as:

> In the third form (exec(["command", "argv0"], "arg1", ...)), starting a two-element array at the beginning of the command, the first element is the command to be executed, and the second argument is used as the argv[0] value, which may show up in process listings.

See https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-exec.

However, since this form messes with proc titles, it seems to affect scripts settting their own proc titles.

### What is your fix for the problem, implemented in this PR?

My fix is to use the simpler form:

> In the second form (exec("command1", "arg1", ...)), the first is taken as a command name and the rest are passed as parameters to command with no shell expansion.

We were not passing any special proc title, so I don't think we need the third form, and this simpler form allows custom proc titles inside scripts to work just fine.

### Why did you choose this fix out of the possible options?

I chose this fix because I couldn't figure out a better one.

Closes #7135.