### PR TITLE
Fix ruby core dsl spec.rb failure, warning on build_metadata.rb

### DIFF
--- a/lib/bundler/build_metadata.rb
+++ b/lib/bundler/build_metadata.rb
@@ -23,7 +23,7 @@ module Bundler
 
     # The SHA for the git commit the bundler gem was built from.
     def self.git_commit_sha
-      return @git_commit_sha if @git_commit_sha
+      return @git_commit_sha if instance_variable_defined? :@git_commit_sha
 
       # If Bundler has been installed without its .git directory and without a
       # commit instance variable then we can't determine its commits SHA.

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -271,7 +271,7 @@ RSpec.describe Bundler::Dsl do
     it "will raise a Bundler::GemfileError" do
       gemfile "gem 'foo', :path => /unquoted/string/syntax/error"
       expect { Bundler::Dsl.evaluate(bundled_app("Gemfile"), nil, true) }.
-        to raise_error(Bundler::GemfileError, /There was an error parsing `Gemfile`:( compile error -)? unknown regexp options - trg. Bundler cannot continue./)
+        to raise_error(Bundler::GemfileError, /There was an error parsing `Gemfile`:( compile error -)? unknown regexp options - trg.+ Bundler cannot continue./)
     end
   end
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Travis CI job on Ruby master was failing & had a nuisance warning.

### What is your fix for the problem, implemented in this PR?

1. dls_spec.rb - Minor change to the error msg regexp match string

2. build_metadata.rb - change `if @git_commit_sha` to `if instance_variable_defined? :@git_commit_sha`