### PR TITLE
Fix nested bundle exec's when bundler is a default gem

### DIFF
--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -287,9 +287,15 @@ module Bundler
     public :set_env
 
     def set_bundle_variables
+      # bundler exe & lib folders have same root folder, typical gem installation
       exe_file = File.expand_path("../../../exe/bundle", __FILE__)
-      # for Ruby core repository
-      exe_file = File.expand_path("../../../../bin/bundle", __FILE__) unless File.exist?(exe_file)
+
+      # for Ruby core repository testing
+      exe_file = File.expand_path("../../../bin/bundle", __FILE__) unless File.exist?(exe_file)
+
+      # bundler is a default gem, exe path is separate
+      exe_file = Bundler.rubygems.bin_path("bundler", "bundle", VERSION) unless File.exist?(exe_file)
+
       Bundler::SharedHelpers.set_env "BUNDLE_BIN_PATH", exe_file
       Bundler::SharedHelpers.set_env "BUNDLE_GEMFILE", find_gemfile.to_s
       Bundler::SharedHelpers.set_env "BUNDLER_VERSION", Bundler::VERSION

--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -402,8 +402,10 @@ RSpec.describe Bundler::SharedHelpers do
 
       it "sets BUNDLE_BIN_PATH to the bundle executable file" do
         subject.set_bundle_environment
-        bundle_exe = ruby_core? ? "../../../../../bin/bundle" : "../../../exe/bundle"
-        expect(ENV["BUNDLE_BIN_PATH"]).to eq(File.expand_path(bundle_exe, __FILE__))
+        bundle_exe = ruby_core? ? "../../../bin/bundle" : "../../../exe/bundle"
+        bin_path = ENV["BUNDLE_BIN_PATH"]
+        expect(bin_path).to eq(File.expand_path(bundle_exe, __FILE__))
+        expect(File.exist?(bin_path)).to be true
       end
     end
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that when bundler is a default gem, nested `bundle exec` commands generate a LoadError.

```
/home/travis/.rvm/rubies/ruby-head/bin/bundle:30:in `load': cannot load such file --
/home/travis/.rvm/rubies/ruby-head/lib/bin/bundle (LoadError)
```

### What was your diagnosis of the problem?

Not accounting for Bundler being installed as a default gem. When it's a default, the lib and exe folders do not share the same root folder.

This was the result of a change in https://github.com/bundler/bundler/commit/e742c3d5f458a4a59cf0eaab2567eca844f956d1 (#7100).

### Repo Example

Using Ruby master/trunk/ruby-head (as of https://github.com/ruby/ruby/commit/0c6c937904aafc1809386bd892a2d114d22d01fe), from a folder where `bundle exec` can be ran:

```
bundle exec "bundle exec 'ruby -v'"
```

### What is your fix for the problem, implemented in this PR?

Small adjustment to logic for finding the correct exe/bundle file.

### Why did you choose this fix out of the possible options?

I chose this fix because it's similar to previous code.

Fixes #7244.