### PR TITLE
Fix specs with rubygems master installed globally

### DIFF
--- a/lib/bundler/source/metadata.rb
+++ b/lib/bundler/source/metadata.rb
@@ -13,6 +13,7 @@ module Bundler
           idx << Gem::Specification.new do |s|
             s.name     = "bundler"
             s.version  = VERSION
+            s.license  = "MIT"
             s.platform = Gem::Platform::RUBY
             s.source   = self
             s.authors  = ["bundler team"]

--- a/lib/bundler/source/metadata.rb
+++ b/lib/bundler/source/metadata.rb
@@ -18,6 +18,8 @@ module Bundler
             s.source   = self
             s.authors  = ["bundler team"]
             s.bindir   = "exe"
+            s.homepage = "https://bundler.io"
+            s.summary  = "The best way to manage your application's dependencies"
             s.executables = %w[bundle]
             # can't point to the actual gemspec or else the require paths will be wrong
             s.loaded_from = File.expand_path("..", __FILE__)

--- a/spec/commands/licenses_spec.rb
+++ b/spec/commands/licenses_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "bundle licenses" do
   it "prints license information for all gems in the bundle" do
     bundle "licenses"
 
-    expect(err).to include("bundler: Unknown")
+    expect(out).to include("bundler: MIT")
     expect(out).to include("with_license: MIT")
   end
 

--- a/spec/commands/show_spec.rb
+++ b/spec/commands/show_spec.rb
@@ -68,10 +68,23 @@ RSpec.describe "bundle show", :bundler => "< 3" do
     it "prints summary of gems" do
       bundle "show --verbose"
 
-      expect(out).to include("* actionmailer (2.3.2)")
-      expect(out).to include("\tSummary:  This is just a fake gem for testing")
-      expect(out).to include("\tHomepage: No website available.")
-      expect(out).to include("\tStatus:   Up to date")
+      expect(out).to include <<~MSG
+        * actionmailer (2.3.2)
+        \tSummary:  This is just a fake gem for testing
+        \tHomepage: http://example.com
+        \tStatus:   Up to date
+      MSG
+    end
+
+    it "includes bundler in the summary of gems" do
+      bundle "show --verbose"
+
+      expect(out).to include <<~MSG
+        * bundler (#{Bundler::VERSION})
+        \tSummary:  The best way to manage your application's dependencies
+        \tHomepage: https://bundler.io
+        \tStatus:   Up to date
+      MSG
     end
   end
 

--- a/spec/commands/show_spec.rb
+++ b/spec/commands/show_spec.rb
@@ -30,19 +30,9 @@ RSpec.describe "bundle show", :bundler => "< 3" do
       expect(out).to eq(default_bundle_path("gems", "rails-2.3.2").to_s)
     end
 
-    it "prints deprecation" do
-      bundle "show rails"
-      expect(err).to eq("[DEPRECATED] use `bundle info rails` instead of `bundle show rails`")
-    end
-
     it "prints path if gem exists in bundle (with --paths option)" do
       bundle "show rails --paths"
       expect(out).to eq(default_bundle_path("gems", "rails-2.3.2").to_s)
-    end
-
-    it "prints deprecation when called with a gem and the --paths option" do
-      bundle "show rails --paths"
-      expect(err).to eq("[DEPRECATED] use `bundle info rails --path` instead of `bundle show rails --paths`")
     end
 
     it "warns if path no longer exists on disk" do
@@ -59,10 +49,6 @@ RSpec.describe "bundle show", :bundler => "< 3" do
       expect(out).to eq(root.to_s)
     end
 
-    it "prints deprecation when called with bundler" do
-      bundle "show bundler"
-      expect(err).to eq("[DEPRECATED] use `bundle info bundler` instead of `bundle show bundler`")
-    end
     it "complains if gem not in bundle" do
       bundle "show missing"
       expect(err).to match(/could not find gem 'missing'/i)
@@ -77,12 +63,6 @@ RSpec.describe "bundle show", :bundler => "< 3" do
       # Gem names are the last component of their path.
       gem_list = out.split.map {|p| p.split("/").last }
       expect(gem_list).to eq(gem_list.sort)
-    end
-
-    it "prints a deprecation when called with the --paths option" do
-      bundle "show --paths"
-
-      expect(err).to eq("[DEPRECATED] use `bundle list` instead of `bundle show --paths`")
     end
 
     it "prints summary of gems" do

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -483,6 +483,30 @@ The :gist git source is deprecated, and will be removed in the future. Add this 
 
       pending "fails with a helpful message", :bundler => "3"
     end
+
+    context "with the --paths option" do
+      before do
+        bundle "show --paths"
+      end
+
+      it "prints a deprecation warning recommending `bundle list`", :bundler => "2" do
+        expect(deprecations).to include("use `bundle list` instead of `bundle show --paths`")
+      end
+
+      pending "fails with a helpful message", :bundler => "3"
+    end
+
+    context "with a gem argument and the --paths option" do
+      before do
+        bundle "show rack --paths"
+      end
+
+      it "prints deprecation warning recommending `bundle info`", :bundler => "2" do
+        expect(deprecations).to include("use `bundle info rack --path` instead of `bundle show rack --paths`")
+      end
+
+      pending "fails with a helpful message", :bundler => "3"
+    end
   end
 
   context "bundle console" do

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -480,9 +480,9 @@ The :gist git source is deprecated, and will be removed in the future. Add this 
       it "prints a deprecation warning recommending `bundle info`", :bundler => "2" do
         expect(deprecations).to include("use `bundle info rack` instead of `bundle show rack`")
       end
-    end
 
-    pending "fails with a helpful message", :bundler => "3"
+      pending "fails with a helpful message", :bundler => "3"
+    end
   end
 
   context "bundle console" do


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was if you have rubygems's master installed globally, bundler specs no longer pass.

### What was your diagnosis of the problem?

My diagnosis was that having rubygems master installed, installs bundler's master as a default gem. That actually makes bundler behave better. In particular, `bundle show` and `bundle licenses` start properly handling the `bundler` gem itself.

### What is your fix for the problem, implemented in this PR?

My fix is to change bundler's code to fix this specs in every situation, and not only when the bundler version being tested is also installed as a default gem.

NOTE: I also included some changes to unify `bundle show` deprecation specs in the file that tests all deprecations.