### PR TITLE
Remove incorrect `man:clobber` task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -242,6 +242,7 @@ namespace :man do
       end
       task :build_all_pages => "index.txt"
 
+      desc "Remove all built man pages"
       task :clean do
         leftovers = Dir["man/*"].reject do |f|
           File.extname(f) == ".ronn"
@@ -251,11 +252,6 @@ namespace :man do
 
       desc "Build the man pages"
       task :build => ["man:clean", "man:build_all_pages"]
-
-      desc "Remove all built man pages"
-      task :clobber do
-        rm_rf "lib/bundler/man"
-      end
     end
   end
 end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that `man:clobber` was listed under `bin/rake -T` but it wasn't working because it was trying to remove a non existent folder.

### What was your diagnosis of the problem?

My diagnosis was that the correct task is actually `bin/rake man:clean`.

### What is your fix for the problem, implemented in this PR?

My fix is to remove `man:clobber` and move its description on top of `man:clean`, so that it's correctly listed under `bin/rake -T`.