### PR TITLE
Remove `add_development_dependency` from gemspec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -265,18 +265,20 @@ begin
 
   require "automatiek"
 rescue LoadError
+  msg = "We couldn't activate automatiek (#{automatiek_requirement}). Try `gem install automatiek:'#{automatiek_requirement}'` to be able to vendor gems"
+
   namespace :vendor do
     desc "Vendor a specific version of molinillo"
-    task(:molinillo) { abort "We couldn't activate automatiek (#{automatiek_requirement}). Try `gem install automatiek:'#{automatiek_requirement}'` to be able to vendor gems" }
+    task(:molinillo) { abort msg }
 
     desc "Vendor a specific version of fileutils"
-    task(:fileutils) { abort "We couldn't activate automatiek (#{automatiek_requirement}). Try `gem install automatiek:'#{automatiek_requirement}'` to be able to vendor gems" }
+    task(:fileutils) { abort msg }
 
     desc "Vendor a specific version of thor"
-    task(:thor) { abort "We couldn't activate automatiek (#{automatiek_requirement}). Try `gem install automatiek:'#{automatiek_requirement}'` to be able to vendor gems" }
+    task(:thor) { abort msg }
 
     desc "Vendor a specific version of net-http-persistent"
-    task(:"net-http-persistent") { abort "We couldn't activate automatiek (#{automatiek_requirement}). Try `gem install automatiek:'#{automatiek_requirement}'` to be able to vendor gems" }
+    task(:"net-http-persistent") { abort msg }
   end
 else
   desc "Vendor a specific version of molinillo"

--- a/bin/bundle1
+++ b/bin/bundle1
@@ -1,8 +1,0 @@
-#!/usr/bin/env ruby
-# frozen_string_literal: true
-
-module Bundler
-  VERSION = "1.98".freeze
-end
-
-load File.expand_path("../bundle", __FILE__)

--- a/bin/rake
+++ b/bin/rake
@@ -3,18 +3,10 @@
 
 load File.expand_path("../with_rubygems", __FILE__) if ENV["RGV"]
 
-require "rubygems"
-
-bundler_spec = Gem::Specification.load(File.expand_path("../../bundler.gemspec", __FILE__))
-rake = bundler_spec.development_dependencies.find do |dep|
-  dep.name == "rake"
-end
-
-rake_requirement = rake.requirement.to_s
+require_relative "../spec/support/rubygems_ext"
 
 begin
-  gem "rake", rake_requirement
-  load Gem.bin_path("rake", "rake")
-rescue Gem::LoadError
-  warn "We couln't activate rake (#{rake_requirement}). Run `gem install rake:'#{rake_requirement}'`"
+  Spec::Rubygems.gem_load("rake", "rake")
+rescue Gem::LoadError => e
+  warn "We couln't activate rake (#{e.requirement}). Run `gem install rake:'#{e.requirement}'`"
 end

--- a/bin/rspec
+++ b/bin/rspec
@@ -3,18 +3,10 @@
 
 load File.expand_path("../with_rubygems", __FILE__) if ENV["RGV"]
 
-require "rubygems"
-
-bundler_spec = Gem::Specification.load(File.expand_path("../../bundler.gemspec", __FILE__))
-rspec = bundler_spec.development_dependencies.find do |dep|
-  dep.name == "rspec"
-end
-
-rspec_requirement = rspec.requirement.to_s
+require_relative "../spec/support/rubygems_ext"
 
 begin
-  gem "rspec", rspec_requirement
-  load Gem.bin_path("rspec-core", "rspec")
-rescue Gem::LoadError
-  warn "We couln't activate rspec (#{rspec_requirement}). Try `gem install rspec:'#{rspec_requirement}'`"
+  Spec::Rubygems.gem_load("rspec-core", "rspec")
+rescue Gem::LoadError => e
+  warn "We couln't activate rspec (#{e.requirement}). Run `gem install rspec:'#{e.requirement}'`"
 end

--- a/bin/rubocop
+++ b/bin/rubocop
@@ -3,18 +3,10 @@
 
 load File.expand_path("../with_rubygems", __FILE__) if ENV["RGV"]
 
-require "rubygems"
-
-bundler_spec = Gem::Specification.load(File.expand_path("../../bundler.gemspec", __FILE__))
-rubocop = bundler_spec.dependencies.find do |dep|
-  dep.name == "rubocop"
-end
-
-rubocop_requirement = rubocop.requirement.to_s
+require_relative "../spec/support/rubygems_ext"
 
 begin
-  gem "rubocop", rubocop_requirement
-  load Gem.bin_path("rubocop", "rubocop")
-rescue Gem::LoadError
-  warn "We couln't activate rubocop (#{rubocop_requirement}). Try `gem install rubocop:'#{rubocop_requirement}'`"
+  Spec::Rubygems.gem_load("rubocop", "rubocop")
+rescue Gem::LoadError => e
+  warn "We couln't activate rubocop (#{e.requirement}). Run `gem install rubocop:'#{e.requirement}'`"
 end

