### PR TITLE
Auto multiplatform

### DIFF
--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -172,6 +172,8 @@ module Bundler
     end
 
     def retrieve_active_spec(strict, definition, current_spec)
+      return unless current_spec.match_platform(Bundler.local_platform)
+
       if strict
         active_spec = definition.find_resolved_spec(current_spec)
       else

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -519,9 +519,7 @@ module Bundler
     end
 
     def add_current_platform
-      current_platform = Bundler.local_platform
-      add_platform(current_platform) if Bundler.feature_flag.specific_platform?
-      add_platform(generic(current_platform))
+      current_platforms.each {|platform| add_platform(platform) }
     end
 
     def find_resolved_spec(current_spec)
@@ -544,6 +542,14 @@ module Bundler
     end
 
   private
+
+    def current_platforms
+      current_platform = Bundler.local_platform
+      platforms = []
+      platforms << current_platform if Bundler.feature_flag.specific_platform?
+      platforms << generic(current_platform)
+      platforms
+    end
 
     def change_reason
       if unlocking?

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -113,7 +113,7 @@ module Bundler
       end
       @unlocking ||= @unlock[:ruby] ||= (!@locked_ruby_version ^ !@ruby_version)
 
-      add_current_platform unless Bundler.frozen_bundle?
+      add_platforms unless Bundler.frozen_bundle?
 
       converge_path_sources_to_gemspec_sources
       @path_changes = converge_paths
@@ -542,6 +542,12 @@ module Bundler
     end
 
   private
+
+    def add_platforms
+      (@dependencies.flat_map(&:expanded_platforms) + current_platforms).uniq.each do |platform|
+        add_platform(platform)
+      end
+    end
 
     def current_platforms
       current_platform = Bundler.local_platform

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -518,10 +518,6 @@ module Bundler
       raise InvalidOption, "Unable to remove the platform `#{platform}` since the only platforms are #{@platforms.join ", "}"
     end
 
-    def add_current_platform
-      current_platforms.each {|platform| add_platform(platform) }
-    end
-
     def find_resolved_spec(current_spec)
       specs.find_by_name_and_platform(current_spec.name, current_spec.platform)
     end

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -892,7 +892,7 @@ module Bundler
         next if !remote && !dep.current_platform?
         platforms = dep.gem_platforms(sorted_platforms)
         if platforms.empty? && !Bundler.settings[:disable_platform_warnings]
-          mapped_platforms = dep.platforms.map {|p| Dependency::PLATFORM_MAP[p] }
+          mapped_platforms = dep.expanded_platforms
           Bundler.ui.warn \
             "The dependency #{dep} will be unused by any of the platforms Bundler is installing for. " \
             "Bundler is installing for #{@platforms.join ", "} but the dependency " \

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -896,17 +896,7 @@ module Bundler
       dependencies.each do |dep|
         dep = Dependency.new(dep, ">= 0") unless dep.respond_to?(:name)
         next if !remote && !dep.current_platform?
-        platforms = dep.gem_platforms(sorted_platforms)
-        if platforms.empty? && !Bundler.settings[:disable_platform_warnings]
-          mapped_platforms = dep.expanded_platforms
-          Bundler.ui.warn \
-            "The dependency #{dep} will be unused by any of the platforms Bundler is installing for. " \
-            "Bundler is installing for #{@platforms.join ", "} but the dependency " \
-            "is only for #{mapped_platforms.join ", "}. " \
-            "To add those platforms to the bundle, " \
-            "run `bundle lock --add-platform #{mapped_platforms.join " "}`."
-        end
-        platforms.each do |p|
+        dep.gem_platforms(sorted_platforms).each do |p|
           deps << DepProxy.new(dep, p) if remote || p == generic_local_platform
         end
       end

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -547,10 +547,10 @@ module Bundler
 
     def current_platforms
       current_platform = Bundler.local_platform
-      platforms = []
-      platforms << current_platform if Bundler.feature_flag.specific_platform?
-      platforms << generic(current_platform)
-      platforms
+      [].tap do |platforms|
+        platforms << current_platform if Bundler.feature_flag.specific_platform?
+        platforms << generic(current_platform)
+      end
     end
 
     def change_reason

