### PR TITLE
Point to CoC which contains the contributor covenant

### DIFF
--- a/lib/bundler/templates/newgem/README.md.tt
+++ b/lib/bundler/templates/newgem/README.md.tt
@@ -32,7 +32,8 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/<%= config[:github_username] %>/<%= config[:name] %>.<% if config[:coc] %> This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.<% end %>
+Bug reports and pull requests are welcome on GitHub at https://github.com/<%= config[:github_username] %>/<%= config[:name] %>.<% if config[:coc] %> This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/<%= config[:github_username] %>/<%= config[:name] %>/blob/master/CODE_OF_CONDUCT.md).<% end %>
+
 <% if config[:mit] -%>
 
 ## License


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The generated README contains two different links to contributor covenant. Since the generated Code of Conduct *contains* the text of the Contributor Covenant, we can just point the generated README to the generated CoC, and explicitly refer to it as the code of conduct. 

### What is your fix for the problem, implemented in this PR?

The generated readme now points to the gems CoC (which contains the Contributor Covenant)

Closes #6905.