### PR TITLE
Second try at azure fix

### DIFF
--- a/.azure-pipelines/patch_readline.sh
+++ b/.azure-pipelines/patch_readline.sh
@@ -1,3 +1,3 @@
 ruby_version=$(ruby -e 'puts RUBY_VERSION')
 
-git apply --ignore-space-change --ignore-whitespace .azure-pipelines\rbreadline.diff --directory=C:/hostedtoolcache/windows/Ruby/$ruby_version/x64/lib/ruby/site_ruby --unsafe-paths
+git apply --ignore-space-change --ignore-whitespace '.azure-pipelines\rbreadline.diff' --directory="C:/hostedtoolcache/windows/Ruby/$ruby_version/x64/lib/ruby/site_ruby" --unsafe-paths

--- a/.azure-pipelines/patch_readline.sh
+++ b/.azure-pipelines/patch_readline.sh
@@ -1,0 +1,3 @@
+ruby_version=$(ruby -e 'puts RUBY_VERSION')
+
+git apply --ignore-space-change --ignore-whitespace .azure-pipelines\rbreadline.diff --directory=C:/hostedtoolcache/windows/Ruby/$ruby_version/x64/lib/ruby/site_ruby --unsafe-paths

--- a/.azure-pipelines/steps.yml
+++ b/.azure-pipelines/steps.yml
@@ -2,7 +2,7 @@ steps:
 
 - task: UseRubyVersion@0
   inputs:
-    versionSpec: '= 2.4.5'
+    versionSpec: '= 2.4'
 
 - script: |
     ruby -v
@@ -16,7 +16,7 @@ steps:
   displayName: 'work around readline crash (for https://github.com/bundler/bundler/issues/6902)'
 
 - script: |
-    git apply --ignore-space-change --ignore-whitespace .azure-pipelines\rbreadline.diff --directory=C:/hostedtoolcache/windows/Ruby/2.4.5/x64/lib/ruby/site_ruby --unsafe-paths
+    bash .azure-pipelines\patch_readline.sh
   displayName: 'patch local readline implementation (for https://github.com/bundler/bundler/issues/6907)'
 
 - script: |


### PR DESCRIPTION
This is a followup to #7186.

### What was the end-user problem that led to this PR?

The problem was that Azure CI is still unstable.

### What was your diagnosis of the problem?

My diagnosis was that sometimes MRI 2.4.3 is used, and sometimes MRI 2.4.5 is used instead.

### What is your fix for the problem, implemented in this PR?

My fix, for now, is to make the steps independent from the ruby included in the container that it's run. 

### Why did you choose this fix out of the possible options?

I chose this fix because other better fixes require more work and I don't want to spend a lot of time on this at the moment.