--- a/lib/bundler/dependency.rb
+++ b/lib/bundler/dependency.rb
@@ -105,9 +105,13 @@ module Bundler
     def gem_platforms(valid_platforms)
       return valid_platforms if @platforms.empty?
 
-      @gem_platforms ||= @platforms.map {|pl| PLATFORM_MAP[pl] }.compact.uniq
+      @gem_platforms ||= expanded_platforms.compact.uniq
 
       valid_platforms & @gem_platforms
+    end
+
+    def expanded_platforms
+      @platforms.map {|pl| PLATFORM_MAP[pl] }
     end
 
     def should_include?

--- a/lib/bundler/inline.rb
+++ b/lib/bundler/inline.rb
@@ -60,7 +60,7 @@ def gemfile(install = false, options = {}, &gemfile)
 
     Bundler.ui = ui if install
     if install || missing_specs.call
-      Bundler.settings.temporary(:inline => true, :disable_platform_warnings => true) do
+      Bundler.settings.temporary(:inline => true) do
         installer = Bundler::Installer.install(Bundler.root, definition, :system => true)
         installer.post_install_messages.each do |name, message|
           Bundler.ui.info "Post-install message from #{name}:\n#{message}"

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -25,7 +25,6 @@ module Bundler
       disable_exec_load
       disable_local_branch_check
       disable_multisource
-      disable_platform_warnings
       disable_shared_gems
       disable_version_check
       force_ruby_platform

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -176,8 +176,6 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
    When set, Gemfiles containing multiple sources will produce errors
    instead of warnings.
    Use `bundle config unset disable_multisource` to unset.
-* `disable_platform_warnings` (`BUNDLE_DISABLE_PLATFORM_WARNINGS`):
-   Disable warnings during bundle install when a dependency is unused on the current platform.
 * `disable_shared_gems` (`BUNDLE_DISABLE_SHARED_GEMS`):
    Stop Bundler from accessing gems installed to RubyGems' normal location.
 * `disable_version_check` (`BUNDLE_DISABLE_VERSION_CHECK`):

--- a/spec/commands/lock_spec.rb
+++ b/spec/commands/lock_spec.rb
@@ -284,7 +284,7 @@ RSpec.describe "bundle lock" do
 
     simulate_platform(mingw) { bundle! :lock }
 
-    expect(the_bundle.lockfile).to read_as(strip_whitespace(<<-G))
+    lockfile_should_be <<-G
       GEM
         remote: #{file_uri_for(gem_repo4)}/
         specs:
@@ -309,7 +309,7 @@ RSpec.describe "bundle lock" do
 
     simulate_platform(rb) { bundle! :lock }
 
-    expect(the_bundle.lockfile).to read_as(strip_whitespace(<<-G))
+    lockfile_should_be <<-G
       GEM
         remote: #{file_uri_for(gem_repo4)}/
         specs:

