### PR TITLE
RUBY_ENGINE should always be defined after 1.8.7

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -47,7 +47,7 @@ namespace :spec do
     end]
 
     # JRuby can't build ronn, so we skip that
-    deps.delete("ronn") if defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby"
+    deps.delete("ronn") if RUBY_ENGINE == "jruby"
 
     gem_install_command = "install --no-document --conservative " + deps.sort_by {|name, _| name }.map do |name, version|
       "'#{name}:#{version}'"

--- a/lib/bundler/current_ruby.rb
+++ b/lib/bundler/current_ruby.rb
@@ -38,28 +38,27 @@ module Bundler
     ].freeze
 
     def ruby?
-      !mswin? && (!defined?(RUBY_ENGINE) || RUBY_ENGINE == "ruby" ||
-          RUBY_ENGINE == "rbx" || RUBY_ENGINE == "maglev" || RUBY_ENGINE == "truffleruby")
+      !mswin? && (RUBY_ENGINE == "ruby" || RUBY_ENGINE == "rbx" || RUBY_ENGINE == "maglev" || RUBY_ENGINE == "truffleruby")
     end
 
     def mri?
-      !mswin? && (!defined?(RUBY_ENGINE) || RUBY_ENGINE == "ruby")
+      !mswin? && RUBY_ENGINE == "ruby"
     end
 
     def rbx?
-      ruby? && defined?(RUBY_ENGINE) && RUBY_ENGINE == "rbx"
+      ruby? && RUBY_ENGINE == "rbx"
     end
 
     def jruby?
-      defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby"
+      RUBY_ENGINE == "jruby"
     end
 
     def maglev?
-      defined?(RUBY_ENGINE) && RUBY_ENGINE == "maglev"
+      RUBY_ENGINE == "maglev"
     end
 
     def truffleruby?
-      defined?(RUBY_ENGINE) && RUBY_ENGINE == "truffleruby"
+      RUBY_ENGINE == "truffleruby"
     end
 
     def mswin?

--- a/lib/bundler/installer/standalone.rb
+++ b/lib/bundler/installer/standalone.rb
@@ -12,8 +12,7 @@ module Bundler
       end
       File.open File.join(bundler_path, "setup.rb"), "w" do |file|
         file.puts "require 'rbconfig'"
-        file.puts "# ruby 1.8.7 doesn't define RUBY_ENGINE"
-        file.puts "ruby_engine = defined?(RUBY_ENGINE) ? RUBY_ENGINE : 'ruby'"
+        file.puts "ruby_engine = RUBY_ENGINE"
         file.puts "ruby_version = RbConfig::CONFIG[\"ruby_version\"]"
         file.puts "path = File.expand_path('..', __FILE__)"
         paths.each do |path|

--- a/lib/bundler/ruby_version.rb
+++ b/lib/bundler/ruby_version.rb
@@ -102,12 +102,7 @@ module Bundler
     end
 
     def self.system
-      ruby_engine = if defined?(RUBY_ENGINE) && !RUBY_ENGINE.nil?
-        RUBY_ENGINE.dup
-      else
-        # not defined in ruby 1.8.7
-        "ruby"
-      end
+      ruby_engine = RUBY_ENGINE.dup
       # :sob: mocking RUBY_VERSION breaks stuff on 1.8.7
       ruby_version = ENV.fetch("BUNDLER_SPEC_RUBY_VERSION") { RUBY_VERSION }.dup
       ruby_engine_version = case ruby_engine

--- a/spec/bundler/ruby_version_spec.rb
+++ b/spec/bundler/ruby_version_spec.rb
@@ -426,22 +426,12 @@ RSpec.describe "Bundler::RubyVersion and its subclasses" do
       end
 
       describe "#engine" do
-        context "RUBY_ENGINE is defined" do
-          before { stub_const("RUBY_ENGINE", "jruby") }
-          before { stub_const("JRUBY_VERSION", "2.1.1") }
+        before { stub_const("RUBY_ENGINE", "jruby") }
+        before { stub_const("JRUBY_VERSION", "2.1.1") }
 
-          it "should return a copy of the value of RUBY_ENGINE" do
-            expect(subject.engine).to eq("jruby")
-            expect(subject.engine).to_not be(RUBY_ENGINE)
-          end
-        end
-
-        context "RUBY_ENGINE is not defined" do
-          before { stub_const("RUBY_ENGINE", nil) }
-
-          it "should return the string 'ruby'" do
-            expect(subject.engine).to eq("ruby")
-          end
+        it "should return a copy of the value of RUBY_ENGINE" do
+          expect(subject.engine).to eq("jruby")
+          expect(subject.engine).to_not be(RUBY_ENGINE)
         end
       end
 

--- a/spec/support/hax.rb
+++ b/spec/support/hax.rb
@@ -40,7 +40,7 @@ end
 
 class Object
   if ENV["BUNDLER_SPEC_RUBY_ENGINE"]
-    if defined?(RUBY_ENGINE) && RUBY_ENGINE != "jruby" && ENV["BUNDLER_SPEC_RUBY_ENGINE"] == "jruby"
+    if RUBY_ENGINE != "jruby" && ENV["BUNDLER_SPEC_RUBY_ENGINE"] == "jruby"
       begin
         # this has to be done up front because psych will try to load a .jar
         # if it thinks its on jruby
@@ -50,7 +50,7 @@ class Object
       end
     end
 
-    remove_const :RUBY_ENGINE if defined?(RUBY_ENGINE)
+    remove_const :RUBY_ENGINE
     RUBY_ENGINE = ENV["BUNDLER_SPEC_RUBY_ENGINE"]
 
     if RUBY_ENGINE == "jruby"

--- a/spec/support/platforms.rb
+++ b/spec/support/platforms.rb
@@ -65,7 +65,7 @@ module Spec
     end
 
     def local_ruby_engine
-      ENV["BUNDLER_SPEC_RUBY_ENGINE"] || (defined?(RUBY_ENGINE) ? RUBY_ENGINE : "ruby")
+      ENV["BUNDLER_SPEC_RUBY_ENGINE"] || RUBY_ENGINE
     end
 
     def local_engine_version


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that we have code checking that `RUBY_ENGINE` everytime it's used and I think it's unnecessary.

### What was your diagnosis of the problem?

My diagnosis was that every ruby implementation newer than 1.8 should define this.

### What is your fix for the problem, implemented in this PR?

My fix is to remove the unnecessary code.