### PR TITLE
Add Dependencies section to info command

### DIFF
--- a/lib/bundler/cli/info.rb
+++ b/lib/bundler/cli/info.rb
@@ -55,8 +55,22 @@ module Bundler
       gem_info << "\tSummary: #{spec.summary}\n" if spec.summary
       gem_info << "\tHomepage: #{spec.homepage}\n" if spec.homepage
       gem_info << "\tPath: #{spec.full_gem_path}\n"
-      gem_info << "\tDefault Gem: yes" if spec.respond_to?(:default_gem?) && spec.default_gem?
+      gem_info << "\tDefault Gem: yes\n" if spec.respond_to?(:default_gem?) && spec.default_gem?
+      gem_info << "\tDependencies:\n"
+      gem_info << "\t\t#{gem_dependencies.join("\n\t\t")}\n"
       Bundler.ui.info gem_info
+    end
+
+    def gem_dependencies
+      dependencies = Bundler.definition.specs.map do |spec|
+        dependency = spec.dependencies.find {|dep| dep.name == gem_name }
+        next unless dependency
+        requirements_list = dependency.requirements_list
+        requirements_list << "any version" if requirements_list.empty?
+        "#{spec.name} (#{spec.version}) depends on #{gem_name} (#{requirements_list.join(", ")})"
+      end.compact.sort
+      dependencies << "(none)" if dependencies.empty?
+      dependencies
     end
   end
 end

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -62,6 +62,22 @@ RSpec.describe "bundle info" do
         expect(out).to_not include("Homepage:")
       end
     end
+
+    context "when gem has a dependency" do
+      it "prints the details" do
+        bundle "info actionpack"
+
+        expect(out).to include("Dependencies:\n\t\trails (2.3.2) depends on actionpack (= 2.3.2)")
+      end
+    end
+
+    context "when gem has no dependencies" do
+      it "prints a placeholder" do
+        bundle "info rails"
+
+        expect(out).to include("Dependencies:\n\t\t(none)")
+      end
+    end
   end
 
   context "with a git repo in the Gemfile" do


### PR DESCRIPTION
Add a 'Dependencies' section at the bottom of the `info` command output.
This displays the name, version, and imposed version requirements of
all gems in the bundle that depend on the given gem. This intends to
provide a better alternative to manually searching the lockfile for
dependency information.

This PR is intended to resolve Issue #7164.

Example of the `bundle info` command output with this enhancement:
```
$ bundle info actionpack
  * actionpack (2.3.2)
	Summary: This is just a fake gem for testing
	Homepage: http://example.com
	Path: /Users/acerone/Code/bundler/tmp/gems/system/gems/actionpack-2.3.2
	Dependencies:
		rails (2.3.2) depends on actionpack (= 2.3.2)
```

----------------------------------------------------------------------------------------

Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was...
Users resorting to manually searching the lockfile for version constraints imposed by a gem's dependencies.

### What was your diagnosis of the problem?

My diagnosis was...
There is a lack of tooling (lack of a Bundler command) to display the version constraints imposed by a gem's dependencies.

### What is your fix for the problem, implemented in this PR?

My fix...
Adding a "Dependencies" section to the `bundle info [GEM]` command that displays the version constraints imposed by a gem's dependencies, in a similar format to Bundler's "could not find compatible versions" message.

### Why did you choose this fix out of the possible options?

I chose this fix because...
It seems like the fix with the broadest applicability, and [seems to be supported by André Arko](https://twitter.com/indirect/status/974343146430595072).
