### PR TITLE
Add debugging information to flaky test

### DIFF
--- a/spec/bundler/fetcher/compact_index_spec.rb
+++ b/spec/bundler/fetcher/compact_index_spec.rb
@@ -11,11 +11,14 @@ RSpec.describe Bundler::Fetcher::CompactIndex do
   end
 
   describe "#specs_for_names" do
+    let(:thread_list) { Thread.list.select {|thread| thread.status == "run" } }
+    let(:thread_inspection) { thread_list.map {|th| "  * #{th}:\n    #{th.backtrace_locations.join("\n    ")}" }.join("\n") }
+
     it "has only one thread open at the end of the run" do
       compact_index.specs_for_names(["lskdjf"])
 
-      thread_count = Thread.list.count {|thread| thread.status == "run" }
-      expect(thread_count).to eq 1
+      thread_count = thread_list.count
+      expect(thread_count).to eq(1), "Expected 1 active thread after `#specs_for_names`, but found #{thread_count}. In particular, found:\n#{thread_inspection}"
     end
 
     it "calls worker#stop during the run" do


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that last master build failed with a test failure I had never seen: https://travis-ci.org/bundler/bundler/jobs/538089338.

### What was your diagnosis of the problem?

My diagnosis was that this failure _is_ indeed order dependent, since it only appeared after enabling test suite randomization. BUT, this failure is not consistently reproducible.

### What is your fix for the problem, implemented in this PR?

This PR does not fix the problem. It only adds some debugging information, so we have more information to figure this out when it happens again.

### Why did you choose this fix out of the possible options?

I chose this ~fix~ change because it's no clear to me why this happened or how to fix it.