--- a/bundler.gemspec
+++ b/bundler.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake",       "~> 12.0"
   s.add_development_dependency "ronn",       "~> 0.7.3"
   s.add_development_dependency "rspec",      "~> 3.6"
-  s.add_development_dependency "rubocop",    "= 0.71.0"
+  s.add_development_dependency "rubocop",    "= 0.72.0"
   s.add_development_dependency "rubocop-performance", "= 1.4.0"
 
   s.files = Dir.glob("{lib,exe}/**/*", File::FNM_DOTMATCH).reject {|f| File.directory?(f) }

--- a/bundler.gemspec
+++ b/bundler.gemspec
@@ -34,13 +34,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version     = ">= 2.3.0"
   s.required_rubygems_version = ">= 2.5.0"
 
-  s.add_development_dependency "automatiek", "~> 0.1.0"
-  s.add_development_dependency "rake",       "~> 12.0"
-  s.add_development_dependency "ronn",       "~> 0.7.3"
-  s.add_development_dependency "rspec",      "~> 3.6"
-  s.add_development_dependency "rubocop",    "= 0.72.0"
-  s.add_development_dependency "rubocop-performance", "= 1.4.0"
-
   s.files = Dir.glob("{lib,exe}/**/*", File::FNM_DOTMATCH).reject {|f| File.directory?(f) }
 
   # we don't check in man pages, but we need to ship them because

--- a/spec/support/rubygems_ext.rb
+++ b/spec/support/rubygems_ext.rb
@@ -1,11 +1,20 @@
 # frozen_string_literal: true
 
 require "rubygems/user_interaction"
-require "support/path"
+require_relative "path"
 require "fileutils"
 
 module Spec
   module Rubygems
+    DEV_DEPS = {
+      "automatiek" => "~> 0.1.0",
+      "rake" => "~> 12.0",
+      "ronn" => "~> 0.7.3",
+      "rspec" => "~> 3.6",
+      "rubocop" => "= 0.72.0",
+      "rubocop-performance" => "= 1.4.0",
+    }.freeze
+
     DEPS = {
       # artifice doesn't support rack 2.x now.
       "rack" => "< 2.0",
@@ -17,8 +26,32 @@ module Spec
       "rake" => "12.3.2",
       "builder" => "~> 3.2",
       # ruby-graphviz is used by the viz tests
-      "ruby-graphviz" => nil,
+      "ruby-graphviz" => ">= 0.a",
     }.freeze
+
+    def self.dev_setup
+      deps = DEV_DEPS
+
+      # JRuby can't build ronn, so we skip that
+      deps.delete("ronn") if RUBY_ENGINE == "jruby"
+
+      install_gems(deps)
+    end
+
+    def self.gem_load(gem_name, bin_container)
+      gem_activate(gem_name)
+      load Gem.bin_path(gem_name, bin_container)
+    end
+
+    def self.gem_activate(gem_name)
+      gem_requirement = DEV_DEPS[gem_name]
+      gem gem_name, gem_requirement
+    end
+
+    def self.gem_require(gem_name)
+      gem_activate(gem_name)
+      require gem_name
+    end
 
     def self.setup
       Gem.clear_paths

--- a/spec/support/rubygems_ext.rb
+++ b/spec/support/rubygems_ext.rb
@@ -6,21 +6,19 @@ require "fileutils"
 
 module Spec
   module Rubygems
-    DEPS = begin
-      {
-        # artifice doesn't support rack 2.x now.
-        "rack" => "< 2.0",
-        "rack-test" => "~> 1.1",
-        "artifice" => "~> 0.6.0",
-        "compact_index" => "~> 0.11.0",
-        "sinatra" => "~> 1.4.7",
-        # Rake version has to be consistent for tests to pass
-        "rake" => "12.3.2",
-        "builder" => "~> 3.2",
-        # ruby-graphviz is used by the viz tests
-        "ruby-graphviz" => nil,
-      }
-    end
+    DEPS = {
+      # artifice doesn't support rack 2.x now.
+      "rack" => "< 2.0",
+      "rack-test" => "~> 1.1",
+      "artifice" => "~> 0.6.0",
+      "compact_index" => "~> 0.11.0",
+      "sinatra" => "~> 1.4.7",
+      # Rake version has to be consistent for tests to pass
+      "rake" => "12.3.2",
+      "builder" => "~> 3.2",
+      # ruby-graphviz is used by the viz tests
+      "ruby-graphviz" => nil,
+    }.freeze
 
     def self.setup
       Gem.clear_paths


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that our development setup is complicated, and that we are using `add_development_dependency` even though in my opinion its usage should be discouraged.

### What was your diagnosis of the problem?

My diagnosis was that our development dependencies are split between the gemspec and the `spec/support/rubygems_ext` file. We can simplify this and centralize everything in the support file.


### What is your fix for the problem, implemented in this PR?

My fix is to simplify our development setup by moving everything to `spec/support/rubygems_ext`, while also getting rid of `add_development_dependency` in our gemspec.

### Why did you choose this fix out of the possible options?

I chose this fix because it simplifies our setup and it further discourages usage of `add_development_dependency` (after #7222).
