### PR TITLE
Revert "Remove unused filter"

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -69,8 +69,11 @@ RSpec.configure do |config|
     config.filter_run_excluding :realworld => true
   end
 
+  git_version = Bundler::Source::Git::GitProxy.new(nil, nil, nil).version
+
   config.filter_run_excluding :ruby => RequirementChecker.against(RUBY_VERSION)
   config.filter_run_excluding :rubygems => RequirementChecker.against(Gem::VERSION)
+  config.filter_run_excluding :git => RequirementChecker.against(git_version)
   config.filter_run_excluding :rubygems_master => (ENV["RGV"] != "master")
   config.filter_run_excluding :bundler => RequirementChecker.against(Bundler::VERSION.split(".")[0])
   config.filter_run_excluding :ruby_repo => !(ENV["BUNDLE_RUBY"] && ENV["BUNDLE_GEM"]).nil?


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that I removed the `:git` filter from our specs in ac282dc9de5e20db85e9cdf23b97763a2a2cc292 because I thought it was unused, but it's not.

### What was your diagnosis of the problem?

My diagnosis was that the filter is actually used once:

https://github.com/bundler/bundler/blob/3ec8165eec0a1af8c45ee258d3e7cb61fba875a2/spec/update/git_spec.rb#L162

### What is your fix for the problem, implemented in this PR?

My fix is to revert the commit.