### PR TITLE
Add Bundler::Definition.no_lock accessor for skipping lock file creation/update

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -7,6 +7,11 @@ module Bundler
   class Definition
     include GemHelpers
 
+    class << self
+      # Do not create or modify a lockfile (Makes #lock a noop)
+      attr_accessor :no_lock
+    end
+
     attr_reader(
       :dependencies,
       :locked_deps,
@@ -325,6 +330,8 @@ module Bundler
     end
 
     def lock(file, preserve_unknown_sections = false)
+      return if Definition.no_lock
+
       contents = to_lock
 
       # Convert to \r\n if the existing lock has them

--- a/spec/bundler/definition_spec.rb
+++ b/spec/bundler/definition_spec.rb
@@ -31,6 +31,16 @@ RSpec.describe Bundler::Definition do
           to raise_error(Bundler::TemporaryResourceError, /temporarily unavailable/)
       end
     end
+    context "when Bundler::Definition.no_lock is set to true" do
+      subject { Bundler::Definition.new(nil, [], Bundler::SourceList.new, []) }
+      before { Bundler::Definition.no_lock = true }
+      after { Bundler::Definition.no_lock = false }
+
+      it "does not create a lock file" do
+        subject.lock("Gemfile.lock")
+        expect(File.file?("Gemfile.lock")).to eq false
+      end
+    end
   end
 
   describe "detects changes" do


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

I would like a way to avoid creating a `Gemfile.lock` file when doing `require "bundler/setup"` when I have a `Gemfile` without a `Gemfile.lock`.

### What was your diagnosis of the problem?

`Bundler::Definition#lock` is called when requiring `bundler/setup`, and attempts to create `Gemfile.lock`.  I was able to avoid the problem by doing this:

```ruby
require 'bundler'
Bundler::Definition.send(:define_method, :lock){|*|}
require "bundler/setup"
```

However, that is a very brittle approach that is prone to breakage in future updates to bundler if Bundler's internal API changes.

### What is your fix for the problem, implemented in this PR?

Add `Bundler::Definition.no_lock` accessor.  Set to `true`, this makes `Bundler::Defintion#lock` be a no-op.  Then you can do this to avoid the creation of the lock file:

```ruby
require 'bundler'
Bundler::Definition.no_lock = true
require "bundler/setup"
```

The advantage of this is that it can handle future changes to the bundler internal API.

### Why did you choose this fix out of the possible options?

This seemed to be the simplest approach that would work.
