### PR TITLE
More `require_relative`

### DIFF
--- a/exe/bundle
+++ b/exe/bundle
@@ -7,7 +7,7 @@ Signal.trap("INT") do
   exit 1
 end
 
-require "bundler"
+require_relative "../lib/bundler"
 # Check if an older version of bundler is installed
 $LOAD_PATH.each do |path|
   next unless path =~ %r{/bundler-0\.(\d+)} && $1.to_i < 9
@@ -18,9 +18,9 @@ $LOAD_PATH.each do |path|
   abort(err)
 end
 
-require "bundler/friendly_errors"
+require_relative "../lib/bundler/friendly_errors"
 Bundler.with_friendly_errors do
-  require "bundler/cli"
+  require_relative "../lib/bundler/cli"
 
   # Allow any command to use --help flag to show help for that command
   help_flags = %w[--help -h]

--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -564,7 +564,7 @@ EOF
   private
 
     def eval_yaml_gemspec(path, contents)
-      Kernel.send(:require, "bundler/psyched_yaml")
+      require_relative "bundler/psyched_yaml"
 
       # If the YAML is invalid, Syck raises an ArgumentError, and Psych
       # raises a Psych::SyntaxError. See psyched_yaml.rb for more info.

--- a/lib/bundler/vendor/thor/lib/thor.rb
+++ b/lib/bundler/vendor/thor/lib/thor.rb
@@ -1,5 +1,5 @@
 require "set"
-require "bundler/vendor/thor/lib/thor/base"
+require_relative "thor/base"
 
 class Bundler::Thor
   class << self

--- a/lib/bundler/vendor/thor/lib/thor/actions.rb
+++ b/lib/bundler/vendor/thor/lib/thor/actions.rb
@@ -1,11 +1,11 @@
 require "uri"
-require "bundler/vendor/thor/lib/thor/core_ext/io_binary_read"
-require "bundler/vendor/thor/lib/thor/actions/create_file"
-require "bundler/vendor/thor/lib/thor/actions/create_link"
-require "bundler/vendor/thor/lib/thor/actions/directory"
-require "bundler/vendor/thor/lib/thor/actions/empty_directory"
-require "bundler/vendor/thor/lib/thor/actions/file_manipulation"
-require "bundler/vendor/thor/lib/thor/actions/inject_into_file"
+require_relative "core_ext/io_binary_read"
+require_relative "actions/create_file"
+require_relative "actions/create_link"
+require_relative "actions/directory"
+require_relative "actions/empty_directory"
+require_relative "actions/file_manipulation"
+require_relative "actions/inject_into_file"
 
 class Bundler::Thor
   module Actions

--- a/lib/bundler/vendor/thor/lib/thor/actions/create_file.rb
+++ b/lib/bundler/vendor/thor/lib/thor/actions/create_file.rb
@@ -1,4 +1,4 @@
-require "bundler/vendor/thor/lib/thor/actions/empty_directory"
+require_relative "empty_directory"
 
 class Bundler::Thor
   module Actions

--- a/lib/bundler/vendor/thor/lib/thor/actions/create_link.rb
+++ b/lib/bundler/vendor/thor/lib/thor/actions/create_link.rb
@@ -1,4 +1,4 @@
-require "bundler/vendor/thor/lib/thor/actions/create_file"
+require_relative "create_file"
 
 class Bundler::Thor
   module Actions

--- a/lib/bundler/vendor/thor/lib/thor/actions/directory.rb
+++ b/lib/bundler/vendor/thor/lib/thor/actions/directory.rb
@@ -1,4 +1,4 @@
-require "bundler/vendor/thor/lib/thor/actions/empty_directory"
+require_relative "empty_directory"
 
 class Bundler::Thor
   module Actions

--- a/lib/bundler/vendor/thor/lib/thor/actions/inject_into_file.rb
+++ b/lib/bundler/vendor/thor/lib/thor/actions/inject_into_file.rb
@@ -1,4 +1,4 @@
-require "bundler/vendor/thor/lib/thor/actions/empty_directory"
+require_relative "empty_directory"
 
 class Bundler::Thor
   module Actions

--- a/lib/bundler/vendor/thor/lib/thor/base.rb
+++ b/lib/bundler/vendor/thor/lib/thor/base.rb
@@ -1,12 +1,12 @@
-require "bundler/vendor/thor/lib/thor/command"
-require "bundler/vendor/thor/lib/thor/core_ext/hash_with_indifferent_access"
-require "bundler/vendor/thor/lib/thor/core_ext/ordered_hash"
-require "bundler/vendor/thor/lib/thor/error"
-require "bundler/vendor/thor/lib/thor/invocation"
-require "bundler/vendor/thor/lib/thor/parser"
-require "bundler/vendor/thor/lib/thor/shell"
-require "bundler/vendor/thor/lib/thor/line_editor"
-require "bundler/vendor/thor/lib/thor/util"
+require_relative "command"
+require_relative "core_ext/hash_with_indifferent_access"
+require_relative "core_ext/ordered_hash"
+require_relative "error"
+require_relative "invocation"
+require_relative "parser"
+require_relative "shell"
+require_relative "line_editor"
+require_relative "util"
 
 class Bundler::Thor
   autoload :Actions,    File.expand_path("actions", __dir__)

