### PR TITLE
Improve fileutils require

### DIFF
--- a/lib/bundler/vendor/fileutils/lib/fileutils.rb
+++ b/lib/bundler/vendor/fileutils/lib/fileutils.rb
@@ -6,7 +6,7 @@ rescue LoadError
   # for make mjit-headers
 end
 
-require "bundler/vendor/fileutils/lib/fileutils/version"
+require_relative "fileutils/version"
 
 #
 # = fileutils.rb


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was there's [upstream changes in fileutils](https://github.com/ruby/fileutils/pull/35).

### What is your fix for the problem, implemented in this PR?

My fix is to port the upstream changes, which consist of using `require_relative` everywhere.
