### PR TITLE
Bump rubocop to 0.68.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+require: rubocop-performance
+
 AllCops:
   DisabledByDefault: true
   TargetRubyVersion: 2.3
@@ -219,16 +221,6 @@ Lint/Void:
 Layout/AccessModifierIndentation:
   Enabled: true
   EnforcedStyle: outdent
-  Exclude:
-    - 'lib/bundler/cli.rb'
-    - 'lib/bundler/definition.rb'
-    - 'lib/bundler/feature_flag.rb'
-    - 'lib/bundler/gem_helpers.rb'
-    - 'lib/bundler/index.rb'
-    - 'lib/bundler/remote_specification.rb'
-    - 'lib/bundler/shared_helpers.rb'
-    - 'lib/bundler/source/path.rb'
-    - 'spec/realworld/gemfile_source_header_spec.rb'
 
 Layout/AlignArray:
   Enabled: true
@@ -309,19 +301,19 @@ Layout/EndOfLine:
 Layout/ExtraSpacing:
   Enabled: true
 
-Layout/FirstParameterIndentation:
-  Enabled: true
-
-Layout/IndentArray:
-  Enabled: true
-  EnforcedStyle: consistent
-
 Layout/IndentAssignment:
   Enabled: true
 
-Layout/IndentHash:
+Layout/IndentFirstArrayElement:
+  Enabled: true
+  EnforcedStyle: consistent
+
+Layout/IndentFirstHashElement:
   Enabled: true
   EnforcedStyle: special_inside_parentheses
+
+Layout/IndentFirstArgument:
+  Enabled: true
 
 Layout/IndentationConsistency:
   Enabled: true
@@ -464,19 +456,10 @@ Performance/EndWith:
 Performance/FixedSize:
   Enabled: true
 
-Performance/LstripRstrip:
-  Enabled: true
-
-Performance/RedundantSortBy:
-  Enabled: true
-
 Performance/RegexpMatch:
   Enabled: true
 
 Performance/ReverseEach:
-  Enabled: true
-
-Performance/Sample:
   Enabled: true
 
 Performance/Size:
@@ -731,6 +714,9 @@ Style/RedundantParentheses:
 Style/RedundantSelf:
   Enabled: true
 
+Style/RedundantSortBy:
+  Enabled: true
+
 Style/RegexpLiteral:
   Enabled: true
 
@@ -738,6 +724,9 @@ Style/RescueModifier:
   Enabled: true
 
 Style/RescueStandardError:
+  Enabled: true
+
+Style/Sample:
   Enabled: true
 
 Style/SelfAssignment:
@@ -767,6 +756,9 @@ Style/StringLiterals:
 Style/StringLiteralsInInterpolation:
   Enabled: true
   EnforcedStyle: double_quotes
+
+Style/Strip:
+  Enabled: true
 
 Style/StructInheritance:
   Enabled: true

--- a/bundler.gemspec
+++ b/bundler.gemspec
@@ -38,7 +38,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake",       "~> 12.0"
   s.add_development_dependency "ronn",       "~> 0.7.3"
   s.add_development_dependency "rspec",      "~> 3.6"
-  s.add_development_dependency "rubocop",    "= 0.65.0"
+  s.add_development_dependency "rubocop",    "= 0.68.0"
+  s.add_development_dependency "rubocop-performance", "~> 1.1"
 
   s.files = Dir.glob("{lib,exe}/**/*", File::FNM_DOTMATCH).reject {|f| File.directory?(f) }
 

--- a/lib/bundler/friendly_errors.rb
+++ b/lib/bundler/friendly_errors.rb
@@ -5,7 +5,7 @@ require_relative "vendored_thor"
 
 module Bundler
   module FriendlyErrors
-  module_function
+    module_function # rubocop:disable Layout/AccessModifierIndentation
 
     def log_error(error)
       case error

--- a/lib/bundler/gem_version_promoter.rb
+++ b/lib/bundler/gem_version_promoter.rb
@@ -81,8 +81,8 @@ module Bundler
           sort_dep_specs(spec_groups, locked_spec)
         end.tap do |specs|
           if DEBUG
-            STDERR.puts before_result
-            STDERR.puts " after sort_versions: #{debug_format_result(dep, specs).inspect}"
+            warn before_result
+            warn " after sort_versions: #{debug_format_result(dep, specs).inspect}"
           end
         end
       end

--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -75,7 +75,7 @@ module Bundler
       return unless debug?
       debug_info = yield
       debug_info = debug_info.inspect unless debug_info.is_a?(String)
-      STDERR.puts debug_info.split("\n").map {|s| "  " * depth + s }
+      warn debug_info.split("\n").map {|s| "  " * depth + s }
     end
 
     def debug?

--- a/lib/bundler/uri_credentials_filter.rb
+++ b/lib/bundler/uri_credentials_filter.rb
@@ -2,7 +2,7 @@
 
 module Bundler
   module URICredentialsFilter
-  module_function
+    module_function # rubocop:disable Layout/AccessModifierIndentation
 
     def credential_filtered_uri(uri_to_anonymize)
       return uri_to_anonymize if uri_to_anonymize.nil?

--- a/lib/bundler/yaml_serializer.rb
+++ b/lib/bundler/yaml_serializer.rb
@@ -3,7 +3,7 @@
 module Bundler
   # A stub yaml serializer that can handle only hashes and strings (as of now).
   module YAMLSerializer
-  module_function
+    module_function # rubocop:disable Layout/AccessModifierIndentation
 
     def dump(hash)
       yaml = String.new("---")

--- a/spec/realworld/gemfile_source_header_spec.rb
+++ b/spec/realworld/gemfile_source_header_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "fetching dependencies with a mirrored source", :realworld => tru
     expect(the_bundle).to include_gems "weakling 0.0.3"
   end
 
-  private
+private
 
   def setup_server
     require_rack


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that our rubocop version is getting outdated. Also, I added [a PR to rubocop](https://github.com/rubocop-hq/rubocop/pull/6935) so that we can remove the exclusions in our configuration, and it has now been released.

### What is your fix for the problem, implemented in this PR?

My fix is to update rubocop to the latest version, update the configuration, and fix new offenses.