### PR TITLE
Fix file URIs on Windows

### DIFF
--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -99,7 +99,7 @@ module Bundler
 
       uri = URI.parse("#{remote_uri}#{Gem::MARSHAL_SPEC_DIR}#{spec_file_name}.rz")
       if uri.scheme == "file"
-        path = Gem.win_platform? ? uri.path[1..-1] : uri.path
+        path = Bundler.rubygems.correct_for_windows_path(uri.path)
         Bundler.load_marshal Bundler.rubygems.inflate(Gem.read_binary(path))
       elsif cached_spec_path = gemspec_cached_path(spec_file_name)
         Bundler.load_gemspec(cached_spec_path)

--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -99,7 +99,8 @@ module Bundler
 
       uri = URI.parse("#{remote_uri}#{Gem::MARSHAL_SPEC_DIR}#{spec_file_name}.rz")
       if uri.scheme == "file"
-        Bundler.load_marshal Bundler.rubygems.inflate(Gem.read_binary(uri.path))
+        path = Gem.win_platform? ? uri.path[1..-1] : uri.path
+        Bundler.load_marshal Bundler.rubygems.inflate(Gem.read_binary(path))
       elsif cached_spec_path = gemspec_cached_path(spec_file_name)
         Bundler.load_gemspec(cached_spec_path)
       else

--- a/lib/bundler/fetcher/index.rb
+++ b/lib/bundler/fetcher/index.rb
@@ -30,7 +30,7 @@ module Bundler
 
         uri = URI.parse("#{remote_uri}#{Gem::MARSHAL_SPEC_DIR}#{spec_file_name}.rz")
         if uri.scheme == "file"
-          path = Gem.win_platform? ? uri.path[1..-1] : uri.path
+          path = Bundler.rubygems.correct_for_windows_path(uri.path)
           Bundler.load_marshal Bundler.rubygems.inflate(Gem.read_binary(path))
         elsif cached_spec_path = gemspec_cached_path(spec_file_name)
           Bundler.load_gemspec(cached_spec_path)

--- a/lib/bundler/fetcher/index.rb
+++ b/lib/bundler/fetcher/index.rb
@@ -30,7 +30,8 @@ module Bundler
 
         uri = URI.parse("#{remote_uri}#{Gem::MARSHAL_SPEC_DIR}#{spec_file_name}.rz")
         if uri.scheme == "file"
-          Bundler.load_marshal Bundler.rubygems.inflate(Gem.read_binary(uri.path))
+          path = Gem.win_platform? ? uri.path[1..-1] : uri.path
+          Bundler.load_marshal Bundler.rubygems.inflate(Gem.read_binary(path))
         elsif cached_spec_path = gemspec_cached_path(spec_file_name)
           Bundler.load_gemspec(cached_spec_path)
         else

--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -139,11 +139,9 @@ module Bundler
     end
 
     def inflate(obj)
-      if defined?(Gem::Util)
-        Gem::Util.inflate(obj)
-      else
-        Gem.inflate(obj)
-      end
+      require "rubygems/util"
+
+      Gem::Util.inflate(obj)
     end
 
     def correct_for_windows_path(path)

--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -146,6 +146,18 @@ module Bundler
       end
     end
 
+    def correct_for_windows_path(path)
+      require "rubygems/util"
+
+      if Gem::Util.respond_to?(:correct_for_windows_path)
+        Gem::Util.correct_for_windows_path(path)
+      elsif path[0].chr == "/" && path[1].chr =~ /[a-z]/i && path[2].chr == ":"
+        path[1..-1]
+      else
+        path
+      end
+    end
+
     def sources=(val)
       # Gem.configuration creates a new Gem::ConfigFile, which by default will read ~/.gemrc
       # If that file exists, its settings (including sources) will overwrite the values we

--- a/lib/bundler/source/rubygems/remote.rb
+++ b/lib/bundler/source/rubygems/remote.rb
@@ -25,8 +25,7 @@ module Bundler
 
             cache_uri = original_uri || uri
 
-            # URI::File of Ruby 2.6 returns empty string when given "file://".
-            host = defined?(URI::File) && cache_uri.is_a?(URI::File) ? nil : cache_uri.host
+            host = cache_uri.to_s.start_with?("file://") ? nil : cache_uri.host
 
             uri_parts = [host, cache_uri.user, cache_uri.port, cache_uri.path]
             uri_digest = SharedHelpers.digest(:MD5).hexdigest(uri_parts.compact.join("."))

--- a/spec/bundler/bundler_spec.rb
+++ b/spec/bundler/bundler_spec.rb
@@ -192,7 +192,7 @@ EOF
   describe "#mkdir_p" do
     it "creates a folder at the given path" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 

--- a/spec/bundler/cli_spec.rb
+++ b/spec/bundler/cli_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "bundle executable" do
   context "when ENV['BUNDLE_GEMFILE'] is set to an empty string" do
     it "ignores it" do
       gemfile bundled_app("Gemfile"), <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem 'rack'
       G
 
@@ -55,7 +55,7 @@ RSpec.describe "bundle executable" do
   context "when ENV['RUBYGEMS_GEMDEPS'] is set" do
     it "displays a warning" do
       gemfile bundled_app("Gemfile"), <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem 'rack'
       G
 

--- a/spec/bundler/definition_spec.rb
+++ b/spec/bundler/definition_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Bundler::Definition do
       build_lib "foo", "1.0", :path => lib_path("foo")
 
       install_gemfile <<-G
-        source "file://localhost#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo", :path => "#{lib_path("foo")}"
       G
 
@@ -57,7 +57,7 @@ RSpec.describe Bundler::Definition do
               rack (= 1.0)
 
         GEM
-          remote: file://localhost#{gem_repo1}/
+          remote: #{file_uri_for(gem_repo1)}/
           specs:
             rack (1.0.0)
 
@@ -76,7 +76,7 @@ RSpec.describe Bundler::Definition do
       build_lib "foo", "1.0", :path => lib_path("foo")
 
       install_gemfile <<-G
-        source "file://localhost#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo", :path => "#{lib_path("foo")}"
       G
 
@@ -95,7 +95,7 @@ RSpec.describe Bundler::Definition do
               rack (= 1.0)
 
         GEM
-          remote: file://localhost#{gem_repo1}/
+          remote: #{file_uri_for(gem_repo1)}/
           specs:
             rack (1.0.0)
 
@@ -117,7 +117,7 @@ RSpec.describe Bundler::Definition do
       end
 
       install_gemfile <<-G
-        source "file://localhost#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo", :path => "#{lib_path("foo")}"
       G
 
@@ -132,7 +132,7 @@ RSpec.describe Bundler::Definition do
               rack (= 1.0)
 
         GEM
-          remote: file://localhost#{gem_repo1}/
+          remote: #{file_uri_for(gem_repo1)}/
           specs:
             rack (1.0.0)
 
@@ -149,7 +149,7 @@ RSpec.describe Bundler::Definition do
 
     it "for a rubygems gem" do
       install_gemfile <<-G
-        source "file://localhost#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo"
       G
 
@@ -158,7 +158,7 @@ RSpec.describe Bundler::Definition do
       expect(out).to match(/using resolution from the lockfile/)
       lockfile_should_be <<-G
         GEM
-          remote: file://localhost#{gem_repo1}/
+          remote: #{file_uri_for(gem_repo1)}/
           specs:
             foo (1.0)
 
@@ -179,7 +179,7 @@ RSpec.describe Bundler::Definition do
       context "with lockfile" do
         before do
           install_gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "foo"
           G
         end
@@ -202,13 +202,13 @@ RSpec.describe Bundler::Definition do
       context "eager unlock" do
         let(:source_list) do
           Bundler::SourceList.new.tap do |source_list|
-            source_list.global_rubygems_source = "file://#{gem_repo4}"
+            source_list.global_rubygems_source = "#{file_uri_for(gem_repo4)}"
           end
         end
 
         before do
           gemfile <<-G
-            source "file://#{gem_repo4}"
+            source "#{file_uri_for(gem_repo4)}"
             gem 'isolated_owner'
 
             gem 'shared_owner_a'
@@ -217,7 +217,7 @@ RSpec.describe Bundler::Definition do
 
           lockfile <<-L
             GEM
-              remote: file://#{gem_repo4}
+              remote: #{file_uri_for(gem_repo4)}
               specs:
                 isolated_dep (2.0.1)
                 isolated_owner (1.0.1)

--- a/spec/bundler/env_spec.rb
+++ b/spec/bundler/env_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Bundler::Env do
 
         lockfile <<-L
           GEM
-            remote: file:#{gem_repo1}/
+            remote: #{file_uri_for(gem_repo1)}/
             specs:
               rack (1.0.0)
 
@@ -136,7 +136,7 @@ RSpec.describe Bundler::Env do
         create_file "other/Gemfile-other", "gem 'rack'"
         create_file "other/Gemfile", "eval_gemfile 'Gemfile-other'"
         create_file "Gemfile-alt", <<-G
-          source "file:#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           eval_gemfile "other/Gemfile"
         G
         gemfile "eval_gemfile #{File.expand_path("Gemfile-alt").dump}"
@@ -154,7 +154,7 @@ RSpec.describe Bundler::Env do
           ### Gemfile-alt
 
           ```ruby
-          source "file:#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           eval_gemfile "other/Gemfile"
           ```
 

--- a/spec/bundler/friendly_errors_spec.rb
+++ b/spec/bundler/friendly_errors_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Bundler, "friendly errors" do
 
     it "reports a relevant friendly error message" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 

--- a/spec/bundler/gem_helper_spec.rb
+++ b/spec/bundler/gem_helper_spec.rb
@@ -213,7 +213,7 @@ RSpec.describe Bundler::GemHelper do
 
         before do
           Dir.chdir(app_path) do
-            sys_exec("git remote add origin file://#{repo.path}")
+            sys_exec("git remote add origin #{file_uri_for(repo.path)}")
             sys_exec('git commit -a -m "initial commit"')
           end
         end

--- a/spec/bundler/plugin/installer_spec.rb
+++ b/spec/bundler/plugin/installer_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Bundler::Plugin::Installer do
         end
 
         let(:result) do
-          installer.install(["ga-plugin"], :git => "file://#{lib_path("ga-plugin")}")
+          installer.install(["ga-plugin"], :git => "#{file_uri_for(lib_path("ga-plugin"))}")
         end
 
         it "returns the installed spec after installing" do
@@ -98,7 +98,7 @@ RSpec.describe Bundler::Plugin::Installer do
 
       context "rubygems plugins" do
         let(:result) do
-          installer.install(["re-plugin"], :source => "file://#{gem_repo2}")
+          installer.install(["re-plugin"], :source => "#{file_uri_for(gem_repo2)}")
         end
 
         it "returns the installed spec after installing " do
@@ -113,7 +113,7 @@ RSpec.describe Bundler::Plugin::Installer do
 
       context "multiple plugins" do
         let(:result) do
-          installer.install(["re-plugin", "ma-plugin"], :source => "file://#{gem_repo2}")
+          installer.install(["re-plugin", "ma-plugin"], :source => "#{file_uri_for(gem_repo2)}")
         end
 
         it "returns the installed spec after installing " do

--- a/spec/cache/cache_path_spec.rb
+++ b/spec/cache/cache_path_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe "bundle package" do
   before do
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack"
     G
   end

--- a/spec/cache/gems_spec.rb
+++ b/spec/cache/gems_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "bundle cache" do
       build_gem "omg", :path => bundled_app("vendor/cache")
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "omg"
       G
 
@@ -104,7 +104,7 @@ RSpec.describe "bundle cache" do
 
     it "caches remote and builtin gems" do
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem 'builtin_gem', '1.0.2'
         gem 'rack', '1.0.0'
       G
@@ -120,7 +120,7 @@ RSpec.describe "bundle cache" do
       end
 
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem 'builtin_gem_2', '1.0.2'
       G
 
@@ -147,7 +147,7 @@ RSpec.describe "bundle cache" do
       system_gems "rack-1.0.0"
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         git "#{lib_path("foo-1.0")}" do
           gem 'foo'
         end
@@ -177,7 +177,7 @@ RSpec.describe "bundle cache" do
     before :each do
       build_repo2
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "rack"
         gem "actionpack"
       G
@@ -203,7 +203,7 @@ RSpec.describe "bundle cache" do
 
     it "adds new gems and dependencies" do
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "rails"
       G
       expect(cached_gem("rails-2.3.2")).to exist
@@ -212,7 +212,7 @@ RSpec.describe "bundle cache" do
 
     it "removes .gems for removed gems and dependencies" do
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "rack"
       G
       expect(cached_gem("rack-1.0.0")).to exist
@@ -224,7 +224,7 @@ RSpec.describe "bundle cache" do
       build_git "rack"
 
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "rack", :git => "#{lib_path("rack-1.0")}"
         gem "actionpack"
       G
@@ -236,7 +236,7 @@ RSpec.describe "bundle cache" do
     it "doesn't remove gems that are for another platform" do
       simulate_platform "java" do
         install_gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "platform_specific"
         G
 
@@ -246,7 +246,7 @@ RSpec.describe "bundle cache" do
 
       simulate_new_machine
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "platform_specific"
       G
 
@@ -273,7 +273,7 @@ RSpec.describe "bundle cache" do
 
     it "does not say that it is removing gems when it isn't actually doing so" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
       bundle "cache"
@@ -283,7 +283,7 @@ RSpec.describe "bundle cache" do
 
     it "does not warn about all if it doesn't have any git/path dependency" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
       bundle "cache"

--- a/spec/cache/platform_spec.rb
+++ b/spec/cache/platform_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe "bundle cache with multiple platforms" do
   before :each do
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       platforms :mri, :rbx do
         gem "rack", "1.0.0"
@@ -16,7 +16,7 @@ RSpec.describe "bundle cache with multiple platforms" do
 
     lockfile <<-G
       GEM
-        remote: file:#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           rack (1.0.0)
           activesupport (2.3.5)

--- a/spec/commands/add_spec.rb
+++ b/spec/commands/add_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "bundle add" do
     build_git "foo", "2.0"
 
     install_gemfile <<-G
-      source "file://#{gem_repo2}"
+      source "#{file_uri_for(gem_repo2)}"
       gem "weakling", "~> 0.0.1"
     G
   end
@@ -84,9 +84,9 @@ RSpec.describe "bundle add" do
 
   describe "with --source" do
     it "adds dependency with specified source" do
-      bundle "add 'foo' --source='file://#{gem_repo2}'"
+      bundle "add 'foo' --source='#{file_uri_for(gem_repo2)}'"
 
-      expect(bundled_app("Gemfile").read).to match(%r{gem "foo", "~> 2.0", :source => "file:\/\/#{gem_repo2}"})
+      expect(bundled_app("Gemfile").read).to match(/gem "foo", "~> 2.0", :source => "#{file_uri_for(gem_repo2)}"/)
       expect(the_bundle).to include_gems "foo 2.0"
     end
   end
@@ -123,8 +123,8 @@ RSpec.describe "bundle add" do
   end
 
   it "using combination of short form options works like long form" do
-    bundle "add 'foo' -s='file://#{gem_repo2}' -g='development' -v='~>1.0'"
-    expect(bundled_app("Gemfile").read).to include %(gem "foo", "~> 1.0", :group => :development, :source => "file://#{gem_repo2}")
+    bundle "add 'foo' -s='#{file_uri_for(gem_repo2)}' -g='development' -v='~>1.0'"
+    expect(bundled_app("Gemfile").read).to include %(gem "foo", "~> 1.0", :group => :development, :source => "#{file_uri_for(gem_repo2)}")
     expect(the_bundle).to include_gems "foo 1.1"
   end
 
@@ -137,7 +137,7 @@ RSpec.describe "bundle add" do
     bundle "add 'werk_it'"
     expect(err).to match("Could not find gem 'werk_it' in")
 
-    bundle "add 'werk_it' -s='file://#{gem_repo2}'"
+    bundle "add 'werk_it' -s='#{file_uri_for(gem_repo2)}'"
     expect(err).to match("Could not find gem 'werk_it' in rubygems repository")
   end
 
@@ -200,7 +200,7 @@ RSpec.describe "bundle add" do
   describe "when a gem is added which is already specified in Gemfile with version" do
     it "shows an error when added with different version requirement" do
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "rack", "1.0"
       G
 
@@ -212,7 +212,7 @@ RSpec.describe "bundle add" do
 
     it "shows error when added without version requirements" do
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "rack", "1.0"
       G
 
@@ -227,7 +227,7 @@ RSpec.describe "bundle add" do
   describe "when a gem is added which is already specified in Gemfile without version" do
     it "shows an error when added with different version requirement" do
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "rack"
       G
 

--- a/spec/commands/binstubs_spec.rb
+++ b/spec/commands/binstubs_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "bundle binstubs <gem>" do
   context "when the gem exists in the lockfile" do
     it "sets up the binstub" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 
@@ -15,7 +15,7 @@ RSpec.describe "bundle binstubs <gem>" do
 
     it "does not install other binstubs" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
         gem "rails"
       G
@@ -28,7 +28,7 @@ RSpec.describe "bundle binstubs <gem>" do
 
     it "does install multiple binstubs" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
         gem "rails"
       G
@@ -41,7 +41,7 @@ RSpec.describe "bundle binstubs <gem>" do
 
     it "allows installing all binstubs" do
       install_gemfile! <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rails"
       G
 
@@ -53,7 +53,7 @@ RSpec.describe "bundle binstubs <gem>" do
 
     it "displays an error when used without any gem" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 
@@ -64,7 +64,7 @@ RSpec.describe "bundle binstubs <gem>" do
 
     it "displays an error when used with --all and gems" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 
@@ -76,7 +76,7 @@ RSpec.describe "bundle binstubs <gem>" do
     context "when generating bundle binstub outside bundler" do
       it "should abort" do
         install_gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "rack"
         G
 
@@ -117,7 +117,7 @@ RSpec.describe "bundle binstubs <gem>" do
           end
         end
         install_gemfile! <<-G
-          source "file://#{gem_repo2}"
+          source "#{file_uri_for(gem_repo2)}"
           gem "rack"
           gem "prints_loaded_gems"
         G
@@ -245,7 +245,7 @@ RSpec.describe "bundle binstubs <gem>" do
     it "sets correct permissions for binstubs" do
       with_umask(0o002) do
         install_gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "rack"
         G
 
@@ -258,7 +258,7 @@ RSpec.describe "bundle binstubs <gem>" do
     context "when using --shebang" do
       it "sets the specified shebang for the the binstub" do
         install_gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "rack"
         G
 
@@ -272,7 +272,7 @@ RSpec.describe "bundle binstubs <gem>" do
   context "when the gem doesn't exist" do
     it "displays an error with correct status" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
       G
 
       bundle "binstubs doesnt_exist"
@@ -285,7 +285,7 @@ RSpec.describe "bundle binstubs <gem>" do
   context "--path" do
     it "sets the binstubs dir" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 
@@ -296,7 +296,7 @@ RSpec.describe "bundle binstubs <gem>" do
 
     it "setting is saved for bundle install", :bundler => "< 3" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
         gem "rails"
       G
@@ -311,7 +311,7 @@ RSpec.describe "bundle binstubs <gem>" do
   context "with --standalone option" do
     before do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
     end
@@ -342,7 +342,7 @@ RSpec.describe "bundle binstubs <gem>" do
       end
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 
@@ -362,7 +362,7 @@ RSpec.describe "bundle binstubs <gem>" do
         end
 
         install_gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "rack"
         G
 
@@ -377,7 +377,7 @@ RSpec.describe "bundle binstubs <gem>" do
   context "when the gem has no bins" do
     it "suggests child gems if they have bins" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack-obama"
       G
 
@@ -388,7 +388,7 @@ RSpec.describe "bundle binstubs <gem>" do
 
     it "works if child gems don't have bins" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "actionpack"
       G
 
@@ -398,7 +398,7 @@ RSpec.describe "bundle binstubs <gem>" do
 
     it "works if the gem has development dependencies" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "with_development_dependency"
       G
 
@@ -410,7 +410,7 @@ RSpec.describe "bundle binstubs <gem>" do
   context "when BUNDLE_INSTALL is specified" do
     it "performs an automatic bundle install" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 
@@ -422,7 +422,7 @@ RSpec.describe "bundle binstubs <gem>" do
 
     it "does nothing when already up to date" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 

--- a/spec/commands/check_spec.rb
+++ b/spec/commands/check_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe "bundle check" do
   it "returns success when the Gemfile is satisfied" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rails"
     G
 
@@ -14,7 +14,7 @@ RSpec.describe "bundle check" do
 
   it "works with the --gemfile flag when not in the directory" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rails"
     G
 
@@ -25,7 +25,7 @@ RSpec.describe "bundle check" do
 
   it "creates a Gemfile.lock by default if one does not exist" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rails"
     G
 
@@ -38,7 +38,7 @@ RSpec.describe "bundle check" do
 
   it "does not create a Gemfile.lock if --dry-run was passed" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rails"
     G
 
@@ -53,7 +53,7 @@ RSpec.describe "bundle check" do
     system_gems ["rails-2.3.2"]
 
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rails"
     G
 
@@ -63,7 +63,7 @@ RSpec.describe "bundle check" do
 
   it "prints a generic error if a Gemfile.lock does not exist and a toplevel dependency does not exist" do
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rails"
     G
 
@@ -74,16 +74,16 @@ RSpec.describe "bundle check" do
 
   it "prints a generic message if you changed your lockfile" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem 'rails'
     G
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem 'rails_fail'
     G
 
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rails"
       gem "rails_fail"
     G
@@ -94,7 +94,7 @@ RSpec.describe "bundle check" do
 
   it "remembers --without option from install", :bundler => "< 3" do
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       group :foo do
         gem "rack"
       end
@@ -108,7 +108,7 @@ RSpec.describe "bundle check" do
   it "uses the without setting" do
     bundle! "config set without foo"
     install_gemfile! <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       group :foo do
         gem "rack"
       end
@@ -120,14 +120,14 @@ RSpec.describe "bundle check" do
 
   it "ensures that gems are actually installed and not just cached" do
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack", :group => :foo
     G
 
     bundle :install, forgotten_command_line_options(:without => "foo")
 
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack"
     G
 
@@ -138,7 +138,7 @@ RSpec.describe "bundle check" do
 
   it "ignores missing gems restricted to other platforms" do
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack"
       platforms :#{not_local_tag} do
         gem "activesupport"
@@ -149,7 +149,7 @@ RSpec.describe "bundle check" do
 
     lockfile <<-G
       GEM
-        remote: file:#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           activesupport (2.3.5)
           rack (1.0.0)
@@ -169,7 +169,7 @@ RSpec.describe "bundle check" do
 
   it "works with env conditionals" do
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack"
       env :NOT_GOING_TO_BE_SET do
         gem "activesupport"
@@ -180,7 +180,7 @@ RSpec.describe "bundle check" do
 
     lockfile <<-G
       GEM
-        remote: file:#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           activesupport (2.3.5)
           rack (1.0.0)
@@ -227,7 +227,7 @@ RSpec.describe "bundle check" do
 
   it "fails when there's no lock file and frozen is set" do
     install_gemfile! <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo"
     G
 
@@ -241,7 +241,7 @@ RSpec.describe "bundle check" do
   context "--path", :bundler => "< 3" do
     before do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rails"
       G
       bundle "install --path vendor/bundle"
@@ -263,7 +263,7 @@ RSpec.describe "bundle check" do
   context "--path vendor/bundle after installing gems in the default directory" do
     it "returns false" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rails"
       G
 
@@ -277,7 +277,7 @@ RSpec.describe "bundle check" do
     before :each do
       system_gems "rack-1.0.0"
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", "1.0"
       G
     end
@@ -301,7 +301,7 @@ RSpec.describe "bundle check" do
     def lock_with(bundler_version = nil)
       lock = <<-L
         GEM
-          remote: file:#{gem_repo1}/
+          remote: #{file_uri_for(gem_repo1)}/
           specs:
             rack (1.0.0)
 
@@ -321,7 +321,7 @@ RSpec.describe "bundle check" do
 
     before do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
     end

--- a/spec/commands/clean_spec.rb
+++ b/spec/commands/clean_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "bundle clean" do
 
   it "removes unused gems that are different" do
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "thin"
       gem "foo"
@@ -28,7 +28,7 @@ RSpec.describe "bundle clean" do
     bundle! "install", forgotten_command_line_options(:path => "vendor/bundle", :clean => false)
 
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "thin"
     G
@@ -46,7 +46,7 @@ RSpec.describe "bundle clean" do
 
   it "removes old version of gem if unused" do
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "rack", "0.9.1"
       gem "foo"
@@ -55,7 +55,7 @@ RSpec.describe "bundle clean" do
     bundle "install", forgotten_command_line_options(:path => "vendor/bundle", :clean => false)
 
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "rack", "1.0.0"
       gem "foo"
@@ -74,7 +74,7 @@ RSpec.describe "bundle clean" do
 
   it "removes new version of gem if unused" do
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "rack", "1.0.0"
       gem "foo"
@@ -83,7 +83,7 @@ RSpec.describe "bundle clean" do
     bundle! "install", forgotten_command_line_options(:path => "vendor/bundle", :clean => false)
 
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "rack", "0.9.1"
       gem "foo"
@@ -102,7 +102,7 @@ RSpec.describe "bundle clean" do
 
   it "removes gems in bundle without groups" do
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "foo"
 
@@ -129,7 +129,7 @@ RSpec.describe "bundle clean" do
     git_path = lib_path("foo-1.0")
 
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "rack", "1.0.0"
       git "#{git_path}", :ref => "#{revision}" do
@@ -152,7 +152,7 @@ RSpec.describe "bundle clean" do
     revision = revision_for(git_path)
 
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "rack", "1.0.0"
       git "#{git_path}", :ref => "#{revision}" do
@@ -163,7 +163,7 @@ RSpec.describe "bundle clean" do
     bundle "install", forgotten_command_line_options(:path => "vendor/bundle")
 
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "rack", "1.0.0"
     G
@@ -188,7 +188,7 @@ RSpec.describe "bundle clean" do
     revision = revision_for(lib_path("foo-bar"))
 
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "rack", "1.0.0"
       git "#{lib_path("foo-bar")}" do
@@ -239,7 +239,7 @@ RSpec.describe "bundle clean" do
     revision = revision_for(git_path)
 
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "rack", "1.0.0"
       group :test do
@@ -260,7 +260,7 @@ RSpec.describe "bundle clean" do
 
   it "does not blow up when using without groups" do
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "rack"
 
@@ -278,7 +278,7 @@ RSpec.describe "bundle clean" do
   it "displays an error when used without --path" do
     bundle! "config set path.system true"
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "rack", "1.0.0"
     G
@@ -292,7 +292,7 @@ RSpec.describe "bundle clean" do
   # handling bundle clean upgrade path from the pre's
   it "removes .gem/.gemspec file even if there's no corresponding gem dir" do
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "thin"
       gem "foo"
@@ -301,7 +301,7 @@ RSpec.describe "bundle clean" do
     bundle "install", forgotten_command_line_options(:path => "vendor/bundle")
 
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "foo"
     G
@@ -323,14 +323,14 @@ RSpec.describe "bundle clean" do
     bundle! "config set path.system true"
 
     install_gemfile! <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "thin"
       gem "rack"
     G
 
     install_gemfile! <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "rack"
     G
@@ -342,7 +342,7 @@ RSpec.describe "bundle clean" do
 
   it "--clean should override the bundle setting on install", :bundler => "< 3" do
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "thin"
       gem "rack"
@@ -350,7 +350,7 @@ RSpec.describe "bundle clean" do
     bundle "install", forgotten_command_line_options(:path => "vendor/bundle", :clean => true)
 
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "rack"
     G
@@ -364,7 +364,7 @@ RSpec.describe "bundle clean" do
     build_repo2
 
     gemfile <<-G
-      source "file://#{gem_repo2}"
+      source "#{file_uri_for(gem_repo2)}"
 
       gem "foo"
     G
@@ -384,7 +384,7 @@ RSpec.describe "bundle clean" do
     build_repo2
 
     install_gemfile! <<-G
-      source "file://#{gem_repo2}"
+      source "#{file_uri_for(gem_repo2)}"
 
       gem "foo"
     G
@@ -406,7 +406,7 @@ RSpec.describe "bundle clean" do
 
   it "does not clean automatically on --path" do
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "thin"
       gem "rack"
@@ -414,7 +414,7 @@ RSpec.describe "bundle clean" do
     bundle "install", forgotten_command_line_options(:path => "vendor/bundle")
 
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "rack"
     G
