### PR TITLE
Use `Gem.add_to_load_path` if available

### DIFF
--- a/lib/bundler/plugin.rb
+++ b/lib/bundler/plugin.rb
@@ -256,7 +256,7 @@ module Bundler
       @hooks_by_event = Hash.new {|h, k| h[k] = [] }
 
       load_paths = spec.load_paths
-      add_to_load_path(load_paths)
+      Bundler.rubygems.add_to_load_path(load_paths)
       path = Pathname.new spec.full_gem_path
 
       begin
@@ -288,7 +288,7 @@ module Bundler
       # done to avoid conflicts
       path = index.plugin_path(name)
 
-      add_to_load_path(index.load_paths(name))
+      Bundler.rubygems.add_to_load_path(index.load_paths(name))
 
       load path.join(PLUGIN_FILE_NAME)
 
@@ -298,17 +298,8 @@ module Bundler
       raise
     end
 
-    def add_to_load_path(load_paths)
-      if insert_index = Bundler.rubygems.load_path_insert_index
-        $LOAD_PATH.insert(insert_index, *load_paths)
-      else
-        $LOAD_PATH.unshift(*load_paths)
-      end
-    end
-
     class << self
-      private :load_plugin, :register_plugin, :save_plugins, :validate_plugin!,
-        :add_to_load_path
+      private :load_plugin, :register_plugin, :save_plugins, :validate_plugin!
     end
   end
 end

--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -39,10 +39,6 @@ module Bundler
       Gem::Command.build_args = args
     end
 
-    def load_path_insert_index
-      Gem.load_path_insert_index
-    end
-
     def loaded_specs(name)
       Gem.loaded_specs[name]
     end
@@ -50,7 +46,7 @@ module Bundler
     def add_to_load_path(paths)
       return Gem.add_to_load_path(*paths) if Gem.respond_to?(:add_to_load_path)
 
-      if insert_index = load_path_insert_index
+      if insert_index = Gem.load_path_insert_index
         # Gem directories must come after -I and ENV['RUBYLIB']
         $LOAD_PATH.insert(insert_index, *paths)
       else

--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -47,6 +47,18 @@ module Bundler
       Gem.loaded_specs[name]
     end
 
+    def add_to_load_path(paths)
+      return Gem.add_to_load_path(*paths) if Gem.respond_to?(:add_to_load_path)
+
+      if insert_index = load_path_insert_index
+        # Gem directories must come after -I and ENV['RUBYLIB']
+        $LOAD_PATH.insert(insert_index, *paths)
+      else
+        # We are probably testing in core, -I and RUBYLIB don't apply
+        $LOAD_PATH.unshift(*paths)
+      end
+    end
+
     def mark_loaded(spec)
       if spec.respond_to?(:activated=)
         current = Gem.loaded_specs[spec.name]

--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -34,13 +34,7 @@ module Bundler
         spec.load_paths.reject {|path| $LOAD_PATH.include?(path) }
       end.reverse.flatten
 
-      if insert_index = Bundler.rubygems.load_path_insert_index
-        # Gem directories must come after -I and ENV['RUBYLIB']
-        $LOAD_PATH.insert(insert_index, *load_paths)
-      else
-        # We are probably testing in core, -I and RUBYLIB don't apply
-        $LOAD_PATH.unshift(*load_paths)
-      end
+      Bundler.rubygems.add_to_load_path(load_paths)
 
       setup_manpath
 

--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -34,7 +34,6 @@ module Bundler
         spec.load_paths.reject {|path| $LOAD_PATH.include?(path) }
       end.reverse.flatten
 
-      # See Gem::Specification#add_self_to_load_path (since RubyGems 1.8)
       if insert_index = Bundler.rubygems.load_path_insert_index
         # Gem directories must come after -I and ENV['RUBYLIB']
         $LOAD_PATH.insert(insert_index, *load_paths)


### PR DESCRIPTION
This is a follow up to https://github.com/rubygems/rubygems/pull/2749.

### What is your fix for the problem, implemented in this PR?

My fix is to unify all LOAD_PATH manipulation in a single place, that uses rubygems logic if available.