### PR TITLE
Allow bundle activation if v2.0 >= than required

### DIFF
--- a/lib/bundler/templates/Executable.bundler
+++ b/lib/bundler/templates/Executable.bundler
@@ -75,17 +75,19 @@ m = Module.new do
   end
 
   def activate_bundler(bundler_version)
-    if Gem::Version.correct?(bundler_version) && Gem::Version.new(bundler_version).release < Gem::Version.new("2.0")
-      bundler_version = "< 2"
+    required_version = if Gem::Version.correct?(bundler_version)
+      return "< 2" if Gem::Version.new(bundler_version).release < Gem::Version.new("2.0")
+
+      ">= #{bundler_version}"
     end
     gem_error = activation_error_handling do
-      gem "bundler", bundler_version
+      gem "bundler", (required_version || bundler_version)
     end
     return if gem_error.nil?
     require_error = activation_error_handling do
       require "bundler/version"
     end
-    return if require_error.nil? && Gem::Requirement.new(bundler_version).satisfied_by?(Gem::Version.new(Bundler::VERSION))
+    return if require_error.nil? && Gem::Requirement.new(required_version || bundler_version).satisfied_by?(Gem::Version.new(Bundler::VERSION))
     warn "Activating bundler (#{bundler_version}) failed:\n#{gem_error.message}\n\nTo install the version of bundler this project requires, run `gem install bundler -v '#{bundler_version}'`"
     exit 42
   end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

If a newer version of bundler ins installed on the system, but the one on the Gemfile.lock is not, running commands using binstubs will fail for bundler >= 2.0

### What was your diagnosis of the problem?

The template is too strict with v2.0

### What is your fix for the problem, implemented in this PR?

Activate bundler versions as long as they are greater than the one on the lock file

### Why did you choose this fix out of the possible options?

This is just a quick fix to the problem I describe, other improvements can be done I just wanted to validate first that this would be a desired behavior.


I tested locally that the problem is fixed. If you think this should work like that (v1 used to and still does) I can fix all the broken specs.
