### PR TITLE
Rename local variables for readability

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -782,7 +782,7 @@ module Bundler
 
         # Path sources have special logic
         if s.source.instance_of?(Source::Path) || s.source.instance_of?(Source::Gemspec)
-          other_sources_specs = begin
+          new_specs = begin
             s.source.specs
           rescue PathError, GitError
             # if we won't need the source (according to the lockfile),
@@ -794,18 +794,18 @@ module Bundler
             raise
           end
 
-          other = other_sources_specs[s].first
+          new_spec = new_specs[s].first
 
           # If the spec is no longer in the path source, unlock it. This
           # commonly happens if the version changed in the gemspec
-          next unless other
+          next unless new_spec
 
-          deps2 = other.dependencies.select {|d| d.type != :development }
-          runtime_dependencies = s.dependencies.select {|d| d.type != :development }
+          new_runtime_deps = new_spec.dependencies.select {|d| d.type != :development }
+          old_runtime_deps = s.dependencies.select {|d| d.type != :development }
           # If the dependencies of the path source have changed and locked spec can't satisfy new dependencies, unlock it
-          next unless deps2.sort == runtime_dependencies.sort || deps2.all? {|d| satisfies_locked_spec?(d) }
+          next unless new_runtime_deps.sort == old_runtime_deps.sort || new_runtime_deps.all? {|d| satisfies_locked_spec?(d) }
 
-          s.dependencies.replace(other.dependencies)
+          s.dependencies.replace(new_spec.dependencies)
         end
 
         converged << s


### PR DESCRIPTION
Extracted from https://github.com/bundler/bundler/pull/7143#discussion_r279187838

> Also, I would split the variable rename, which is great because it makes the code more readable, to a separate commit

### What was the end-user problem that led to this PR?

No end-user is affected because it's just local var name.

As a bundler contributor, I think it's much easier to understand if we rename them.
When I was investigating https://github.com/bundler/bundler/pull/7143, it's hard to understand what `other` stuff and `deps2` is.