### PR TITLE
spec/bundler/shared_helpers_spec.rb - fixup after 7248

### DIFF
--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -402,7 +402,7 @@ RSpec.describe Bundler::SharedHelpers do
 
       it "sets BUNDLE_BIN_PATH to the bundle executable file" do
         subject.set_bundle_environment
-        bundle_exe = ruby_core? ? "../../../bin/bundle" : "../../../exe/bundle"
+        bundle_exe = ruby_core? ? "../../../../bin/bundle" : "../../../exe/bundle"
         bin_path = ENV["BUNDLE_BIN_PATH"]
         expect(bin_path).to eq(File.expand_path(bundle_exe, __FILE__))
         expect(File.exist?(bin_path)).to be true


### PR DESCRIPTION
PR 7248 https://github.com/bundler/bundler/commit/3f57b102c76fea2f701152e087c88f53df17d3d0 incorrectly changed a path calculation.  This reverts.

This only affects testing when `ruby_core?` is true.

After running Azure Pipelines CI in my ruby/ruby fork and checking the  'bundler' jobs, the error was apparent...