### PR TITLE
Drop rubygems 2.5.0 and 2.5.1 support

### DIFF
--- a/bundler.gemspec
+++ b/bundler.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   end
 
   s.required_ruby_version     = ">= 2.3.0"
-  s.required_rubygems_version = ">= 2.5.0"
+  s.required_rubygems_version = ">= 2.5.2"
 
   s.files = Dir.glob("{lib,exe}/**/*", File::FNM_DOTMATCH).reject {|f| File.directory?(f) }
 

--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -314,19 +314,6 @@ module Bundler
       end
     end
 
-    # RubyGems-generated binstubs call Kernel#gem
-    def binstubs_call_gem?
-      !provides?(">= 2.5.2")
-    end
-
-    # only 2.5.2+ has all of the stub methods we want to use, and since this
-    # is a performance optimization _only_,
-    # we'll restrict ourselves to the most
-    # recent RG versions instead of all versions that have stubs
-    def stubs_provide_full_functionality?
-      provides?(">= 2.5.2")
-    end
-
     def replace_gem(specs, specs_by_name)
       reverse_rubygems_kernel_mixin
 
@@ -335,7 +322,6 @@ module Bundler
       kernel = (class << ::Kernel; self; end)
       [kernel, ::Kernel].each do |kernel_class|
         redefine_method(kernel_class, :gem) do |dep, *reqs|
-          executables ||= specs.map(&:executables).flatten if ::Bundler.rubygems.binstubs_call_gem?
           if executables && executables.include?(File.basename(caller.first.split(":").first))
             break
           end

--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -314,12 +314,10 @@ module Bundler
       # no-op, since we validate when re-serializing the gemspec
       def validate_spec(_spec); end
 
-      if Bundler.rubygems.stubs_provide_full_functionality?
-        def load_gemspec(file)
-          stub = Gem::StubSpecification.gemspec_stub(file, install_path.parent, install_path.parent)
-          stub.full_gem_path = Pathname.new(file).dirname.expand_path(root).to_s.untaint
-          StubSpecification.from_stub(stub)
-        end
+      def load_gemspec(file)
+        stub = Gem::StubSpecification.gemspec_stub(file, install_path.parent, install_path.parent)
+        stub.full_gem_path = Pathname.new(file).dirname.expand_path(root).to_s.untaint
+        StubSpecification.from_stub(stub)
       end
 
       def git_scope

--- a/lib/bundler/stub_specification.rb
+++ b/lib/bundler/stub_specification.rb
@@ -63,10 +63,8 @@ module Bundler
       stub.loaded_from
     end
 
-    if Bundler.rubygems.stubs_provide_full_functionality?
-      def matches_for_glob(glob)
-        stub.matches_for_glob(glob)
-      end
+    def matches_for_glob(glob)
+      stub.matches_for_glob(glob)
     end
 
     def raw_require_paths

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -851,7 +851,7 @@ __FILE__: #{path.to_s.inspect}
         bundle :install, :system_bundler => true, :path => "vendor/bundler"
       end
 
-      it "overrides disable_shared_gems so bundler can be found", :ruby_repo, :rubygems => ">= 2.6.2" do
+      it "overrides disable_shared_gems so bundler can be found", :ruby_repo, :rubygems => ">= 2.5.2" do
         system_gems :bundler
         file = bundled_app("file_that_bundle_execs.rb")
         create_file(file, <<-RB)

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -851,7 +851,7 @@ __FILE__: #{path.to_s.inspect}
         bundle :install, :system_bundler => true, :path => "vendor/bundler"
       end
 
-      it "overrides disable_shared_gems so bundler can be found", :ruby_repo, :rubygems => ">= 2.5.2" do
+      it "overrides disable_shared_gems so bundler can be found", :ruby_repo do
         system_gems :bundler
         file = bundled_app("file_that_bundle_execs.rb")
         create_file(file, <<-RB)

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe "bundle info" do
       expect(out).to include("foo (1.0 #{sha[0..6]})")
     end
 
-    it "handles when a version is a '-' prerelease", :rubygems => "2.1" do
+    it "handles when a version is a '-' prerelease" do
       @git = build_git("foo", "1.0.0-beta.1", :path => lib_path("foo"))
       install_gemfile <<-G
         gem "foo", "1.0.0-beta.1", :git => "#{lib_path("foo")}"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that we have some conditional code in bundler dependent on the rubygems version being used, that could be easily removed if we dropped support for rubygems 2.5.0 and 2.5.1.

### What was your diagnosis of the problem?

My diagnosis was that we could drop support for these versions now, to remove all of those conditionals and simplify the integration.

### What is your fix for the problem, implemented in this PR?

My fix is to drop support for rubygems 2.5.0 and 2.5.1.

### Why did you choose this fix out of the possible options?

I chose this fix because the oldest ruby we currently support, 2.3, ships with rubygems 2.5.2, so it's very unlikely that any user of the next bundler version will be using these old rubygems versions, because they would need to explicitly downgrade rubygems!