@@ -427,7 +427,7 @@ RSpec.describe "bundle clean" do
     build_repo2
 
     gemfile <<-G
-      source "file://#{gem_repo2}"
+      source "#{file_uri_for(gem_repo2)}"
 
       gem "foo"
     G
@@ -447,7 +447,7 @@ RSpec.describe "bundle clean" do
     build_repo2
 
     gemfile <<-G
-      source "file://#{gem_repo2}"
+      source "#{file_uri_for(gem_repo2)}"
 
       gem "foo"
     G
@@ -467,7 +467,7 @@ RSpec.describe "bundle clean" do
     bundle! "config set path.system true"
 
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "foo"
       gem "rack"
@@ -475,7 +475,7 @@ RSpec.describe "bundle clean" do
     bundle :install
 
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "rack"
     G
@@ -497,7 +497,7 @@ RSpec.describe "bundle clean" do
     end
     it "returns a helpful error message" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
 
         gem "foo"
         gem "rack"
@@ -505,7 +505,7 @@ RSpec.describe "bundle clean" do
       bundle :install
 
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
 
         gem "rack"
       G
@@ -530,7 +530,7 @@ RSpec.describe "bundle clean" do
     revision = revision_for(lib_path("foo-1.0"))
 
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "foo", :git => "#{lib_path("foo-1.0")}"
     G
@@ -567,7 +567,7 @@ RSpec.describe "bundle clean" do
     end
 
     gemfile <<-G
-      source "file://#{gem_repo2}"
+      source "#{file_uri_for(gem_repo2)}"
 
       gem "bindir"
     G
@@ -590,7 +590,7 @@ RSpec.describe "bundle clean" do
     end
 
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "foo"
       gem "bar", "1.0", :path => "#{relative_path}"
@@ -602,7 +602,7 @@ RSpec.describe "bundle clean" do
 
   it "doesn't remove gems in dry-run mode with path set" do
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "thin"
       gem "foo"
@@ -611,7 +611,7 @@ RSpec.describe "bundle clean" do
     bundle "install", forgotten_command_line_options(:path => "vendor/bundle", :clean => false)
 
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "thin"
     G
@@ -630,7 +630,7 @@ RSpec.describe "bundle clean" do
 
   it "doesn't remove gems in dry-run mode with no path set" do
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "thin"
       gem "foo"
@@ -639,7 +639,7 @@ RSpec.describe "bundle clean" do
     bundle "install", forgotten_command_line_options(:path => "vendor/bundle", :clean => false)
 
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "thin"
     G
@@ -658,7 +658,7 @@ RSpec.describe "bundle clean" do
 
   it "doesn't store dry run as a config setting" do
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "thin"
       gem "foo"
@@ -668,7 +668,7 @@ RSpec.describe "bundle clean" do
     bundle "config set dry_run false"
 
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "thin"
     G
@@ -688,7 +688,7 @@ RSpec.describe "bundle clean" do
 
   it "performs an automatic bundle install" do
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "thin"
       gem "foo"
@@ -697,7 +697,7 @@ RSpec.describe "bundle clean" do
     bundle! "install", forgotten_command_line_options(:path => "vendor/bundle", :clean => false)
 
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "thin"
       gem "weakling"
@@ -716,7 +716,7 @@ RSpec.describe "bundle clean" do
     revision = revision_for(lib_path("very_simple_git_binary-1.0"))
 
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "very_simple_git_binary", :git => "#{lib_path("very_simple_git_binary-1.0")}", :ref => "#{revision}"
     G
@@ -734,7 +734,7 @@ RSpec.describe "bundle clean" do
 
   it "removes extension directories", :ruby_repo do
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "thin"
       gem "very_simple_binary"
@@ -753,7 +753,7 @@ RSpec.describe "bundle clean" do
     expect(simple_binary_extensions_dir).to exist
 
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "thin"
       gem "simple_binary"
@@ -774,7 +774,7 @@ RSpec.describe "bundle clean" do
     short_revision = revision[0..11]
 
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "thin"
       gem "very_simple_git_binary", :git => "#{lib_path("very_simple_git_binary-1.0")}", :ref => "#{revision}"

--- a/spec/commands/config_spec.rb
+++ b/spec/commands/config_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe ".bundle/config" do
   describe "location" do
     before :each do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", "1.0.0"
       G
     end
@@ -68,7 +68,7 @@ RSpec.describe ".bundle/config" do
   describe "global" do
     before(:each) do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", "1.0.0"
       G
     end
@@ -162,7 +162,7 @@ RSpec.describe ".bundle/config" do
   describe "local" do
     before(:each) do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", "1.0.0"
       G
     end
@@ -220,7 +220,7 @@ RSpec.describe ".bundle/config" do
   describe "env" do
     before(:each) do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", "1.0.0"
       G
     end
@@ -293,7 +293,7 @@ RSpec.describe ".bundle/config" do
   describe "gem mirrors" do
     before(:each) do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", "1.0.0"
       G
     end
@@ -360,7 +360,7 @@ E
   describe "very long lines" do
     before(:each) do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", "1.0.0"
       G
     end
@@ -480,7 +480,7 @@ RSpec.describe "setting gemfile via config" do
     it "persists the gemfile location to .bundle/config" do
       File.open(bundled_app("NotGemfile"), "w") do |f|
         f.write <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem 'rack'
         G
       end

--- a/spec/commands/console_spec.rb
+++ b/spec/commands/console_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe "bundle console", :bundler => "< 3" do
   before :each do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack"
       gem "activesupport", :group => :test
       gem "rack_middleware", :group => :development
@@ -28,7 +28,7 @@ RSpec.describe "bundle console", :bundler => "< 3" do
 
   it "starts another REPL if configured as such" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "pry"
     G
     bundle "config set console pry"
@@ -87,7 +87,7 @@ RSpec.describe "bundle console", :bundler => "< 3" do
 
   it "performs an automatic bundle install" do
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack"
       gem "activesupport", :group => :test
       gem "rack_middleware", :group => :development

--- a/spec/commands/doctor_spec.rb
+++ b/spec/commands/doctor_spec.rb
@@ -8,7 +8,7 @@ require "bundler/cli/doctor"
 RSpec.describe "bundle doctor" do
   before(:each) do
     install_gemfile! <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack"
     G
 

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -130,13 +130,13 @@ RSpec.describe "bundle exec" do
     end
 
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack", "0.9.1"
     G
 
     Dir.chdir bundled_app2 do
       install_gemfile bundled_app2("Gemfile"), <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "rack_two", "1.0.0"
       G
     end
@@ -184,7 +184,7 @@ RSpec.describe "bundle exec" do
         end
 
         install_gemfile <<-G
-          source "file://#{gem_repo2}"
+          source "#{file_uri_for(gem_repo2)}"
           gem "irb", "#{specified_irb_version}"
         G
       end
@@ -214,7 +214,7 @@ RSpec.describe "bundle exec" do
         end
 
         install_gemfile <<-G
-          source "file://#{gem_repo2}"
+          source "#{file_uri_for(gem_repo2)}"
           gem "gem_depending_on_old_irb"
         G
 
@@ -238,13 +238,13 @@ RSpec.describe "bundle exec" do
     bundle "config set path.system true"
 
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack", "0.9.1"
     G
 
     Dir.chdir bundled_app2 do
       install_gemfile bundled_app2("Gemfile"), <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "rack_two", "1.0.0"
       G
     end
@@ -259,7 +259,7 @@ RSpec.describe "bundle exec" do
 
   it "handles gems installed with --without" do
     install_gemfile <<-G, forgotten_command_line_options(:without => "middleware")
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack" # rack 0.9.1 and 1.0 exist
 
       group :middleware do
@@ -344,7 +344,7 @@ RSpec.describe "bundle exec" do
   it "raises a helpful error when exec'ing to something outside of the bundle", :ruby_repo do
     bundle! "config set clean false" # want to keep the rackup binstub
     install_gemfile! <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "with_license"
     G
     [true, false].each do |l|
@@ -536,7 +536,7 @@ RSpec.describe "bundle exec" do
 
   it "performs an automatic bundle install" do
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack", "0.9.1"
       gem "foo"
     G
@@ -846,7 +846,7 @@ __FILE__: #{path.to_s.inspect}
     context "with shared gems disabled" do
       before do
         gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "rack"
         G
         bundle :install, :system_bundler => true, :path => "vendor/bundler"

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "bundle info" do
   context "with a standard Gemfile" do
     before do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rails"
       G
     end
@@ -119,7 +119,7 @@ RSpec.describe "bundle info" do
   context "with a valid regexp for gem name", :ruby_repo do
     it "presents alternatives" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
         gem "rack-obama"
       G
@@ -132,7 +132,7 @@ RSpec.describe "bundle info" do
   context "with an invalid regexp for gem name" do
     it "does not find the gem" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rails"
       G
 

--- a/spec/commands/inject_spec.rb
+++ b/spec/commands/inject_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe "bundle inject", :bundler => "< 3" do
   before :each do
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack"
     G
   end
@@ -53,9 +53,9 @@ Usage: "bundle inject GEM VERSION"
 
   context "with source option" do
     it "add gem with source option in gemfile" do
-      bundle "inject 'foo' '>0' --source file://#{gem_repo1}"
+      bundle "inject 'foo' '>0' --source #{file_uri_for(gem_repo1)}"
       gemfile = bundled_app("Gemfile").read
-      str = "gem \"foo\", \"> 0\", :source => \"file://#{gem_repo1}\""
+      str = "gem \"foo\", \"> 0\", :source => \"#{file_uri_for(gem_repo1)}\""
       expect(gemfile).to include str
     end
   end
@@ -105,7 +105,7 @@ Usage: "bundle inject GEM VERSION"
 
     it "doesn't allow Gemfile changes" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack-obama"
       G
       bundle "inject 'rack' '> 0'"

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "bundle install with gem sources" do
   describe "the simple case" do
     it "prints output and returns if no dependencies are specified" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
       G
 
       bundle :install
@@ -22,7 +22,7 @@ RSpec.describe "bundle install with gem sources" do
 
     it "creates a Gemfile.lock" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 
@@ -31,7 +31,7 @@ RSpec.describe "bundle install with gem sources" do
 
     it "does not create ./.bundle by default", :bundler => "< 3" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 
@@ -41,7 +41,7 @@ RSpec.describe "bundle install with gem sources" do
 
     it "does not create ./.bundle by default when installing to system gems" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 
@@ -51,7 +51,7 @@ RSpec.describe "bundle install with gem sources" do
 
     it "creates lock files based on the Gemfile name" do
       gemfile bundled_app("OmgFile"), <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", "1.0"
       G
 
@@ -62,7 +62,7 @@ RSpec.describe "bundle install with gem sources" do
 
     it "doesn't delete the lockfile if one already exists" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem 'rack'
       G
 
@@ -77,7 +77,7 @@ RSpec.describe "bundle install with gem sources" do
 
     it "does not touch the lockfile if nothing changed" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 
@@ -86,7 +86,7 @@ RSpec.describe "bundle install with gem sources" do
 
     it "fetches gems" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem 'rack'
       G
 
@@ -96,7 +96,7 @@ RSpec.describe "bundle install with gem sources" do
 
     it "fetches gems when multiple versions are specified" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem 'rack', "> 0.9", "< 1.0"
       G
 
@@ -106,7 +106,7 @@ RSpec.describe "bundle install with gem sources" do
 
     it "fetches gems when multiple versions are specified take 2" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem 'rack', "< 1.0", "> 0.9"
       G
 
@@ -116,7 +116,7 @@ RSpec.describe "bundle install with gem sources" do
 
     it "raises an appropriate error when gems are specified using symbols" do
       install_gemfile(<<-G)
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem :rack
       G
       expect(exitstatus).to eq(4) if exitstatus
@@ -124,7 +124,7 @@ RSpec.describe "bundle install with gem sources" do
 
     it "pulls in dependencies" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rails"
       G
 
@@ -133,7 +133,7 @@ RSpec.describe "bundle install with gem sources" do
 
     it "does the right version" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", "0.9.1"
       G
 
@@ -142,7 +142,7 @@ RSpec.describe "bundle install with gem sources" do
 
     it "does not install the development dependency" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "with_development_dependency"
       G
 
@@ -152,7 +152,7 @@ RSpec.describe "bundle install with gem sources" do
 
     it "resolves correctly" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "activemerchant"
         gem "rails"
       G
@@ -162,12 +162,12 @@ RSpec.describe "bundle install with gem sources" do
 
     it "activates gem correctly according to the resolved gems" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "activesupport", "2.3.5"
       G
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "activemerchant"
         gem "rails"
       G
@@ -185,7 +185,7 @@ RSpec.describe "bundle install with gem sources" do
       end
 
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "activerecord", "2.3.2"
       G
 
@@ -195,7 +195,7 @@ RSpec.describe "bundle install with gem sources" do
     it "works when the gemfile specifies gems that only exist in the system" do
       build_gem "foo", :to_bundle => true
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
         gem "foo"
       G
@@ -209,7 +209,7 @@ RSpec.describe "bundle install with gem sources" do
       end
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 
@@ -219,7 +219,7 @@ RSpec.describe "bundle install with gem sources" do
     describe "with a gem that installs multiple platforms" do
       it "installs gems for the local platform as first choice" do
         install_gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "platform_specific"
         G
 
@@ -230,7 +230,7 @@ RSpec.describe "bundle install with gem sources" do
       it "falls back on plain ruby" do
         simulate_platform "foo-bar-baz"
         install_gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "platform_specific"
         G
 
@@ -241,7 +241,7 @@ RSpec.describe "bundle install with gem sources" do
       it "installs gems for java" do
         simulate_platform "java"
         install_gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "platform_specific"
         G
 
@@ -253,7 +253,7 @@ RSpec.describe "bundle install with gem sources" do
         simulate_platform mswin
 
         install_gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "platform_specific"
         G
 
@@ -265,7 +265,7 @@ RSpec.describe "bundle install with gem sources" do
     describe "doing bundle install foo" do
       before do
         gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "rack"
         G
       end
@@ -295,8 +295,8 @@ RSpec.describe "bundle install with gem sources" do
       update_repo2
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo1)}"
+        source "#{file_uri_for(gem_repo2)}"
 
         gem "activesupport", "1.2.3"
         gem "rack", "1.2"
@@ -324,7 +324,7 @@ RSpec.describe "bundle install with gem sources" do
     context "throws a warning if a gem is added twice in Gemfile" do
       it "without version requirements" do
         install_gemfile <<-G
-          source "file://#{gem_repo2}"
+          source "#{file_uri_for(gem_repo2)}"
           gem "rack"
           gem "rack"
         G
@@ -336,7 +336,7 @@ RSpec.describe "bundle install with gem sources" do
 
       it "with same versions" do
         install_gemfile <<-G
-          source "file://#{gem_repo2}"
+          source "#{file_uri_for(gem_repo2)}"
           gem "rack", "1.0"
           gem "rack", "1.0"
         G
@@ -350,7 +350,7 @@ RSpec.describe "bundle install with gem sources" do
     context "throws an error if a gem is added twice in Gemfile" do
       it "when version of one dependency is not specified" do
         install_gemfile <<-G
-          source "file://#{gem_repo2}"
+          source "#{file_uri_for(gem_repo2)}"
           gem "rack"
           gem "rack", "1.0"
         G
@@ -361,7 +361,7 @@ RSpec.describe "bundle install with gem sources" do
 
       it "when different versions of both dependencies are specified" do
         install_gemfile <<-G
-          source "file://#{gem_repo2}"
+          source "#{file_uri_for(gem_repo2)}"
           gem "rack", "1.0"
           gem "rack", "1.1"
         G
@@ -373,7 +373,7 @@ RSpec.describe "bundle install with gem sources" do
 
     it "gracefully handles error when rubygems server is unavailable" do
       install_gemfile <<-G, :artifice => nil
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         source "http://0.0.0.0:9384" do
           gem 'foo'
         end
@@ -398,14 +398,14 @@ RSpec.describe "bundle install with gem sources" do
       end
 
       install_gemfile <<-G, :full_index => true
-        source "file:\/\/localhost#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
 
         gem "ajp-rails", "0.0.0"
       G
 
       expect(last_command.stdboth).not_to match(/Error Report/i)
       expect(err).to include("An error occurred while installing ajp-rails (0.0.0), and Bundler cannot continue.").
-        and include(normalize_uri_file("Make sure that `gem install ajp-rails -v '0.0.0' --source 'file://localhost#{gem_repo2}/'` succeeds before bundling."))
+        and include("Make sure that `gem install ajp-rails -v '0.0.0' --source '#{file_uri_for(gem_repo2)}/'` succeeds before bundling.")
     end
 
     it "doesn't blow up when the local .bundle/config is empty" do
@@ -413,7 +413,7 @@ RSpec.describe "bundle install with gem sources" do
       FileUtils.touch(bundled_app(".bundle/config"))
 
       install_gemfile(<<-G)
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
 
         gem 'foo'
       G
@@ -425,7 +425,7 @@ RSpec.describe "bundle install with gem sources" do
       FileUtils.touch("#{Bundler.rubygems.user_home}/.bundle/config")
 
       install_gemfile(<<-G)
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
 
         gem 'foo'
       G
@@ -538,7 +538,7 @@ RSpec.describe "bundle install with gem sources" do
     before do
       FileUtils.mkdir_p(bundled_app("vendor"))
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem 'rack'
       G
     end
@@ -555,7 +555,7 @@ RSpec.describe "bundle install with gem sources" do
   context "after installing with --standalone" do
     before do
       install_gemfile! <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
       forgotten_command_line_options(:path => "bundle")

--- a/spec/commands/issue_spec.rb
+++ b/spec/commands/issue_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe "bundle issue" do
   it "exits with a message" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rails"
     G
 

--- a/spec/commands/licenses_spec.rb
+++ b/spec/commands/licenses_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe "bundle licenses" do
   before :each do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rails"
       gem "with_license"
     G
@@ -18,7 +18,7 @@ RSpec.describe "bundle licenses" do
 
   it "performs an automatic bundle install" do
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rails"
       gem "with_license"
       gem "foo"

--- a/spec/commands/list_spec.rb
+++ b/spec/commands/list_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "bundle list" do
   describe "with without-group option" do
     before do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
 
         gem "rack"
         gem "rspec", :group => [:test]
@@ -48,7 +48,7 @@ RSpec.describe "bundle list" do
   describe "with only-group option" do
     before do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
 
         gem "rack"
         gem "rspec", :group => [:test]
@@ -76,7 +76,7 @@ RSpec.describe "bundle list" do
   context "with name-only option" do
     before do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
 
         gem "rack"
         gem "rspec", :group => [:test]
@@ -104,7 +104,7 @@ RSpec.describe "bundle list" do
       end
 
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "rack"
         gem "rails"
         gem "git_test", :git => "#{lib_path("git_test")}"
@@ -124,7 +124,7 @@ RSpec.describe "bundle list" do
   context "when no gems are in the gemfile" do
     before do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
       G
     end
 
@@ -137,7 +137,7 @@ RSpec.describe "bundle list" do
   context "without options" do
     before do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
 
         gem "rack"
         gem "rspec", :group => [:test]
@@ -153,7 +153,7 @@ RSpec.describe "bundle list" do
   context "when using the ls alias" do
     before do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
 
         gem "rack"
         gem "rspec", :group => [:test]

--- a/spec/commands/lock_spec.rb
+++ b/spec/commands/lock_spec.rb
@@ -13,15 +13,15 @@ RSpec.describe "bundle lock" do
 
   before :each do
     gemfile <<-G
-      source "file://localhost#{repo}"
+      source "#{file_uri_for(repo)}"
       gem "rails"
       gem "with_license"
       gem "foo"
     G
 
-    @lockfile = strip_lockfile(normalize_uri_file(<<-L))
+    @lockfile = strip_lockfile(<<-L)
       GEM
-        remote: file://localhost#{repo}/
+        remote: #{file_uri_for(repo)}/
         specs:
           actionmailer (2.3.2)
             activesupport (= 2.3.2)
@@ -91,12 +91,12 @@ RSpec.describe "bundle lock" do
 
   it "works with --gemfile flag" do
     create_file "CustomGemfile", <<-G
-      source "file://localhost#{repo}"
+      source "#{file_uri_for(repo)}"
       gem "foo"
     G
-    lockfile = strip_lockfile(normalize_uri_file(<<-L))
+    lockfile = strip_lockfile(<<-L)
       GEM
-        remote: file://localhost#{repo}/
+        remote: #{file_uri_for(repo)}/
         specs:
           foo (1.0)
 
@@ -151,7 +151,7 @@ RSpec.describe "bundle lock" do
 
   it "can lock without downloading gems" do
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "thin"
       gem "rack_middleware", :group => "test"
@@ -182,7 +182,7 @@ RSpec.describe "bundle lock" do
 
       # establish a lockfile set to 1.4.3
       install_gemfile <<-G
-        source "file://#{gem_repo4}"
+        source "#{file_uri_for(gem_repo4)}"
         gem 'foo', '1.4.3'
         gem 'bar', '2.0.3'
         gem 'qux', '1.0.0'
@@ -191,7 +191,7 @@ RSpec.describe "bundle lock" do
       # remove 1.4.3 requirement and bar altogether
       # to setup update specs below
       gemfile <<-G
-        source "file://#{gem_repo4}"
+        source "#{file_uri_for(gem_repo4)}"
         gem 'foo'
         gem 'qux'
       G
@@ -276,7 +276,7 @@ RSpec.describe "bundle lock" do
     end
 
     gemfile <<-G
-      source "file://localhost#{gem_repo4}"
+      source "#{file_uri_for(gem_repo4)}"
 
       gem "mixlib-shellout"
       gem "gssapi"
@@ -284,9 +284,9 @@ RSpec.describe "bundle lock" do
 
     simulate_platform(mingw) { bundle! :lock }
 
-    expect(the_bundle.lockfile).to read_as(normalize_uri_file(strip_whitespace(<<-G)))
+    expect(the_bundle.lockfile).to read_as(strip_whitespace(<<-G))
       GEM
-        remote: file://localhost#{gem_repo4}/
+        remote: #{file_uri_for(gem_repo4)}/
         specs:
           ffi (1.9.14-x86-mingw32)
           gssapi (1.2.0)
@@ -309,9 +309,9 @@ RSpec.describe "bundle lock" do
 
     simulate_platform(rb) { bundle! :lock }
 
-    expect(the_bundle.lockfile).to read_as(normalize_uri_file(strip_whitespace(<<-G)))
+    expect(the_bundle.lockfile).to read_as(strip_whitespace(<<-G))
       GEM
-        remote: file://localhost#{gem_repo4}/
+        remote: #{file_uri_for(gem_repo4)}/
         specs:
           ffi (1.9.14)
           ffi (1.9.14-x86-mingw32)

--- a/spec/commands/open_spec.rb
+++ b/spec/commands/open_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe "bundle open" do
   before :each do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rails"
     G
   end
@@ -38,7 +38,7 @@ RSpec.describe "bundle open" do
     ref = git.ref_for("master", 11)
 
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem 'foo', :git => "#{lib_path("foo-1.0")}"
     G
 
@@ -75,7 +75,7 @@ RSpec.describe "bundle open" do
 
   it "performs an automatic bundle install" do
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rails"
       gem "foo"
     G

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "bundle outdated" do
     end
 
     install_gemfile <<-G
-      source "file://#{gem_repo2}"
+      source "#{file_uri_for(gem_repo2)}"
       gem "zebra", :git => "#{lib_path("zebra")}"
       gem "foo", :git => "#{lib_path("foo")}"
       gem "activesupport", "2.3.5"
@@ -57,7 +57,7 @@ RSpec.describe "bundle outdated" do
 
     it "adds gem group to dependency output when repo is updated" do
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
 
         gem "terranova", '8'
 
@@ -78,7 +78,7 @@ RSpec.describe "bundle outdated" do
   describe "with --group option" do
     def test_group_option(group = nil, gems_list_size = 1)
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
 
         gem "weakling", "~> 0.0.1"
         gem "terranova", '8'
@@ -104,7 +104,7 @@ RSpec.describe "bundle outdated" do
 
     it "not outdated gems" do
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
 
         gem "weakling", "~> 0.0.1"
         gem "terranova", '8'
@@ -155,7 +155,7 @@ RSpec.describe "bundle outdated" do
   describe "with --groups option" do
     it "not outdated gems" do
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
 
         gem "weakling", "~> 0.0.1"
         gem "terranova", '8'
@@ -171,7 +171,7 @@ RSpec.describe "bundle outdated" do
 
     it "returns a sorted list of outdated gems by groups" do
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
 
         gem "weakling", "~> 0.0.1"
         gem "terranova", '8'
@@ -209,7 +209,7 @@ RSpec.describe "bundle outdated" do
       bundle! "config set clean false"
 
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "activesupport", "2.3.4"
       G
 
@@ -307,7 +307,7 @@ RSpec.describe "bundle outdated" do
         end
 
         install_gemfile <<-G
-          source "file://#{gem_repo2}"
+          source "#{file_uri_for(gem_repo2)}"
           gem "activesupport", "3.0.0.beta.1"
         G
 
@@ -333,7 +333,7 @@ RSpec.describe "bundle outdated" do
 
     it "only reports gem dependencies when they can actually be updated" do
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "rack_middleware", "1.0"
       G
 
@@ -345,7 +345,7 @@ RSpec.describe "bundle outdated" do
     describe "and filter options" do
       it "only reports gems that match requirement and patch filter level" do
         install_gemfile <<-G
-          source "file://#{gem_repo2}"
+          source "#{file_uri_for(gem_repo2)}"
           gem "activesupport", "~> 2.3"
           gem "weakling", ">= 0.0.1"
         G
@@ -363,7 +363,7 @@ RSpec.describe "bundle outdated" do
 
       it "only reports gems that match requirement and minor filter level" do
         install_gemfile <<-G
-          source "file://#{gem_repo2}"
+          source "#{file_uri_for(gem_repo2)}"
           gem "activesupport", "~> 2.3"
           gem "weakling", ">= 0.0.1"
         G
@@ -381,7 +381,7 @@ RSpec.describe "bundle outdated" do
 
       it "only reports gems that match requirement and major filter level" do
         install_gemfile <<-G
-          source "file://#{gem_repo2}"
+          source "#{file_uri_for(gem_repo2)}"
           gem "activesupport", "~> 2.3"
           gem "weakling", ">= 0.0.1"
         G
@@ -413,7 +413,7 @@ RSpec.describe "bundle outdated" do
 
   it "performs an automatic bundle install" do
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack", "0.9.1"
       gem "foo"
     G
@@ -426,7 +426,7 @@ RSpec.describe "bundle outdated" do
   context "after bundle install --deployment", :bundler => "< 3" do
     before do
       install_gemfile <<-G, forgotten_command_line_options(:deployment => true)
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
 
         gem "rack"
         gem "foo"
@@ -448,7 +448,7 @@ RSpec.describe "bundle outdated" do
   context "after bundle config set deployment true" do
     before do
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
 
         gem "rack"
         gem "foo"
@@ -471,7 +471,7 @@ RSpec.describe "bundle outdated" do
   context "update available for a gem on a different platform" do
     before do
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "laduradura", '= 5.15.2'
       G
     end
@@ -485,7 +485,7 @@ RSpec.describe "bundle outdated" do
   context "update available for a gem on the same platform while multiple platforms used for gem" do
     it "reports that updates are available if the Ruby platform is used" do
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "laduradura", '= 5.15.2', :platforms => [:ruby, :jruby]
       G
 
@@ -497,7 +497,7 @@ RSpec.describe "bundle outdated" do
       simulate_ruby_engine "jruby", "1.6.7" do
         simulate_platform "jruby" do
           install_gemfile <<-G
-            source "file://#{gem_repo2}"
+            source "#{file_uri_for(gem_repo2)}"
             gem "laduradura", '= 5.15.2', :platforms => [:ruby, :jruby]
           G
 
@@ -676,7 +676,7 @@ RSpec.describe "bundle outdated" do
 
         # establish a lockfile set to 1.0.0
         install_gemfile <<-G
-        source "file://#{gem_repo4}"
+        source "#{file_uri_for(gem_repo4)}"
         gem 'patch', '1.0.0'
         gem 'minor', '1.0.0'
         gem 'major', '1.0.0'
@@ -685,7 +685,7 @@ RSpec.describe "bundle outdated" do
         # remove 1.4.3 requirement and bar altogether
         # to setup update specs below
         gemfile <<-G
