### PR TITLE
Fully switch to https sources

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -291,12 +291,7 @@ module Bundler
 "https://github.com/#{repo_name}.git"
         RUBY
         repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
-        if Bundler.feature_flag.github_https?
-          "https://github.com/#{repo_name}.git"
-        else
-          Bundler::SharedHelpers.major_deprecation 2, "Setting `github.https` to false is deprecated and won't be supported in the future."
-          "git://github.com/#{repo_name}.git"
-        end
+        "https://github.com/#{repo_name}.git"
       end
 
       git_source(:gist) do |repo_name|

--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -44,7 +44,7 @@ module Bundler
     settings_flag(:plugins) { @bundler_version >= Gem::Version.new("1.14") }
     settings_flag(:print_only_version_number) { bundler_3_mode? }
     settings_flag(:setup_makes_kernel_gem_public) { !bundler_3_mode? }
-    settings_flag(:skip_default_git_sources) { bundler_4_mode? }
+    settings_flag(:skip_default_git_sources) { bundler_3_mode? }
     settings_flag(:specific_platform) { bundler_3_mode? }
     settings_flag(:suppress_install_using_messages) { bundler_3_mode? }
     settings_flag(:unlock_source_unlocks_spec) { !bundler_3_mode? }
@@ -52,8 +52,6 @@ module Bundler
     settings_flag(:use_gem_version_promoter_for_major_updates) { bundler_3_mode? }
 
     settings_option(:default_cli_command) { bundler_3_mode? ? :cli_help : :install }
-
-    settings_method(:github_https?, "github.https") { bundler_2_mode? }
 
     def initialize(bundler_version)
       @bundler_version = Gem::Version.create(bundler_version)

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -33,7 +33,6 @@ module Bundler
       frozen
       gem.coc
       gem.mit
-      github.https
       global_path_appends_ruby_scope
       global_gem_cache
       ignore_messages

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -25,60 +25,17 @@ RSpec.describe Bundler::Dsl do
       expect { subject.git_source(:example) }.to raise_error(Bundler::InvalidOption)
     end
 
-    context "github_https feature flag" do
-      it "is true when github.https is true" do
-        bundle "config set github.https true"
-        expect(Bundler.feature_flag.github_https?).to eq true
-      end
-    end
-
-    shared_examples_for "the github DSL" do |protocol|
-      context "when full repo is used" do
-        let(:repo) { "indirect/sparks" }
-
-        it "converts :github to URI using #{protocol}" do
-          subject.gem("sparks", :github => repo)
-          github_uri = "#{protocol}://github.com/#{repo}.git"
-          expect(subject.dependencies.first.source.uri).to eq(github_uri)
-        end
+    context "default hosts", :bundler => "2" do
+      it "converts :github to URI using https" do
+        subject.gem("sparks", :github => "indirect/sparks")
+        github_uri = "https://github.com/indirect/sparks.git"
+        expect(subject.dependencies.first.source.uri).to eq(github_uri)
       end
 
-      context "when shortcut repo is used" do
-        let(:repo) { "rails" }
-
-        it "converts :github to URI using #{protocol}" do
-          subject.gem("sparks", :github => repo)
-          github_uri = "#{protocol}://github.com/#{repo}/#{repo}.git"
-          expect(subject.dependencies.first.source.uri).to eq(github_uri)
-        end
-      end
-    end
-
-    context "default hosts (git, gist)" do
-      context "when github.https config is true" do
-        before { bundle "config set github.https true" }
-
-        it_behaves_like "the github DSL", "https"
-      end
-
-      context "when github.https config is false", :bundler => "2" do
-        before { bundle "config set github.https false" }
-
-        it_behaves_like "the github DSL", "git"
-      end
-
-      context "when github.https config is false", :bundler => "3" do
-        before { bundle "config set github.https false" }
-
-        pending "should show a proper message about the removed setting"
-      end
-
-      context "by default", :bundler => "2" do
-        it_behaves_like "the github DSL", "https"
-      end
-
-      context "by default", :bundler => "3" do
-        it_behaves_like "the github DSL", "https"
+      it "converts :github shortcut to URI using https" do
+        subject.gem("sparks", :github => "rails")
+        github_uri = "https://github.com/rails/rails.git"
+        expect(subject.dependencies.first.source.uri).to eq(github_uri)
       end
 
       it "converts numeric :gist to :git" do
@@ -106,7 +63,7 @@ RSpec.describe Bundler::Dsl do
       end
     end
 
-    context "default git sources", :bundler => "4" do
+    context "default git sources", :bundler => "3" do
       it "has none" do
         expect(subject.instance_variable_get(:@git_sources)).to eq({})
       end
@@ -285,7 +242,7 @@ RSpec.describe Bundler::Dsl do
       end
     end
 
-    describe "#github", :bundler => "3" do
+    describe "#github", :bundler => "2" do
       it "from github" do
         spree_gems = %w[spree_core spree_api spree_backend]
         subject.github "spree" do
