### PR TITLE
Remove `global_path_appends_ruby_scope` setting

### DIFF
--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -37,7 +37,6 @@ module Bundler
     settings_flag(:deployment_means_frozen) { bundler_3_mode? }
     settings_flag(:disable_multisource) { bundler_3_mode? }
     settings_flag(:forget_cli_options) { bundler_3_mode? }
-    settings_flag(:global_path_appends_ruby_scope) { bundler_3_mode? }
     settings_flag(:global_gem_cache) { bundler_3_mode? }
     settings_flag(:only_update_to_newer_versions) { bundler_3_mode? }
     settings_flag(:path_relative_to_cwd) { bundler_3_mode? }

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -209,17 +209,17 @@ module Bundler
       key  = key_for(:path)
       path = ENV[key] || @global_config[key]
       if path && !@temporary.key?(key) && !@local_config.key?(key)
-        return Path.new(path, true, false, false)
+        return Path.new(path, false, false)
       end
 
       system_path = self["path.system"] || (self[:disable_shared_gems] == false)
-      Path.new(self[:path], true, system_path, Bundler.feature_flag.default_install_uses_path?)
+      Path.new(self[:path], system_path, Bundler.feature_flag.default_install_uses_path?)
     end
 
-    Path = Struct.new(:explicit_path, :append_ruby_scope, :system_path, :default_install_uses_path) do
+    Path = Struct.new(:explicit_path, :system_path, :default_install_uses_path) do
       def path
         path = base_path
-        path = File.join(path, Bundler.ruby_scope) if append_ruby_scope && !use_system_gems?
+        path = File.join(path, Bundler.ruby_scope) unless use_system_gems?
         path
       end
 

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -33,7 +33,6 @@ module Bundler
       frozen
       gem.coc
       gem.mit
-      global_path_appends_ruby_scope
       global_gem_cache
       ignore_messages
       init_gems_rb
@@ -205,13 +204,12 @@ module Bundler
       locations
     end
 
-    # for legacy reasons, in Bundler 1, the ruby scope isnt appended when the setting comes from ENV or the global config,
-    # nor do we respect :disable_shared_gems
+    # for legacy reasons, in Bundler 2, we do not respect :disable_shared_gems
     def path
       key  = key_for(:path)
       path = ENV[key] || @global_config[key]
       if path && !@temporary.key?(key) && !@local_config.key?(key)
-        return Path.new(path, Bundler.feature_flag.global_path_appends_ruby_scope?, false, false)
+        return Path.new(path, true, false, false)
       end
 
       system_path = self["path.system"] || (self[:disable_shared_gems] == false)

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -202,9 +202,6 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
 * `global_gem_cache` (`BUNDLE_GLOBAL_GEM_CACHE`):
    Whether Bundler should cache all gems globally, rather than locally to the
    installing Ruby installation.
-* `global_path_appends_ruby_scope` (`BUNDLE_GLOBAL_PATH_APPENDS_RUBY_SCOPE`):
-   Whether Bundler should append the Ruby scope (e.g. engine and ABI version)
-   to a globally-configured path.
 * `ignore_messages` (`BUNDLE_IGNORE_MESSAGES`): When set, no post install
    messages will be printed. To silence a single gem, use dot notation like
    `ignore_messages.httparty true`.

--- a/spec/install/bundler_spec.rb
+++ b/spec/install/bundler_spec.rb
@@ -140,7 +140,6 @@ RSpec.describe "bundle install" do
 
     it "can install dependencies with newer bundler version with a local path" do
       bundle! "config set path .bundle"
-      bundle! "config set global_path_appends_ruby_scope true"
       install_gemfile! <<-G
         source "file://#{gem_repo2}"
         gem "rails", "3.0"

--- a/spec/install/gems/sudo_spec.rb
+++ b/spec/install/gems/sudo_spec.rb
@@ -52,8 +52,6 @@ RSpec.describe "when using sudo", :sudo => true do
     end
 
     it "installs when BUNDLE_PATH is owned by root" do
-      bundle! "config set global_path_appends_ruby_scope false" # consistency in tests between 1.x and 2.x modes
-
       bundle_path = tmp("owned_by_root")
       FileUtils.mkdir_p bundle_path
       sudo "chown -R root #{bundle_path}"
@@ -64,14 +62,12 @@ RSpec.describe "when using sudo", :sudo => true do
         gem "rack", '1.0'
       G
 
-      expect(bundle_path.join("gems/rack-1.0.0")).to exist
-      expect(bundle_path.join("gems/rack-1.0.0").stat.uid).to eq(0)
+      expect(bundle_path.join(Bundler.ruby_scope, "gems/rack-1.0.0")).to exist
+      expect(bundle_path.join(Bundler.ruby_scope, "gems/rack-1.0.0").stat.uid).to eq(0)
       expect(the_bundle).to include_gems "rack 1.0"
     end
 
     it "installs when BUNDLE_PATH does not exist" do
-      bundle! "config set global_path_appends_ruby_scope false" # consistency in tests between 1.x and 2.x modes
-
       root_path = tmp("owned_by_root")
       FileUtils.mkdir_p root_path
       sudo "chown -R root #{root_path}"
