### PR TITLE
bundler/inline should install gems to BUNDLE_PATH

### DIFF
--- a/spec/runtime/inline_spec.rb
+++ b/spec/runtime/inline_spec.rb
@@ -291,6 +291,19 @@ RSpec.describe "bundler/inline#gemfile" do
     expect(out).to eq "1.0.0"
   end
 
+  context "when BUNDLE_PATH is set" do
+    it "installs inline gems to the system path regardless" do
+      script <<-RUBY, :env => { "BUNDLE_PATH" => "./vendor/inline" }
+        gemfile(true) do
+          source "file://#{gem_repo1}"
+          gem "rack"
+        end
+      RUBY
+      expect(last_command).to be_success
+      expect(system_gem_path("gems/rack-1.0.0")).to exist
+    end
+  end
+
   it "skips platform warnings" do
     simulate_platform "ruby"
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

This addresses the problem described in issue #7131. `bundler/inline` does not respect `BUNDLE_PATH` env variable and installs gems to the default location.

### What was your diagnosis of the problem?

`Bundler.configure` is not called at any point in `bundler/inline`.

### What is your fix for the problem, implemented in this PR?

To call it :)

### Why did you choose this fix out of the possible options?

When bundler is invoked via `bundle install` this method gets called.

---

The included test is failing without this change as expected.

I have also tested it manually using the code from the issue on ruby 2.6 and with bundler `1.17.2` & `2.0.1`.