### PR TITLE
Remove unnecessary `order_matters` param

### DIFF
--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -20,7 +20,7 @@ module Bundler
     end
 
     def default_gemfile
-      gemfile = find_gemfile(:order_matters)
+      gemfile = find_gemfile
       raise GemfileNotFound, "Could not locate Gemfile" unless gemfile
       Pathname.new(gemfile).untaint.expand_path
     end
@@ -226,7 +226,7 @@ module Bundler
       raise Bundler::PathError, message
     end
 
-    def find_gemfile(order_matters = false)
+    def find_gemfile
       given = ENV["BUNDLE_GEMFILE"]
       return given if given && !given.empty?
       find_file(*gemfile_names)
@@ -291,7 +291,7 @@ module Bundler
       # for Ruby core repository
       exe_file = File.expand_path("../../../../bin/bundle", __FILE__) unless File.exist?(exe_file)
       Bundler::SharedHelpers.set_env "BUNDLE_BIN_PATH", exe_file
-      Bundler::SharedHelpers.set_env "BUNDLE_GEMFILE", find_gemfile(:order_matters).to_s
+      Bundler::SharedHelpers.set_env "BUNDLE_GEMFILE", find_gemfile.to_s
       Bundler::SharedHelpers.set_env "BUNDLER_VERSION", Bundler::VERSION
     end
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that the `find_gemfile` method was receiving an `order_matters` parameter that's no longer used anywhere.

### What is your fix for the problem, implemented in this PR?

My fix is to remove the parameter.