### PR TITLE
Fix to update conservatively for gemspec update

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -802,8 +802,10 @@ module Bundler
 
           deps2 = other.dependencies.select {|d| d.type != :development }
           runtime_dependencies = s.dependencies.select {|d| d.type != :development }
-          # If the dependencies of the path source have changed, unlock it
-          next unless runtime_dependencies.sort == deps2.sort
+          # If the dependencies of the path source have changed and locked spec can't satisfy new dependencies, unlock it
+          next unless deps2.sort == runtime_dependencies.sort || deps2.all? {|d| satisfies_locked_spec?(d) }
+
+          s.dependencies.replace(other.dependencies)
         end
 
         converged << s

--- a/spec/install/gemfile/path_spec.rb
+++ b/spec/install/gemfile/path_spec.rb
@@ -484,6 +484,68 @@ RSpec.describe "bundle install with explicit source paths" do
 
       expect(the_bundle).to include_gems "rack 1.0.0"
     end
+
+    it "keeps using the same version if it's compatible" do
+      build_lib "foo", "1.0", :path => lib_path("foo") do |s|
+        s.add_dependency "rack", "0.9.1"
+      end
+
+      bundle "install"
+
+      expect(the_bundle).to include_gems "rack 0.9.1"
+
+      lockfile_should_be <<-G
+        PATH
+          remote: #{lib_path("foo")}
+          specs:
+            foo (1.0)
+              rack (= 0.9.1)
+
+        GEM
+          remote: #{URI.parse("file://#{gem_repo1}/")}
+          specs:
+            rack (0.9.1)
+
+        PLATFORMS
+          #{lockfile_platforms}
+
+        DEPENDENCIES
+          foo!
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      G
+
+      build_lib "foo", "1.0", :path => lib_path("foo") do |s|
+        s.add_dependency "rack"
+      end
+
+      bundle "install"
+
+      lockfile_should_be <<-G
+        PATH
+          remote: #{lib_path("foo")}
+          specs:
+            foo (1.0)
+              rack
+
+        GEM
+          remote: #{URI.parse("file://#{gem_repo1}/")}
+          specs:
+            rack (0.9.1)
+
+        PLATFORMS
+          #{lockfile_platforms}
+
+        DEPENDENCIES
+          foo!
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      G
+
+      expect(the_bundle).to include_gems "rack 0.9.1"
+    end
   end
 
   describe "switching sources" do


### PR DESCRIPTION
Fix https://github.com/bundler/bundler/issues/6967

### What was the end-user problem that led to this PR?

https://github.com/bundler/bundler/issues/6967

### What was your diagnosis of the problem?

My diagnosis was https://github.com/bundler/bundler/blob/ec8f98574a90de1e87a50e00141180d761f161dc/lib/bundler/definition.rb#L806 is loose

### What is your fix for the problem, implemented in this PR?

My fix makes it strict

### Why did you choose this fix out of the possible options?

I think I don't have any other options
