### PR TITLE
Don't re-resolve locked platform specific gems

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -813,7 +813,7 @@ module Bundler
 
       resolve = SpecSet.new(converged)
       expanded_deps = expand_dependencies(deps, true)
-      @locked_specs_incomplete_for_platform = !resolve.for(expanded_deps, @unlock[:gems], true, true)
+      @locked_specs_incomplete_for_platform = !resolve.for(expand_dependencies(deps), @unlock[:gems], true, true)
       resolve = resolve.for(expanded_deps, @unlock[:gems], false, false, false)
       diff    = nil
 

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -812,9 +812,8 @@ module Bundler
       end
 
       resolve = SpecSet.new(converged)
-      expanded_deps = expand_dependencies(deps, true)
       @locked_specs_incomplete_for_platform = !resolve.for(expand_dependencies(deps), @unlock[:gems], true, true)
-      resolve = resolve.for(expanded_deps, @unlock[:gems], false, false, false)
+      resolve = resolve.for(expand_dependencies(deps, true), @unlock[:gems], false, false, false)
       diff    = nil
 
       # Now, we unlock any sources that do not have anymore gems pinned to it

--- a/spec/bundler/definition_spec.rb
+++ b/spec/bundler/definition_spec.rb
@@ -147,6 +147,34 @@ RSpec.describe Bundler::Definition do
       G
     end
 
+    it "for a locked gem for another platform" do
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gem "only_java", platform: :jruby
+      G
+
+      bundle "lock --add-platform java"
+      bundle :check, :env => { "DEBUG" => 1 }
+
+      expect(out).to match(/using resolution from the lockfile/)
+      lockfile_should_be <<-G
+        GEM
+          remote: #{file_uri_for(gem_repo1)}/
+          specs:
+            only_java (1.1-java)
+
+        PLATFORMS
+          java
+          #{lockfile_platforms}
+
+        DEPENDENCIES
+          only_java
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      G
+    end
+
     it "for a rubygems gem" do
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that when you have locked platform gems in your lockfile for a platform different than the running one, the lockfile was always getting re-resolved.

### What was your diagnosis of the problem?

My diagnosis was that the dependencies passed on to the `SpecSet#for` call that's supposed to check that no dependencies are missing for the current platform, always include all dependencies for all platforms. And thus platform missing dependencies are always detected. The reason for that is that `expand_dependencies` was being passed `remote = true`

https://github.com/bundler/bundler/blob/0b5da910e71760eb585b34d08d43ea31b988ca24/lib/bundler/definition.rb#L815-L816

and thus not excluding dependencies exclusive for other platforms

https://github.com/bundler/bundler/blob/0b5da910e71760eb585b34d08d43ea31b988ca24/lib/bundler/definition.rb#L887

### What is your fix for the problem, implemented in this PR?

My fix is to skip the second argument to `expand_dependencies` in this case, so that it works in its default "local mode" and the dependencies for other platforms are properly filtered out.

### Why did you choose this fix out of the possible options?

I chose this fix because it fixes the issue in a simple way.