--- a/lib/bundler/vendor/thor/lib/thor/group.rb
+++ b/lib/bundler/vendor/thor/lib/thor/group.rb
@@ -1,4 +1,4 @@
-require "bundler/vendor/thor/lib/thor/base"
+require_relative "base"
 
 # Bundler::Thor has a special class called Bundler::Thor::Group. The main difference to Bundler::Thor class
 # is that it invokes all commands at once. It also include some methods that allows

--- a/lib/bundler/vendor/thor/lib/thor/line_editor.rb
+++ b/lib/bundler/vendor/thor/lib/thor/line_editor.rb
@@ -1,5 +1,5 @@
-require "bundler/vendor/thor/lib/thor/line_editor/basic"
-require "bundler/vendor/thor/lib/thor/line_editor/readline"
+require_relative "line_editor/basic"
+require_relative "line_editor/readline"
 
 class Bundler::Thor
   module LineEditor

--- a/lib/bundler/vendor/thor/lib/thor/parser.rb
+++ b/lib/bundler/vendor/thor/lib/thor/parser.rb
@@ -1,4 +1,4 @@
-require "bundler/vendor/thor/lib/thor/parser/argument"
-require "bundler/vendor/thor/lib/thor/parser/arguments"
-require "bundler/vendor/thor/lib/thor/parser/option"
-require "bundler/vendor/thor/lib/thor/parser/options"
+require_relative "parser/argument"
+require_relative "parser/arguments"
+require_relative "parser/option"
+require_relative "parser/options"

--- a/lib/bundler/vendor/thor/lib/thor/runner.rb
+++ b/lib/bundler/vendor/thor/lib/thor/runner.rb
@@ -1,6 +1,6 @@
-require "bundler/vendor/thor/lib/thor"
-require "bundler/vendor/thor/lib/thor/group"
-require "bundler/vendor/thor/lib/thor/core_ext/io_binary_read"
+require_relative "../thor"
+require_relative "group"
+require_relative "core_ext/io_binary_read"
 
 require "yaml"
 require "digest/md5"
@@ -111,7 +111,7 @@ class Bundler::Thor::Runner < Bundler::Thor #:nodoc: # rubocop:disable ClassLeng
 
   desc "version", "Show Bundler::Thor version"
   def version
-    require "bundler/vendor/thor/lib/thor/version"
+    require_relative "version"
     say "Bundler::Thor #{Bundler::Thor::VERSION}"
   end
 

--- a/lib/bundler/vendor/thor/lib/thor/shell/color.rb
+++ b/lib/bundler/vendor/thor/lib/thor/shell/color.rb
@@ -1,4 +1,4 @@
-require "bundler/vendor/thor/lib/thor/shell/basic"
+require_relative "basic"
 
 class Bundler::Thor
   module Shell

--- a/lib/bundler/vendor/thor/lib/thor/shell/html.rb
+++ b/lib/bundler/vendor/thor/lib/thor/shell/html.rb
@@ -1,4 +1,4 @@
-require "bundler/vendor/thor/lib/thor/shell/basic"
+require_relative "basic"
 
 class Bundler::Thor
   module Shell

--- a/lib/bundler/vendored_thor.rb
+++ b/lib/bundler/vendored_thor.rb
@@ -2,7 +2,7 @@
 
 module Bundler
   def self.require_thor_actions
-    Kernel.send(:require, "bundler/vendor/thor/lib/thor/actions")
+    require_relative "vendor/thor/lib/thor/actions"
   end
 end
 require_relative "vendor/thor/lib/thor"


### PR DESCRIPTION
This is a follow up to #7062 and #7100, migrating the last missing internal requires to use `require_relative`. I thought I had migrated everything already, but I had not.

As a note, I'm migrating thor's code here. I will open a PR to upstream's thor to incorporate this changes, but thor is still stuck with 1.8 support, so we have to wait a bit. Given the very low activity thor has, it's fine to make the changes here first, and wait until we can incorporate them upstream.
 
### What was the end-user problem that led to this PR?

The problem was that sometimes we can end up requiring the default version of bundler, instead of the current copy that's being run, and that's dangerous and can cause version mismatch issues.

### What is your fix for the problem, implemented in this PR?

My fix is to always use `require_relative` for internal requires.