### PR TITLE
Configure Sponsor button on GitHub

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: https://rubytogether.org


### PR DESCRIPTION
Once this file is committed to the repo, GitHub will let us enable a "Sponsor" button, as part of [GitHub's new sponsorship system](https://github.blog/2019-05-23-announcing-github-sponsors-a-new-way-to-contribute-to-open-source/).