### PR TITLE
Replace `bundler_2:install` task with `bundler_3:install`

### DIFF
--- a/task/bundler_3.rake
+++ b/task/bundler_3.rake
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-namespace :bundler_2 do
+namespace :bundler_3 do
   task :install do
-    ENV["BUNDLER_SPEC_SUB_VERSION"] = "2.0.0.dev"
+    ENV["BUNDLER_SPEC_SUB_VERSION"] = "3.0.0.dev"
     Rake::Task["override_version"].invoke
     Rake::Task["install"].invoke
     sh("git", "checkout", "--", "lib/bundler/version.rb")


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that the `bundler_2:install` task is no longer meaningful.

### What was your diagnosis of the problem?

My diagnosis was that master points to 2.x now, so this task is useless.

### What is your fix for the problem, implemented in this PR?

My fix is move it to `bundler_3:install`.

### Why did you choose this fix out of the possible options?

I chose this fix because it keeps the shortcut, but for a useful future version.
