### PR TITLE
Improve azure configuration

### DIFF
--- a/.azure-pipelines/steps.yml
+++ b/.azure-pipelines/steps.yml
@@ -28,7 +28,7 @@ steps:
   displayName: 'gem install rspec_junit_formatter'
 
 - script: |
-    timeout 50m bash -c 'ruby -r rspec_junit_formatter bin/rspec --format progress --format RspecJunitFormatter -o rspec/bundler-junit-results.xml' || exit 0
+    ruby -r rspec_junit_formatter bin/rspec --format progress --format RspecJunitFormatter -o rspec/bundler-junit-results.xml || exit 0
   displayName: 'ruby bin/rspec'
 
 - task: PublishTestResults@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,3 +4,4 @@ jobs:
     vmImage: 'vs2017-win2016'
   steps:
   - template: .azure-pipelines/steps.yml
+  timeoutInMinutes: 0


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that failures in Azure are not logged, so it hard to improve the situation.

### What is your fix for the problem, implemented in this PR?

My fix is to configure Azure to run until completion without any timeouts, and remove intercepting the global timeout (which we did to make sure build is still green when it times out), because it's no longer necessary. Now we should be able to see the failures on every PR.