### PR TITLE
Use real paths for `bundle clean`

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -317,7 +317,7 @@ module Bundler
     end
 
     def spec_git_paths
-      sources.git_sources.map {|s| s.path.to_s }
+      sources.git_sources.map {|s| File.realpath(s.path) }
     end
 
     def groups


### PR DESCRIPTION
Fixes #7208.

### What was the end-user problem that led to this PR?

The problem was that since rubygems 3.0, `bundle clean` incorrectly cleans git gems when they are installed to a symlinked location, but still being used.

### What was your diagnosis of the problem?

My diagnosis was that since https://github.com/rubygems/rubygems/pull/2352, `Gem.dir` returns an array of realpaths, not symlinked ones. However, we don't do the same resolution on the `bundler` side, so in this situation git gems are not correctly skipped from the cleanup.

### What is your fix for the problem, implemented in this PR?

My fix is to resolve the array of paths `bundle clean` uses to do its thing into an array of real paths, just like rubygems does now.

### Why did you choose this fix out of the possible options?

I chose this fix because it fixes the problem.
