### PR TITLE
Clearer `MissingRevision` git errors

### DIFF
--- a/spec/bundler/source/git/git_proxy_spec.rb
+++ b/spec/bundler/source/git/git_proxy_spec.rb
@@ -128,17 +128,18 @@ RSpec.describe Bundler::Source::Git::GitProxy do
 
     context "when given a SHA as a revision" do
       let(:revision) { "abcd" * 10 }
+      let(:command) { "reset --hard #{revision}" }
 
       it "fails gracefully when resetting to the revision fails" do
         expect(subject).to receive(:git_retry).with(start_with("clone ")) { destination.mkpath }
         expect(subject).to receive(:git_retry).with(start_with("fetch "))
-        expect(subject).to receive(:git).with("reset --hard #{revision}").and_raise(Bundler::Source::Git::GitCommandError, "command")
+        expect(subject).to receive(:git).with(command).and_raise(Bundler::Source::Git::GitCommandError, command)
         expect(subject).not_to receive(:git)
 
         expect { subject.copy_to(destination, submodules) }.
           to raise_error(
             Bundler::Source::Git::MissingGitRevisionError,
-            "Git error: command `git command` in directory #{destination} has failed.\n" \
+            "Git error: command `git #{command}` in directory #{destination} has failed.\n" \
             "Revision #{revision} does not exist in the repository #{uri}. Maybe you misspelled it?" \
           )
       end

--- a/spec/bundler/source/git/git_proxy_spec.rb
+++ b/spec/bundler/source/git/git_proxy_spec.rb
@@ -136,8 +136,11 @@ RSpec.describe Bundler::Source::Git::GitProxy do
         expect(subject).not_to receive(:git)
 
         expect { subject.copy_to(destination, submodules) }.
-          to raise_error(Bundler::Source::Git::MissingGitRevisionError,
-            "Revision #{revision} does not exist in the repository #{uri}. Maybe you misspelled it?")
+          to raise_error(
+            Bundler::Source::Git::MissingGitRevisionError,
+            "Git error: command `git command` in directory #{destination} has failed.\n" \
+            "Revision #{revision} does not exist in the repository #{uri}. Maybe you misspelled it?" \
+          )
       end
     end
   end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that sometimes we get the error "Revision xxxxxx does not exist in the repository https://github.com/my_user/my_repo. Maybe you misspelled?"

### What was your diagnosis of the problem?

My diagnosis was that it's not always easy to troubleshoot this error, because you don't even know which git command failed in the first place.

### What is your fix for the problem, implemented in this PR?

My fix is to also include in the error the command that originally failed.

### Why did you choose this fix out of the possible options?

I chose this fix because I think it will help users with troubleshooting.
