### PR TITLE
Bump rubocop to 0.71

### DIFF
--- a/bundler.gemspec
+++ b/bundler.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake",       "~> 12.0"
   s.add_development_dependency "ronn",       "~> 0.7.3"
   s.add_development_dependency "rspec",      "~> 3.6"
-  s.add_development_dependency "rubocop",    "= 0.68.1"
+  s.add_development_dependency "rubocop",    "= 0.71.0"
   s.add_development_dependency "rubocop-performance", "~> 1.1"
 
   s.files = Dir.glob("{lib,exe}/**/*", File::FNM_DOTMATCH).reject {|f| File.directory?(f) }

--- a/bundler.gemspec
+++ b/bundler.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "ronn",       "~> 0.7.3"
   s.add_development_dependency "rspec",      "~> 3.6"
   s.add_development_dependency "rubocop",    "= 0.71.0"
-  s.add_development_dependency "rubocop-performance", "~> 1.1"
+  s.add_development_dependency "rubocop-performance", "= 1.4.0"
 
   s.files = Dir.glob("{lib,exe}/**/*", File::FNM_DOTMATCH).reject {|f| File.directory?(f) }
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that [our build broke](https://travis-ci.org/bundler/bundler/jobs/548144536) due to a dependency incompatibility caused by a new release of `rubocop-performance`.

### What was your diagnosis of the problem?

My diagnosis was that our requirements were very loose for `rubocop-performance`, but very strict for `rubocop`, so very likely to break on `rubocop-performance` releases.

### What is your fix for the problem, implemented in this PR?

My fix is to upgrade `rubocop` to fix the current issue, and to lock `rubocop-performance` so it doesn't happen again in the future.

### Why did you choose this fix out of the possible options?

I chose this fix because it works now and in the future.
