### PR TITLE
New dependencies option to `bundle outdated` command

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -386,6 +386,7 @@ module Bundler
     D
     method_option "group", :type => :string, :banner => "List gems from a specific group"
     method_option "groups", :type => :boolean, :banner => "List gems organized by groups"
+    method_option "with-new-dependencies", :type => :boolean, :banner => "Show new dependencies or changed"
     method_option "local", :type => :boolean, :banner =>
       "Do not attempt to fetch gems remotely and use the gem cache instead"
     method_option "pre", :type => :boolean, :banner => "Check for newer pre-release gems"

--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -145,7 +145,8 @@ module Bundler
                 gem[:active_spec],
                 gem[:dependency],
                 groups,
-                options_include_groups.any?
+                options_include_groups.any?,
+                options[:'with-new-dependencies']
               )
             end
           end
@@ -156,7 +157,8 @@ module Bundler
               gem[:active_spec],
               gem[:dependency],
               gem[:groups],
-              options_include_groups.any?
+              options_include_groups.any?,
+              options[:'with-new-dependencies']
             )
           end
         end
@@ -199,7 +201,7 @@ module Bundler
       end
     end
 
-    def print_gem(current_spec, active_spec, dependency, groups, options_include_groups)
+    def print_gem(current_spec, active_spec, dependency, groups, options_include_groups, with_dependencies)
       spec_version = "#{active_spec.version}#{active_spec.git_version}"
       spec_version += " (from #{active_spec.loaded_from})" if Bundler.ui.debug? && active_spec.loaded_from
       current_version = "#{current_spec.version}#{current_spec.git_version}"
@@ -220,6 +222,19 @@ module Bundler
       end
 
       Bundler.ui.info output_message.rstrip
+
+      if with_dependencies
+        active_spec_deps = dependencies_to_str(active_spec.dependencies)
+        current_spec_deps = dependencies_to_str(current_spec.dependencies)
+        new_deps = active_spec_deps - current_spec_deps
+        return if new_deps.size == 0
+
+        Bundler.ui.info "    > #{new_deps.join(", ")}".rstrip
+      end
+    end
+
+    def dependencies_to_str(dependencies)
+      dependencies.to_a.map { |d| "#{d.name} #{d.requirement}" }.sort
     end
 
     def check_for_deployment_mode

--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -234,7 +234,7 @@ module Bundler
     end
 
     def dependencies_to_str(dependencies)
-      dependencies.to_a.map { |d| "#{d.name} #{d.requirement}" }
+      dependencies.to_a.map {|d| "#{d.name} #{d.requirement}" }
     end
 
     def check_for_deployment_mode

--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -229,12 +229,12 @@ module Bundler
         new_deps = active_spec_deps - current_spec_deps
         return if new_deps.size == 0
 
-        Bundler.ui.info "    > #{new_deps.join(", ")}".rstrip
+        Bundler.ui.info "    > #{new_deps.sort.join(", ")}".rstrip
       end
     end
 
     def dependencies_to_str(dependencies)
-      dependencies.to_a.map { |d| "#{d.name} #{d.requirement}" }.sort
+      dependencies.to_a.map { |d| "#{d.name} #{d.requirement}" }
     end
 
     def check_for_deployment_mode

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -75,6 +75,32 @@ RSpec.describe "bundle outdated" do
     end
   end
 
+  describe "--with-new-dependencies option" do
+    before :each do
+      install_gemfile <<-G
+        source "file://#{gem_repo2}"
+
+        gem "duradura", '7.0'
+      G
+
+      update_repo2 do
+        build_gem "duradura", "8.0" do |g|
+          g.add_dependency "actionpack", "5.1.4"
+        end
+      end
+    end
+
+    it "show new dependencies with the flag" do
+      bundle "outdated --with-new-dependencies"
+      expect(out).to include("    > actionpack = 5.1.4")
+    end
+
+    it "not show new dependencies without the flag" do
+      bundle "outdated"
+      expect(out).not_to include("    > actionpack = 5.1.4")
+    end
+  end
+
   describe "with --group option" do
     def test_group_option(group = nil, gems_list_size = 1)
       install_gemfile <<-G


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

This PR is an improvement, I think the new or changed dependencies can be relevant for end users. This information can be present after the outdated information.

### What was your diagnosis of the problem?

My diagnosis was to add the dependency information after the outdated information like this example:
```
bundle outdated --with-new-dependencies
....
....
  * sass (newest 3.7.4, installed 3.4.24)
    > sass-listen ~> 4.0.0
  * sass-rails (newest 5.0.7, installed 5.0.6, requested ~> 5.0) in group "default"
  * selenium-webdriver (newest 3.142.3, installed 2.53.4) in group "test"
    > childprocess >= 0.5, < 2.0, rubyzip ~> 1.2, >= 1.2.2
  * sexp_processor (newest 4.12.1, installed 4.11.0)
  * sidekiq (newest 5.2.7, installed 4.2.10) in group "default"
    > connection_pool ~> 2.2, >= 2.2.2, rack >= 1.5.0, redis >= 3.3.5, < 5
  * simplecov (newest 0.16.1, installed 0.14.1) in group "test"
    > docile ~> 1.1
  * simplecov-html (newest 0.10.2, installed 0.10.0)
  * slop (newest 4.6.2, installed 3.6.0)
....
```

### What is your fix for the problem, implemented in this PR?

My fix is append the new or changed dependencies after the outdated output.

### Why did you choose this fix out of the possible options?

I chose this fix because I think it's relevant information to show at the outdated screen.
