### PR TITLE
Fix a typo on a spec comment

### DIFF
--- a/spec/runtime/executable_spec.rb
+++ b/spec/runtime/executable_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe "Running bin/* commands" do
   end
 
   it "use BUNDLE_GEMFILE gemfile for binstub" do
-    # context with bin/bunlder w/ default Gemfile
+    # context with bin/bundler w/ default Gemfile
     bundle! "binstubs bundler"
 
     # generate other Gemfile with executable gem


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was there's a typo on a comment.

### What was your diagnosis of the problem?

My diagnosis was that typos are bad because they difficult reading and distract devs.

### What is your fix for the problem, implemented in this PR?

My fix is to spell bundler properly.

### Why did you choose this fix out of the possible options?

I chose this fix because `bundler` is the only word that makes sense in the context :)