--- a/spec/install/gemfile/platform_spec.rb
+++ b/spec/install/gemfile/platform_spec.rb
@@ -372,7 +372,7 @@ RSpec.describe "bundle install with platform conditionals" do
     expect(out).not_to match(/Could not find gem 'some_gem/)
   end
 
-  it "prints a helpful warning when a dependency is unused on any platform" do
+  it "resolves all platforms by default and without warning messages" do
     simulate_platform "ruby"
     simulate_ruby_engine "ruby"
 
@@ -384,9 +384,27 @@ RSpec.describe "bundle install with platform conditionals" do
 
     bundle! "install"
 
-    expect(err).to include <<-O.strip
-The dependency #{Gem::Dependency.new("rack", ">= 0")} will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for x86-mingw32, x86-mswin32, x64-mingw32, java. To add those platforms to the bundle, run `bundle lock --add-platform x86-mingw32 x86-mswin32 x64-mingw32 java`.
-    O
+    expect(err).to be_empty
+
+    lockfile_should_be <<-L
+      GEM
+        remote: #{file_uri_for(gem_repo1)}/
+        specs:
+          rack (1.0.0)
+
+      PLATFORMS
+        java
+        ruby
+        x64-mingw32
+        x86-mingw32
+        x86-mswin32
+
+      DEPENDENCIES
+        rack
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
   end
 
   context "when disable_platform_warnings is true" do

--- a/spec/install/gemfile/platform_spec.rb
+++ b/spec/install/gemfile/platform_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe "bundle install across platforms" do
       gem "pry"
     G
 
-    expect(the_bundle.lockfile).to read_as strip_whitespace(<<-L)
+    lockfile_should_be <<-L
       GEM
         remote: #{file_uri_for(gem_repo4)}/
         specs:
@@ -160,7 +160,7 @@ RSpec.describe "bundle install across platforms" do
          #{Bundler::VERSION}
     L
 
-    expect(the_bundle.lockfile).to read_as good_lockfile
+    lockfile_should_be good_lockfile
 
     bad_lockfile = strip_whitespace <<-L
       GEM
@@ -196,23 +196,23 @@ RSpec.describe "bundle install across platforms" do
     aggregate_failures do
       lockfile bad_lockfile
       bundle! :install
-      expect(the_bundle.lockfile).to read_as good_lockfile
+      lockfile_should_be good_lockfile
 
       lockfile bad_lockfile
       bundle! :update, :all => true
-      expect(the_bundle.lockfile).to read_as good_lockfile
+      lockfile_should_be good_lockfile
 
       lockfile bad_lockfile
       bundle! "update ffi"
-      expect(the_bundle.lockfile).to read_as good_lockfile
+      lockfile_should_be good_lockfile
 
       lockfile bad_lockfile
       bundle! "update empyrean"
-      expect(the_bundle.lockfile).to read_as good_lockfile
+      lockfile_should_be good_lockfile
 
       lockfile bad_lockfile
       bundle! :lock
-      expect(the_bundle.lockfile).to read_as good_lockfile
+      lockfile_should_be good_lockfile
     end
   end
 

--- a/spec/install/gemfile/platform_spec.rb
+++ b/spec/install/gemfile/platform_spec.rb
@@ -406,25 +406,6 @@ RSpec.describe "bundle install with platform conditionals" do
          #{Bundler::VERSION}
     L
   end
-
-  context "when disable_platform_warnings is true" do
-    before { bundle! "config set disable_platform_warnings true" }
-
-    it "does not print the warning when a dependency is unused on any platform" do
-      simulate_platform "ruby"
-      simulate_ruby_engine "ruby"
-
-      gemfile <<-G
-        source "#{file_uri_for(gem_repo1)}"
-
-        gem "rack", :platform => [:mingw, :mswin, :x64_mingw, :jruby]
-      G
-
-      bundle! "install"
-
-      expect(out).not_to match(/The dependency (.*) will be unused/)
-    end
-  end
 end
 
 RSpec.describe "when a gem has no architecture" do

--- a/spec/runtime/require_spec.rb
+++ b/spec/runtime/require_spec.rb
@@ -425,7 +425,7 @@ RSpec.describe "Bundler.require with platform specific dependencies" do
       source "#{file_uri_for(gem_repo1)}"
 
       platforms :#{not_local_tag} do
-        gem "fail", :require => "omgomg"
+        gem "platform_specific", :require => "omgomg"
       end
 
       gem "rack", "1.0.0"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that currently if the gemfile include gems for specific platforms, like the default `gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby] ` Rails uses, bundler will _always_ print a noisy warning, but I don't think users are doing anything wrong, just running `bundle install` on it.

Also, unless they run `bundle lock --add-platform x86-mingw32 x86-mswin32 x64-mingw32 java`, and commit the resulting lockfile, they will continue to get the same warning over and over again.

### What was your diagnosis of the problem?

My diagnosis was that the right thing to do is that instead of warning users, bundler does the right thing by default. That is:

* Resolve the gemfile and lock it for all platforms present in the Gemfile.
* Install gems for the current platform if requested.

### What is your fix for the problem, implemented in this PR?

My fix is to do just that.

### Why did you choose this fix out of the possible options?

I chose this fix because I think it's better for our users. We currently have a specific setting to avoid this warning, which I guess we added given the complaints. We no longer need that setting, nor the warning, so I removed both.