@@ -83,8 +79,8 @@ RSpec.describe "when using sudo", :sudo => true do
         gem "rack", '1.0'
       G
 
-      expect(bundle_path.join("gems/rack-1.0.0")).to exist
-      expect(bundle_path.join("gems/rack-1.0.0").stat.uid).to eq(0)
+      expect(bundle_path.join(Bundler.ruby_scope, "gems/rack-1.0.0")).to exist
+      expect(bundle_path.join(Bundler.ruby_scope, "gems/rack-1.0.0").stat.uid).to eq(0)
       expect(the_bundle).to include_gems "rack 1.0"
     end
 

--- a/spec/install/path_spec.rb
+++ b/spec/install/path_spec.rb
@@ -113,71 +113,36 @@ RSpec.describe "bundle install" do
           expect(the_bundle).to include_gems "rack 1.0.0"
         end
 
-        context "with global_path_appends_ruby_scope set", :bundler => "3" do
-          it "installs gems to ." do
-            set_bundle_path(type, ".")
-            bundle! "config set --global disable_shared_gems true"
+        it "installs gems to ." do
+          set_bundle_path(type, ".")
+          bundle! "config set --global disable_shared_gems true"
 
-            bundle! :install
+          bundle! :install
 
-            paths_to_exist = %w[cache/rack-1.0.0.gem gems/rack-1.0.0 specifications/rack-1.0.0.gemspec].map {|path| bundled_app(Bundler.ruby_scope, path) }
-            expect(paths_to_exist).to all exist
-            expect(the_bundle).to include_gems "rack 1.0.0"
-          end
-
-          it "installs gems to the path" do
-            set_bundle_path(type, bundled_app("vendor").to_s)
-
-            bundle! :install
-
-            expect(bundled_app("vendor", Bundler.ruby_scope, "gems/rack-1.0.0")).to be_directory
-            expect(the_bundle).to include_gems "rack 1.0.0"
-          end
-
-          it "installs gems to the path relative to root when relative" do
-            set_bundle_path(type, "vendor")
-
-            FileUtils.mkdir_p bundled_app("lol")
-            Dir.chdir(bundled_app("lol")) do
-              bundle! :install
-            end
-
-            expect(bundled_app("vendor", Bundler.ruby_scope, "gems/rack-1.0.0")).to be_directory
-            expect(the_bundle).to include_gems "rack 1.0.0"
-          end
+          paths_to_exist = %w[cache/rack-1.0.0.gem gems/rack-1.0.0 specifications/rack-1.0.0.gemspec].map {|path| bundled_app(Bundler.ruby_scope, path) }
+          expect(paths_to_exist).to all exist
+          expect(the_bundle).to include_gems "rack 1.0.0"
         end
 
-        context "with global_path_appends_ruby_scope unset", :bundler => "< 3" do
-          it "installs gems to ." do
-            set_bundle_path(type, ".")
-            bundle! "config set --global disable_shared_gems true"
+        it "installs gems to the path" do
+          set_bundle_path(type, bundled_app("vendor").to_s)
 
+          bundle! :install
+
+          expect(bundled_app("vendor", Bundler.ruby_scope, "gems/rack-1.0.0")).to be_directory
+          expect(the_bundle).to include_gems "rack 1.0.0"
+        end
+
+        it "installs gems to the path relative to root when relative" do
+          set_bundle_path(type, "vendor")
+
+          FileUtils.mkdir_p bundled_app("lol")
+          Dir.chdir(bundled_app("lol")) do
             bundle! :install
-
-            expect([bundled_app("cache/rack-1.0.0.gem"), bundled_app("gems/rack-1.0.0"), bundled_app("specifications/rack-1.0.0.gemspec")]).to all exist
-            expect(the_bundle).to include_gems "rack 1.0.0"
           end
 
-          it "installs gems to BUNDLE_PATH with #{type}" do
-            set_bundle_path(type, bundled_app("vendor").to_s)
-
-            bundle :install
-
-            expect(bundled_app("vendor/gems/rack-1.0.0")).to be_directory
-            expect(the_bundle).to include_gems "rack 1.0.0"
-          end
-
-          it "installs gems to BUNDLE_PATH relative to root when relative" do
-            set_bundle_path(type, "vendor")
-
-            FileUtils.mkdir_p bundled_app("lol")
-            Dir.chdir(bundled_app("lol")) do
-              bundle :install
-            end
-
-            expect(bundled_app("vendor/gems/rack-1.0.0")).to be_directory
-            expect(the_bundle).to include_gems "rack 1.0.0"
-          end
+          expect(bundled_app("vendor", Bundler.ruby_scope, "gems/rack-1.0.0")).to be_directory
+          expect(the_bundle).to include_gems "rack 1.0.0"
         end
       end
     end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was we're artificially holding shipping bug fixes like the fact the ruby scope is not included in the install path when `BUNDLE_PATH` is used as an environment variable or global setting.

### What was your diagnosis of the problem?

My diagnosis was that we can remove the setting, and that it's fine that affected users rerun `bundle install` to get their installation paths fixed.

### What is your fix for the problem, implemented in this PR?

My fix is to remove the setting.