### PR TITLE
Remove `add_development_dependency` from new gems

### DIFF
--- a/lib/bundler/templates/newgem/Gemfile.tt
+++ b/lib/bundler/templates/newgem/Gemfile.tt
@@ -2,3 +2,11 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in <%= config[:name] %>.gemspec
 gemspec
+
+gem "rake", "~> 12.0"
+<%- if config[:ext] -%>
+gem "rake-compiler"
+<%- end -%>
+<%- if config[:test] -%>
+gem "<%= config[:test] %>", "~> <%= config[:test_framework_version] %>"
+<%- end -%>

--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -33,11 +33,4 @@ Gem::Specification.new do |spec|
 <%- end -%>
 
   spec.add_development_dependency "bundler", "~> <%= config[:bundler_version] %>"
-  spec.add_development_dependency "rake", "~> 12.0"
-<%- if config[:ext] -%>
-  spec.add_development_dependency "rake-compiler"
-<%- end -%>
-<%- if config[:test] -%>
-  spec.add_development_dependency "<%= config[:test] %>", "~> <%= config[:test_framework_version] %>"
-<%- end -%>
 end

--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -31,6 +31,4 @@ Gem::Specification.new do |spec|
 <%- if config[:ext] -%>
   spec.extensions    = ["ext/<%= config[:underscored_name] %>/extconf.rb"]
 <%- end -%>
-
-  spec.add_development_dependency "bundler", "~> <%= config[:bundler_version] %>"
 end

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -363,9 +363,14 @@ RSpec.describe "bundle gem" do
         expect(bundled_app("test_gem/spec/spec_helper.rb")).to exist
       end
 
-      it "depends on a specific version of rspec" do
-        rspec_dep = generated_gemspec.development_dependencies.find {|d| d.name == "rspec" }
-        expect(rspec_dep).to be_specific
+      it "depends on a specific version of rspec in generated Gemfile" do
+        Dir.chdir(bundled_app("test_gem")) do
+          builder = Bundler::Dsl.new
+          builder.eval_gemfile(bundled_app("test_gem/Gemfile"))
+          builder.dependencies
+          rspec_dep = builder.dependencies.find {|d| d.name == "rspec" }
+          expect(rspec_dep).to be_specific
+        end
       end
 
       it "requires 'test-gem'" do
@@ -411,8 +416,13 @@ RSpec.describe "bundle gem" do
       end
 
       it "depends on a specific version of minitest" do
-        minitest_dep = generated_gemspec.development_dependencies.find {|d| d.name == "minitest" }
-        expect(minitest_dep).to be_specific
+        Dir.chdir(bundled_app("test_gem")) do
+          builder = Bundler::Dsl.new
+          builder.eval_gemfile(bundled_app("test_gem/Gemfile"))
+          builder.dependencies
+          minitest_dep = builder.dependencies.find {|d| d.name == "minitest" }
+          expect(minitest_dep).to be_specific
+        end
       end
 
       it "builds spec skeleton" do
@@ -703,7 +713,7 @@ RSpec.describe "bundle gem" do
       end
 
       it "includes rake-compiler" do
-        expect(bundled_app("test_gem/test_gem.gemspec").read).to include('spec.add_development_dependency "rake-compiler"')
+        expect(bundled_app("test_gem/Gemfile").read).to include('gem "rake-compiler"')
       end
 
       it "depends on compile task for build" do
@@ -808,7 +818,7 @@ Usage: "bundle gem NAME [OPTIONS]"
       RAKEFILE
 
       expect(bundled_app("foobar/Rakefile").read).to eq(rakefile)
-      expect(bundled_app("foobar/foobar.gemspec").read).to include('spec.add_development_dependency "rspec"')
+      expect(bundled_app("foobar/Gemfile").read).to include('gem "rspec"')
     end
 
     it "asks about MIT license" do

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -727,8 +727,7 @@ RSpec.describe "bundle gem" do
 
   describe "uncommon gem names" do
     it "can deal with two dashes" do
-      bundle "gem a--a"
-      Bundler.clear_gemspec_cache
+      execute_bundle_gem("a--a")
 
       expect(bundled_app("a--a/a--a.gemspec")).to exist
     end

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -411,8 +411,8 @@ RSpec.describe "bundle gem" do
       end
 
       it "depends on a specific version of minitest" do
-        rspec_dep = generated_gemspec.development_dependencies.find {|d| d.name == "minitest" }
-        expect(rspec_dep).to be_specific
+        minitest_dep = generated_gemspec.development_dependencies.find {|d| d.name == "minitest" }
+        expect(minitest_dep).to be_specific
       end
 
       it "builds spec skeleton" do


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that a lot of gems in the wild use `add_development_dependency` for their development dependencies, but using `Gemfile`'s for that is more useful.

### What was your diagnosis of the problem?

My diagnosis was that the current situation is due to the fact that bundler generates a gem skeleton that uses `add_development_dependency` by default.

### What is your fix for the problem, implemented in this PR?

My fix is to stop using `add_development_dependency` in generated gems, and instead use the Gemfile.

### Why did you choose this fix out of the possible options?

I chose this fix because it encourages better practices.