-        source "file://#{gem_repo4}"
+        source "#{file_uri_for(gem_repo4)}"
         gem 'patch'
         gem 'minor'
         gem 'major'
@@ -744,7 +744,7 @@ RSpec.describe "bundle outdated" do
 
         # establish a lockfile set to 1.4.3
         install_gemfile <<-G
-          source "file://#{gem_repo4}"
+          source "#{file_uri_for(gem_repo4)}"
           gem 'foo', '1.4.3'
           gem 'bar', '2.0.3'
           gem 'qux', '1.0.0'
@@ -753,7 +753,7 @@ RSpec.describe "bundle outdated" do
         # remove 1.4.3 requirement and bar altogether
         # to setup update specs below
         gemfile <<-G
-          source "file://#{gem_repo4}"
+          source "#{file_uri_for(gem_repo4)}"
           gem 'foo'
           gem 'qux'
         G
@@ -779,13 +779,13 @@ RSpec.describe "bundle outdated" do
       end
 
       install_gemfile <<-G
-        source "file://#{gem_repo4}"
+        source "#{file_uri_for(gem_repo4)}"
         gem 'weakling', '0.2'
         gem 'bar', '2.1'
       G
 
       gemfile  <<-G
-        source "file://#{gem_repo4}"
+        source "#{file_uri_for(gem_repo4)}"
         gem 'weakling'
       G
 

--- a/spec/commands/package_spec.rb
+++ b/spec/commands/package_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "bundle package" do
   context "with --gemfile" do
     it "finds the gemfile" do
       gemfile bundled_app("NotGemfile"), <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem 'rack'
       G
 
@@ -19,7 +19,7 @@ RSpec.describe "bundle package" do
     context "without a gemspec" do
       it "caches all dependencies except bundler itself" do
         gemfile <<-D
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem 'rack'
           gem 'bundler'
         D
@@ -49,7 +49,7 @@ RSpec.describe "bundle package" do
 
         it "caches all dependencies except bundler and the gemspec specified gem" do
           gemfile <<-D
-            source "file://#{gem_repo1}"
+            source "#{file_uri_for(gem_repo1)}"
             gem 'rack'
             gemspec
           D
@@ -80,7 +80,7 @@ RSpec.describe "bundle package" do
 
         it "caches all dependencies except bundler and the gemspec specified gem" do
           gemfile <<-D
-            source "file://#{gem_repo1}"
+            source "#{file_uri_for(gem_repo1)}"
             gem 'rack'
             gemspec
           D
@@ -123,7 +123,7 @@ RSpec.describe "bundle package" do
 
       it "caches all dependencies except bundler and the gemspec specified gems" do
         gemfile <<-D
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem 'rack'
           gemspec :name => 'mygem'
           gemspec :name => 'mygem_test'
@@ -144,7 +144,7 @@ RSpec.describe "bundle package" do
   context "with --path", :bundler => "< 3" do
     it "sets root directory for gems" do
       gemfile <<-D
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem 'rack'
       D
 
@@ -158,7 +158,7 @@ RSpec.describe "bundle package" do
   context "with --no-install" do
     it "puts the gems in vendor/cache but does not install them" do
       gemfile <<-D
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem 'rack'
       D
 
@@ -170,7 +170,7 @@ RSpec.describe "bundle package" do
 
     it "does not prevent installing gems with bundle install" do
       gemfile <<-D
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem 'rack'
       D
 
@@ -182,7 +182,7 @@ RSpec.describe "bundle package" do
 
     it "does not prevent installing gems with bundle update" do
       gemfile <<-D
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", "1.0.0"
       D
 
@@ -196,7 +196,7 @@ RSpec.describe "bundle package" do
   context "with --all-platforms" do
     it "puts the gems in vendor/cache even for other rubies" do
       gemfile <<-D
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem 'rack', :platforms => :ruby_19
       D
 
@@ -208,7 +208,7 @@ RSpec.describe "bundle package" do
   context "with --frozen" do
     before do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
       bundle "install"
@@ -219,7 +219,7 @@ RSpec.describe "bundle package" do
     it "tries to install with frozen" do
       bundle! "config set deployment true"
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
         gem "rack-obama"
       G
@@ -239,7 +239,7 @@ RSpec.describe "bundle install with gem sources" do
     it "does not hit the remote at all" do
       build_repo2
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "rack"
       G
 
@@ -254,7 +254,7 @@ RSpec.describe "bundle install with gem sources" do
     it "does not hit the remote at all" do
       build_repo2
       install_gemfile! <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "rack"
       G
 
@@ -268,7 +268,7 @@ RSpec.describe "bundle install with gem sources" do
 
     it "does not reinstall already-installed gems" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
       bundle :pack
@@ -285,7 +285,7 @@ RSpec.describe "bundle install with gem sources" do
     it "ignores cached gems for the wrong platform" do
       simulate_platform "java" do
         install_gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "platform_specific"
         G
         bundle :pack
@@ -295,7 +295,7 @@ RSpec.describe "bundle install with gem sources" do
 
       simulate_platform "ruby" do
         install_gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "platform_specific"
         G
         run "require 'platform_specific' ; puts PLATFORM_SPECIFIC"
@@ -305,7 +305,7 @@ RSpec.describe "bundle install with gem sources" do
 
     it "does not update the cache if --no-cache is passed" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
       bundled_app("vendor/cache").mkpath

--- a/spec/commands/post_bundle_message_spec.rb
+++ b/spec/commands/post_bundle_message_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe "post bundle message" do
   before :each do
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack"
       gem "activesupport", "2.3.5", :group => [:emo, :test]
       group :test do
@@ -103,7 +103,7 @@ RSpec.describe "post bundle message" do
     describe "with misspelled or non-existent gem name" do
       it "should report a helpful error message", :bundler => "< 3" do
         install_gemfile <<-G
-          source "file://localhost#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "rack"
           gem "not-a-gem", :group => :development
         G
@@ -112,25 +112,25 @@ RSpec.describe "post bundle message" do
 
       it "should report a helpful error message", :bundler => "3" do
         install_gemfile <<-G
-          source "file://localhost#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "rack"
           gem "not-a-gem", :group => :development
         G
-        expect(err).to include normalize_uri_file(<<-EOS.strip)
-Could not find gem 'not-a-gem' in rubygems repository file://localhost#{gem_repo1}/ or installed locally.
+        expect(err).to include <<-EOS.strip
+Could not find gem 'not-a-gem' in rubygems repository #{file_uri_for(gem_repo1)}/ or installed locally.
 The source does not contain any versions of 'not-a-gem'
         EOS
       end
 
       it "should report a helpful error message with reference to cache if available" do
         install_gemfile <<-G
-          source "file://localhost#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "rack"
         G
         bundle :cache
         expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
         install_gemfile <<-G
-          source "file://localhost#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "rack"
           gem "not-a-gem", :group => :development
         G

--- a/spec/commands/pristine_spec.rb
+++ b/spec/commands/pristine_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "bundle pristine", :ruby_repo do
     end
 
     install_gemfile! <<-G
-      source "file://#{gem_repo2}"
+      source "#{file_uri_for(gem_repo2)}"
       gem "weakling"
       gem "very_simple_binary"
       gem "foo", :git => "#{lib_path("foo")}"

--- a/spec/commands/remove_spec.rb
+++ b/spec/commands/remove_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "bundle remove" do
   context "when no gems are specified" do
     it "throws error" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
       G
 
       bundle "remove"
@@ -16,7 +16,7 @@ RSpec.describe "bundle remove" do
   context "when --install flag is specified" do
     it "removes gems from .bundle" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
 
         gem "rack"
       G
@@ -32,7 +32,7 @@ RSpec.describe "bundle remove" do
     context "when gem is present in gemfile" do
       it "shows success for removed gem" do
         gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
 
           gem "rack"
         G
@@ -41,7 +41,7 @@ RSpec.describe "bundle remove" do
 
         expect(out).to include("rack was removed.")
         gemfile_should_be <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
         G
       end
     end
@@ -49,7 +49,7 @@ RSpec.describe "bundle remove" do
     context "when gem is not present in gemfile" do
       it "shows warning for gem that could not be removed" do
         gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
         G
 
         bundle "remove rack"
@@ -63,7 +63,7 @@ RSpec.describe "bundle remove" do
     context "when all gems are present in gemfile" do
       it "shows success fir all removed gems" do
         gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
 
           gem "rack"
           gem "rails"
@@ -74,7 +74,7 @@ RSpec.describe "bundle remove" do
         expect(out).to include("rack was removed.")
         expect(out).to include("rails was removed.")
         gemfile_should_be <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         G
       end
     end
@@ -82,7 +82,7 @@ RSpec.describe "bundle remove" do
     context "when some gems are not present in the gemfile" do
       it "shows warning for those not present and success for those that can be removed" do
         gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
 
           gem "rails"
           gem "minitest"
@@ -93,7 +93,7 @@ RSpec.describe "bundle remove" do
 
         expect(err).to include("`rack` is not specified in #{bundled_app("Gemfile")} so it could not be removed.")
         gemfile_should_be <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
 
           gem "rails"
           gem "minitest"
@@ -106,7 +106,7 @@ RSpec.describe "bundle remove" do
   context "with inline groups" do
     it "removes the specified gem" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
 
         gem "rack", :group => [:dev]
       G
@@ -115,7 +115,7 @@ RSpec.describe "bundle remove" do
 
       expect(out).to include("rack was removed.")
       gemfile_should_be <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
       G
     end
   end
@@ -124,7 +124,7 @@ RSpec.describe "bundle remove" do
     context "when single group block with gem to be removed is present" do
       it "removes the group block" do
         gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
 
           group :test do
             gem "rspec"
@@ -135,7 +135,7 @@ RSpec.describe "bundle remove" do
 
         expect(out).to include("rspec was removed.")
         gemfile_should_be <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
         G
       end
     end
@@ -143,7 +143,7 @@ RSpec.describe "bundle remove" do
     context "when gem to be removed is outside block" do
       it "does not modify group" do
         gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
 
           gem "rack"
           group :test do
@@ -155,7 +155,7 @@ RSpec.describe "bundle remove" do
 
         expect(out).to include("rack was removed.")
         gemfile_should_be <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
 
           group :test do
             gem "coffee-script-source"
@@ -167,7 +167,7 @@ RSpec.describe "bundle remove" do
     context "when an empty block is also present" do
       it "removes all empty blocks" do
         gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
 
           group :test do
             gem "rspec"
@@ -181,7 +181,7 @@ RSpec.describe "bundle remove" do
 
         expect(out).to include("rspec was removed.")
         gemfile_should_be <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
         G
       end
     end
@@ -189,7 +189,7 @@ RSpec.describe "bundle remove" do
     context "when the gem belongs to mutiple groups" do
       it "removes the groups" do
         gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
 
           group :test, :serioustest do
             gem "rspec"
@@ -200,7 +200,7 @@ RSpec.describe "bundle remove" do
 
         expect(out).to include("rspec was removed.")
         gemfile_should_be <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
         G
       end
     end
@@ -208,7 +208,7 @@ RSpec.describe "bundle remove" do
     context "when the gem is present in mutiple groups" do
       it "removes all empty blocks" do
         gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
 
           group :one do
             gem "rspec"
@@ -223,7 +223,7 @@ RSpec.describe "bundle remove" do
 
         expect(out).to include("rspec was removed.")
         gemfile_should_be <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
         G
       end
     end
@@ -233,7 +233,7 @@ RSpec.describe "bundle remove" do
     context "when all the groups will be empty after removal" do
       it "removes the empty nested blocks" do
         gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
 
           group :test do
             group :serioustest do
@@ -246,7 +246,7 @@ RSpec.describe "bundle remove" do
 
         expect(out).to include("rspec was removed.")
         gemfile_should_be <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
         G
       end
     end
@@ -254,7 +254,7 @@ RSpec.describe "bundle remove" do
     context "when outer group will not be empty after removal" do
       it "removes only empty blocks" do
         install_gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
 
           group :test do
             gem "rack-test"
@@ -269,7 +269,7 @@ RSpec.describe "bundle remove" do
 
         expect(out).to include("rspec was removed.")
         gemfile_should_be <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
 
           group :test do
             gem "rack-test"
@@ -282,7 +282,7 @@ RSpec.describe "bundle remove" do
     context "when inner group will not be empty after removal" do
       it "removes only empty blocks" do
         install_gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
 
           group :test do
             group :serioustest do
@@ -296,7 +296,7 @@ RSpec.describe "bundle remove" do
 
         expect(out).to include("rspec was removed.")
         gemfile_should_be <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
 
           group :test do
             group :serioustest do
@@ -312,7 +312,7 @@ RSpec.describe "bundle remove" do
     context "when mutiple gems are present in same line" do
       it "shows warning for gems not removed" do
         install_gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "rack"; gem "rails"
         G
 
@@ -320,7 +320,7 @@ RSpec.describe "bundle remove" do
 
         expect(err).to include("Gems could not be removed. rack (>= 0) would also have been removed.")
         gemfile_should_be <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "rack"; gem "rails"
         G
       end
@@ -329,7 +329,7 @@ RSpec.describe "bundle remove" do
     context "when some gems could not be removed" do
       it "shows warning for gems not removed and success for those removed" do
         install_gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem"rack"
           gem"rspec"
           gem "rails"
@@ -342,7 +342,7 @@ RSpec.describe "bundle remove" do
         expect(out).to include("minitest was removed.")
         expect(out).to include("rack, rspec could not be removed.")
         gemfile_should_be <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem"rack"
           gem"rspec"
         G
@@ -359,11 +359,11 @@ RSpec.describe "bundle remove" do
 
     it "removes gems and empty source blocks" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
 
         gem "rack"
 
-        source "file://#{gem_repo3}" do
+        source "#{file_uri_for(gem_repo3)}" do
           gem "rspec"
         end
       G
@@ -374,7 +374,7 @@ RSpec.describe "bundle remove" do
 
       expect(out).to include("rspec was removed.")
       gemfile_should_be <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
 
         gem "rack"
       G
@@ -389,7 +389,7 @@ RSpec.describe "bundle remove" do
         G
 
         install_gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
 
           eval_gemfile "Gemfile-other"
 
@@ -409,7 +409,7 @@ RSpec.describe "bundle remove" do
         G
 
         install_gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
 
           eval_gemfile "Gemfile-other"
         G
@@ -429,7 +429,7 @@ RSpec.describe "bundle remove" do
         G
 
         install_gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
 
           eval_gemfile "Gemfile-other"
         G
@@ -447,7 +447,7 @@ RSpec.describe "bundle remove" do
         G
 
         install_gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
 
           eval_gemfile "Gemfile-other"
           gem "rack"
@@ -458,7 +458,7 @@ RSpec.describe "bundle remove" do
         expect(out).to include("rack was removed.")
         expect(err).to include("`rack` is not specified in #{bundled_app("Gemfile-other")} so it could not be removed.")
         gemfile_should_be <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
 
           eval_gemfile "Gemfile-other"
         G
@@ -472,7 +472,7 @@ RSpec.describe "bundle remove" do
         G
 
         install_gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
 
           eval_gemfile "Gemfile-other"
           gem "rack"
@@ -483,7 +483,7 @@ RSpec.describe "bundle remove" do
         expect(out).to include("rack was removed.")
         expect(err).to include("Gems could not be removed. rails (>= 0) would also have been removed.")
         gemfile_should_be <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
 
           eval_gemfile "Gemfile-other"
         G
@@ -497,7 +497,7 @@ RSpec.describe "bundle remove" do
         G
 
         install_gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
 
           eval_gemfile "Gemfile-other"
           gem "rails"; gem "rack"
@@ -508,7 +508,7 @@ RSpec.describe "bundle remove" do
         expect(err).to include("Gems could not be removed. rails (>= 0) would also have been removed.")
         expect(bundled_app("Gemfile-other").read).to include("gem \"rack\"")
         gemfile_should_be <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
 
           eval_gemfile "Gemfile-other"
           gem "rails"; gem "rack"
@@ -523,7 +523,7 @@ RSpec.describe "bundle remove" do
         G
 
         install_gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
 
           eval_gemfile "Gemfile-other"
           gem"rack"
@@ -540,7 +540,7 @@ RSpec.describe "bundle remove" do
   context "with install_if" do
     it "removes gems inside blocks and empty blocks" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
 
         install_if(lambda { false }) do
           gem "rack"
@@ -551,7 +551,7 @@ RSpec.describe "bundle remove" do
 
       expect(out).to include("rack was removed.")
       gemfile_should_be <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
       G
     end
   end
@@ -559,7 +559,7 @@ RSpec.describe "bundle remove" do
   context "with env" do
     it "removes gems inside blocks and empty blocks" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
 
         env "BUNDLER_TEST" do
           gem "rack"
@@ -570,7 +570,7 @@ RSpec.describe "bundle remove" do
 
       expect(out).to include("rack was removed.")
       gemfile_should_be <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
       G
     end
   end
@@ -583,7 +583,7 @@ RSpec.describe "bundle remove" do
       end
 
       install_gemfile(<<-G)
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gemspec :path => '#{tmp.join("foo")}', :name => 'foo'
       G
 

--- a/spec/commands/show_spec.rb
+++ b/spec/commands/show_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
   context "with a standard Gemfile" do
     before :each do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rails"
       G
     end
@@ -156,7 +156,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
 
   it "performs an automatic bundle install" do
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo"
     G
 
@@ -168,7 +168,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
   context "with a valid regexp for gem name" do
     it "presents alternatives", :ruby_repo do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
         gem "rack-obama"
       G
@@ -181,7 +181,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
   context "with an invalid regexp for gem name" do
     it "does not find the gem" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rails"
       G
 
@@ -200,7 +200,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
 
     it "doesn't update gems to newer versions" do
       install_gemfile! <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "rails"
       G
 

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "bundle update" do
     build_repo2
 
     install_gemfile <<-G
-      source "file://#{gem_repo2}"
+      source "#{file_uri_for(gem_repo2)}"
       gem "activesupport"
       gem "rack-obama"
       gem "platform_specific"
@@ -25,7 +25,7 @@ RSpec.describe "bundle update" do
 
     it "doesn't delete the Gemfile.lock file if something goes wrong" do
       gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "activesupport"
         gem "rack-obama"
         exit!
@@ -48,7 +48,7 @@ RSpec.describe "bundle update" do
 
     it "doesn't delete the Gemfile.lock file if something goes wrong" do
       gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "activesupport"
         gem "rack-obama"
         exit!
@@ -61,7 +61,7 @@ RSpec.describe "bundle update" do
   describe "with --gemfile" do
     it "creates lock files based on the Gemfile name" do
       gemfile bundled_app("OmgFile"), <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", "1.0"
       G
 
@@ -154,7 +154,7 @@ RSpec.describe "bundle update" do
         end
 
         install_gemfile! <<-G
-          source "file:#{gem_repo4}"
+          source "#{file_uri_for(gem_repo4)}"
           gem "slim-rails"
           gem "slim_lint"
         G
@@ -180,7 +180,7 @@ RSpec.describe "bundle update" do
         end
 
         install_gemfile! <<-G
-          source "file:#{gem_repo4}"
+          source "#{file_uri_for(gem_repo4)}"
           gem "a"
           gem "b"
         G
@@ -188,7 +188,7 @@ RSpec.describe "bundle update" do
         expect(the_bundle).to include_gems("a 1.0", "b 2.0")
 
         gemfile <<-G
-          source "file://#{gem_repo4}"
+          source "#{file_uri_for(gem_repo4)}"
           gem "a"
           gem "b", "1.0"
         G
@@ -212,7 +212,7 @@ RSpec.describe "bundle update" do
   describe "with --group option" do
     it "should update only specified group gems" do
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "activesupport", :group => :development
         gem "rack"
       G
@@ -227,7 +227,7 @@ RSpec.describe "bundle update" do
     context "when conservatively updating a group with non-group sub-deps" do
       it "should update only specified group gems" do
         install_gemfile <<-G
-          source "file://#{gem_repo2}"
+          source "#{file_uri_for(gem_repo2)}"
           gem "activemerchant", :group => :development
           gem "activesupport"
         G
@@ -245,7 +245,7 @@ RSpec.describe "bundle update" do
       before :each do
         build_git "foo", :path => lib_path("activesupport")
         install_gemfile <<-G
-          source "file://#{gem_repo2}"
+          source "#{file_uri_for(gem_repo2)}"
           gem "activesupport", :group => :development
           gem "foo", :git => "#{lib_path("activesupport")}"
         G
@@ -264,7 +264,7 @@ RSpec.describe "bundle update" do
     context "when bundler itself is a transitive dependency" do
       it "executes without error" do
         install_gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "activesupport", :group => :development
           gem "rack"
         G
@@ -307,7 +307,7 @@ RSpec.describe "bundle update" do
   describe "with --source option" do
     it "should not update gems not included in the source that happen to have the same name", :bundler => "< 3" do
       install_gemfile! <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "activesupport"
       G
       update_repo2 { build_gem "activesupport", "3.0" }
@@ -318,7 +318,7 @@ RSpec.describe "bundle update" do
 
     it "should not update gems not included in the source that happen to have the same name", :bundler => "3" do
       install_gemfile! <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "activesupport"
       G
       update_repo2 { build_gem "activesupport", "3.0" }
@@ -332,7 +332,7 @@ RSpec.describe "bundle update" do
 
       it "should not update gems not included in the source that happen to have the same name" do
         install_gemfile <<-G
-          source "file://#{gem_repo2}"
+          source "#{file_uri_for(gem_repo2)}"
           gem "activesupport"
         G
         update_repo2 { build_gem "activesupport", "3.0" }
@@ -353,7 +353,7 @@ RSpec.describe "bundle update" do
       end
 
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "harry"
         gem "fred"
       G
@@ -398,7 +398,7 @@ RSpec.describe "bundle update" do
       end
 
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "harry"
         gem "fred"
       G
@@ -439,7 +439,7 @@ RSpec.describe "bundle update in more complicated situations" do
 
   it "will eagerly unlock dependencies of a specified gem" do
     install_gemfile <<-G
-      source "file://#{gem_repo2}"
+      source "#{file_uri_for(gem_repo2)}"
 
       gem "thin"
       gem "rack-obama"
@@ -457,7 +457,7 @@ RSpec.describe "bundle update in more complicated situations" do
 
   it "will warn when some explicitly updated gems are not updated" do
     install_gemfile! <<-G
-      source "file:#{gem_repo2}"
+      source "#{file_uri_for(gem_repo2)}"
 
       gem "thin"
       gem "rack-obama"
@@ -497,7 +497,7 @@ RSpec.describe "bundle update in more complicated situations" do
     G
 
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack"
     G
 
@@ -508,9 +508,9 @@ RSpec.describe "bundle update in more complicated situations" do
 
   it "will update only from pinned source" do
     install_gemfile <<-G
-      source "file://#{gem_repo2}"
+      source "#{file_uri_for(gem_repo2)}"
 
-      source "file://#{gem_repo1}" do
+      source "#{file_uri_for(gem_repo1)}" do
         gem "thin"
       end
     G
@@ -533,13 +533,13 @@ RSpec.describe "bundle update in more complicated situations" do
       end
 
       gemfile <<-G
-        source "file://#{gem_repo4}"
+        source "#{file_uri_for(gem_repo4)}"
         gem "a"
       G
 
       lockfile <<-L
         GEM
-          remote: file://#{gem_repo4}
+          remote: #{file_uri_for(gem_repo4)}
           specs:
             a (0.9-java)
 
@@ -572,13 +572,13 @@ RSpec.describe "bundle update in more complicated situations" do
       end
 
       gemfile <<-G
-        source "file://#{gem_repo4}"
+        source "#{file_uri_for(gem_repo4)}"
         gem "a", platform: :jruby
       G
 
       lockfile <<-L
         GEM
-          remote: file://#{gem_repo4}
+          remote: #{file_uri_for(gem_repo4)}
           specs:
             a (0.9-java)
 
@@ -605,7 +605,7 @@ RSpec.describe "bundle update without a Gemfile.lock" do
     build_repo2
 
     gemfile <<-G
-      source "file://#{gem_repo2}"
+      source "#{file_uri_for(gem_repo2)}"
 
       gem "rack", "1.0"
     G
@@ -625,7 +625,7 @@ RSpec.describe "bundle update when a gem depends on a newer version of bundler" 
     end
 
     gemfile <<-G
-      source "file://#{gem_repo2}"
+      source "#{file_uri_for(gem_repo2)}"
       gem "rails", "3.0.1"
     G
   end
@@ -650,7 +650,7 @@ RSpec.describe "bundle update" do
     build_repo2
 
     install_gemfile <<-G
-      source "file://#{gem_repo2}"
+      source "#{file_uri_for(gem_repo2)}"
       gem "activesupport"
     G
 
@@ -675,7 +675,7 @@ RSpec.describe "bundle update" do
       end
 
       install_gemfile! <<-G
-        source "file://#{gem_repo4}"
+        source "#{file_uri_for(gem_repo4)}"
         gem "bar"
         gem "foo"
       G
@@ -702,7 +702,7 @@ RSpec.describe "bundle update" do
 
   it "shows error message when Gemfile.lock is not preset and gem is specified" do
     install_gemfile <<-G
-      source "file://#{gem_repo2}"
+      source "#{file_uri_for(gem_repo2)}"
       gem "activesupport"
     G
 
@@ -828,7 +828,7 @@ RSpec.describe "bundle update --bundler" do
     end
 
     install_gemfile! <<-G