@@ -299,19 +256,6 @@ RSpec.describe Bundler::Dsl do
     end
 
     describe "#github", :bundler => "3" do
-      it "from github" do
-        spree_gems = %w[spree_core spree_api spree_backend]
-        subject.github "spree" do
-          spree_gems.each {|spree_gem| subject.send :gem, spree_gem }
-        end
-
-        subject.dependencies.each do |d|
-          expect(d.source.uri).to eq("https://github.com/spree/spree.git")
-        end
-      end
-    end
-
-    describe "#github", :bundler => "4" do
       it "from github" do
         expect do
           spree_gems = %w[spree_core spree_api spree_backend]

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -365,38 +365,30 @@ RSpec.describe "major deprecations" do
   end
 
   describe Bundler::Dsl do
-    let(:msg) do
-      <<-EOS
-The :github git source is deprecated, and will be removed in the future. Change any "reponame" :github sources to "username/reponame". Add this code to the top of your Gemfile to ensure it continues to work:
-
-    git_source(:github) {|repo_name| "https://github.com/\#{repo_name}.git" }
-
-      EOS
-    end
-
     before do
       @rubygems = double("rubygems")
       allow(Bundler::Source::Rubygems).to receive(:new) { @rubygems }
     end
 
     context "with github gems" do
-      it "warns about the https change if people are opting out" do
-        Bundler.settings.temporary "github.https" => false
-        expect(Bundler::SharedHelpers).to receive(:major_deprecation).with(3, msg)
-        expect(Bundler::SharedHelpers).to receive(:major_deprecation).with(2, "Setting `github.https` to false is deprecated and won't be supported in the future.")
-        subject.gem("sparks", :github => "indirect/sparks")
-      end
+      it "warns about removal", :bundler => "2" do
+        msg = <<-EOS
+The :github git source is deprecated, and will be removed in the future. Change any "reponame" :github sources to "username/reponame". Add this code to the top of your Gemfile to ensure it continues to work:
 
-      it "upgrades to https by default", :bundler => "2" do
+    git_source(:github) {|repo_name| "https://github.com/\#{repo_name}.git" }
+
+        EOS
         expect(Bundler::SharedHelpers).to receive(:major_deprecation).with(3, msg)
         subject.gem("sparks", :github => "indirect/sparks")
         github_uri = "https://github.com/indirect/sparks.git"
         expect(subject.dependencies.first.source.uri).to eq(github_uri)
       end
+
+      pending "should fail with a helpful error", :bundler => "3"
     end
 
     context "with bitbucket gems" do
-      it "warns about removal" do
+      it "warns about removal", :bundler => "2" do
         allow(Bundler.ui).to receive(:deprecate)
         msg = <<-EOS
 The :bitbucket git source is deprecated, and will be removed in the future. Add this code to the top of your Gemfile to ensure it continues to work:
@@ -411,10 +403,12 @@ The :bitbucket git source is deprecated, and will be removed in the future. Add 
         expect(Bundler::SharedHelpers).to receive(:major_deprecation).with(3, msg)
         subject.gem("not-really-a-gem", :bitbucket => "mcorp/flatlab-rails")
       end
+
+      pending "should fail with a helpful error", :bundler => "3"
     end
 
     context "with gist gems" do
-      it "warns about removal" do
+      it "warns about removal", :bundler => "2" do
         allow(Bundler.ui).to receive(:deprecate)
         msg = <<-EOS
 The :gist git source is deprecated, and will be removed in the future. Add this code to the top of your Gemfile to ensure it continues to work:
@@ -425,6 +419,8 @@ The :gist git source is deprecated, and will be removed in the future. Add this 
         expect(Bundler::SharedHelpers).to receive(:major_deprecation).with(3, msg)
         subject.gem("not-really-a-gem", :gist => "1234")
       end
+
+      pending "should fail with a helpful error", :bundler => "3"
     end
   end
 

--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -173,7 +173,6 @@ RSpec.describe "The library itself" do
       forget_cli_options
       gem.coc
       gem.mit
-      github.https
       inline
       use_gem_version_promoter_for_major_updates
     ]


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that in https://github.com/bundler/bundler/pull/7000 I implemented a plan to migrate to https source by default and deprecate github/gist/bitbucket builtin sources, but I changed my mind and I think it's overkill.

The reasons I changed my mind are:

* We [actually announced the switch](https://bundler.io/blog/2019/01/03/announcing-bundler-2.html) and the fact that it didn't happen was not intented. So this can be considered as fixing a bug.

* We have warned non https git sources for ages

https://github.com/bundler/bundler/blob/a6533c0fe6541cc929f895ee0b7a9b673d34cb4d/lib/bundler/source_list.rb#L144-L153

I think people should be ready by now.

Also, we introduced a new setting `github.https` that seems to do essentially the same thing as `git.allow_insecure`. 

### What is your fix for the problem, implemented in this PR?

My fix is to take the initial approach of https://github.com/bundler/bundler/pull/6911 and actually do this in the next release.