### PR TITLE
Better test specific file searching

### DIFF
--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -253,6 +253,19 @@ module Bundler
       current  = File.expand_path(SharedHelpers.pwd).untaint
 
       until !File.directory?(current) || current == previous
+        if ENV["BUNDLE_SPEC_RUN"]
+          # avoid stepping above the tmp directory when testing
+          gemspec = if ENV["BUNDLE_RUBY"] && ENV["BUNDLE_GEM"]
+            # for Ruby Core
+            "lib/bundler/bundler.gemspec"
+          else
+            "bundler.gemspec"
+          end
+
+          # avoid stepping above the tmp directory when testing
+          return nil if File.file?(File.join(current, gemspec))
+        end
+
         names.each do |name|
           filename = File.join(current, name)
           yield filename

--- a/spec/bundler/cli_spec.rb
+++ b/spec/bundler/cli_spec.rb
@@ -141,7 +141,6 @@ To install the latest version, run `gem install bundler`
           bundle! "config get --parseable foo"
           expect(last_command.stdboth).to eq ""
 
-          ensure_no_gemfile
           bundle "platform --ruby"
           expect(last_command.stdboth).to eq "Could not locate Gemfile"
         end

--- a/spec/bundler/settings_spec.rb
+++ b/spec/bundler/settings_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe Bundler::Settings do
       subject(:settings) { described_class.new(nil) }
 
       it "raises a GemfileNotFound error with explanation" do
-        ensure_no_gemfile
         expect { subject.set_local("foo", "bar") }.
           to raise_error(Bundler::GemfileNotFound, "Could not locate Gemfile")
       end

--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe Bundler::SharedHelpers do
       before { ENV["BUNDLE_GEMFILE"] = nil }
 
       it "raises a GemfileNotFound error" do
-        ensure_no_gemfile
         expect { subject.default_gemfile }.to raise_error(
           Bundler::GemfileNotFound, "Could not locate Gemfile"
         )

--- a/spec/commands/check_spec.rb
+++ b/spec/commands/check_spec.rb
@@ -199,7 +199,6 @@ RSpec.describe "bundle check" do
   end
 
   it "outputs an error when the default Gemfile is not found" do
-    ensure_no_gemfile
     bundle :check
     expect(exitstatus).to eq(10) if exitstatus
     expect(err).to include("Could not locate Gemfile")

--- a/spec/commands/config_spec.rb
+++ b/spec/commands/config_spec.rb
@@ -391,10 +391,10 @@ E
   describe "subcommands" do
     it "list", :ruby_repo do
       bundle! "config list"
-      expect(out).to eq "Settings are listed in order of priority. The top value will be used."
+      expect(out).to eq "Settings are listed in order of priority. The top value will be used.\nspec_run\nSet via BUNDLE_SPEC_RUN: \"true\""
 
       bundle! "config list", :parseable => true
-      expect(out).to be_empty
+      expect(out).to eq "spec_run=true"
     end
 
     it "get" do

--- a/spec/other/cli_dispatch_spec.rb
+++ b/spec/other/cli_dispatch_spec.rb
@@ -2,14 +2,12 @@
 
 RSpec.describe "bundle command names" do
   it "work when given fully" do
-    ensure_no_gemfile
     bundle "install"
     expect(err).to eq("Could not locate Gemfile")
     expect(last_command.stdboth).not_to include("Ambiguous command")
   end
 
   it "work when not ambiguous" do
-    ensure_no_gemfile
     bundle "ins"
     expect(err).to eq("Could not locate Gemfile")
     expect(last_command.stdboth).not_to include("Ambiguous command")

--- a/spec/runtime/gem_tasks_spec.rb
+++ b/spec/runtime/gem_tasks_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "require 'bundler/gem_tasks'" do
 
   it "includes the relevant tasks" do
     with_gem_path_as(Spec::Path.base_system_gems.to_s) do
-      sys_exec "#{rake} -T"
+      sys_exec "#{rake} -T", "RUBYOPT" => "-I#{bundler_path}"
     end
 
     expect(err).to eq("")

--- a/spec/runtime/load_spec.rb
+++ b/spec/runtime/load_spec.rb
@@ -45,7 +45,6 @@ RSpec.describe "Bundler.load" do
 
   describe "without a gemfile" do
     it "raises an exception if the default gemfile is not found" do
-      ensure_no_gemfile
       expect do
         Bundler.load
       end.to raise_error(Bundler::GemfileNotFound, /could not locate gemfile/i)
@@ -56,6 +55,19 @@ RSpec.describe "Bundler.load" do
         ENV["BUNDLE_GEMFILE"] = "omg.rb"
         Bundler.load
       end.to raise_error(Bundler::GemfileNotFound, /omg\.rb/)
+    end
+
+    it "does not find a Gemfile above the testing directory" do
+      bundler_gemfile = tmp.join("../Gemfile")
+      unless File.exist?(bundler_gemfile)
+        FileUtils.touch(bundler_gemfile)
+        @remove_bundler_gemfile = true
+      end
+      begin
+        expect { Bundler.load }.to raise_error(Bundler::GemfileNotFound)
+      ensure
+        bundler_gemfile.rmtree if @remove_bundler_gemfile
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,7 @@ $debug = false
 Spec::Manpages.setup unless Gem.win_platform?
 Spec::Rubygems.setup
 ENV["RUBYOPT"] = "#{ENV["RUBYOPT"]} -r#{Spec::Path.spec_dir}/support/hax.rb"
+ENV["BUNDLE_SPEC_RUN"] = "true"
 
 # Don't wrap output in tests
 ENV["THOR_COLUMNS"] = "10000"

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -313,12 +313,6 @@ module Spec
       bundle :lock, opts
     end
 
-    # Makes tests that require absence of any Gemfiles pass, even if the running
-    # system has a Gemfile further up from the specs folder
-    def ensure_no_gemfile
-      allow(Bundler::SharedHelpers).to receive(:search_up).and_return(nil)
-    end
-
     def install_gems(*gems)
       options = gems.last.is_a?(Hash) ? gems.pop : {}
       gem_repo = options.fetch(:gem_repo) { gem_repo1 }


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that in #7138 I removed some test specific code from lib, but it's not quite working.

### What was your diagnosis of the problem?

My diagnosis was that the mocking I used to fix the issue of bundler looking for files outside of bundler's clone doesn't work inside subprocesses, which many of our specs use. That means some specs were currently failing if you have Gemfile's on `.bundle` folders up in the directory hierarchy ascending from your bundler's clone

### What is your fix for the problem, implemented in this PR?

My fix is revert to the previous approach of using a test specific environment variable to prevent search up higher than the test directory when running our specs.

### Why did you choose this fix out of the possible options?

I initially tried to monkeypatch the gemfile finding helpers only inside specs, but that caused load order issues (I monkeypatched the helpers insde `support/hax.rb`, that caused the monkeypatched lib code to be loaded _before_ the rest of `bundler`, which caused issues in some specs).

Overall, the old approach is the only one that works without issues, so I'm reverting to it, at least for now.