### PR TITLE
`bundle gem` spec refactor

### DIFF
--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe "bundle gem" do
-  def reset!
-    super
-    global_config "BUNDLE_GEM__MIT" => "false", "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__COC" => "false"
-  end
-
   def execute_bundle_gem(gem_name, flag = "")
     bundle! "gem #{gem_name} #{flag}"
     # reset gemspec cache for each test because of commit 3d4163a
@@ -22,6 +17,7 @@ RSpec.describe "bundle gem" do
   end
 
   before do
+    global_config "BUNDLE_GEM__MIT" => "false", "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__COC" => "false"
     git_config_content = <<-EOF
     [user]
       name = "Bundler User"
@@ -136,7 +132,6 @@ RSpec.describe "bundle gem" do
     context "git config github.user is absent" do
       before do
         sys_exec("git config --unset github.user")
-        reset!
         in_app_root
         bundle "gem #{gem_name}"
       end
@@ -209,7 +204,6 @@ RSpec.describe "bundle gem" do
 
   context "gem naming with relative paths" do
     before do
-      reset!
       in_app_root
     end
 
@@ -281,7 +275,6 @@ RSpec.describe "bundle gem" do
       before do
         `git config --unset user.name`
         `git config --unset user.email`
-        reset!
         in_app_root
         bundle "gem #{gem_name}"
       end
@@ -322,7 +315,6 @@ RSpec.describe "bundle gem" do
 
     context "--exe parameter set" do
       before do
-        reset!
         in_app_root
         bundle "gem #{gem_name} --exe"
       end
@@ -338,7 +330,6 @@ RSpec.describe "bundle gem" do
 
     context "--bin parameter set" do
       before do
-        reset!
         in_app_root
         bundle "gem #{gem_name} --bin"
       end
@@ -354,7 +345,6 @@ RSpec.describe "bundle gem" do
 
     context "no --test parameter" do
       before do
-        reset!
         in_app_root
         bundle "gem #{gem_name}"
       end
@@ -370,7 +360,6 @@ RSpec.describe "bundle gem" do
 
     context "--test parameter set to rspec" do
       before do
-        reset!
         in_app_root
         bundle "gem #{gem_name} --test=rspec"
       end
@@ -397,7 +386,6 @@ RSpec.describe "bundle gem" do
 
     context "gem.test setting set to rspec" do
       before do
-        reset!
         in_app_root
         bundle "config set gem.test rspec"
         bundle "gem #{gem_name}"
@@ -412,7 +400,6 @@ RSpec.describe "bundle gem" do
 
     context "gem.test setting set to rspec and --test is set to minitest" do
       before do
-        reset!
         in_app_root
         bundle "config set gem.test rspec"
         bundle "gem #{gem_name} --test=minitest"
@@ -426,7 +413,6 @@ RSpec.describe "bundle gem" do
 
     context "--test parameter set to minitest" do
       before do
-        reset!
         in_app_root
         bundle "gem #{gem_name} --test=minitest"
       end
@@ -456,7 +442,6 @@ RSpec.describe "bundle gem" do
 
     context "gem.test setting set to minitest" do
       before do
-        reset!
         in_app_root
         bundle "config set gem.test minitest"
         bundle "gem #{gem_name}"
@@ -482,7 +467,6 @@ RSpec.describe "bundle gem" do
 
     context "--test with no arguments" do
       before do
-        reset!
         in_app_root
         bundle "gem #{gem_name} --test"
       end
@@ -499,7 +483,6 @@ RSpec.describe "bundle gem" do
 
     context "--edit option" do
       it "opens the generated gemspec in the user's text editor" do
-        reset!
         in_app_root
         output = bundle "gem #{gem_name} --edit=echo"
         gemspec_path = File.join(Dir.pwd, gem_name, "#{gem_name}.gemspec")
@@ -515,7 +498,6 @@ RSpec.describe "bundle gem" do
       before do
         global_config "BUNDLE_GEM__MIT" => "true", "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__COC" => "false"
       end
-      after { reset! }
       it_behaves_like "--mit flag"
       it_behaves_like "--no-mit flag"
     end
@@ -529,7 +511,6 @@ RSpec.describe "bundle gem" do
       before do
         global_config "BUNDLE_GEM__MIT" => "false", "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__COC" => "true"
       end
-      after { reset! }
       it_behaves_like "--coc flag"
       it_behaves_like "--no-coc flag"
     end
@@ -572,7 +553,6 @@ RSpec.describe "bundle gem" do
       before do
         `git config --unset user.name`
         `git config --unset user.email`
-        reset!
         in_app_root
         bundle "gem #{gem_name}"
       end
@@ -604,7 +584,6 @@ RSpec.describe "bundle gem" do
 
     context "--bin parameter set" do
       before do
-        reset!
         in_app_root
         bundle "gem #{gem_name} --bin"
       end
@@ -620,7 +599,6 @@ RSpec.describe "bundle gem" do
 
     context "no --test parameter" do
       before do
-        reset!
         in_app_root
         bundle "gem #{gem_name}"
       end
@@ -636,7 +614,6 @@ RSpec.describe "bundle gem" do
 
     context "--test parameter set to rspec" do
       before do
-        reset!
         in_app_root
         bundle "gem #{gem_name} --test=rspec"
       end
@@ -671,7 +648,6 @@ RSpec.describe "bundle gem" do
 
     context "--test parameter set to minitest" do
       before do
-        reset!
         in_app_root
         bundle "gem #{gem_name} --test=minitest"
       end
@@ -713,7 +689,6 @@ RSpec.describe "bundle gem" do
 
     context "--test with no arguments" do
       before do
-        reset!
         in_app_root
         bundle "gem #{gem_name} --test"
       end
@@ -726,7 +701,6 @@ RSpec.describe "bundle gem" do
 
     context "--ext parameter set" do
       before do
-        reset!
         in_app_root
         bundle "gem test_gem --ext"
       end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that before I figured I needed to revert https://github.com/bundler/bundler/pull/7138 due to the specs no longer being stable, I debugged some failures in the `bundle gem` suite and ended up writing some refactorings.

### What was your diagnosis of the problem?

My diagnosis was that something was wrong with these tests but in the end they were just flaky because of #7038.

In any case, I think the refactorings I wrote improve readabily. In particular, extending the global `reset!` method called before each spec, and reusing it again in the middle of some of these specs was kind of confusing. 