### PR TITLE
Removed the environmental variables that are BUNDLE_USER_*.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -101,6 +101,7 @@ RSpec.configure do |config|
     Spec::Rubygems.setup
     ENV["RUBYOPT"] = "#{ENV["RUBYOPT"]} -r#{Spec::Path.spec_dir}/support/hax.rb"
     ENV["BUNDLE_SPEC_RUN"] = "true"
+    ENV["BUNDLE_USER_CONFIG"] = ENV["BUNDLE_USER_CACHE"] = ENV["BUNDLE_USER_PLUGIN"] = nil
 
     # Don't wrap output in tests
     ENV["THOR_COLUMNS"] = "10000"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

When the users uses `BUNDLE_USER_*` environmental variables like `BUNDLE_USER_CONFIG`, the rspec example of Bundler affected by them failed.

### What was your diagnosis of the problem?

The current spec_helper didn't clear and restore them.

### What is your fix for the problem, implemented in this PR?

I remove and restore them same as `Bundler::EnvironmentPreserver::BUNDLER_PREFIX`

### Why did you choose this fix out of the possible options?

This is the most simple solution with the current implementation.