-      source "file:#{gem_repo4}"
+      source "#{file_uri_for(gem_repo4)}"
       gem "rack"
     G
     lockfile lockfile.sub(/(^\s*)#{Bundler::VERSION}($)/, '\11.0.0\2')
@@ -862,7 +862,7 @@ RSpec.describe "bundle update conservative" do
 
       # establish a lockfile set to 1.4.3
       install_gemfile <<-G
-        source "file://#{gem_repo4}"
+        source "#{file_uri_for(gem_repo4)}"
         gem 'foo', '1.4.3'
         gem 'bar', '2.0.3'
         gem 'qux', '1.0.0'
@@ -871,7 +871,7 @@ RSpec.describe "bundle update conservative" do
       # remove 1.4.3 requirement and bar altogether
       # to setup update specs below
       gemfile <<-G
-        source "file://#{gem_repo4}"
+        source "#{file_uri_for(gem_repo4)}"
         gem 'foo'
         gem 'qux'
       G
@@ -941,7 +941,7 @@ RSpec.describe "bundle update conservative" do
       end
 
       gemfile <<-G
-        source "file://#{gem_repo4}"
+        source "#{file_uri_for(gem_repo4)}"
         gem 'isolated_owner'
 
         gem 'shared_owner_a'
@@ -950,7 +950,7 @@ RSpec.describe "bundle update conservative" do
 
       lockfile <<-L
         GEM
-          remote: file://#{gem_repo4}
+          remote: #{file_uri_for(gem_repo4)}
           specs:
             isolated_dep (2.0.1)
             isolated_owner (1.0.1)
@@ -994,7 +994,7 @@ RSpec.describe "bundle update conservative" do
 
     it "should match bundle install conservative update behavior when not eagerly unlocking" do
       gemfile <<-G
-        source "file://#{gem_repo4}"
+        source "#{file_uri_for(gem_repo4)}"
         gem 'isolated_owner', '1.0.2'
 
         gem 'shared_owner_a', '3.0.2'

--- a/spec/commands/viz_spec.rb
+++ b/spec/commands/viz_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "bundle viz", :bundler => "< 3", :if => Bundler.which("dot") do
 
   it "graphs gems from the Gemfile" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack"
       gem "rack-obama"
     G
@@ -46,7 +46,7 @@ RSpec.describe "bundle viz", :bundler => "< 3", :if => Bundler.which("dot") do
     end
 
     install_gemfile <<-G
-      source "file://#{gem_repo2}"
+      source "#{file_uri_for(gem_repo2)}"
       gem "rack", "= 1.3.pre"
       gem "rack-obama"
     G
@@ -87,7 +87,7 @@ RSpec.describe "bundle viz", :bundler => "< 3", :if => Bundler.which("dot") do
 
     it "loads the correct ruby-graphviz gem" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
         gem "rack-obama"
       G
@@ -116,7 +116,7 @@ RSpec.describe "bundle viz", :bundler => "< 3", :if => Bundler.which("dot") do
   context "--without option" do
     it "one group" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "activesupport"
 
         group :rails do
@@ -130,7 +130,7 @@ RSpec.describe "bundle viz", :bundler => "< 3", :if => Bundler.which("dot") do
 
     it "two groups" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "activesupport"
 
         group :rack do

--- a/spec/install/binstubs_spec.rb
+++ b/spec/install/binstubs_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "bundle install" do
       gemfile <<-G
         require 'rubygems'
         def Gem.bindir; "/usr/bin"; end
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 
@@ -29,7 +29,7 @@ RSpec.describe "bundle install" do
       end
 
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "fake"
         gem "rack"
       G

--- a/spec/install/bundler_spec.rb
+++ b/spec/install/bundler_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "bundle install" do
 
     it "are forced to the current bundler version" do
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "rails", "3.0"
       G
 
@@ -23,7 +23,7 @@ RSpec.describe "bundle install" do
 
     it "are not added if not already present" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
       expect(the_bundle).not_to include_gems "bundler #{Bundler::VERSION}"
@@ -31,7 +31,7 @@ RSpec.describe "bundle install" do
 
     it "causes a conflict if explicitly requesting a different version" do
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "rails", "3.0"
         gem "bundler", "0.9.2"
       G
@@ -53,13 +53,13 @@ RSpec.describe "bundle install" do
 
     it "works for gems with multiple versions in its dependencies" do
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
 
         gem "multiple_versioned_deps"
       G
 
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
 
         gem "multiple_versioned_deps"
         gem "rack"
@@ -70,7 +70,7 @@ RSpec.describe "bundle install" do
 
     it "includes bundler in the bundle when it's a child dependency" do
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "rails", "3.0"
       G
 
@@ -80,7 +80,7 @@ RSpec.describe "bundle install" do
 
     it "allows gem 'bundler' when Bundler is not in the Gemfile or its dependencies" do
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "rack"
       G
 
@@ -90,7 +90,7 @@ RSpec.describe "bundle install" do
 
     it "causes a conflict if child dependencies conflict" do
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "activemerchant"
         gem "rails_fail"
       G
@@ -109,7 +109,7 @@ RSpec.describe "bundle install" do
 
     it "causes a conflict if a child dependency conflicts with the Gemfile" do
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "rails_fail"
         gem "activesupport", "2.3.5"
       G
@@ -128,7 +128,7 @@ RSpec.describe "bundle install" do
     it "can install dependencies with newer bundler version with system gems" do
       bundle! "config set path.system true"
       install_gemfile! <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "rails", "3.0"
       G
 
@@ -141,7 +141,7 @@ RSpec.describe "bundle install" do
     it "can install dependencies with newer bundler version with a local path" do
       bundle! "config set path .bundle"
       install_gemfile! <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "rails", "3.0"
       G
 
@@ -162,7 +162,7 @@ RSpec.describe "bundle install" do
         end
 
         install_gemfile! <<-G
-          source "file://#{gem_repo4}"
+          source "#{file_uri_for(gem_repo4)}"
           gem "requires_nonexistant_bundler"
         G
 

--- a/spec/install/deploy_spec.rb
+++ b/spec/install/deploy_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe "install with --deployment or --frozen" do
   before do
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack"
     G
   end
@@ -94,7 +94,7 @@ RSpec.describe "install with --deployment or --frozen" do
 
   it "works with sources given by a block" do
     install_gemfile! <<-G
-      source "file://#{gem_repo1}" do
+      source "#{file_uri_for(gem_repo1)}" do
         gem "rack"
       end
     G
@@ -123,7 +123,7 @@ RSpec.describe "install with --deployment or --frozen" do
 
     it "explodes with the --deployment flag if you make a change and don't check in the lockfile" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
         gem "rack-obama"
       G
@@ -139,7 +139,7 @@ RSpec.describe "install with --deployment or --frozen" do
     it "works if a path gem is missing but is in a without group" do
       build_lib "path_gem"
       install_gemfile! <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rake"
         gem "path_gem", :path => "#{lib_path("path_gem-1.0")}", :group => :development
       G
@@ -154,7 +154,7 @@ RSpec.describe "install with --deployment or --frozen" do
     it "explodes if a path gem is missing" do
       build_lib "path_gem"
       install_gemfile! <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rake"
         gem "path_gem", :path => "#{lib_path("path_gem-1.0")}", :group => :development
       G
@@ -167,7 +167,7 @@ RSpec.describe "install with --deployment or --frozen" do
 
     it "can have --frozen set via an environment variable", :bundler => "< 3" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
         gem "rack-obama"
       G
@@ -183,7 +183,7 @@ RSpec.describe "install with --deployment or --frozen" do
 
     it "can have --deployment set via an environment variable" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
         gem "rack-obama"
       G
@@ -199,7 +199,7 @@ RSpec.describe "install with --deployment or --frozen" do
 
     it "can have --frozen set to false via an environment variable" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
         gem "rack-obama"
       G
@@ -214,7 +214,7 @@ RSpec.describe "install with --deployment or --frozen" do
 
     it "explodes if you remove a gem and don't check in the lockfile" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "activesupport"
       G
 
@@ -227,7 +227,7 @@ RSpec.describe "install with --deployment or --frozen" do
 
     it "explodes if you add a source" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", :git => "git://hubz.com"
       G
 
@@ -241,12 +241,12 @@ RSpec.describe "install with --deployment or --frozen" do
       build_git "rack"
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", :git => "#{lib_path("rack-1.0")}"
       G
 
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 
@@ -262,13 +262,13 @@ RSpec.describe "install with --deployment or --frozen" do
       build_git "rack", :path => lib_path("rack")
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", :git => "#{lib_path("rack")}"
         gem "foo", :git => "#{lib_path("rack")}"
       G
 
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
         gem "foo", :git => "#{lib_path("rack")}"
       G
@@ -360,7 +360,7 @@ RSpec.describe "install with --deployment or --frozen" do
       bundle! "config set --local deployment true"
 
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", "1.0.0"
         gem "rack-obama"
       G

--- a/spec/install/failure_spec.rb
+++ b/spec/install/failure_spec.rb
@@ -15,12 +15,12 @@ RSpec.describe "bundle install" do
       end
 
       install_gemfile <<-G
-        source "file:\/\/localhost#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "rails"
       G
-      expect(err).to end_with(normalize_uri_file(<<-M.strip))
+      expect(err).to end_with(<<-M.strip)
 An error occurred while installing activesupport (2.3.2), and Bundler cannot continue.
-Make sure that `gem install activesupport -v '2.3.2' --source 'file://localhost#{gem_repo2}/'` succeeds before bundling.
+Make sure that `gem install activesupport -v '2.3.2' --source '#{file_uri_for(gem_repo2)}/'` succeeds before bundling.
 
 In Gemfile:
   rails was resolved to 2.3.2, which depends on
@@ -41,7 +41,7 @@ In Gemfile:
         end
 
         install_gemfile <<-G
-          source "file:\/\/localhost#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "rails"
           gem "activesupport", :git => "#{lib_path("activesupport")}"
         G
@@ -69,7 +69,7 @@ In Gemfile:
         end
 
         install_gemfile <<-G
-          source "file:\/\/localhost#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "rails"
 
           git "#{lib_path("activesupport")}" do
@@ -106,14 +106,14 @@ In Gemfile:
       end
 
       install_gemfile <<-G
-        source "file:\/\/localhost#{gem_repo4}"
-        source "file:\/\/localhost#{gem_repo2}" do
+        source "#{file_uri_for(gem_repo4)}"
+        source "#{file_uri_for(gem_repo2)}" do
           gem "rails"
         end
       G
-      expect(err).to end_with(normalize_uri_file(<<-M.strip))
+      expect(err).to end_with(<<-M.strip)
 An error occurred while installing activesupport (2.3.2), and Bundler cannot continue.
-Make sure that `gem install activesupport -v '2.3.2' --source 'file://localhost#{gem_repo2}/'` succeeds before bundling.
+Make sure that `gem install activesupport -v '2.3.2' --source '#{file_uri_for(gem_repo2)}/'` succeeds before bundling.
 
 In Gemfile:
   rails was resolved to 2.3.2, which depends on
@@ -133,7 +133,7 @@ In Gemfile:
 
       it "removes the downloaded .gem" do
         install_gemfile <<-G
-          source "file:#{gem_repo4}"
+          source "#{file_uri_for(gem_repo4)}"
           gem "a"
         G
 

--- a/spec/install/gemfile/eval_gemfile_spec.rb
+++ b/spec/install/gemfile/eval_gemfile_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "bundle install with gemfile that uses eval_gemfile" do
       create_file "other/Gemfile-other", "gem 'rack'"
       create_file "other/Gemfile", "eval_gemfile 'Gemfile-other'"
       create_file "Gemfile-alt", <<-G
-        source "file:#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         eval_gemfile "other/Gemfile"
       G
       install_gemfile! "eval_gemfile File.expand_path('Gemfile-alt')"

--- a/spec/install/gemfile/gemspec_spec.rb
+++ b/spec/install/gemfile/gemspec_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "bundle install from an existing gemspec" do
       s.add_development_dependency "bar-dev", "=1.0.0"
     end
     install_gemfile <<-G
-      source "file://#{gem_repo2}"
+      source "#{file_uri_for(gem_repo2)}"
       gemspec :path => '#{tmp.join("foo")}'
     G
 
@@ -32,7 +32,7 @@ RSpec.describe "bundle install from an existing gemspec" do
     FileUtils.mv tmp.join("foo", "foo.gemspec"), tmp.join("foo", ".gemspec")
 
     install_gemfile <<-G
-      source "file://#{gem_repo2}"
+      source "#{file_uri_for(gem_repo2)}"
       gemspec :path => '#{tmp.join("foo")}'
     G
 
@@ -51,7 +51,7 @@ RSpec.describe "bundle install from an existing gemspec" do
       s.add_dependency "baz", ">= 1.0", "< 1.1"
     end
     install_gemfile <<-G
-      source "file://#{gem_repo2}"
+      source "#{file_uri_for(gem_repo2)}"
       gemspec :path => '#{tmp.join("foo")}'
     G
 
@@ -62,7 +62,7 @@ RSpec.describe "bundle install from an existing gemspec" do
     build_lib("foo", :path => tmp.join("foo"), :gemspec => false)
 
     install_gemfile(<<-G)
-      source "file://#{gem_repo2}"
+      source "#{file_uri_for(gem_repo2)}"
       gemspec :path => '#{tmp.join("foo")}'
     G
     expect(err).to match(/There are no gemspecs at #{tmp.join('foo')}/)
@@ -74,7 +74,7 @@ RSpec.describe "bundle install from an existing gemspec" do
     end
 
     install_gemfile(<<-G)
-      source "file://#{gem_repo2}"
+      source "#{file_uri_for(gem_repo2)}"
       gemspec :path => '#{tmp.join("foo")}'
     G
     expect(err).to match(/There are multiple gemspecs at #{tmp.join('foo')}/)
@@ -88,7 +88,7 @@ RSpec.describe "bundle install from an existing gemspec" do
     end
 
     install_gemfile(<<-G)
-      source "file://#{gem_repo2}"
+      source "#{file_uri_for(gem_repo2)}"
       gemspec :path => '#{tmp.join("foo")}', :name => 'foo'
     G
 
@@ -104,7 +104,7 @@ RSpec.describe "bundle install from an existing gemspec" do
     end
 
     install_gemfile(<<-G)
-      source "file://#{gem_repo2}"
+      source "#{file_uri_for(gem_repo2)}"
       gemspec :path => '#{tmp.join("foo")}', :name => 'foo', :development_group => :dev
     G
 
@@ -115,7 +115,7 @@ RSpec.describe "bundle install from an existing gemspec" do
 
   it "should match a lockfile even if the gemspec defines development dependencies" do
     build_lib("foo", :path => tmp.join("foo")) do |s|
-      s.write("Gemfile", "source 'file://#{gem_repo1}'\ngemspec")
+      s.write("Gemfile", "source '#{file_uri_for(gem_repo1)}'\ngemspec")
       s.add_dependency "actionpack", "=2.3.2"
       s.add_development_dependency "rake", "=12.3.2"
     end
@@ -140,7 +140,7 @@ RSpec.describe "bundle install from an existing gemspec" do
     end
 
     install_gemfile! <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gemspec :path => '#{tmp.join("foo")}'
     G
 
@@ -159,7 +159,7 @@ RSpec.describe "bundle install from an existing gemspec" do
     end
 
     install_gemfile! <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gemspec :path => '#{tmp.join("foo")}'
     G
 
@@ -231,7 +231,7 @@ RSpec.describe "bundle install from an existing gemspec" do
     build_gem "foo", "0.0.1", :to_bundle => true
 
     install_gemfile <<-G
-      source "file://#{gem_repo2}"
+      source "#{file_uri_for(gem_repo2)}"
       gem "deps"
       gemspec :path => '#{tmp.join("foo")}', :name => 'foo'
     G
@@ -252,7 +252,7 @@ RSpec.describe "bundle install from an existing gemspec" do
     end
 
     install_gemfile! <<-G
-      source "file://#{gem_repo2}"
+      source "#{file_uri_for(gem_repo2)}"
       gem "deps"
       gemspec :path => '#{tmp.join("foo")}', :name => 'foo'
     G
@@ -285,7 +285,7 @@ RSpec.describe "bundle install from an existing gemspec" do
         end
 
         install_gemfile! <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gemspec
         G
 
@@ -318,7 +318,7 @@ RSpec.describe "bundle install from an existing gemspec" do
 
     it "should install the child gemspec's deps" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gemspec
       G
 
@@ -440,7 +440,7 @@ RSpec.describe "bundle install from an existing gemspec" do
         %w[ruby jruby].each do |platform|
           simulate_platform(platform) do
             install_gemfile <<-G
-              source "file://localhost#{gem_repo2}"
+              source "#{file_uri_for(gem_repo2)}"
               gemspec
             G
           end
@@ -456,7 +456,7 @@ RSpec.describe "bundle install from an existing gemspec" do
         context "as a runtime dependency" do
           it "keeps java dependencies in the lockfile" do
             expect(the_bundle).to include_gems "foo 1.0", "platform_specific 1.0 RUBY"
-            expect(lockfile).to eq normalize_uri_file(strip_whitespace(<<-L))
+            expect(lockfile).to eq strip_whitespace(<<-L)
               PATH
                 remote: .
                 specs:
@@ -464,7 +464,7 @@ RSpec.describe "bundle install from an existing gemspec" do
                     platform_specific
 
               GEM
-                remote: file://localhost#{gem_repo2}/
+                remote: #{file_uri_for(gem_repo2)}/
                 specs:
                   platform_specific (1.0)
                   platform_specific (1.0-java)
@@ -487,14 +487,14 @@ RSpec.describe "bundle install from an existing gemspec" do
 
           it "keeps java dependencies in the lockfile" do
             expect(the_bundle).to include_gems "foo 1.0", "platform_specific 1.0 RUBY"
-            expect(lockfile).to eq normalize_uri_file(strip_whitespace(<<-L))
+            expect(lockfile).to eq strip_whitespace(<<-L)
               PATH
                 remote: .
                 specs:
                   foo (1.0)
 
               GEM
-                remote: file://localhost#{gem_repo2}/
+                remote: #{file_uri_for(gem_repo2)}/
                 specs:
                   platform_specific (1.0)
                   platform_specific (1.0-java)
@@ -519,14 +519,14 @@ RSpec.describe "bundle install from an existing gemspec" do
 
           it "keeps java dependencies in the lockfile" do
             expect(the_bundle).to include_gems "foo 1.0", "indirect_platform_specific 1.0", "platform_specific 1.0 RUBY"
-            expect(lockfile).to eq normalize_uri_file(strip_whitespace(<<-L))
+            expect(lockfile).to eq strip_whitespace(<<-L)
               PATH
                 remote: .
                 specs:
                   foo (1.0)
 
               GEM
-                remote: file://localhost#{gem_repo2}/
+                remote: #{file_uri_for(gem_repo2)}/
                 specs:
                   indirect_platform_specific (1.0)
                     platform_specific
@@ -563,7 +563,7 @@ RSpec.describe "bundle install from an existing gemspec" do
       simulate_platform "ruby"
 
       install_gemfile! <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gemspec :path => '#{tmp.join("foo")}', :name => 'foo'
       G
 
@@ -574,7 +574,7 @@ RSpec.describe "bundle install from an existing gemspec" do
       simulate_platform "ruby"
 
       install_gemfile! <<-G, forgotten_command_line_options(:without => "development")
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gemspec :path => '#{tmp.join("foo")}', :name => 'foo'
       G
 

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "bundle install with git sources" do
       end
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         git "#{lib_path("foo-1.0")}" do
           gem 'foo'
         end
@@ -143,7 +143,7 @@ RSpec.describe "bundle install with git sources" do
 
       Dir.chdir tmp("bundled_app.bck")
       gemfile tmp("bundled_app.bck/Gemfile"), <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         git "#{lib_path("foo-1.0")}" do
           gem 'foo'
         end
@@ -161,7 +161,7 @@ RSpec.describe "bundle install with git sources" do
     before do
       build_git "foo"
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
 
         git "#{lib_path("foo-1.0")}" do
@@ -402,7 +402,7 @@ RSpec.describe "bundle install with git sources" do
       end
 
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
       G
 
@@ -423,7 +423,7 @@ RSpec.describe "bundle install with git sources" do
       end
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
       G
 
@@ -443,7 +443,7 @@ RSpec.describe "bundle install with git sources" do
       end
 
       install_gemfile! <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
       G
 
@@ -459,7 +459,7 @@ RSpec.describe "bundle install with git sources" do
       build_git "rack", "0.8"
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
       G
 
@@ -481,7 +481,7 @@ RSpec.describe "bundle install with git sources" do
       build_git "rack", "0.8"
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
       G
 
@@ -501,7 +501,7 @@ RSpec.describe "bundle install with git sources" do
       build_git "rack", "0.8"
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
       G
 
@@ -523,7 +523,7 @@ RSpec.describe "bundle install with git sources" do
       FileUtils.cp_r("#{lib_path("rack-0.8")}/.", lib_path("local-rack"))
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", :git => "#{lib_path("rack-0.8")}"
       G
 
@@ -545,7 +545,7 @@ RSpec.describe "bundle install with git sources" do
       FileUtils.cp_r("#{lib_path("rack-0.8")}/.", lib_path("local-rack"))
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", :git => "#{lib_path("rack-0.8")}"
       G
 
@@ -565,7 +565,7 @@ RSpec.describe "bundle install with git sources" do
       end
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
       G
 
@@ -582,7 +582,7 @@ RSpec.describe "bundle install with git sources" do
       end
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
       G
 
@@ -613,7 +613,7 @@ RSpec.describe "bundle install with git sources" do
       build_git "rack", "0.8"
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", :git => "#{lib_path("rack-0.8")}"
       G
 
@@ -632,7 +632,7 @@ RSpec.describe "bundle install with git sources" do
       end
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo", :git => "#{lib_path("nested")}"
       G
 
@@ -642,14 +642,14 @@ RSpec.describe "bundle install with git sources" do
 
     it "correctly unlocks when changing to a git source" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", "0.9.1"
       G
 
       build_git "rack", :path => lib_path("rack")
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", "1.0.0", :git => "#{lib_path("rack")}"
       G
 
@@ -658,14 +658,14 @@ RSpec.describe "bundle install with git sources" do
 
     it "correctly unlocks when changing to a git source without versions" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 
       build_git "rack", "1.2", :path => lib_path("rack")
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", :git => "#{lib_path("rack")}"
       G
 
@@ -712,7 +712,7 @@ RSpec.describe "bundle install with git sources" do
     end
 
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", :git => "#{lib_path("foo-1.0")}"
       gem "rails", "2.3.2"
     G
@@ -742,7 +742,7 @@ RSpec.describe "bundle install with git sources" do
     end
 
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "bar", :git => "#{lib_path("foo")}"
       gem "rails", "2.3.2"
     G
@@ -769,7 +769,7 @@ RSpec.describe "bundle install with git sources" do
     build_git "foo", :gemspec => false
 
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", "1.0", :git => "#{lib_path("foo-1.0")}"
       gem "rails", "2.3.2"
     G
@@ -957,12 +957,12 @@ RSpec.describe "bundle install with git sources" do
       end
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "bar", :path => "#{lib_path("bar")}"
       G
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "bar", :git => "#{lib_path("bar")}"
       G
 
@@ -971,7 +971,7 @@ RSpec.describe "bundle install with git sources" do
 
     it "doesn't explode when switching Gem to Git source" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack-obama"
         gem "rack", "1.0.0"
       G
@@ -981,7 +981,7 @@ RSpec.describe "bundle install with git sources" do
       end
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack-obama"
         gem "rack", "1.0.0", :git => "#{lib_path("rack-1.0")}"
       G
@@ -996,7 +996,7 @@ RSpec.describe "bundle install with git sources" do
       build_git "valim"
 
       install_gemfile <<-G
-        gem "valim", :git => "file://#{lib_path("valim-1.0")}"
+        gem "valim", :git => "#{file_uri_for(lib_path("valim-1.0"))}"
       G
 
       old_revision = revision_for(lib_path("valim-1.0"))
@@ -1023,12 +1023,12 @@ RSpec.describe "bundle install with git sources" do
       revision = revision_for(lib_path("foo-1.0"))
 
       install_gemfile <<-G
-        gem "foo", :git => "file://#{lib_path("foo-1.0")}", :ref => "#{revision}"
+        gem "foo", :git => "#{file_uri_for(lib_path("foo-1.0"))}", :ref => "#{revision}"
       G
       expect(out).to_not match(/Revision.*does not exist/)
 
       install_gemfile <<-G
-        gem "foo", :git => "file://#{lib_path("foo-1.0")}", :ref => "deadbeef"
+        gem "foo", :git => "#{file_uri_for(lib_path("foo-1.0"))}", :ref => "deadbeef"
       G
       expect(err).to include("Revision deadbeef does not exist in the repository")
     end
@@ -1039,7 +1039,7 @@ RSpec.describe "bundle install with git sources" do
       build_git "valim", :path => lib_path("valim")
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "valim", "= 1.0", :git => "#{lib_path("valim")}"
       G
 
@@ -1128,7 +1128,7 @@ RSpec.describe "bundle install with git sources" do
       end
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo", :git => "#{lib_path("foo-1.0")}"
       G
 
@@ -1168,7 +1168,7 @@ RSpec.describe "bundle install with git sources" do
         git_commit_sha = git_reader.ref_for("HEAD")
 
         install_gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "foo", :git => "#{lib_path("foo-1.0")}", :ref => "#{git_commit_sha}"
         G
 
@@ -1193,7 +1193,7 @@ RSpec.describe "bundle install with git sources" do
       end
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo", :git => "#{lib_path("foo-1.0")}"
       G
 
@@ -1223,7 +1223,7 @@ In Gemfile:
       end
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo", :git => "#{lib_path("foo-1.0")}"
       G
 
@@ -1236,7 +1236,7 @@ In Gemfile:
       expect(installed_time).to match(/\A\d+\.\d+\z/)
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo", :git => "#{lib_path("foo-1.0")}"
       G
 
@@ -1264,7 +1264,7 @@ In Gemfile:
       end
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", "0.9.1"
         gem "foo", :git => "#{lib_path("foo-1.0")}"
       G
@@ -1278,7 +1278,7 @@ In Gemfile:
       expect(installed_time).to match(/\A\d+\.\d+\z/)
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", "1.0.0"
         gem "foo", :git => "#{lib_path("foo-1.0")}"
       G
@@ -1307,7 +1307,7 @@ In Gemfile:
       end
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo", :git => "#{lib_path("foo-1.0")}"
       G
 
@@ -1322,7 +1322,7 @@ In Gemfile:
       expect(installed_time).to match(/\A\d+\.\d+\z/)
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo", :git => "#{lib_path("foo-1.0")}", :branch => "branch2"
       G
 
@@ -1355,7 +1355,7 @@ In Gemfile:
       ENV["GIT_WORK_TREE"] = "bar"
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         git "#{lib_path("xxxxxx-1.0")}" do
           gem 'xxxxxx'
         end

--- a/spec/install/gemfile/groups_spec.rb
+++ b/spec/install/gemfile/groups_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "bundle install with groups" do
   describe "installing with no options" do
     before :each do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
         group :emo do
           gem "activesupport", "2.3.5"
@@ -74,7 +74,7 @@ RSpec.describe "bundle install with groups" do
     describe "with gems assigned to a single group" do
       before :each do
         gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "rack"
           group :emo do
             gem "activesupport", "2.3.5"
@@ -115,7 +115,7 @@ RSpec.describe "bundle install with groups" do
 
       it "does not effect the resolve" do
         gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "activesupport"
           group :emo do
             gem "rails", "2.3.2"
@@ -243,7 +243,7 @@ RSpec.describe "bundle install with groups" do
     describe "with gems assigned to multiple groups" do
       before :each do
         gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "rack"
           group :emo, :lolercoaster do
             gem "activesupport", "2.3.5"
@@ -264,7 +264,7 @@ RSpec.describe "bundle install with groups" do
       describe "with a gem defined multiple times in different groups" do
         before :each do
           gemfile <<-G
-            source "file://#{gem_repo1}"
+            source "#{file_uri_for(gem_repo1)}"
             gem "rack"
 
             group :emo do
@@ -302,7 +302,7 @@ RSpec.describe "bundle install with groups" do
     describe "nesting groups" do
       before :each do
         gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "rack"
           group :emo do
             group :lolercoaster do
@@ -327,7 +327,7 @@ RSpec.describe "bundle install with groups" do
   describe "when loading only the default group" do
     it "should not load all groups" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
         gem "activesupport", :groups => :development
       G
@@ -354,7 +354,7 @@ RSpec.describe "bundle install with groups" do
       build_repo2
       system_gems "rack-0.9.1" do
         install_gemfile <<-G, forgotten_command_line_options(:without => "rack")
-          source "file://#{gem_repo2}"
+          source "#{file_uri_for(gem_repo2)}"
           gem "rack"
 
           group :rack do

--- a/spec/install/gemfile/install_if.rb
+++ b/spec/install/gemfile/install_if.rb
@@ -3,7 +3,7 @@
 describe "bundle install with install_if conditionals" do
   it "follows the install_if DSL" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       install_if(lambda { true }) do
         gem "activesupport", "2.3.5"
       end
@@ -20,7 +20,7 @@ describe "bundle install with install_if conditionals" do
 
     lockfile_should_be <<-L
       GEM
-        remote: file:#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           activesupport (2.3.5)
           foo (1.0)

--- a/spec/install/gemfile/lockfile_spec.rb
+++ b/spec/install/gemfile/lockfile_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe "bundle install with a lockfile present" do
   let(:gf) { <<-G }
-    source "file://#{gem_repo1}"
+    source "#{file_uri_for(gem_repo1)}"
 
     gem "rack", "1.0.0"
   G

--- a/spec/install/gemfile/path_spec.rb
+++ b/spec/install/gemfile/path_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe "bundle install with explicit source paths" do
     end
 
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", :path => "#{lib_path("nested")}"
     G
 
@@ -196,7 +196,7 @@ RSpec.describe "bundle install with explicit source paths" do
     end
 
     gemfile = <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gemspec
     G
 
@@ -215,7 +215,7 @@ RSpec.describe "bundle install with explicit source paths" do
     end
 
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gemspec :path => "#{lib_path("foo")}"
     G
 
@@ -231,7 +231,7 @@ RSpec.describe "bundle install with explicit source paths" do
     Dir.chdir lib_path("foo")
 
     install_gemfile lib_path("foo/Gemfile"), <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gemspec
     G
 
@@ -252,7 +252,7 @@ RSpec.describe "bundle install with explicit source paths" do
     Dir.chdir lib_path("foo")
 
     install_gemfile lib_path("foo/Gemfile"), <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gemspec
     G
 
@@ -390,7 +390,7 @@ RSpec.describe "bundle install with explicit source paths" do
   context "existing lockfile" do
     it "rubygems gems don't re-resolve without changes" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem 'rack-obama', '1.0'
         gem 'net-ssh', '1.0'
       G
@@ -410,7 +410,7 @@ RSpec.describe "bundle install with explicit source paths" do
       end
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem 'rack-obama', :path => "#{lib_path("omg")}"
         gem 'net-ssh', :path => "#{lib_path("omg")}"
       G
@@ -470,7 +470,7 @@ RSpec.describe "bundle install with explicit source paths" do
       build_lib "foo", "1.0", :path => lib_path("foo")
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo", :path => "#{lib_path("foo")}"
       G
     end
@@ -502,7 +502,7 @@ RSpec.describe "bundle install with explicit source paths" do
               rack (= 0.9.1)
 
         GEM
-          remote: #{URI.parse("file://#{gem_repo1}/")}
+          remote: #{file_uri_for(gem_repo1)}/
           specs:
             rack (0.9.1)
 
@@ -530,7 +530,7 @@ RSpec.describe "bundle install with explicit source paths" do
               rack
 
         GEM
-          remote: #{URI.parse("file://#{gem_repo1}/")}
+          remote: #{file_uri_for(gem_repo1)}/
           specs:
             rack (0.9.1)
 
@@ -559,12 +559,12 @@ RSpec.describe "bundle install with explicit source paths" do
       end
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "bar", :git => "#{lib_path("bar")}"
       G
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "bar", :path => "#{lib_path("bar")}"
       G
 
@@ -578,7 +578,7 @@ RSpec.describe "bundle install with explicit source paths" do
       end
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "bar"
         path "#{lib_path("foo")}" do
           gem "foo"
@@ -588,7 +588,7 @@ RSpec.describe "bundle install with explicit source paths" do
       build_lib "bar", "1.0", :path => lib_path("foo/bar")
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         path "#{lib_path("foo")}" do
           gem "foo"
           gem "bar"

--- a/spec/install/gemfile/platform_spec.rb
+++ b/spec/install/gemfile/platform_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "bundle install across platforms" do
   it "maintains the same lockfile if all gems are compatible across platforms" do
     lockfile <<-G
       GEM
-        remote: file:#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           rack (0.9.1)
 
@@ -16,7 +16,7 @@ RSpec.describe "bundle install across platforms" do
     G
 
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "rack"
     G
@@ -27,7 +27,7 @@ RSpec.describe "bundle install across platforms" do
   it "pulls in the correct platform specific gem" do
     lockfile <<-G
       GEM
-        remote: file:#{gem_repo1}
+        remote: #{file_uri_for(gem_repo1)}
         specs:
           platform_specific (1.0)
           platform_specific (1.0-java)
@@ -42,7 +42,7 @@ RSpec.describe "bundle install across platforms" do
 
     simulate_platform "java"
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "platform_specific"
     G
@@ -53,7 +53,7 @@ RSpec.describe "bundle install across platforms" do
   it "works with gems that have different dependencies" do
     simulate_platform "java"
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "nokogiri"
     G
@@ -64,7 +64,7 @@ RSpec.describe "bundle install across platforms" do
 
     simulate_platform "ruby"
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "nokogiri"
     G
@@ -96,15 +96,15 @@ RSpec.describe "bundle install across platforms" do
     simulate_platform java
 
     install_gemfile! <<-G
-      source "file://localhost/#{gem_repo4}"
+      source "#{file_uri_for(gem_repo4)}"
 
       gem "empyrean", "0.1.0"
       gem "pry"
     G
 
-    expect(the_bundle.lockfile).to read_as normalize_uri_file(strip_whitespace(<<-L))
+    expect(the_bundle.lockfile).to read_as strip_whitespace(<<-L)
       GEM
-        remote: file://localhost/#{gem_repo4}/
+        remote: #{file_uri_for(gem_repo4)}/
         specs:
           coderay (1.1.2)
           empyrean (0.1.0)
@@ -132,7 +132,7 @@ RSpec.describe "bundle install across platforms" do
 
     good_lockfile = strip_whitespace(<<-L)
       GEM
-        remote: file://localhost/#{gem_repo4}/
+        remote: #{file_uri_for(gem_repo4)}/
         specs:
           coderay (1.1.2)
           empyrean (0.1.0)
@@ -160,11 +160,11 @@ RSpec.describe "bundle install across platforms" do
          #{Bundler::VERSION}
     L
 
-    expect(the_bundle.lockfile).to read_as normalize_uri_file(good_lockfile)
+    expect(the_bundle.lockfile).to read_as good_lockfile
 
     bad_lockfile = strip_whitespace <<-L
       GEM
-        remote: file://localhost/#{gem_repo4}/
+        remote: #{file_uri_for(gem_repo4)}/
         specs:
           coderay (1.1.2)
           empyrean (0.1.0)
@@ -196,30 +196,30 @@ RSpec.describe "bundle install across platforms" do
     aggregate_failures do
       lockfile bad_lockfile
       bundle! :install
-      expect(the_bundle.lockfile).to read_as normalize_uri_file(good_lockfile)
+      expect(the_bundle.lockfile).to read_as good_lockfile
 
       lockfile bad_lockfile
       bundle! :update, :all => true
-      expect(the_bundle.lockfile).to read_as normalize_uri_file(good_lockfile)
+      expect(the_bundle.lockfile).to read_as good_lockfile
 
       lockfile bad_lockfile
       bundle! "update ffi"
-      expect(the_bundle.lockfile).to read_as normalize_uri_file(good_lockfile)
+      expect(the_bundle.lockfile).to read_as good_lockfile
 
       lockfile bad_lockfile
       bundle! "update empyrean"
-      expect(the_bundle.lockfile).to read_as normalize_uri_file(good_lockfile)
+      expect(the_bundle.lockfile).to read_as good_lockfile
 
       lockfile bad_lockfile
       bundle! :lock
-      expect(the_bundle.lockfile).to read_as normalize_uri_file(good_lockfile)
+      expect(the_bundle.lockfile).to read_as good_lockfile
     end
   end
 
   it "works the other way with gems that have different dependencies" do
     simulate_platform "ruby"
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "nokogiri"
     G
@@ -243,7 +243,7 @@ RSpec.describe "bundle install across platforms" do
     end
 
     install_gemfile! <<-G
-      source "file://#{gem_repo2}"
+      source "#{file_uri_for(gem_repo2)}"
 
       gem "facter"
     G
@@ -258,7 +258,7 @@ RSpec.describe "bundle install across platforms" do
 
   it "fetches gems again after changing the version of Ruby" do
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "rack", "1.0.0"
     G
@@ -275,7 +275,7 @@ end
 RSpec.describe "bundle install with platform conditionals" do
   it "installs gems tagged w/ the current platforms" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       platforms :#{local_tag} do
         gem "nokogiri"
@@ -287,7 +287,7 @@ RSpec.describe "bundle install with platform conditionals" do
 
   it "does not install gems tagged w/ another platforms" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack"
       platforms :#{not_local_tag} do
         gem "nokogiri"
@@ -300,7 +300,7 @@ RSpec.describe "bundle install with platform conditionals" do
 
   it "installs gems tagged w/ the current platforms inline" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "nokogiri", :platforms => :#{local_tag}
     G
     expect(the_bundle).to include_gems "nokogiri 1.4.2"
@@ -308,7 +308,7 @@ RSpec.describe "bundle install with platform conditionals" do
 
   it "does not install gems tagged w/ another platforms inline" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack"
       gem "nokogiri", :platforms => :#{not_local_tag}
     G
@@ -318,7 +318,7 @@ RSpec.describe "bundle install with platform conditionals" do
 
   it "installs gems tagged w/ the current platform inline" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "nokogiri", :platform => :#{local_tag}
     G
     expect(the_bundle).to include_gems "nokogiri 1.4.2"
@@ -326,7 +326,7 @@ RSpec.describe "bundle install with platform conditionals" do
 
   it "doesn't install gems tagged w/ another platform inline" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "nokogiri", :platform => :#{not_local_tag}
     G
     expect(the_bundle).not_to include_gems "nokogiri 1.4.2"
@@ -350,7 +350,7 @@ RSpec.describe "bundle install with platform conditionals" do
     simulate_ruby_engine "ruby"
 
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "some_gem", :platform => :rbx
     G
 
@@ -364,7 +364,7 @@ RSpec.describe "bundle install with platform conditionals" do
     other_ruby_version_tag = RUBY_VERSION =~ /^1\.8/ ? :ruby_19 : :ruby_18
 
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "some_gem", platform: :#{other_ruby_version_tag}
     G
 
@@ -377,7 +377,7 @@ RSpec.describe "bundle install with platform conditionals" do
     simulate_ruby_engine "ruby"
 
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "rack", :platform => [:mingw, :mswin, :x64_mingw, :jruby]
     G
@@ -397,7 +397,7 @@ The dependency #{Gem::Dependency.new("rack", ">= 0")} will be unused by any of t
       simulate_ruby_engine "ruby"
 
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
 
         gem "rack", :platform => [:mingw, :mswin, :x64_mingw, :jruby]
       G

--- a/spec/install/gemfile/ruby_spec.rb
+++ b/spec/install/gemfile/ruby_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe "ruby requirement" do
   # requirement. This test verifies the fix, committed in bfbad5c5.
   it "allows adding gems" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       ruby "#{RUBY_VERSION}"
       gem "rack"
     G
 
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       ruby "#{RUBY_VERSION}"
       gem "rack"
       gem "rack-obama"
@@ -28,7 +28,7 @@ RSpec.describe "ruby requirement" do
 
   it "allows removing the ruby version requirement" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       ruby "~> #{RUBY_VERSION}"
       gem "rack"
     G
@@ -36,7 +36,7 @@ RSpec.describe "ruby requirement" do
     expect(lockfile).to include("RUBY VERSION")
 
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack"
     G
 
@@ -46,7 +46,7 @@ RSpec.describe "ruby requirement" do
 
   it "allows changing the ruby version requirement to something compatible" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       ruby ">= 1.0.0"
       gem "rack"
     G
@@ -56,7 +56,7 @@ RSpec.describe "ruby requirement" do
     simulate_ruby_version "5100"
 
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       ruby ">= 1.0.1"
       gem "rack"
     G
@@ -67,7 +67,7 @@ RSpec.describe "ruby requirement" do
 
   it "allows changing the ruby version requirement to something incompatible" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       ruby ">= 1.0.0"
       gem "rack"
     G
@@ -77,7 +77,7 @@ RSpec.describe "ruby requirement" do
     simulate_ruby_version "5100"
 
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       ruby ">= 5000.0"
       gem "rack"
     G
@@ -88,7 +88,7 @@ RSpec.describe "ruby requirement" do
 
   it "allows requirements with trailing whitespace" do
     install_gemfile! <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       ruby "#{RUBY_VERSION}\\n \t\\n"
       gem "rack"
     G
@@ -98,7 +98,7 @@ RSpec.describe "ruby requirement" do
 
   it "fails gracefully with malformed requirements" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       ruby ">= 0", "-.\\0"
       gem "rack"
     G

--- a/spec/install/gemfile/sources_spec.rb
+++ b/spec/install/gemfile/sources_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
       before do
         gemfile <<-G
-          source "file://localhost#{gem_repo3}"
-          source "file://localhost#{gem_repo1}"
+          source "#{file_uri_for(gem_repo3)}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "rack-obama"
           gem "rack"
         G
@@ -31,7 +31,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
         bundle :install
 
         expect(err).to include("Warning: the gem 'rack' was found in multiple sources.")
-        expect(err).to include(normalize_uri_file("Installed from: file://localhost#{gem_repo1}"))
+        expect(err).to include("Installed from: #{file_uri_for(gem_repo1)}")
         expect(the_bundle).to include_gems("rack-obama 1.0.0", "rack 1.0.0", :source => "remote1")
       end
 
@@ -47,8 +47,8 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
       before do
         gemfile <<-G
-          source "file://localhost#{gem_repo3}"
-          source "file://localhost#{gem_repo1}"
+          source "#{file_uri_for(gem_repo3)}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "rack-obama"
           gem "rack", "1.0.0" # force it to install the working version in repo1
         G
@@ -58,7 +58,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
       it "warns about ambiguous gems, but installs anyway", :bundler => "2" do
         expect(err).to include("Warning: the gem 'rack' was found in multiple sources.")
-        expect(err).to include(normalize_uri_file("Installed from: file://localhost#{gem_repo1}"))
+        expect(err).to include("Installed from: #{file_uri_for(gem_repo1)}")
         expect(the_bundle).to include_gems("rack-obama 1.0.0", "rack 1.0.0", :source => "remote1")
       end
 
@@ -85,8 +85,8 @@ RSpec.describe "bundle install with gems on multiple sources" do
         end
 
         gemfile <<-G
-          source "file://#{gem_repo3}"
-          source "file://#{gem_repo1}" do
+          source "#{file_uri_for(gem_repo3)}"
+          source "#{file_uri_for(gem_repo1)}" do
             gem "thin" # comes first to test name sorting
             gem "rack"
           end
@@ -128,9 +128,9 @@ RSpec.describe "bundle install with gems on multiple sources" do
         end
 
         gemfile <<-G
-          source "file://#{gem_repo3}"
+          source "#{file_uri_for(gem_repo3)}"
           gem "rack-obama" # should come from repo3!
-          gem "rack", :source => "file://#{gem_repo1}"
+          gem "rack", :source => "#{file_uri_for(gem_repo1)}"
         G
       end
 
@@ -158,8 +158,8 @@ RSpec.describe "bundle install with gems on multiple sources" do
           end
 
           gemfile <<-G
-            source "file://#{gem_repo2}"
-            source "file://#{gem_repo3}" do
+            source "#{file_uri_for(gem_repo2)}"
+            source "#{file_uri_for(gem_repo3)}" do
               gem "depends_on_rack"
             end
           G
@@ -222,8 +222,8 @@ RSpec.describe "bundle install with gems on multiple sources" do
         context "and not in any other sources" do
           before do
             gemfile <<-G
-              source "file://#{gem_repo2}"
-              source "file://#{gem_repo3}" do
+              source "#{file_uri_for(gem_repo2)}"
+              source "#{file_uri_for(gem_repo3)}" do
                 gem "depends_on_rack"
               end
             G
@@ -239,9 +239,9 @@ RSpec.describe "bundle install with gems on multiple sources" do
         context "and in yet another source", :bundler => "< 3" do
           before do
             gemfile <<-G
-              source "file://localhost#{gem_repo1}"
-              source "file://localhost#{gem_repo2}"
-              source "file://localhost#{gem_repo3}" do
+              source "#{file_uri_for(gem_repo1)}"
+              source "#{file_uri_for(gem_repo2)}"
+              source "#{file_uri_for(gem_repo3)}" do
                 gem "depends_on_rack"
               end
             G
@@ -251,7 +251,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
           it "installs from the other source and warns about ambiguous gems", :bundler => "2" do
             expect(err).to include("Warning: the gem 'rack' was found in multiple sources.")
-            expect(err).to include(normalize_uri_file("Installed from: file://localhost#{gem_repo2}"))
+            expect(err).to include("Installed from: #{file_uri_for(gem_repo2)}")
             expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0")
           end
 
@@ -271,11 +271,11 @@ RSpec.describe "bundle install with gems on multiple sources" do
             end
 
             gemfile <<-G
-              source "file://#{gem_repo3}" # contains depends_on_rack
-              source "file://#{gem_repo2}" # contains broken rack
+              source "#{file_uri_for(gem_repo3)}" # contains depends_on_rack
+              source "#{file_uri_for(gem_repo2)}" # contains broken rack
 
               gem "depends_on_rack" # installed from gem_repo3
-              gem "rack", :source => "file://#{gem_repo1}"
+              gem "rack", :source => "#{file_uri_for(gem_repo1)}"
             G
           end
 
@@ -321,11 +321,11 @@ RSpec.describe "bundle install with gems on multiple sources" do
           end
 
           gemfile <<-G
-            source "file://#{gem_repo2}"
+            source "#{file_uri_for(gem_repo2)}"
 
             gem "depends_on_rack"
 
-            source "file://#{gem_repo3}" do
+            source "#{file_uri_for(gem_repo3)}" do
               gem "unrelated_gem"
             end
           G
@@ -389,8 +389,8 @@ RSpec.describe "bundle install with gems on multiple sources" do
         end
 
         gemfile <<-G
-          source "file://#{gem_repo3}"
-          gem "not_in_repo1", :source => "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo3)}"
+          gem "not_in_repo1", :source => "#{file_uri_for(gem_repo1)}"
         G
       end
 
@@ -406,8 +406,8 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
         lockfile <<-L
           GEM
-            remote: file:#{gem_repo1}
-            remote: file:#{gem_repo3}
+            remote: #{file_uri_for(gem_repo1)}
+            remote: #{file_uri_for(gem_repo3)}
             specs:
               rack (0.9.1)
 
@@ -419,8 +419,8 @@ RSpec.describe "bundle install with gems on multiple sources" do
         L
 
         gemfile <<-G
-          source "file://#{gem_repo1}"
-          source "file://#{gem_repo3}" do
+          source "#{file_uri_for(gem_repo1)}"
+          source "#{file_uri_for(gem_repo3)}" do
             gem 'rack'
           end
         G
@@ -437,7 +437,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
         build_lib "foo"
 
         gemfile <<-G
-          gem "rack", :source => "file://#{gem_repo1}"
+          gem "rack", :source => "#{file_uri_for(gem_repo1)}"
           gem "foo", :path => "#{lib_path("foo-1.0")}"
         G
       end
@@ -457,7 +457,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
       system_gems "rack-0.9.1"
 
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack" # shoud come from repo1!
       G
     end
@@ -479,10 +479,10 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
       # Installing this gemfile...
       gemfile <<-G
-        source 'file://#{gem_repo1}'
+        source '#{file_uri_for(gem_repo1)}'
         gem 'rack'
-        gem 'foo', '~> 0.1', :source => 'file://#{gem_repo4}'
-        gem 'bar', '~> 0.1', :source => 'file://#{gem_repo4}'
+        gem 'foo', '~> 0.1', :source => '#{file_uri_for(gem_repo4)}'
+        gem 'bar', '~> 0.1', :source => '#{file_uri_for(gem_repo4)}'
       G
 
       bundle! :install, forgotten_command_line_options(:path => "../gems/system")
@@ -497,10 +497,10 @@ RSpec.describe "bundle install with gems on multiple sources" do
     it "allows them to be unlocked separately" do
       # And install this gemfile, updating only foo.
       install_gemfile <<-G
-        source 'file://#{gem_repo1}'
+        source '#{file_uri_for(gem_repo1)}'
         gem 'rack'
-        gem 'foo', '~> 0.2', :source => 'file://#{gem_repo4}'
-        gem 'bar', '~> 0.1', :source => 'file://#{gem_repo4}'
+        gem 'foo', '~> 0.2', :source => '#{file_uri_for(gem_repo4)}'
+        gem 'bar', '~> 0.1', :source => '#{file_uri_for(gem_repo4)}'
       G
 
       # It should update foo to 0.2, but not the (locked) bar 0.1
@@ -518,10 +518,10 @@ RSpec.describe "bundle install with gems on multiple sources" do
         build_git "git2"
 
         install_gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "rails"
 
-          source "file://#{gem_repo3}" do
+          source "#{file_uri_for(gem_repo3)}" do
             gem "rack"
           end
 
@@ -543,15 +543,15 @@ RSpec.describe "bundle install with gems on multiple sources" do
   context "when a gem is installed to system gems" do
     before do
       install_gemfile! <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
     end
 
     context "and the gemfile changes" do
       it "is still able to find that gem from remote sources" do
-        source_uri = "file://#{gem_repo1}"
-        second_uri = "file://#{gem_repo4}"
+        source_uri = "#{file_uri_for(gem_repo1)}"
+        second_uri = "#{file_uri_for(gem_repo4)}"
 
         build_repo4 do
           build_gem "rack", "2.0.1.1.forked"
@@ -589,7 +589,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
   describe "source changed to one containing a higher version of a dependency" do
     before do
       install_gemfile! <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
 
         gem "rack"
       G
@@ -603,7 +603,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
       end
 
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "rack"
         gemspec :path => "#{tmp.join("gemspec_test")}"
       G
@@ -628,17 +628,17 @@ RSpec.describe "bundle install with gems on multiple sources" do
       end
 
       install_gemfile <<-G
-        source "file://localhost#{gem_repo4}"
-        source "file://localhost#{gem_repo1}" do
+        source "#{file_uri_for(gem_repo4)}"
+        source "#{file_uri_for(gem_repo1)}" do
           gem "thin"
         end
         gem "depends_on_rack"
       G
       expect(last_command).to be_failure
-      expect(err).to eq normalize_uri_file(strip_whitespace(<<-EOS).strip)
+      expect(err).to eq strip_whitespace(<<-EOS).strip
         The gem 'rack' was found in multiple relevant sources.
-          * rubygems repository file://localhost#{gem_repo1}/ or installed locally
-          * rubygems repository file://localhost#{gem_repo4}/ or installed locally
+          * rubygems repository #{file_uri_for(gem_repo1)}/ or installed locally
+          * rubygems repository #{file_uri_for(gem_repo4)}/ or installed locally
         You must add this gem to the source block for the source you wish it to be installed from.
       EOS
       expect(the_bundle).not_to be_locked

--- a/spec/install/gemfile/specific_platform_spec.rb
+++ b/spec/install/gemfile/specific_platform_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "bundle install with specific_platform enabled" do
   end
 
   let(:google_protobuf) { <<-G }
-    source "file:#{gem_repo2}"
+    source "#{file_uri_for(gem_repo2)}"
     gem "google-protobuf"
   G
 
@@ -75,7 +75,7 @@ RSpec.describe "bundle install with specific_platform enabled" do
 
     it "uses the platform-specific gem with extra dependencies" do
       install_gemfile! <<-G
-        source "file:#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "facter"
       G
 

--- a/spec/install/gemfile_spec.rb
+++ b/spec/install/gemfile_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "bundle install" do
   context "with --gemfile" do
     it "finds the gemfile" do
       gemfile bundled_app("NotGemfile"), <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem 'rack'
       G
 
@@ -30,7 +30,7 @@ RSpec.describe "bundle install" do
   context "with gemfile set via config" do
     before do
       gemfile bundled_app("NotGemfile"), <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem 'rack'
       G
 
@@ -73,7 +73,7 @@ RSpec.describe "bundle install" do
       simulate_ruby_version "2.3.0" do
         simulate_ruby_engine "jruby", "9.1.2.0" do
           install_gemfile! <<-G
-            source "file://#{gem_repo1}"
+            source "#{file_uri_for(gem_repo1)}"
             ruby "2.3.0", :engine => :jruby, :engine_version => "9.1.2.0"
           G
 
@@ -86,7 +86,7 @@ RSpec.describe "bundle install" do
       simulate_ruby_version "2.3.0" do
         simulate_ruby_engine "jruby", "9.1.2.0" do
           install_gemfile! <<-G
-            source "file://#{gem_repo1}"
+            source "#{file_uri_for(gem_repo1)}"
             ruby "2.3.0", :engine => :jruby, :engine_version => "9.1.2.0"
             gem "rack"
           G

--- a/spec/install/gems/compact_index_spec.rb
+++ b/spec/install/gems/compact_index_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe "compact index api" do
 
     gemfile <<-G
       source "#{source_uri}"
-      git "file:///#{lib_path("foo-1.0")}" do
+      git "#{file_uri_for(lib_path("foo-1.0"))}" do
         gem 'foo'
       end
     G
@@ -111,7 +111,7 @@ RSpec.describe "compact index api" do
 
     gemfile <<-G
       source "#{source_uri}"
-      gem 'foo', :git => "file:///#{lib_path("foo-1.0")}"
+      gem 'foo', :git => "#{file_uri_for(lib_path("foo-1.0"))}"
     G
 
     bundle! :install, :artifice => "compact_index"
@@ -125,7 +125,7 @@ RSpec.describe "compact index api" do
     build_git "foo"
     gemfile <<-G
       source "#{source_uri}"
-      gem 'foo', :git => "file:///#{lib_path("foo-1.0")}"
+      gem 'foo', :git => "#{file_uri_for(lib_path("foo-1.0"))}"
     G
 
     bundle "install", :artifice => "compact_index"
@@ -623,7 +623,7 @@ The checksum of /versions does not match the checksum provided by the server! So
     it "strips http basic auth creds when warning about ambiguous sources", :bundler => "< 3" do
       gemfile <<-G
         source "#{basic_auth_source_uri}"
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 

--- a/spec/install/gems/dependency_api_spec.rb
+++ b/spec/install/gems/dependency_api_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "gemcutter's dependency API" do
 
     gemfile <<-G
       source "#{source_uri}"
-      git "file:///#{lib_path("foo-1.0")}" do
+      git "#{file_uri_for(lib_path("foo-1.0"))}" do
         gem 'foo'
       end
     G
@@ -91,7 +91,7 @@ RSpec.describe "gemcutter's dependency API" do
 
     gemfile <<-G
       source "#{source_uri}"
-      gem 'foo', :git => "file:///#{lib_path("foo-1.0")}"
+      gem 'foo', :git => "#{file_uri_for(lib_path("foo-1.0"))}"
     G
 
     bundle :install, :artifice => "endpoint"
@@ -105,7 +105,7 @@ RSpec.describe "gemcutter's dependency API" do
     build_git "foo"
     gemfile <<-G
       source "#{source_uri}"
-      gem 'foo', :git => "file:///#{lib_path("foo-1.0")}"
+      gem 'foo', :git => "#{file_uri_for(lib_path("foo-1.0"))}"
     G
 
     bundle "install", :artifice => "endpoint"
@@ -597,7 +597,7 @@ RSpec.describe "gemcutter's dependency API" do
     it "strips http basic auth creds when warning about ambiguous sources", :bundler => "< 3" do
       gemfile <<-G
         source "#{basic_auth_source_uri}"
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 

--- a/spec/install/gems/env_spec.rb
+++ b/spec/install/gems/env_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "bundle install with ENV conditionals" do
   describe "when just setting an ENV key as a string" do
     before :each do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
 
         env "BUNDLER_TEST" do
           gem "rack"
@@ -27,7 +27,7 @@ RSpec.describe "bundle install with ENV conditionals" do
   describe "when just setting an ENV key as a symbol" do
     before :each do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
 
         env :BUNDLER_TEST do
           gem "rack"
@@ -50,7 +50,7 @@ RSpec.describe "bundle install with ENV conditionals" do
   describe "when setting a string to match the env" do
     before :each do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
 
         env "BUNDLER_TEST" => "foo" do
           gem "rack"
@@ -79,7 +79,7 @@ RSpec.describe "bundle install with ENV conditionals" do
   describe "when setting a regex to match the env" do
     before :each do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
 
         env "BUNDLER_TEST" => /foo/ do
           gem "rack"

--- a/spec/install/gems/flex_spec.rb
+++ b/spec/install/gems/flex_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe "bundle flex_install" do
   it "installs the gems as expected" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem 'rack'
     G
 
@@ -13,7 +13,7 @@ RSpec.describe "bundle flex_install" do
 
   it "installs even when the lockfile is invalid" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem 'rack'
     G
 
@@ -21,7 +21,7 @@ RSpec.describe "bundle flex_install" do
     expect(the_bundle).to be_locked
 
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem 'rack', '1.0'
     G
 
@@ -34,7 +34,7 @@ RSpec.describe "bundle flex_install" do
     build_repo2
 
     install_gemfile <<-G
-      source "file://#{gem_repo2}"
+      source "#{file_uri_for(gem_repo2)}"
       gem "rack-obama"
     G
 
@@ -42,7 +42,7 @@ RSpec.describe "bundle flex_install" do
 
     update_repo2
     install_gemfile <<-G
-      source "file://#{gem_repo2}"
+      source "#{file_uri_for(gem_repo2)}"
       gem "rack-obama", "1.0"
     G
 
@@ -54,14 +54,14 @@ RSpec.describe "bundle flex_install" do
       build_repo2
 
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem 'rack'
       G
 
       update_repo2
 
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem 'rack'
         gem 'activesupport', '2.3.5'
       G
@@ -73,14 +73,14 @@ RSpec.describe "bundle flex_install" do
       build_repo2
 
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "rack-obama"
       G
 
       update_repo2
 
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "rack-obama"
         gem "thin"
       G
@@ -93,7 +93,7 @@ RSpec.describe "bundle flex_install" do
     it "removes gems without changing the versions of remaining gems" do
       build_repo2
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem 'rack'
         gem 'activesupport', '2.3.5'
       G
@@ -101,7 +101,7 @@ RSpec.describe "bundle flex_install" do
       update_repo2
 
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem 'rack'
       G
 
@@ -109,7 +109,7 @@ RSpec.describe "bundle flex_install" do
       expect(the_bundle).not_to include_gems "activesupport 2.3.5"
 
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem 'rack'
         gem 'activesupport', '2.3.2'
       G
@@ -120,7 +120,7 @@ RSpec.describe "bundle flex_install" do
     it "removes top level dependencies when removed from the Gemfile while leaving other dependencies intact" do
       build_repo2
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem 'rack'
         gem 'activesupport', '2.3.5'
       G
@@ -128,7 +128,7 @@ RSpec.describe "bundle flex_install" do
       update_repo2
 
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem 'rack'
       G
 
@@ -138,7 +138,7 @@ RSpec.describe "bundle flex_install" do
     it "removes child dependencies" do
       build_repo2
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem 'rack-obama'
         gem 'activesupport'
       G
@@ -147,7 +147,7 @@ RSpec.describe "bundle flex_install" do
 
       update_repo2
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem 'activesupport'
       G
 
@@ -160,7 +160,7 @@ RSpec.describe "bundle flex_install" do
     before(:each) do
       build_repo2
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "rack_middleware"
       G
 
@@ -177,7 +177,7 @@ RSpec.describe "bundle flex_install" do
       end
 
       gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "rack-obama", "2.0"
         gem "rack_middleware"
       G
@@ -216,13 +216,13 @@ RSpec.describe "bundle flex_install" do
   describe "subtler cases" do
     before :each do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
         gem "rack-obama"
       G
 
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", "0.9.1"
         gem "rack-obama"
       G
@@ -247,19 +247,19 @@ RSpec.describe "bundle flex_install" do
     it "updates the lockfile", :bundler => "< 3" do
       build_repo2
       install_gemfile! <<-G
-        source "file://localhost#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
       install_gemfile! <<-G
-        source "file://localhost#{gem_repo1}"
-        source "file://localhost#{gem_repo2}"
+        source "#{file_uri_for(gem_repo1)}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "rack"
       G
 
       lockfile_should_be <<-L
       GEM
-        remote: file://localhost#{gem_repo1}/
-        remote: file://localhost#{gem_repo2}/
+        remote: #{file_uri_for(gem_repo1)}/
+        remote: #{file_uri_for(gem_repo2)}/
         specs:
           rack (1.0.0)
 
@@ -277,25 +277,25 @@ RSpec.describe "bundle flex_install" do
     it "updates the lockfile", :bundler => "3" do
       build_repo2
       install_gemfile! <<-G
-        source "file://localhost#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 
       install_gemfile! <<-G
-        source "file://localhost#{gem_repo1}"
-        source "file://localhost#{gem_repo2}" do
+        source "#{file_uri_for(gem_repo1)}"
+        source "#{file_uri_for(gem_repo2)}" do
         end
         gem "rack"
       G
 
       lockfile_should_be <<-L
       GEM
-        remote: file://localhost#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           rack (1.0.0)
 
       GEM
-        remote: file://localhost#{gem_repo2}/
+        remote: #{file_uri_for(gem_repo2)}/
         specs:
 
       PLATFORMS
@@ -333,14 +333,14 @@ RSpec.describe "bundle flex_install" do
     it "prints the correct error message" do
       # install Rails 3.0.0.rc
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "rails", "3.0.0.rc4"
         gem "capybara", "0.3.9"
       G
 
       # upgrade Rails to 3.0.0 and then install again
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "rails", "3.0.0"
         gem "capybara", "0.3.9"
       G

--- a/spec/install/gems/mirror_spec.rb
+++ b/spec/install/gems/mirror_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "bundle install with a mirror configured" do
   describe "when the mirror does not match the gem source" do
     before :each do
       gemfile <<-G
-        source "file://localhost#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
 
         gem "rack"
       G
@@ -13,7 +13,7 @@ RSpec.describe "bundle install with a mirror configured" do
 
     it "installs from the normal location" do
       bundle :install
-      expect(out).to include(normalize_uri_file("Fetching source index from file://localhost#{gem_repo1}"))
+      expect(out).to include("Fetching source index from #{file_uri_for(gem_repo1)}")
       expect(the_bundle).to include_gems "rack 1.0"
     end
   end
@@ -22,17 +22,17 @@ RSpec.describe "bundle install with a mirror configured" do
     before :each do
       gemfile <<-G
         # This source is bogus and doesn't have the gem we're looking for
-        source "file://localhost#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
 
         gem "rack"
       G
-      bundle "config set --local mirror.file://localhost#{gem_repo2} file://localhost#{gem_repo1}"
+      bundle "config set --local mirror.#{file_uri_for(gem_repo2)} #{file_uri_for(gem_repo1)}"
     end
 
     it "installs the gem from the mirror" do
       bundle :install
-      expect(out).to include(normalize_uri_file("Fetching source index from file://localhost#{gem_repo1}"))
-      expect(out).not_to include(normalize_uri_file("Fetching source index from file://localhost#{gem_repo2}"))
+      expect(out).to include("Fetching source index from #{file_uri_for(gem_repo1)}")
+      expect(out).not_to include("Fetching source index from #{file_uri_for(gem_repo2)}")
       expect(the_bundle).to include_gems "rack 1.0"
     end
   end

--- a/spec/install/gems/native_extensions_spec.rb
+++ b/spec/install/gems/native_extensions_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "installing a gem with native extensions", :ruby_repo do
     end
 
     gemfile <<-G
-      source "file://#{gem_repo2}"
+      source "#{file_uri_for(gem_repo2)}"
       gem "c_extension"
     G
 

--- a/spec/install/gems/post_install_spec.rb
+++ b/spec/install/gems/post_install_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "bundle install" do
     context "when gems include post install messages" do
       it "should display the post-install messages after installing" do
         gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem 'rack'
           gem 'thin'
           gem 'rack-obama'
@@ -24,7 +24,7 @@ RSpec.describe "bundle install" do
     context "when gems do not include post install messages" do
       it "should not display any post-install messages" do
         gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "activesupport"
         G
 
@@ -36,7 +36,7 @@ RSpec.describe "bundle install" do
     context "when a dependecy includes a post install message" do
       it "should display the post install message" do
         gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem 'rack_middleware'
         G
 
@@ -54,7 +54,7 @@ RSpec.describe "bundle install" do
           s.post_install_message = "Foo's post install message"
         end
         gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem 'foo', :git => '#{lib_path("foo-1.0")}'
         G
 
@@ -68,7 +68,7 @@ RSpec.describe "bundle install" do
           s.post_install_message = "Foo's post install message"
         end
         gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem 'foo', :git => '#{lib_path("foo-1.0")}'
         G
         bundle :install
@@ -77,7 +77,7 @@ RSpec.describe "bundle install" do
           s.post_install_message = "Foo's 1.1 post install message"
         end
         gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem 'foo', :git => '#{lib_path("foo-1.1")}'
         G
         bundle :install
@@ -91,7 +91,7 @@ RSpec.describe "bundle install" do
           s.post_install_message = "Foo's post install message"
         end
         gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem 'foo', :git => '#{lib_path("foo-1.0")}'
         G
 
@@ -110,7 +110,7 @@ RSpec.describe "bundle install" do
           s.post_install_message = nil
         end
         gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem 'foo', :git => '#{lib_path("foo-1.0")}'
         G
 
@@ -123,7 +123,7 @@ RSpec.describe "bundle install" do
   context "when ignore post-install messages for gem is set" do
     it "doesn't display any post-install messages" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 
@@ -137,7 +137,7 @@ RSpec.describe "bundle install" do
   context "when ignore post-install messages for all gems" do
     it "doesn't display any post-install messages" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 

--- a/spec/install/gems/resolving_spec.rb
+++ b/spec/install/gems/resolving_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe "bundle install with install-time dependencies" do
   it "installs gems with implicit rake dependencies", :ruby_repo do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "with_implicit_rake_dep"
       gem "another_implicit_rake_dep"
       gem "rake"
@@ -31,7 +31,7 @@ RSpec.describe "bundle install with install-time dependencies" do
     end
 
     install_gemfile <<-G
-      source "file://#{gem_repo2}"
+      source "#{file_uri_for(gem_repo2)}"
       gem "actionpack", "2.3.2"
     G
 
@@ -41,7 +41,7 @@ RSpec.describe "bundle install with install-time dependencies" do
   describe "with crazy rubygem plugin stuff" do
     it "installs plugins" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "net_b"
       G
 
@@ -50,7 +50,7 @@ RSpec.describe "bundle install with install-time dependencies" do
 
     it "installs plugins depended on by other plugins", :ruby_repo do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "net_a"
       G
 
@@ -59,7 +59,7 @@ RSpec.describe "bundle install with install-time dependencies" do
 
     it "installs multiple levels of dependencies", :ruby_repo do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "net_c"
         gem "net_e"
       G
@@ -70,7 +70,7 @@ RSpec.describe "bundle install with install-time dependencies" do
     context "with ENV['DEBUG_RESOLVER'] set" do
       it "produces debug output" do
         gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "net_c"
           gem "net_e"
         G
@@ -84,7 +84,7 @@ RSpec.describe "bundle install with install-time dependencies" do
     context "with ENV['DEBUG_RESOLVER_TREE'] set" do
       it "produces debug output" do
         gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "net_c"
           gem "net_e"
         G
@@ -203,7 +203,7 @@ RSpec.describe "bundle install with install-time dependencies" do
       end
 
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem 'require_rubygems'
       G
 

--- a/spec/install/gems/standalone_spec.rb
+++ b/spec/install/gems/standalone_spec.rb
@@ -51,7 +51,7 @@ RSpec.shared_examples "bundle install --standalone" do
   describe "with simple gems" do
     before do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rails"
       G
       bundle! :install, forgotten_command_line_options(:path => bundled_app("bundle")).merge(:standalone => true)
@@ -70,7 +70,7 @@ RSpec.shared_examples "bundle install --standalone" do
   describe "with gems with native extension", :ruby_repo do
     before do
       install_gemfile <<-G, forgotten_command_line_options(:path => bundled_app("bundle")).merge(:standalone => true)
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "very_simple_binary"
       G
     end
@@ -118,7 +118,7 @@ RSpec.shared_examples "bundle install --standalone" do
       build_git "devise", "1.0"
 
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rails"
         gem "devise", :git => "#{lib_path("devise-1.0")}"
       G
@@ -141,7 +141,7 @@ RSpec.shared_examples "bundle install --standalone" do
       build_git "devise", "1.0"
 
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rails"
 
         group :test do
@@ -276,7 +276,7 @@ RSpec.shared_examples "bundle install --standalone" do
   describe "with --binstubs", :bundler => "< 3" do
     before do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rails"
       G
       bundle! :install, forgotten_command_line_options(:path => bundled_app("bundle")).merge(:standalone => true, :binstubs => true)

--- a/spec/install/gems/sudo_spec.rb
+++ b/spec/install/gems/sudo_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "when using sudo", :sudo => true do
 
       it "installs" do
         install_gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "rack"
         G
 
@@ -38,7 +38,7 @@ RSpec.describe "when using sudo", :sudo => true do
 
     it "installs" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", '1.0'
         gem "thin"
       G
@@ -50,7 +50,7 @@ RSpec.describe "when using sudo", :sudo => true do
 
     it "installs rake and a gem dependent on rake in the same session" do
       gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "rake"
           gem "another_implicit_rake_dep"
       G
@@ -65,7 +65,7 @@ RSpec.describe "when using sudo", :sudo => true do
 
       ENV["BUNDLE_PATH"] = bundle_path.to_s
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", '1.0'
       G
 
@@ -82,7 +82,7 @@ RSpec.describe "when using sudo", :sudo => true do
 
       ENV["BUNDLE_PATH"] = bundle_path.to_s
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", '1.0'
       G
 
@@ -93,7 +93,7 @@ RSpec.describe "when using sudo", :sudo => true do
 
     it "installs extensions/" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "very_simple_binary"
       G
 
@@ -114,7 +114,7 @@ RSpec.describe "when using sudo", :sudo => true do
 
     it "installs" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", '1.0'
       G
 
@@ -129,7 +129,7 @@ RSpec.describe "when using sudo", :sudo => true do
       end
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
       tmpdirs = Dir.glob("#{Dir.tmpdir}/bundler*")
@@ -146,7 +146,7 @@ RSpec.describe "when using sudo", :sudo => true do
       sudo "chmod ugo-w #{gem_home}"
 
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", '1.0'
       G
 
@@ -162,7 +162,7 @@ RSpec.describe "when using sudo", :sudo => true do
     let(:warning) { "Don't run Bundler as root." }
 
     before do
-      gemfile %(source "file://#{gem_repo1}")
+      gemfile %(source "#{file_uri_for(gem_repo1)}")
     end
 
     it "warns against that" do

--- a/spec/install/gems/win32_spec.rb
+++ b/spec/install/gems/win32_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "bundle install with win32-generated lockfile" do
   it "should read lockfile" do
     File.open(bundled_app("Gemfile.lock"), "wb") do |f|
       f << "GEM\r\n"
-      f << "  remote: file:#{gem_repo1}/\r\n"
+      f << "  remote: #{file_uri_for(gem_repo1)}/\r\n"
       f << "  specs:\r\n"
       f << "\r\n"
       f << "    rack (1.0.0)\r\n"
@@ -17,7 +17,7 @@ RSpec.describe "bundle install with win32-generated lockfile" do
     end
 
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "rack"
     G

--- a/spec/install/gemspecs_spec.rb
+++ b/spec/install/gemspecs_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "bundle install" do
 
     it "still installs correctly" do
       gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "yaml_spec"
       G
       bundle :install

--- a/spec/install/git_spec.rb
+++ b/spec/install/git_spec.rb
@@ -40,12 +40,12 @@ RSpec.describe "bundle install" do
       revision = build_git("foo").ref_for("HEAD")
 
       gemfile <<-G
-        gem "foo", :git => "file://#{lib_path("foo-1.0")}", :group => :development
+        gem "foo", :git => "#{file_uri_for(lib_path("foo-1.0"))}", :group => :development
       G
 
       lockfile <<-L
         GIT
-          remote: file://#{lib_path("foo-1.0")}
+          remote: #{file_uri_for(lib_path("foo-1.0"))}
           revision: #{revision}
           specs:
             foo (1.0)

--- a/spec/install/global_cache_spec.rb
+++ b/spec/install/global_cache_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe "global gem caching" do
       revision = revision_for(lib_path("very_simple_git_binary-1.0"))[0, 12]
 
       install_gemfile! <<-G
-        source "file:#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
 
         gem "very_simple_binary"
         gem "very_simple_git_binary", :git => "#{lib_path("very_simple_git_binary-1.0")}"

--- a/spec/install/path_spec.rb
+++ b/spec/install/path_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "bundle install" do
       end
 
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
     end
@@ -89,7 +89,7 @@ RSpec.describe "bundle install" do
       end
 
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
     end
@@ -178,7 +178,7 @@ RSpec.describe "bundle install" do
       end
 
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "very_simple_binary"
       G
 
@@ -210,7 +210,7 @@ RSpec.describe "bundle install" do
 
     it "reports the file exists" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 

--- a/spec/install/prereleases_spec.rb
+++ b/spec/install/prereleases_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "bundle install" do
   describe "when prerelease gems are available" do
     it "finds prereleases" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "not_released"
       G
       expect(the_bundle).to include_gems "not_released 1.0.pre"
@@ -12,7 +12,7 @@ RSpec.describe "bundle install" do
 
     it "uses regular releases if available" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "has_prerelease"
       G
       expect(the_bundle).to include_gems "has_prerelease 1.0"
@@ -20,7 +20,7 @@ RSpec.describe "bundle install" do
 
     it "uses prereleases if requested" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "has_prerelease", "1.1.pre"
       G
       expect(the_bundle).to include_gems "has_prerelease 1.1.pre"
@@ -31,7 +31,7 @@ RSpec.describe "bundle install" do
     it "still works" do
       build_repo3
       install_gemfile <<-G
-        source "file://#{gem_repo3}"
+        source "#{file_uri_for(gem_repo3)}"
         gem "rack"
       G
 

--- a/spec/install/process_lock_spec.rb
+++ b/spec/install/process_lock_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "process lock spec" do
       end
 
       install_gemfile! <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 

--- a/spec/install/redownload_spec.rb
+++ b/spec/install/redownload_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe "bundle install" do
   before :each do
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack"
     G
   end

--- a/spec/install/security_policy_spec.rb
+++ b/spec/install/security_policy_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "policies with unsigned gems" do
   before do
     build_security_repo
     gemfile <<-G
-      source "file://#{security_repo}"
+      source "#{file_uri_for(security_repo)}"
       gem "rack"
       gem "signed_gem"
     G
@@ -47,7 +47,7 @@ RSpec.describe "policies with signed gems and no CA" do
   before do
     build_security_repo
     gemfile <<-G
-      source "file://#{security_repo}"
+      source "#{file_uri_for(security_repo)}"
       gem "signed_gem"
     G
   end

--- a/spec/install/yanked_spec.rb
+++ b/spec/install/yanked_spec.rb
@@ -10,7 +10,7 @@ RSpec.context "when installing a bundle that includes yanked gems" do
   it "throws an error when the original gem version is yanked" do
     lockfile <<-L
        GEM
-         remote: file://#{gem_repo4}
+         remote: #{file_uri_for(gem_repo4)}
          specs:
            foo (10.0.0)
 
@@ -23,7 +23,7 @@ RSpec.context "when installing a bundle that includes yanked gems" do
     L
 
     install_gemfile <<-G
-        source "file://#{gem_repo4}"
+        source "#{file_uri_for(gem_repo4)}"
         gem "foo", "10.0.0"
     G
 
@@ -32,7 +32,7 @@ RSpec.context "when installing a bundle that includes yanked gems" do
 
   it "throws the original error when only the Gemfile specifies a gem version that doesn't exist" do
     install_gemfile <<-G
-        source "file://#{gem_repo4}"
+        source "#{file_uri_for(gem_repo4)}"
         gem "foo", "10.0.0"
     G
 
@@ -44,13 +44,13 @@ end
 RSpec.context "when using gem before installing" do
   it "does not suggest the author has yanked the gem" do
     gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", "0.9.1"
     G
 
     lockfile <<-L
        GEM
-         remote: file://#{gem_repo1}
+         remote: #{file_uri_for(gem_repo1)}
          specs:
            rack (0.9.1)
 

--- a/spec/lock/lockfile_spec.rb
+++ b/spec/lock/lockfile_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe "the lockfile format" do
 
   it "generates a simple lockfile for a single source, gem" do
     install_gemfile <<-G
-      source "file://localhost#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "rack"
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file://localhost#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           rack (1.0.0)
 
@@ -37,7 +37,7 @@ RSpec.describe "the lockfile format" do
         specs:
 
       GEM
-        remote: file://localhost#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           rack (1.0.0)
 
@@ -53,14 +53,14 @@ RSpec.describe "the lockfile format" do
     L
 
     install_gemfile <<-G
-      source "file://localhost#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "rack"
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file://localhost#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           rack (1.0.0)
 
@@ -80,7 +80,7 @@ RSpec.describe "the lockfile format" do
 
     lockfile <<-L
       GEM
-        remote: file://localhost#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           rack (1.0.0)
 
@@ -95,14 +95,14 @@ RSpec.describe "the lockfile format" do
     L
 
     install_gemfile <<-G
-      source "file://localhost#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "rack"
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file://localhost#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           rack (1.0.0)
 
@@ -120,7 +120,7 @@ RSpec.describe "the lockfile format" do
   it "updates the lockfile's bundler version if not present" do
     lockfile <<-L
       GEM
-        remote: file://localhost#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           rack (1.0.0)
 
@@ -132,14 +132,14 @@ RSpec.describe "the lockfile format" do
     L
 
     install_gemfile <<-G
-      source "file://localhost#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "rack", "> 0"
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file://localhost#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           rack (1.0.0)
 
@@ -160,7 +160,7 @@ RSpec.describe "the lockfile format" do
 
     lockfile <<-L
       GEM
-        remote: file://localhost#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           rack (1.0.0)
 
@@ -175,7 +175,7 @@ RSpec.describe "the lockfile format" do
     L
 
     install_gemfile <<-G
-      source "file://localhost#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "rack"
     G
@@ -189,7 +189,7 @@ RSpec.describe "the lockfile format" do
 
     lockfile_should_be <<-G
       GEM
-        remote: file://localhost#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           rack (1.0.0)
 
@@ -210,7 +210,7 @@ RSpec.describe "the lockfile format" do
 
     lockfile <<-L
       GEM
-        remote: file://localhost#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           rack (1.0.0)
 
@@ -225,7 +225,7 @@ RSpec.describe "the lockfile format" do
     L
 
     install_gemfile <<-G
-      source "file://localhost#{gem_repo1}/"
+      source "#{file_uri_for(gem_repo1)}/"
 
       gem "rack"
     G
@@ -237,7 +237,7 @@ RSpec.describe "the lockfile format" do
 
     lockfile_should_be <<-G
       GEM
-        remote: file://localhost#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           rack (1.0.0)
 
@@ -254,14 +254,14 @@ RSpec.describe "the lockfile format" do
 
   it "generates a simple lockfile for a single source, gem with dependencies" do
     install_gemfile <<-G
-      source "file://localhost#{gem_repo1}/"
+      source "#{file_uri_for(gem_repo1)}/"
 
       gem "rack-obama"
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file://localhost#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           rack (1.0.0)
           rack-obama (1.0)
@@ -280,14 +280,14 @@ RSpec.describe "the lockfile format" do
 
   it "generates a simple lockfile for a single source, gem with a version requirement" do
     install_gemfile <<-G
-      source "file://localhost#{gem_repo1}/"
+      source "#{file_uri_for(gem_repo1)}/"
 
       gem "rack-obama", ">= 1.0"
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file://localhost#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           rack (1.0.0)
           rack-obama (1.0)
@@ -378,13 +378,13 @@ RSpec.describe "the lockfile format" do
 
   it "generates lockfiles with multiple requirements" do
     install_gemfile <<-G
-      source "file://localhost#{gem_repo1}/"
+      source "#{file_uri_for(gem_repo1)}/"
       gem "net-sftp"
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file://localhost#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           net-sftp (1.1.1)
             net-ssh (>= 1.0.0, < 1.99.0)
@@ -463,7 +463,7 @@ RSpec.describe "the lockfile format" do
     build_lib "omg", :path => lib_path("omg")
 
     gemfile <<-G
-      source "file://localhost#{gem_repo1}/"
+      source "#{file_uri_for(gem_repo1)}/"
 
       platforms :#{not_local_tag} do
         gem "omg", :path => "#{lib_path("omg")}"
@@ -479,7 +479,7 @@ RSpec.describe "the lockfile format" do
         specs:
 
       GEM
-        remote: file://localhost#{gem_repo1}//
+        remote: #{file_uri_for(gem_repo1)}//
         specs:
           rack (1.0.0)
 
@@ -650,7 +650,7 @@ RSpec.describe "the lockfile format" do
     bar = build_git "bar"
 
     install_gemfile <<-G
-      source "file://localhost#{gem_repo1}/"
+      source "#{file_uri_for(gem_repo1)}/"
 
       gem "rack"
       gem "foo", :path => "#{lib_path("foo-1.0")}"
@@ -670,7 +670,7 @@ RSpec.describe "the lockfile format" do
           foo (1.0)
 
       GEM
-        remote: file://localhost#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           rack (1.0.0)
 
@@ -689,7 +689,7 @@ RSpec.describe "the lockfile format" do
 
   it "lists gems alphabetically" do
     install_gemfile <<-G
-      source "file://localhost#{gem_repo1}/"
+      source "#{file_uri_for(gem_repo1)}/"
 
       gem "thin"
       gem "actionpack"
@@ -698,7 +698,7 @@ RSpec.describe "the lockfile format" do
 
     lockfile_should_be <<-G
       GEM
-        remote: file://localhost#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           actionpack (2.3.2)
             activesupport (= 2.3.2)
@@ -724,14 +724,14 @@ RSpec.describe "the lockfile format" do
 
   it "orders dependencies' dependencies in alphabetical order" do
     install_gemfile <<-G
-      source "file://localhost#{gem_repo1}/"
+      source "#{file_uri_for(gem_repo1)}/"
 
       gem "rails"
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file://localhost#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           actionmailer (2.3.2)
             activesupport (= 2.3.2)
@@ -763,13 +763,13 @@ RSpec.describe "the lockfile format" do
 
   it "orders dependencies by version" do
     install_gemfile <<-G
-      source "file://localhost#{gem_repo1}/"
+      source "#{file_uri_for(gem_repo1)}/"
       gem 'double_deps'
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file://localhost#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           double_deps (1.0)
             net-ssh
@@ -789,14 +789,14 @@ RSpec.describe "the lockfile format" do
 
   it "does not add the :require option to the lockfile" do
     install_gemfile <<-G
-      source "file://localhost#{gem_repo1}/"
+      source "#{file_uri_for(gem_repo1)}/"
 
       gem "rack-obama", ">= 1.0", :require => "rack/obama"
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file://localhost#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           rack (1.0.0)
           rack-obama (1.0)
@@ -815,14 +815,14 @@ RSpec.describe "the lockfile format" do
 
   it "does not add the :group option to the lockfile" do
     install_gemfile <<-G
-      source "file://localhost#{gem_repo1}/"
+      source "#{file_uri_for(gem_repo1)}/"
 
       gem "rack-obama", ">= 1.0", :group => :test
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file://localhost#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           rack (1.0.0)
           rack-obama (1.0)
@@ -956,7 +956,7 @@ RSpec.describe "the lockfile format" do
   it "keeps existing platforms in the lockfile", :bundler => "< 3" do
     lockfile <<-G
       GEM
-        remote: file://localhost#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           rack (1.0.0)
 
@@ -971,14 +971,14 @@ RSpec.describe "the lockfile format" do
     G
 
     install_gemfile <<-G
-      source "file://localhost#{gem_repo1}/"
+      source "#{file_uri_for(gem_repo1)}/"
 
       gem "rack"
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file://localhost#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           rack (1.0.0)
 
@@ -997,7 +997,7 @@ RSpec.describe "the lockfile format" do
   it "keeps existing platforms in the lockfile", :bundler => "3" do
     lockfile <<-G
       GEM
-        remote: file://localhost#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           rack (1.0.0)
 
@@ -1012,14 +1012,14 @@ RSpec.describe "the lockfile format" do
     G
 
     install_gemfile <<-G
-      source "file://localhost#{gem_repo1}/"
+      source "#{file_uri_for(gem_repo1)}/"
 
       gem "rack"
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file://localhost#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           rack (1.0.0)
 
@@ -1046,13 +1046,13 @@ RSpec.describe "the lockfile format" do
     simulate_platform "universal-java-16"
 
     install_gemfile! <<-G
-      source "file://localhost#{gem_repo2}"
+      source "#{file_uri_for(gem_repo2)}"
       gem "platform_specific"
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file://localhost#{gem_repo2}/
+        remote: #{file_uri_for(gem_repo2)}/
         specs:
           platform_specific (1.0-java)
 
@@ -1077,13 +1077,13 @@ RSpec.describe "the lockfile format" do
     simulate_platform "universal-java-16"
 
     install_gemfile! <<-G
-      source "file://localhost#{gem_repo2}"
+      source "#{file_uri_for(gem_repo2)}"
       gem "platform_specific"
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file://localhost#{gem_repo2}/
+        remote: #{file_uri_for(gem_repo2)}/
         specs:
           platform_specific (1.0-java)
           platform_specific (1.0-universal-java-16)
@@ -1102,19 +1102,19 @@ RSpec.describe "the lockfile format" do
 
   it "does not add duplicate gems" do
     install_gemfile <<-G
-      source "file://localhost#{gem_repo1}/"
+      source "#{file_uri_for(gem_repo1)}/"
       gem "rack"
     G
 
     install_gemfile <<-G
-      source "file://localhost#{gem_repo1}/"
+      source "#{file_uri_for(gem_repo1)}/"
       gem "rack"
       gem "activesupport"
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file://localhost#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           activesupport (2.3.5)
           rack (1.0.0)
@@ -1133,14 +1133,14 @@ RSpec.describe "the lockfile format" do
 
   it "does not add duplicate dependencies" do
     install_gemfile <<-G
-      source "file://localhost#{gem_repo1}/"
+      source "#{file_uri_for(gem_repo1)}/"
       gem "rack"
       gem "rack"
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file://localhost#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           rack (1.0.0)
 
@@ -1157,14 +1157,14 @@ RSpec.describe "the lockfile format" do
 
   it "does not add duplicate dependencies with versions" do
     install_gemfile <<-G
-      source "file://localhost#{gem_repo1}/"
+      source "#{file_uri_for(gem_repo1)}/"
       gem "rack", "1.0"
       gem "rack", "1.0"
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file://localhost#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           rack (1.0.0)
 
@@ -1181,14 +1181,14 @@ RSpec.describe "the lockfile format" do
 
   it "does not add duplicate dependencies in different groups" do
     install_gemfile <<-G
-      source "file://localhost#{gem_repo1}/"
+      source "#{file_uri_for(gem_repo1)}/"
       gem "rack", "1.0", :group => :one
       gem "rack", "1.0", :group => :two
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file://localhost#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           rack (1.0.0)
 
@@ -1205,7 +1205,7 @@ RSpec.describe "the lockfile format" do
 
   it "raises if two different versions are used" do
     install_gemfile <<-G
-      source "file://localhost#{gem_repo1}/"
+      source "#{file_uri_for(gem_repo1)}/"
       gem "rack", "1.0"
       gem "rack", "1.1"
     G
@@ -1216,7 +1216,7 @@ RSpec.describe "the lockfile format" do
 
   it "raises if two different sources are used" do
     install_gemfile <<-G
-      source "file://localhost#{gem_repo1}/"
+      source "#{file_uri_for(gem_repo1)}/"
       gem "rack"
       gem "rack", :git => "git://hubz.com"
     G
@@ -1227,13 +1227,13 @@ RSpec.describe "the lockfile format" do
 
   it "works correctly with multiple version dependencies" do
     install_gemfile <<-G
-      source "file://localhost#{gem_repo1}/"
+      source "#{file_uri_for(gem_repo1)}/"
       gem "rack", "> 0.9", "< 1.0"
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file://localhost#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           rack (0.9.1)
 
@@ -1250,14 +1250,14 @@ RSpec.describe "the lockfile format" do
 
   it "captures the Ruby version in the lockfile" do
     install_gemfile <<-G
-      source "file://localhost#{gem_repo1}/"
+      source "#{file_uri_for(gem_repo1)}/"
       ruby '#{RUBY_VERSION}'
       gem "rack", "> 0.9", "< 1.0"
     G
 
     lockfile_should_be <<-G
       GEM
-        remote: file://localhost#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           rack (0.9.1)
 
@@ -1286,7 +1286,7 @@ RSpec.describe "the lockfile format" do
     revision = revision_for(lib_path("omg"))
 
     gemfile <<-G
-      source "file://localhost#{gem_repo1}/"
+      source "#{file_uri_for(gem_repo1)}/"
       gem "omg", :git => "#{lib_path("omg")}", :branch => 'master'
     G
 
@@ -1310,7 +1310,7 @@ RSpec.describe "the lockfile format" do
           omg (1.0)
 
       GEM
-        remote: file://localhost#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
 
       PLATFORMS
@@ -1337,7 +1337,7 @@ RSpec.describe "the lockfile format" do
           omg (1.0)
 
       GEM
-        remote: file://localhost#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
 
       PLATFORMS
@@ -1354,7 +1354,7 @@ RSpec.describe "the lockfile format" do
   it "raises a helpful error message when the lockfile is missing deps" do
     lockfile <<-L
       GEM
-        remote: file://localhost#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           rack_middleware (1.0)
 
@@ -1366,7 +1366,7 @@ RSpec.describe "the lockfile format" do
     L
 
     install_gemfile <<-G
-      source "file://localhost#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack_middleware"
     G
 
@@ -1383,7 +1383,7 @@ RSpec.describe "the lockfile format" do
       build_repo2
 
       install_gemfile <<-G
-        source "file://localhost#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "rack"
       G
       set_lockfile_mtime_to_known_value
@@ -1445,7 +1445,7 @@ RSpec.describe "the lockfile format" do
   it "refuses to install if Gemfile.lock contains conflict markers" do
     lockfile <<-L
       GEM
-        remote: file://localhost#{gem_repo1}//
+        remote: #{file_uri_for(gem_repo1)}//
         specs:
       <<<<<<<
           rack (1.0.0)
@@ -1464,7 +1464,7 @@ RSpec.describe "the lockfile format" do
     L
 
     install_gemfile(<<-G)
-      source "file://localhost#{gem_repo1}/"
+      source "#{file_uri_for(gem_repo1)}/"
       gem "rack"
     G
 

--- a/spec/other/ext_spec.rb
+++ b/spec/other/ext_spec.rb
@@ -49,7 +49,7 @@ end
 RSpec.describe "Gem::SourceIndex#refresh!" do
   before do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack"
     G
   end

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "major deprecations" do
   describe "Bundler" do
     before do
       install_gemfile! <<-G
-        source "file:#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
     end
@@ -196,7 +196,7 @@ RSpec.describe "major deprecations" do
   describe "bundle update" do
     before do
       install_gemfile <<-G
-        source "file:#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
     end
@@ -217,7 +217,7 @@ RSpec.describe "major deprecations" do
   describe "bundle install --binstubs" do
     before do
       install_gemfile <<-G, :binstubs => true
-        source "file:#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
     end
@@ -232,7 +232,7 @@ RSpec.describe "major deprecations" do
   context "bundle install with both gems.rb and Gemfile present" do
     it "should not warn about gems.rb" do
       create_file "gems.rb", <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 
@@ -243,7 +243,7 @@ RSpec.describe "major deprecations" do
     it "should print a proper warning, and use gems.rb" do
       create_file "gems.rb"
       install_gemfile! <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 
@@ -260,7 +260,7 @@ RSpec.describe "major deprecations" do
       bundle "config set --local path vendor/bundle"
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
     end
@@ -302,8 +302,8 @@ RSpec.describe "major deprecations" do
   context "bundle install with multiple sources" do
     before do
       install_gemfile <<-G
-        source "file://localhost#{gem_repo3}"
-        source "file://localhost#{gem_repo1}"
+        source "#{file_uri_for(gem_repo3)}"
+        source "#{file_uri_for(gem_repo1)}"
       G
     end
 
@@ -325,7 +325,7 @@ RSpec.describe "major deprecations" do
     before do
       create_file "gems.rb"
       install_gemfile! <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", :group => :test
       G
 
@@ -427,7 +427,7 @@ The :gist git source is deprecated, and will be removed in the future. Add this 
   context "bundle show" do
     before do
       install_gemfile! <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
     end

--- a/spec/other/platform_spec.rb
+++ b/spec/other/platform_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "bundle platform" do
 
     it "returns all the output" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
 
         #{ruby_version_correct}
 
@@ -33,7 +33,7 @@ G
 
     it "returns all the output including the patchlevel" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
 
         #{ruby_version_correct_patchlevel}
 
@@ -56,7 +56,7 @@ G
 
     it "doesn't print ruby version requirement if it isn't specified" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
 
         gem "foo"
       G
@@ -74,7 +74,7 @@ G
 
     it "doesn't match the ruby version requirement" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
 
         #{ruby_version_incorrect}
 
@@ -99,7 +99,7 @@ G
   context "--ruby" do
     it "returns ruby version when explicit" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         ruby "1.9.3", :engine => 'ruby', :engine_version => '1.9.3'
 
         gem "foo"
@@ -112,7 +112,7 @@ G
 
     it "defaults to MRI" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         ruby "1.9.3"
 
         gem "foo"
@@ -125,7 +125,7 @@ G
 
     it "handles jruby" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         ruby "1.8.7", :engine => 'jruby', :engine_version => '1.6.5'
 
         gem "foo"
@@ -138,7 +138,7 @@ G
 
     it "handles rbx" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         ruby "1.8.7", :engine => 'rbx', :engine_version => '1.2.4'
 
         gem "foo"
@@ -151,7 +151,7 @@ G
 
     it "handles truffleruby" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         ruby "2.5.1", :engine => 'truffleruby', :engine_version => '1.0.0-rc6'
 
         gem "foo"
@@ -164,7 +164,7 @@ G
 
     it "raises an error if engine is used but engine version is not" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         ruby "1.8.7", :engine => 'rbx'
 
         gem "foo"
@@ -177,7 +177,7 @@ G
 
     it "raises an error if engine_version is used but engine is not" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         ruby "1.8.7", :engine_version => '1.2.4'
 
         gem "foo"
@@ -190,7 +190,7 @@ G
 
     it "raises an error if engine version doesn't match ruby version for MRI" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         ruby "1.8.7", :engine => 'ruby', :engine_version => '1.2.4'
 
         gem "foo"
@@ -203,7 +203,7 @@ G
 
     it "should print if no ruby version is specified" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
 
         gem "foo"
       G
@@ -294,7 +294,7 @@ G
   context "bundle install" do
     it "installs fine when the ruby version matches" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
 
         #{ruby_version_correct}
@@ -306,7 +306,7 @@ G
     it "installs fine with any engine" do
       simulate_ruby_engine "jruby" do
         install_gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "rack"
 
           #{ruby_version_correct_engineless}
@@ -318,7 +318,7 @@ G
 
     it "installs fine when the patchlevel matches" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
 
         #{ruby_version_correct_patchlevel}
@@ -329,7 +329,7 @@ G
 
     it "doesn't install when the ruby version doesn't match" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
 
         #{ruby_version_incorrect}
@@ -341,7 +341,7 @@ G
 
     it "doesn't install when engine doesn't match" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
 
         #{engine_incorrect}
@@ -354,7 +354,7 @@ G
     it "doesn't install when engine version doesn't match" do
       simulate_ruby_engine "jruby" do
         install_gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "rack"
 
           #{engine_version_incorrect}
@@ -367,7 +367,7 @@ G
 
     it "doesn't install when patchlevel doesn't match" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
 
         #{patchlevel_incorrect}
@@ -381,12 +381,12 @@ G
   context "bundle check" do
     it "checks fine when the ruby version matches" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
 
         #{ruby_version_correct}
@@ -400,12 +400,12 @@ G
     it "checks fine with any engine" do
       simulate_ruby_engine "jruby" do
         install_gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "rack"
         G
 
         gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "rack"
 
           #{ruby_version_correct_engineless}
@@ -419,12 +419,12 @@ G
 
     it "fails when ruby version doesn't match" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
 
         #{ruby_version_incorrect}
@@ -436,12 +436,12 @@ G
 
     it "fails when engine doesn't match" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
 
         #{engine_incorrect}
@@ -454,12 +454,12 @@ G
     it "fails when engine version doesn't match" do
       simulate_ruby_engine "ruby" do
         install_gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "rack"
         G
 
         gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "rack"
 
           #{engine_version_incorrect}
@@ -472,12 +472,12 @@ G
 
     it "fails when patchlevel doesn't match" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
 
         #{patchlevel_incorrect}
@@ -493,7 +493,7 @@ G
       build_repo2
 
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "activesupport"
         gem "rack-obama"
       G
@@ -501,7 +501,7 @@ G
 
     it "updates successfully when the ruby version matches" do
       gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "activesupport"
         gem "rack-obama"
 
@@ -518,7 +518,7 @@ G
     it "updates fine with any engine" do
       simulate_ruby_engine "jruby" do
         gemfile <<-G
-          source "file://#{gem_repo2}"
+          source "#{file_uri_for(gem_repo2)}"
           gem "activesupport"
           gem "rack-obama"
 
@@ -535,7 +535,7 @@ G
 
     it "fails when ruby version doesn't match" do
       gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "activesupport"
         gem "rack-obama"
 
@@ -551,7 +551,7 @@ G
 
     it "fails when ruby engine doesn't match" do
       gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "activesupport"
         gem "rack-obama"
 
@@ -568,7 +568,7 @@ G
     it "fails when ruby engine version doesn't match" do
       simulate_ruby_engine "jruby" do
         gemfile <<-G
-          source "file://#{gem_repo2}"
+          source "#{file_uri_for(gem_repo2)}"
           gem "activesupport"
           gem "rack-obama"
 
@@ -585,7 +585,7 @@ G
 
     it "fails when patchlevel doesn't match" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
 
         #{patchlevel_incorrect}
@@ -602,14 +602,14 @@ G
   context "bundle info" do
     before do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rails"
       G
     end
 
     it "prints path if ruby version is correct" do
       install_gemfile! <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rails"
 
         #{ruby_version_correct}
@@ -622,7 +622,7 @@ G
     it "prints path if ruby version is correct for any engine" do
       simulate_ruby_engine "jruby" do
         install_gemfile! <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "rails"
 
           #{ruby_version_correct_engineless}
@@ -635,7 +635,7 @@ G
 
     it "fails if ruby version doesn't match", :bundler => "< 3" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rails"
 
         #{ruby_version_incorrect}
@@ -647,7 +647,7 @@ G
 
     it "fails if engine doesn't match", :bundler => "< 3" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rails"
 
         #{engine_incorrect}
@@ -660,7 +660,7 @@ G
     it "fails if engine version doesn't match", :bundler => "< 3" do
       simulate_ruby_engine "jruby" do
         gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "rails"
 
           #{engine_version_incorrect}
@@ -673,7 +673,7 @@ G
 
     it "fails when patchlevel doesn't match", :bundler => "< 3" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
 
         #{patchlevel_incorrect}
@@ -690,7 +690,7 @@ G
   context "bundle cache" do
     before do
       install_gemfile <<-G
-        source "file:#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem 'rack'
       G
     end
@@ -709,7 +709,7 @@ G
     it "copies the .gem file to vendor/cache when ruby version matches for any engine" do
       simulate_ruby_engine "jruby" do
         install_gemfile! <<-G
-          source "file:#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem 'rack'
 
           #{ruby_version_correct_engineless}
@@ -757,7 +757,7 @@ G
 
     it "fails when patchlevel doesn't match" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
 
         #{patchlevel_incorrect}
@@ -771,7 +771,7 @@ G
   context "bundle pack" do
     before do
       install_gemfile! <<-G
-        source "file:#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem 'rack'
       G
     end
@@ -790,7 +790,7 @@ G
     it "copies the .gem file to vendor/cache when ruby version matches any engine" do
       simulate_ruby_engine "jruby" do
         install_gemfile! <<-G
-          source "file:#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem 'rack'
 
           #{ruby_version_correct_engineless}
@@ -838,7 +838,7 @@ G
 
     it "fails when patchlevel doesn't match" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
 
         #{patchlevel_incorrect}
@@ -917,7 +917,7 @@ G
 
     it "fails when patchlevel doesn't match" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
 
         #{patchlevel_incorrect}
@@ -931,7 +931,7 @@ G
   context "bundle console", :bundler => "< 3" do
     before do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
         gem "activesupport", :group => :test
         gem "rack_middleware", :group => :development
@@ -940,7 +940,7 @@ G
 
     it "starts IRB with the default group loaded when ruby version matches" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
         gem "activesupport", :group => :test
         gem "rack_middleware", :group => :development
@@ -958,7 +958,7 @@ G
     it "starts IRB with the default group loaded when ruby version matches any engine" do
       simulate_ruby_engine "jruby" do
         gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "rack"
           gem "activesupport", :group => :test
           gem "rack_middleware", :group => :development
@@ -976,7 +976,7 @@ G
 
     it "fails when ruby version doesn't match" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
         gem "activesupport", :group => :test
         gem "rack_middleware", :group => :development
@@ -990,7 +990,7 @@ G
 
     it "fails when engine doesn't match" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
         gem "activesupport", :group => :test
         gem "rack_middleware", :group => :development
@@ -1005,7 +1005,7 @@ G
     it "fails when engine version doesn't match" do
       simulate_ruby_engine "jruby" do
         gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "rack"
           gem "activesupport", :group => :test
           gem "rack_middleware", :group => :development
@@ -1020,7 +1020,7 @@ G
 
     it "fails when patchlevel doesn't match" do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
         gem "activesupport", :group => :test
         gem "rack_middleware", :group => :development
@@ -1036,7 +1036,7 @@ G
   context "Bundler.setup" do
     before do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "yard"
         gem "rack", :group => :test
       G
@@ -1046,7 +1046,7 @@ G
 
     it "makes a Gemfile.lock if setup succeeds" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "yard"
         gem "rack"
 
@@ -1062,7 +1062,7 @@ G
     it "makes a Gemfile.lock if setup succeeds for any engine" do
       simulate_ruby_engine "jruby" do
         install_gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "yard"
           gem "rack"
 
@@ -1078,7 +1078,7 @@ G
 
     it "fails when ruby version doesn't match" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "yard"
         gem "rack"
 
@@ -1098,7 +1098,7 @@ G
 
     it "fails when engine doesn't match" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "yard"
         gem "rack"
 
@@ -1119,7 +1119,7 @@ G
     it "fails when engine version doesn't match" do
       simulate_ruby_engine "jruby" do
         install_gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "yard"
           gem "rack"
 
@@ -1140,7 +1140,7 @@ G
 
     it "fails when patchlevel doesn't match" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "yard"
         gem "rack"
 
@@ -1166,7 +1166,7 @@ G
       end
 
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "activesupport", "2.3.5"
         gem "foo", :git => "#{lib_path("foo")}"
       G
@@ -1179,7 +1179,7 @@ G
       end
 
       gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "activesupport", "2.3.5"
         gem "foo", :git => "#{lib_path("foo")}"
 
@@ -1200,7 +1200,7 @@ G
         end
 
         gemfile <<-G
-          source "file://#{gem_repo2}"
+          source "#{file_uri_for(gem_repo2)}"
           gem "activesupport", "2.3.5"
           gem "foo", :git => "#{lib_path("foo")}"
 
@@ -1220,7 +1220,7 @@ G
       end
 
       gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "activesupport", "2.3.5"
         gem "foo", :git => "#{lib_path("foo")}"
 
@@ -1238,7 +1238,7 @@ G
       end
 
       gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "activesupport", "2.3.5"
         gem "foo", :git => "#{lib_path("foo")}"
 
@@ -1257,7 +1257,7 @@ G
         end
 
         gemfile <<-G
-          source "file://#{gem_repo2}"
+          source "#{file_uri_for(gem_repo2)}"
           gem "activesupport", "2.3.5"
           gem "foo", :git => "#{lib_path("foo")}"
 
@@ -1277,7 +1277,7 @@ G
         end
 
         gemfile <<-G
-          source "file://#{gem_repo2}"
+          source "#{file_uri_for(gem_repo2)}"
           gem "activesupport", "2.3.5"
           gem "foo", :git => "#{lib_path("foo")}"
 
@@ -1297,7 +1297,7 @@ G
         end
 
         gemfile <<-G
-          source "file://#{gem_repo2}"
+          source "#{file_uri_for(gem_repo2)}"
           gem "activesupport", "2.3.5"
           gem "foo", :git => "#{lib_path("foo")}"
 

--- a/spec/plugins/command_spec.rb
+++ b/spec/plugins/command_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "command plugins" do
       end
     end
 
-    bundle "plugin install command-mah --source file://#{gem_repo2}"
+    bundle "plugin install command-mah --source #{file_uri_for(gem_repo2)}"
   end
 
   it "executes without arguments" do
@@ -46,7 +46,7 @@ RSpec.describe "command plugins" do
       end
     end
 
-    bundle "plugin install the-echoer --source file://#{gem_repo2}"
+    bundle "plugin install the-echoer --source #{file_uri_for(gem_repo2)}"
     expect(out).to include("Installed plugin the-echoer")
 
     bundle "echo tacos tofu lasange"
@@ -69,7 +69,7 @@ RSpec.describe "command plugins" do
       end
     end
 
-    bundle "plugin install copycat --source file://#{gem_repo2}"
+    bundle "plugin install copycat --source #{file_uri_for(gem_repo2)}"
 
     expect(out).not_to include("Installed plugin copycat")
 

--- a/spec/plugins/hook_spec.rb
+++ b/spec/plugins/hook_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe "hook plugins" do
         end
       end
 
-      bundle "plugin install before-install-all-plugin --source file://#{gem_repo2}"
+      bundle "plugin install before-install-all-plugin --source #{file_uri_for(gem_repo2)}"
     end
 
     it "runs before all rubygems are installed" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rake"
         gem "rack"
       G
@@ -39,12 +39,12 @@ RSpec.describe "hook plugins" do
         end
       end
 
-      bundle "plugin install before-install-plugin --source file://#{gem_repo2}"
+      bundle "plugin install before-install-plugin --source #{file_uri_for(gem_repo2)}"
     end
 
     it "runs before each rubygem is installed" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rake"
         gem "rack"
       G
@@ -66,12 +66,12 @@ RSpec.describe "hook plugins" do
         end
       end
 
-      bundle "plugin install after-install-all-plugin --source file://#{gem_repo2}"
+      bundle "plugin install after-install-all-plugin --source #{file_uri_for(gem_repo2)}"
     end
 
     it "runs after each rubygem is installed" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rake"
         gem "rack"
       G
@@ -92,12 +92,12 @@ RSpec.describe "hook plugins" do
         end
       end
 
-      bundle "plugin install after-install-plugin --source file://#{gem_repo2}"
+      bundle "plugin install after-install-plugin --source #{file_uri_for(gem_repo2)}"
     end
 
     it "runs after each rubygem is installed" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rake"
         gem "rack"
       G

--- a/spec/plugins/install_spec.rb
+++ b/spec/plugins/install_spec.rb
@@ -9,14 +9,14 @@ RSpec.describe "bundler plugin install" do
   end
 
   it "shows proper message when gem in not found in the source" do
-    bundle "plugin install no-foo --source file://#{gem_repo1}"
+    bundle "plugin install no-foo --source #{file_uri_for(gem_repo1)}"
 
     expect(err).to include("Could not find")
     plugin_should_not_be_installed("no-foo")
   end
 
   it "installs from rubygems source" do
-    bundle "plugin install foo --source file://#{gem_repo2}"
+    bundle "plugin install foo --source #{file_uri_for(gem_repo2)}"
 
     expect(out).to include("Installed plugin foo")
     plugin_should_be_installed("foo")
@@ -24,18 +24,18 @@ RSpec.describe "bundler plugin install" do
 
   context "plugin is already installed" do
     before do
-      bundle "plugin install foo --source file://#{gem_repo2}"
+      bundle "plugin install foo --source #{file_uri_for(gem_repo2)}"
     end
 
     it "doesn't install plugin again" do
-      bundle "plugin install foo --source file://#{gem_repo2}"
+      bundle "plugin install foo --source #{file_uri_for(gem_repo2)}"
       expect(out).not_to include("Installing plugin foo")
       expect(out).not_to include("Installed plugin foo")
     end
   end
 
   it "installs multiple plugins" do
-    bundle "plugin install foo kung-foo --source file://#{gem_repo2}"
+    bundle "plugin install foo kung-foo --source #{file_uri_for(gem_repo2)}"
 
     expect(out).to include("Installed plugin foo")
     expect(out).to include("Installed plugin kung-foo")
@@ -49,7 +49,7 @@ RSpec.describe "bundler plugin install" do
       build_plugin "kung-foo", "1.1"
     end
 
-    bundle "plugin install foo kung-foo --version '1.0' --source file://#{gem_repo2}"
+    bundle "plugin install foo kung-foo --version '1.0' --source #{file_uri_for(gem_repo2)}"
 
     expect(out).to include("Installing foo 1.0")
     expect(out).to include("Installing kung-foo 1.0")
@@ -73,7 +73,7 @@ RSpec.describe "bundler plugin install" do
         s.write("src/fubar.rb")
       end
     end
-    bundle "plugin install testing --source file://#{gem_repo2}"
+    bundle "plugin install testing --source #{file_uri_for(gem_repo2)}"
 
     bundle "check2", "no-color" => false
     expect(out).to eq("mate")
@@ -86,7 +86,7 @@ RSpec.describe "bundler plugin install" do
         build_plugin "kung-foo", "1.1"
       end
 
-      bundle "plugin install foo kung-foo --version '1.0' --source file://#{gem_repo2}"
+      bundle "plugin install foo kung-foo --version '1.0' --source #{file_uri_for(gem_repo2)}"
 
       expect(out).to include("Installing foo 1.0")
       expect(out).to include("Installing kung-foo 1.0")
@@ -96,7 +96,7 @@ RSpec.describe "bundler plugin install" do
         build_gem "charlie"
       end
 
-      bundle "plugin install charlie --source file://#{gem_repo2}"
+      bundle "plugin install charlie --source #{file_uri_for(gem_repo2)}"
 
       expect(err).to include("plugins.rb was not found")
 
@@ -115,7 +115,7 @@ RSpec.describe "bundler plugin install" do
         end
       end
 
-      bundle "plugin install chaplin --source file://#{gem_repo2}"
+      bundle "plugin install chaplin --source #{file_uri_for(gem_repo2)}"
 
       expect(global_plugin_gem("chaplin-1.0")).not_to be_directory
 
@@ -129,7 +129,7 @@ RSpec.describe "bundler plugin install" do
         s.write "plugins.rb"
       end
 
-      bundle "plugin install foo --git file://#{lib_path("foo-1.0")}"
+      bundle "plugin install foo --git #{file_uri_for(lib_path("foo-1.0"))}"
 
       expect(out).to include("Installed plugin foo")
       plugin_should_be_installed("foo")
@@ -157,7 +157,7 @@ RSpec.describe "bundler plugin install" do
   context "Gemfile eval" do
     it "installs plugins listed in gemfile" do
       gemfile <<-G
-        source 'file://#{gem_repo2}'
+        source '#{file_uri_for(gem_repo2)}'
         plugin 'foo'
         gem 'rack', "1.0.0"
       G
@@ -178,7 +178,7 @@ RSpec.describe "bundler plugin install" do
       end
 
       gemfile <<-G
-        source 'file://#{gem_repo2}'
+        source '#{file_uri_for(gem_repo2)}'
         plugin 'foo', "1.0"
       G
 
@@ -207,12 +207,12 @@ RSpec.describe "bundler plugin install" do
     context "in deployment mode" do
       it "installs plugins" do
         install_gemfile! <<-G
-          source 'file://#{gem_repo2}'
+          source '#{file_uri_for(gem_repo2)}'
           gem 'rack', "1.0.0"
         G
 
         install_gemfile! <<-G, forgotten_command_line_options(:deployment => true)
-          source 'file://#{gem_repo2}'
+          source '#{file_uri_for(gem_repo2)}'
           plugin 'foo'
           gem 'rack', "1.0.0"
         G
@@ -233,7 +233,7 @@ RSpec.describe "bundler plugin install" do
         require "bundler/inline"
 
         gemfile do
-          source 'file://#{gem_repo2}'
+          source '#{file_uri_for(gem_repo2)}'
           plugin 'foo'
         end
       RUBY
@@ -246,7 +246,7 @@ RSpec.describe "bundler plugin install" do
   describe "local plugin" do
     it "is installed when inside an app" do
       gemfile ""
-      bundle "plugin install foo --source file://#{gem_repo2}"
+      bundle "plugin install foo --source #{file_uri_for(gem_repo2)}"
 
       plugin_should_be_installed("foo")
       expect(local_plugin_gem("foo-1.0")).to be_directory
@@ -269,7 +269,7 @@ RSpec.describe "bundler plugin install" do
         end
 
         # inside the app
-        gemfile "source 'file://#{gem_repo2}'\nplugin 'fubar'"
+        gemfile "source '#{file_uri_for(gem_repo2)}'\nplugin 'fubar'"
         bundle "install"
 
         update_repo2 do
@@ -288,7 +288,7 @@ RSpec.describe "bundler plugin install" do
 
         # outside the app
         Dir.chdir tmp
-        bundle "plugin install fubar --source file://#{gem_repo2}"
+        bundle "plugin install fubar --source #{file_uri_for(gem_repo2)}"
       end
 
       it "inside the app takes precedence over global plugin" do

--- a/spec/plugins/list_spec.rb
+++ b/spec/plugins/list_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "bundler plugin list" do
 
   context "single plugin installed" do
     it "shows plugin name with commands list" do
-      bundle "plugin install foo --source file://#{gem_repo2}"
+      bundle "plugin install foo --source #{file_uri_for(gem_repo2)}"
       plugin_should_be_installed("foo")
       bundle "plugin list"
 
@@ -49,7 +49,7 @@ RSpec.describe "bundler plugin list" do
 
   context "multiple plugins installed" do
     it "shows plugin names with commands list" do
-      bundle "plugin install foo bar --source file://#{gem_repo2}"
+      bundle "plugin install foo bar --source #{file_uri_for(gem_repo2)}"
       plugin_should_be_installed("foo", "bar")
       bundle "plugin list"
 

--- a/spec/plugins/source/example_spec.rb
+++ b/spec/plugins/source/example_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "real source plugins" do
       build_lib "a-path-gem"
 
       gemfile <<-G
-        source "file://localhost#{gem_repo2}" # plugin source
+        source "#{file_uri_for(gem_repo2)}" # plugin source
         source "#{lib_path("a-path-gem-1.0")}", :type => :mpath do
           gem "a-path-gem"
         end
@@ -78,7 +78,7 @@ RSpec.describe "real source plugins" do
             a-path-gem (1.0)
 
         GEM
-          remote: file://localhost#{gem_repo2}/
+          remote: #{file_uri_for(gem_repo2)}/
           specs:
 
         PLATFORMS
@@ -103,7 +103,7 @@ RSpec.describe "real source plugins" do
             a-path-gem (1.0)
 
         GEM
-          remote: file://localhost#{gem_repo2}/
+          remote: #{file_uri_for(gem_repo2)}/
           specs:
 
         PLATFORMS
@@ -131,7 +131,7 @@ RSpec.describe "real source plugins" do
       end
 
       install_gemfile <<-G
-        source "file://#{gem_repo2}" # plugin source
+        source "#{file_uri_for(gem_repo2)}" # plugin source
         source "#{lib_path("gem-with-bin-1.0")}", :type => :mpath do
           gem "gem-with-bin"
         end
@@ -186,7 +186,7 @@ RSpec.describe "real source plugins" do
               a-path-gem (1.0)
 
           GEM
-            remote: file:#{gem_repo2}/
+            remote: #{file_uri_for(gem_repo2)}/
             specs:
 
           PLATFORMS
@@ -346,8 +346,8 @@ RSpec.describe "real source plugins" do
       build_git "ma-gitp-gem"
 
       gemfile <<-G
-        source "file://localhost#{gem_repo2}" # plugin source
-        source "file://#{lib_path("ma-gitp-gem-1.0")}", :type => :gitp do
+        source "#{file_uri_for(gem_repo2)}" # plugin source
+        source "#{file_uri_for(lib_path("ma-gitp-gem-1.0"))}", :type => :gitp do
           gem "ma-gitp-gem"
         end
       G
@@ -365,14 +365,14 @@ RSpec.describe "real source plugins" do
 
       lockfile_should_be <<-G
         PLUGIN SOURCE
-          remote: file://#{lib_path("ma-gitp-gem-1.0")}
+          remote: #{file_uri_for(lib_path("ma-gitp-gem-1.0"))}
           type: gitp
           revision: #{revision}
           specs:
             ma-gitp-gem (1.0)
 
         GEM
-          remote: file://localhost#{gem_repo2}/
+          remote: #{file_uri_for(gem_repo2)}/
           specs:
 
         PLATFORMS
@@ -392,14 +392,14 @@ RSpec.describe "real source plugins" do
 
       lockfile_should_be <<-G
         PLUGIN SOURCE
-          remote: file://#{lib_path("ma-gitp-gem-1.0")}
+          remote: #{file_uri_for(lib_path("ma-gitp-gem-1.0"))}
           type: gitp
           revision: #{revision}
           specs:
             ma-gitp-gem (1.0)
 
         GEM
-          remote: file://localhost#{gem_repo2}/
+          remote: #{file_uri_for(gem_repo2)}/
           specs:
 
         PLATFORMS
@@ -418,14 +418,14 @@ RSpec.describe "real source plugins" do
         revision = revision_for(lib_path("ma-gitp-gem-1.0"))
         lockfile <<-G
           PLUGIN SOURCE
-            remote: file://#{lib_path("ma-gitp-gem-1.0")}
+            remote: #{file_uri_for(lib_path("ma-gitp-gem-1.0"))}
             type: gitp
             revision: #{revision}
             specs:
               ma-gitp-gem (1.0)
 
           GEM
-            remote: file:#{gem_repo2}/
+            remote: #{file_uri_for(gem_repo2)}/
             specs:
 
           PLATFORMS
@@ -469,8 +469,8 @@ RSpec.describe "real source plugins" do
       it "updates the deps on change in gemfile" do
         update_git "ma-gitp-gem", "1.1", :path => lib_path("ma-gitp-gem-1.0"), :gemspec => true
         gemfile <<-G
-          source "file://#{gem_repo2}" # plugin source
-          source "file://#{lib_path("ma-gitp-gem-1.0")}", :type => :gitp do
+          source "#{file_uri_for(gem_repo2)}" # plugin source
+          source "#{file_uri_for(lib_path("ma-gitp-gem-1.0"))}", :type => :gitp do
             gem "ma-gitp-gem", "1.1"
           end
         G
@@ -486,7 +486,7 @@ RSpec.describe "real source plugins" do
         ref = git.ref_for("master", 11)
 
         install_gemfile <<-G
-          source "file://#{gem_repo2}" # plugin source
+          source "#{file_uri_for(gem_repo2)}" # plugin source
           source  '#{lib_path("foo-1.0")}', :type => :gitp do
             gem "foo"
           end

--- a/spec/plugins/source_spec.rb
+++ b/spec/plugins/source_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe "bundler source plugin" do
 
     it "installs bundler-source-* gem when no handler for source is present" do
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
-        source "file://#{lib_path("gitp")}", :type => :psource do
+        source "#{file_uri_for(gem_repo2)}"
+        source "#{file_uri_for(lib_path("gitp"))}", :type => :psource do
         end
       G
 
@@ -37,8 +37,8 @@ RSpec.describe "bundler source plugin" do
       end
 
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
-        source "file://#{lib_path("gitp")}", :type => :psource do
+        source "#{file_uri_for(gem_repo2)}"
+        source "#{file_uri_for(lib_path("gitp"))}", :type => :psource do
         end
       G
 
@@ -61,11 +61,11 @@ RSpec.describe "bundler source plugin" do
       context "explicit presence in gemfile" do
         before do
           install_gemfile <<-G
-            source "file://#{gem_repo2}"
+            source "#{file_uri_for(gem_repo2)}"
 
             plugin "another-psource"
 
-            source "file://#{lib_path("gitp")}", :type => :psource do
+            source "#{file_uri_for(lib_path("gitp"))}", :type => :psource do
             end
           G
         end
@@ -86,11 +86,11 @@ RSpec.describe "bundler source plugin" do
       context "explicit default source" do
         before do
           install_gemfile <<-G
-            source "file://#{gem_repo2}"
+            source "#{file_uri_for(gem_repo2)}"
 
             plugin "bundler-source-psource"
 
-            source "file://#{lib_path("gitp")}", :type => :psource do
+            source "#{file_uri_for(lib_path("gitp"))}", :type => :psource do
             end
           G
         end

--- a/spec/runtime/executable_spec.rb
+++ b/spec/runtime/executable_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe "Running bin/* commands" do
   before :each do
     install_gemfile! <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack"
     G
   end
@@ -84,7 +84,7 @@ RSpec.describe "Running bin/* commands" do
     end
 
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "bundler"
     G
 
@@ -112,14 +112,14 @@ RSpec.describe "Running bin/* commands" do
 
   it "remembers that the option was specified", :bundler => "< 3" do
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "activesupport"
     G
 
     bundle! :install, forgotten_command_line_options([:binstubs, :bin] => "bin")
 
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "activesupport"
       gem "rack"
     G
@@ -131,7 +131,7 @@ RSpec.describe "Running bin/* commands" do
 
   it "rewrites bins on binstubs (to maintain backwards compatibility)" do
     install_gemfile! <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack"
     G
 
@@ -152,7 +152,7 @@ RSpec.describe "Running bin/* commands" do
     end
 
     create_file("OtherGemfile", <<-G)
-      source "file://#{gem_repo2}"
+      source "#{file_uri_for(gem_repo2)}"
       gem 'bindir'
     G
 

--- a/spec/runtime/inline_spec.rb
+++ b/spec/runtime/inline_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "bundler/inline#gemfile" do
 
     script <<-RUBY
       gemfile(true) do
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       end
     RUBY
@@ -157,7 +157,7 @@ RSpec.describe "bundler/inline#gemfile" do
   it "installs quietly if necessary when the install option is not set" do
     script <<-RUBY
       gemfile do
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       end
 
@@ -232,7 +232,7 @@ RSpec.describe "bundler/inline#gemfile" do
     in_app_root do
       script <<-RUBY
         gemfile do
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "rack"
         end
 
@@ -247,7 +247,7 @@ RSpec.describe "bundler/inline#gemfile" do
   it "installs inline gems when frozen is set" do
     script <<-RUBY, :env => { "BUNDLE_FROZEN" => "true" }
       gemfile do
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       end
 
@@ -264,7 +264,7 @@ RSpec.describe "bundler/inline#gemfile" do
     in_app_root do
       script <<-RUBY
         gemfile do
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "rack"
         end
 
@@ -281,7 +281,7 @@ RSpec.describe "bundler/inline#gemfile" do
 
     script <<-RUBY
       gemfile do
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack" # has the rackup executable
       end
 
@@ -296,7 +296,7 @@ RSpec.describe "bundler/inline#gemfile" do
 
     script <<-RUBY
       gemfile(true) do
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", platform: :jruby
       end
     RUBY

--- a/spec/runtime/load_spec.rb
+++ b/spec/runtime/load_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Bundler.load" do
   describe "with a gemfile" do
     before(:each) do
       install_gemfile! <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
     end
@@ -28,7 +28,7 @@ RSpec.describe "Bundler.load" do
   describe "with a gems.rb file" do
     before(:each) do
       create_file "gems.rb", <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
       bundle! :install
@@ -74,7 +74,7 @@ RSpec.describe "Bundler.load" do
   describe "when called twice" do
     it "doesn't try to load the runtime twice" do
       install_gemfile! <<-G
-        source "file:#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
         gem "activesupport", :group => :test
       G
@@ -98,7 +98,7 @@ RSpec.describe "Bundler.load" do
   describe "not hurting brittle rubygems" do
     it "does not inject #source into the generated YAML of the gem specs" do
       install_gemfile! <<-G
-        source "file:#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "activerecord"
       G
 

--- a/spec/runtime/platform_spec.rb
+++ b/spec/runtime/platform_spec.rb
@@ -3,13 +3,13 @@
 RSpec.describe "Bundler.setup with multi platform stuff" do
   it "raises a friendly error when gems are missing locally" do
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack"
     G
 
     lockfile <<-G
       GEM
-        remote: file:#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           rack (1.0)
 
@@ -35,7 +35,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
   it "will resolve correctly on the current platform when the lockfile was targeted for a different one" do
     lockfile <<-G
       GEM
-        remote: file:#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           nokogiri (1.4.2-java)
             weakling (= 0.0.3)
@@ -50,7 +50,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
 
     simulate_platform "x86-darwin-10"
     install_gemfile! <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "nokogiri"
     G
 
@@ -60,7 +60,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
   it "will add the resolve for the current platform" do
     lockfile <<-G
       GEM
-        remote: file:#{gem_repo1}/
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           nokogiri (1.4.2-java)
             weakling (= 0.0.3)
@@ -76,7 +76,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
     simulate_platform "x86-darwin-100"
 
     install_gemfile! <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "nokogiri"
       gem "platform_specific"
     G
@@ -88,7 +88,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
     simulate_platform "java"
 
     install_gemfile! <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "nokogiri"
       gem "platform_specific"
     G
@@ -103,7 +103,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
   it "allows specifying only-ruby-platform on windows with dependency platforms" do
     simulate_windows do
       install_gemfile! <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "nokogiri", :platforms => [:mingw, :mswin, :x64_mingw, :jruby]
         gem "platform_specific"
       G
@@ -125,7 +125,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
     simulate_windows x64_mingw do
       lockfile <<-L
         GEM
-          remote: file:#{gem_repo2}/
+          remote: #{file_uri_for(gem_repo2)}/
           specs:
             platform_specific (1.0-x86-mingw32)
             requires_platform_specific (1.0)
@@ -140,7 +140,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
       L
 
       install_gemfile! <<-G, :verbose => true
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "requires_platform_specific"
       G
 

--- a/spec/runtime/require_spec.rb
+++ b/spec/runtime/require_spec.rb
@@ -373,7 +373,7 @@ RSpec.describe "Bundler.require" do
 
   it "does not load rubygems gemspecs that are used" do
     install_gemfile! <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack"
     G
 
@@ -422,7 +422,7 @@ end
 RSpec.describe "Bundler.require with platform specific dependencies" do
   it "does not require the gems that are pinned to other platforms" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       platforms :#{not_local_tag} do
         gem "fail", :require => "omgomg"
@@ -437,7 +437,7 @@ RSpec.describe "Bundler.require with platform specific dependencies" do
 
   it "requires gems pinned to multiple platforms, including the current one" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       platforms :#{not_local_tag}, :#{local_tag} do
         gem "rack", :require => "rack"

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Bundler.setup" do
   describe "with no arguments" do
     it "makes all groups available" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", :group => :test
       G
 
@@ -27,7 +27,7 @@ RSpec.describe "Bundler.setup" do
   describe "when called with groups" do
     before(:each) do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "yard"
         gem "rack", :group => :test
       G
@@ -124,7 +124,7 @@ RSpec.describe "Bundler.setup" do
 
     it "puts loaded gems after -I and RUBYLIB", :ruby_repo do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 
@@ -148,7 +148,7 @@ RSpec.describe "Bundler.setup" do
 
     it "orders the load path correctly when there are dependencies" do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rails"
       G
 
@@ -174,7 +174,7 @@ RSpec.describe "Bundler.setup" do
 
     it "falls back to order the load path alphabetically for backwards compatibility" do
       install_gemfile! <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "weakling"
         gem "duradura"
         gem "terranova"
@@ -198,7 +198,7 @@ RSpec.describe "Bundler.setup" do
 
   it "raises if the Gemfile was not yet installed" do
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack"
     G
 
@@ -219,7 +219,7 @@ RSpec.describe "Bundler.setup" do
 
   it "doesn't create a Gemfile.lock if the setup fails" do
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack"
     G
 
@@ -235,14 +235,14 @@ RSpec.describe "Bundler.setup" do
 
   it "doesn't change the Gemfile.lock if the setup fails" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack"
     G
 
     lockfile = File.read(bundled_app("Gemfile.lock"))
 
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack"
       gem "nosuchgem", "10.0"
     G
@@ -259,7 +259,7 @@ RSpec.describe "Bundler.setup" do
 
   it "makes a Gemfile.lock if setup succeeds" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack"
     G
 
@@ -275,12 +275,12 @@ RSpec.describe "Bundler.setup" do
     context "user provides an absolute path" do
       it "uses BUNDLE_GEMFILE to locate the gemfile if present" do
         gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "rack"
         G
 
         gemfile bundled_app("4realz"), <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "activesupport", "2.3.5"
         G
 
@@ -294,7 +294,7 @@ RSpec.describe "Bundler.setup" do
     context "an absolute path is not provided" do
       it "uses BUNDLE_GEMFILE to locate the gemfile if present" do
         gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
         G
 
         bundle "install"
@@ -321,7 +321,7 @@ RSpec.describe "Bundler.setup" do
   it "prioritizes gems in BUNDLE_PATH over gems in GEM_HOME" do
     ENV["BUNDLE_PATH"] = bundled_app(".bundle").to_s
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack", "1.0.0"
     G
 
@@ -336,7 +336,7 @@ RSpec.describe "Bundler.setup" do
     describe "by replacing #gem" do
       before :each do
         install_gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "rack", "0.9.1"
         G
       end
@@ -398,7 +398,7 @@ RSpec.describe "Bundler.setup" do
       before :each do
         system_gems "activesupport-2.3.5"
         install_gemfile <<-G
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "yard"
         G
       end
@@ -427,7 +427,7 @@ RSpec.describe "Bundler.setup" do
       end
 
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         path "#{lib_path("rack-1.0.0")}" do
           gem "rack"
         end
@@ -526,7 +526,7 @@ RSpec.describe "Bundler.setup" do
       FileUtils.cp_r("#{lib_path("rack-0.8")}/.", lib_path("local-rack"))
 
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
       G
 
@@ -544,7 +544,7 @@ RSpec.describe "Bundler.setup" do
       FileUtils.cp_r("#{lib_path("rack-0.8")}/.", lib_path("local-rack"))
 
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
       G
 
@@ -552,7 +552,7 @@ RSpec.describe "Bundler.setup" do
       bundle! :install
 
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", :git => "#{lib_path("rack-0.8")}"
       G
 
@@ -566,7 +566,7 @@ RSpec.describe "Bundler.setup" do
       FileUtils.cp_r("#{lib_path("rack-0.8")}/.", lib_path("local-rack"))
 
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
       G
 
@@ -574,7 +574,7 @@ RSpec.describe "Bundler.setup" do
       bundle! :install
 
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "changed"
       G
 
@@ -588,12 +588,12 @@ RSpec.describe "Bundler.setup" do
       FileUtils.cp_r("#{lib_path("rack-0.8")}/.", lib_path("local-rack"))
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", :git => "#{lib_path("rack-0.8")}", :ref => "master", :branch => "master"
       G
 
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", :git => "#{lib_path("rack-0.8")}", :ref => "master", :branch => "nonexistant"
       G
 
@@ -606,7 +606,7 @@ RSpec.describe "Bundler.setup" do
   describe "when excluding groups" do
     it "doesn't change the resolve if --without is used" do
       install_gemfile <<-G, forgotten_command_line_options(:without => :rails)
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "activesupport"
 
         group :rails do
@@ -621,7 +621,7 @@ RSpec.describe "Bundler.setup" do
 
     it "remembers --without and does not bail on bare Bundler.setup" do
       install_gemfile <<-G, forgotten_command_line_options(:without => :rails)
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "activesupport"
 
         group :rails do
@@ -636,7 +636,7 @@ RSpec.describe "Bundler.setup" do
 
     it "remembers --without and does not include groups passed to Bundler.setup" do
       install_gemfile <<-G, forgotten_command_line_options(:without => :rails)
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "activesupport"
 
         group :rack do
@@ -659,7 +659,7 @@ RSpec.describe "Bundler.setup" do
     build_git "no-gemspec", :gemspec => false
 
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack"
       gem "foo", :git => "#{lib_path("foo-1.0")}"
       gem "no-gemspec", "1.0", :git => "#{lib_path("no-gemspec-1.0")}"
@@ -676,7 +676,7 @@ RSpec.describe "Bundler.setup" do
 
   it "does not load all gemspecs" do
     install_gemfile! <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack"
     G
 
@@ -704,7 +704,7 @@ end
 
   it "ignores empty gem paths" do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack"
     G
 
@@ -728,7 +728,7 @@ end
 
       it "adds the gem's man dir to the MANPATH" do
         install_gemfile! <<-G
-          source "file:#{gem_repo4}"
+          source "#{file_uri_for(gem_repo4)}"
           gem "with_man"
         G
 
@@ -742,7 +742,7 @@ end
 
       it "adds the gem's man dir to the MANPATH" do
         install_gemfile! <<-G
-          source "file:#{gem_repo4}"
+          source "#{file_uri_for(gem_repo4)}"
           gem "with_man"
         G
 
@@ -762,7 +762,7 @@ end
     end
 
     install_gemfile <<-G
-      source "file://#{gem_repo2}"
+      source "#{file_uri_for(gem_repo2)}"
       gem "requirepaths", :require => nil
     G
 
@@ -778,7 +778,7 @@ end
     install_gem full_gem_name
 
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
     G
 
     ruby <<-R
@@ -847,7 +847,7 @@ end
     system_gems "rack-1.0.0"
 
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "activesupport"
     G
 
@@ -931,7 +931,7 @@ end
       system_gems "rack-1.0.0"
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
 
         gem "activesupport", "2.3.5"
       G
@@ -985,7 +985,7 @@ end
       system_gems "rack-1.0.0"
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", "1.0.0"
         gem "activesupport", "2.3.5"
       G
@@ -1073,7 +1073,7 @@ end
     def lock_with(bundler_version = nil)
       lock = <<-L
         GEM
-          remote: file:#{gem_repo1}/
+          remote: #{file_uri_for(gem_repo1)}/
           specs:
             rack (1.0.0)
 
@@ -1093,7 +1093,7 @@ end
 
     before do
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
     end
@@ -1131,7 +1131,7 @@ end
     def lock_with(ruby_version = nil)
       lock = <<-L
         GEM
-          remote: file://localhost#{gem_repo1}/
+          remote: #{file_uri_for(gem_repo1)}/
           specs:
             rack (1.0.0)
 
@@ -1152,13 +1152,13 @@ end
            #{Bundler::VERSION}
       L
 
-      normalize_uri_file(lock)
+      lock
     end
 
     before do
       install_gemfile <<-G
         ruby ">= 0"
-        source "file://localhost#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
       lockfile lock_with(ruby_version)
@@ -1296,7 +1296,7 @@ end
         default_gems.reject! {|g| exemptions.include?(g) }
 
         install_gemfile! <<-G
-          source "file:#{gem_repo4}"
+          source "#{file_uri_for(gem_repo4)}"
           #{default_gems}.each do |g|
             gem g, "999999"
           end
@@ -1315,7 +1315,7 @@ end
         default_gems.reject! {|g| exemptions.include?(g) }
 
         install_gemfile! <<-G
-          source "file:#{gem_repo4}"
+          source "#{file_uri_for(gem_repo4)}"
           #{default_gems}.each do |g|
             gem g, "0.0.0.a"
           end
@@ -1329,7 +1329,7 @@ end
   describe "after setup" do
     it "allows calling #gem on random objects", :bundler => "< 3" do
       install_gemfile <<-G
-        source "file:#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 
@@ -1344,7 +1344,7 @@ end
 
     it "keeps Kernel#gem private", :bundler => "3" do
       install_gemfile! <<-G
-        source "file:#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 
@@ -1360,7 +1360,7 @@ end
 
     it "keeps Kernel#require private" do
       install_gemfile! <<-G
-        source "file:#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 

--- a/spec/support/builders.rb
+++ b/spec/support/builders.rb
@@ -689,7 +689,7 @@ module Spec
           elsif tag = options[:tag]
             `git tag #{Shellwords.shellescape(tag)}`
           elsif options[:remote]
-            silently("git remote add origin file://#{options[:remote]}")
+            silently("git remote add origin #{options[:remote]}")
           elsif options[:push]
             silently("git push origin #{options[:push]}")
           end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -279,7 +279,7 @@ module Spec
       if contents.nil?
         File.open("Gemfile.lock", "r", &:read)
       else
-        create_file("Gemfile.lock", normalize_uri_file(contents), *args)
+        create_file("Gemfile.lock", contents, *args)
       end
     end
 
@@ -287,15 +287,6 @@ module Spec
       # Trim the leading spaces
       spaces = str[/\A\s+/, 0] || ""
       str.gsub(/^#{spaces}/, "")
-    end
-
-    def normalize_uri_file(str)
-      # URI::File of Ruby 2.6 normalize localhost variable with file protocol.
-      if defined?(URI::File)
-        str.gsub(%r{file:\/\/localhost}, "file://")
-      else
-        str
-      end
     end
 
     def install_gemfile(*args)

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -194,7 +194,7 @@ module Spec
     RSpec::Matchers.alias_matcher :include_gem, :include_gems
 
     def have_lockfile(expected)
-      read_as(normalize_uri_file(strip_whitespace(expected)))
+      read_as(strip_whitespace(expected))
     end
 
     def plugin_should_be_installed(*names)

--- a/spec/support/path.rb
+++ b/spec/support/path.rb
@@ -64,10 +64,11 @@ module Spec
 
     def file_uri_for(path)
       protocol = "file://"
+      root = Gem.win_platform? ? "/" : ""
 
-      return protocol + "localhost" + path.to_s if RUBY_VERSION < "2.5"
+      return protocol + "localhost" + root + path.to_s if RUBY_VERSION < "2.5"
 
-      protocol + path.to_s
+      protocol + root + path.to_s
     end
 
     def gem_repo1(*args)

--- a/spec/support/path.rb
+++ b/spec/support/path.rb
@@ -62,6 +62,14 @@ module Spec
       tmp.join("gems/base")
     end
 
+    def file_uri_for(path)
+      protocol = "file://"
+
+      return protocol + "localhost" + path.to_s if RUBY_VERSION < "2.5"
+
+      protocol + path.to_s
+    end
+
     def gem_repo1(*args)
       tmp("gems/remote1", *args)
     end

--- a/spec/update/gemfile_spec.rb
+++ b/spec/update/gemfile_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "bundle update" do
   context "with --gemfile" do
     it "finds the gemfile" do
       gemfile bundled_app("NotGemfile"), <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem 'rack'
       G
 
@@ -21,7 +21,7 @@ RSpec.describe "bundle update" do
   context "with gemfile set via config" do
     before do
       gemfile bundled_app("NotGemfile"), <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem 'rack'
       G
 

--- a/spec/update/gems/post_install_spec.rb
+++ b/spec/update/gems/post_install_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "bundle update" do
 
   before do
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem 'rack', "< 1.0"
       gem 'thin'
     G
@@ -47,7 +47,7 @@ RSpec.describe "bundle update" do
   context "when listed gem is updated" do
     before do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem 'rack'
         gem 'thin'
       G
@@ -62,7 +62,7 @@ RSpec.describe "bundle update" do
   context "when dependency triggers update" do
     before do
       gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem 'rack-obama'
         gem 'thin'
       G

--- a/spec/update/git_spec.rb
+++ b/spec/update/git_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe "bundle update" do
     it "fetches tags from the remote" do
       build_git "foo"
       @remote = build_git("bar", :bare => true)
-      update_git "foo", :remote => @remote.path
+      update_git "foo", :remote => file_uri_for(@remote.path)
       update_git "foo", :push => "master"
 
       install_gemfile <<-G
@@ -139,7 +139,7 @@ RSpec.describe "bundle update" do
 
       it "it unlocks the source when submodules are added to a git source" do
         install_gemfile <<-G
-          source "file:#{gem_repo4}"
+          source "#{file_uri_for(gem_repo4)}"
           git "#{lib_path("has_submodule-1.0")}" do
             gem "has_submodule"
           end
@@ -149,7 +149,7 @@ RSpec.describe "bundle update" do
         expect(out).to eq("GEM")
 
         install_gemfile <<-G
-          source "file:#{gem_repo4}"
+          source "#{file_uri_for(gem_repo4)}"
           git "#{lib_path("has_submodule-1.0")}", :submodules => true do
             gem "has_submodule"
           end
@@ -161,7 +161,7 @@ RSpec.describe "bundle update" do
 
       it "unlocks the source when submodules are removed from git source", :git => ">= 2.9.0" do
         install_gemfile! <<-G
-          source "file:#{gem_repo4}"
+          source "#{file_uri_for(gem_repo4)}"
           git "#{lib_path("has_submodule-1.0")}", :submodules => true do
             gem "has_submodule"
           end
@@ -171,7 +171,7 @@ RSpec.describe "bundle update" do
         expect(out).to eq("GIT")
 
         install_gemfile! <<-G
-          source "file:#{gem_repo4}"
+          source "#{file_uri_for(gem_repo4)}"
           git "#{lib_path("has_submodule-1.0")}" do
             gem "has_submodule"
           end
@@ -204,7 +204,7 @@ RSpec.describe "bundle update" do
       end
 
       install_gemfile <<-G
-        source "file://#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
       G
 
@@ -246,7 +246,7 @@ RSpec.describe "bundle update" do
       end
 
       install_gemfile <<-G
-        source "file://#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         git "#{lib_path("foo")}" do
           gem 'foo'
         end
@@ -291,7 +291,7 @@ RSpec.describe "bundle update" do
       @git = build_git "foo", :path => lib_path("bar")
 
       install_gemfile <<-G
-        source "file://localhost#{gem_repo2}"
+        source "#{file_uri_for(gem_repo2)}"
         git "#{lib_path("bar")}" do
           gem 'foo'
         end
@@ -319,7 +319,7 @@ RSpec.describe "bundle update" do
             foo (2.0)
 
         GEM
-          remote: file://localhost#{gem_repo2}/
+          remote: #{file_uri_for(gem_repo2)}/
           specs:
             rack (1.0.0)
 
@@ -355,7 +355,7 @@ RSpec.describe "bundle update" do
             foo (2.0)
 
         GEM
-          remote: file://localhost#{gem_repo2}/
+          remote: #{file_uri_for(gem_repo2)}/
           specs:
             rack (1.0.0)
 

--- a/spec/update/redownload_spec.rb
+++ b/spec/update/redownload_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe "bundle update" do
   before :each do
     install_gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack"
     G
   end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that file:// URIs were not properly handled on Windows, and those are heavily used by our specs.

### What was your diagnosis of the problem?

My diagnosis was that Windows paths do not start with a slash, so we need to add an extra slash to
separate the host from the path in file:// urls. Otherwise "D:" is parsed as the host segment in the URI.

As a consequence of that change, we also need to strip that leading character when using the path segment for those URIs, so that it's a valid file path on Windows.

This change reduces Windows CI spec failures from 429 to 355.

In order to apply this fix for all file URI's in tests, I extracted a helper method and searched and replaced all file:// ocurrences with the method. The diff is big because of that, but I think it works fine.