### PR TITLE
Add a minimum ruby version to the generated gemspec 

### DIFF
--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -12,6 +12,7 @@ Gem::Specification.new do |spec|
 <%- if config[:mit] -%>
   spec.license       = "MIT"
 <%- end -%>
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
 
   spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
 

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -274,6 +274,12 @@ RSpec.describe "bundle gem" do
         to match(/mygemserver\.com/)
     end
 
+    it "sets a minimum ruby version" do
+      bundler_gemspec = Bundler::GemHelper.new(File.expand_path("../..", __dir__)).gemspec
+
+      expect(bundler_gemspec.required_ruby_version).to eq(generated_gemspec.required_ruby_version)
+    end
+
     it "requires the version file" do
       expect(bundled_app("test_gem/lib/test_gem.rb").read).to match(%r{require "test_gem/version"})
     end

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe "bundle gem" do
     expect(bundled_app("#{gem_name}/lib/test/gem/version.rb")).to exist
   end
 
+  let(:generated_gem) { Bundler::GemHelper.new(bundled_app(gem_name).to_s) }
+
   before do
     global_config "BUNDLE_GEM__MIT" => "false", "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__COC" => "false"
     git_config_content = <<-EOF
@@ -116,7 +118,6 @@ RSpec.describe "bundle gem" do
 
   context "README.md" do
     let(:gem_name) { "test_gem" }
-    let(:generated_gem) { Bundler::GemHelper.new(bundled_app(gem_name).to_s) }
 
     context "git config github.user present" do
       before do
@@ -231,8 +232,6 @@ RSpec.describe "bundle gem" do
     before do
       execute_bundle_gem(gem_name)
     end
-
-    let(:generated_gem) { Bundler::GemHelper.new(bundled_app(gem_name).to_s) }
 
     it "generates a gem skeleton" do
       expect(bundled_app("test_gem/test_gem.gemspec")).to exist
@@ -515,8 +514,6 @@ RSpec.describe "bundle gem" do
     before do
       execute_bundle_gem(gem_name)
     end
-
-    let(:generated_gem) { Bundler::GemHelper.new(bundled_app(gem_name).to_s) }
 
     it "generates a gem skeleton" do
       expect(bundled_app("test-gem/test-gem.gemspec")).to exist

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "bundle gem" do
     expect(bundled_app("#{gem_name}/lib/test/gem/version.rb")).to exist
   end
 
-  let(:generated_gem) { Bundler::GemHelper.new(bundled_app(gem_name).to_s) }
+  let(:generated_gemspec) { Bundler::GemHelper.new(bundled_app(gem_name).to_s).gemspec }
 
   before do
     global_config "BUNDLE_GEM__MIT" => "false", "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__COC" => "false"
@@ -41,22 +41,22 @@ RSpec.describe "bundle gem" do
   shared_examples_for "git config is present" do
     context "git config user.{name,email} present" do
       it "sets gemspec author to git user.name if available" do
-        expect(generated_gem.gemspec.authors.first).to eq("Bundler User")
+        expect(generated_gemspec.authors.first).to eq("Bundler User")
       end
 
       it "sets gemspec email to git user.email if available" do
-        expect(generated_gem.gemspec.email.first).to eq("user@example.com")
+        expect(generated_gemspec.email.first).to eq("user@example.com")
       end
     end
   end
 
   shared_examples_for "git config is absent" do
     it "sets gemspec author to default message if git user.name is not set or empty" do
-      expect(generated_gem.gemspec.authors.first).to eq("TODO: Write your name")
+      expect(generated_gemspec.authors.first).to eq("TODO: Write your name")
     end
 
     it "sets gemspec email to default message if git user.email is not set or empty" do
-      expect(generated_gem.gemspec.email.first).to eq("TODO: Write your email address")
+      expect(generated_gemspec.email.first).to eq("TODO: Write your email address")
     end
   end
 
@@ -270,7 +270,7 @@ RSpec.describe "bundle gem" do
     end
 
     it "sets gemspec metadata['allowed_push_host']" do
-      expect(generated_gem.gemspec.metadata["allowed_push_host"]).
+      expect(generated_gemspec.metadata["allowed_push_host"]).
         to match(/mygemserver\.com/)
     end
 
@@ -358,7 +358,7 @@ RSpec.describe "bundle gem" do
       end
 
       it "depends on a specific version of rspec" do
-        rspec_dep = generated_gem.gemspec.development_dependencies.find {|d| d.name == "rspec" }
+        rspec_dep = generated_gemspec.development_dependencies.find {|d| d.name == "rspec" }
         expect(rspec_dep).to be_specific
       end
 
@@ -405,7 +405,7 @@ RSpec.describe "bundle gem" do
       end
 
       it "depends on a specific version of minitest" do
-        rspec_dep = generated_gem.gemspec.development_dependencies.find {|d| d.name == "minitest" }
+        rspec_dep = generated_gemspec.development_dependencies.find {|d| d.name == "minitest" }
         expect(rspec_dep).to be_specific
       end
 


### PR DESCRIPTION
This PR is a finished version of #4397.

### What was the end-user problem that led to this PR?

The problem was that the generated gemspec for new gems does not impose a minimum ruby version.

### What is your fix for the problem, implemented in this PR?

My fix is to set the minimum ruby version in the generated gemspec to the minimum ruby version supported by bundler itself.

### Why did you choose this fix out of the possible options?

I chose this fix because it's simple.