### PR TITLE
Simplify and improve documentation tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,3 @@ man/*
 
 # rspec failure tracking
 .rspec_status
-
-# files generated during packaging
-/lib/bundler/generated/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ script: rake spec:travis
 before_script:
   - travis_retry rake -E 'module ::Bundler; VERSION = "0.0.0"; end' override_version
   - travis_retry rake spec:travis:deps
-  - travis_retry rake man:build
 
 branches:
   only:
@@ -46,6 +45,9 @@ jobs:
   include:
     - rvm: 2.6.3
       script: rake rubocop
+      stage: linting
+    - rvm: 2.6.3
+      script: rake man:build
       stage: linting
     # Ruby 2.3 also tested in 2.x mode
     - rvm: 2.3.8

--- a/Rakefile
+++ b/Rakefile
@@ -337,5 +337,3 @@ end
 task :default => :spec
 
 Dir["task/*.rake"].each(&method(:load))
-
-task :generate_files => Rake::Task.tasks.select {|t| t.name.start_with?("lib/bundler/generated") }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,8 +22,6 @@ end
 
 $debug = false
 
-Spec::Manpages.setup unless Gem.win_platform?
-
 module Gem
   def self.ruby=(ruby)
     @ruby = ruby

--- a/spec/support/manpages.rb
+++ b/spec/support/manpages.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-module Spec
-  module Manpages
-    def self.setup
-      system(Spec::Path.root.join("bin", "rake").to_s, "man:build") || raise("Failed building man pages")
-    end
-  end
-end

--- a/spec/support/manpages.rb
+++ b/spec/support/manpages.rb
@@ -3,11 +3,6 @@
 module Spec
   module Manpages
     def self.setup
-      man_path = Spec::Path.root.join("man")
-      return if man_path.children(false).select {|file| file.extname == ".ronn" }.all? do |man|
-        Dir[man_path.join("#{man.to_s[0..-6]}*.txt").to_s].any?
-      end
-
       system(Spec::Path.root.join("bin", "rake").to_s, "man:build") || raise("Failed building man pages")
     end
   end

--- a/task/release.rake
+++ b/task/release.rake
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "bundler/gem_tasks"
-task :build => ["build_metadata", "man:build", "generate_files"] do
+task :build => ["build_metadata", "man:build"] do
   Rake::Task["build_metadata:clean"].tap(&:reenable).real_invoke
 end
 task :release => ["man:build", "release:verify_files", "release:verify_github", "build_metadata"]

--- a/task/release.rake
+++ b/task/release.rake
@@ -2,6 +2,7 @@
 
 require "bundler/gem_tasks"
 task :build => ["build_metadata", "man:build"] do
+  Rake::Task["man:clean"].tap(&:reenable).real_invoke
   Rake::Task["build_metadata:clean"].tap(&:reenable).real_invoke
 end
 task :release => ["man:build", "release:verify_files", "release:verify_github", "build_metadata"]


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that running bundler's tests, or installing the development bundler locally leaves generated documentation files around, and that's not neat and can affect developers in various ways. For example, by incorrectly including [bundler's generated documentation inside rubygems's manifest](https://github.com/rubygems/rubygems/pull/2813#issuecomment-507046061).

### What was your diagnosis of the problem?

My diagnosis was that we can make this less likely to happen by not generating docs during our specs (it's not needed), and by cleaning them up after `rake build` or `rake install` (they are needed in the installed copy, but not in the development copy).

### What is your fix for the problem, implemented in this PR?

My fix does that, and cleans up other related stuff.