### PR TITLE
Revert "Migrate requires from exe/ to also be relative"

### DIFF
--- a/exe/bundle
+++ b/exe/bundle
@@ -7,7 +7,7 @@ Signal.trap("INT") do
   exit 1
 end
 
-require_relative "../lib/bundler"
+require "bundler"
 # Check if an older version of bundler is installed
 $LOAD_PATH.each do |path|
   next unless path =~ %r{/bundler-0\.(\d+)} && $1.to_i < 9
@@ -18,9 +18,9 @@ $LOAD_PATH.each do |path|
   abort(err)
 end
 
-require_relative "../lib/bundler/friendly_errors"
+require "bundler/friendly_errors"
 Bundler.with_friendly_errors do
-  require_relative "../lib/bundler/cli"
+  require "bundler/cli"
 
   # Allow any command to use --help flag to show help for that command
   help_flags = %w[--help -h]


### PR DESCRIPTION

### What was the end-user problem that led to this PR?

The problem was that in https://github.com/bundler/bundler/pull/7193, I included [a commit](https://github.com/bundler/bundler/pull/7193/commits/d9d2bf6d522dd36d1ef2732e87cef8b7cba729fd) to migrate requires included in bundler's executable to use `require_relative`. That broke stuff.

### What was your diagnosis of the problem?

My diagnosis was the assumption that if `<install_folder>/exe/bundle` lives on a folder, the corresponding bundler lib lives on `<install_folder>/lib` doesn't hold for default gems. Default gems for gems with executables live in `site_lib` but install their executables in the standard gem location. That means that the reference commit breaks bundler when it is installed as a default gem.

### What is your fix for the problem, implemented in this PR?

My fix is to revert the commit.

### Why did you choose this fix out of the possible options?

I chose this fix because it's the easiest way. The proper long term fix is probably to make default gems behave in a more standard way. There's some ongoing work on that here: https://github.com/rubygems/rubygems/pull/2166.
