### PR TITLE
Improve environment backup and restore

### DIFF
--- a/lib/bundler/environment_preserver.rb
+++ b/lib/bundler/environment_preserver.rb
@@ -6,7 +6,6 @@ module Bundler
     BUNDLER_KEYS = %w[
       BUNDLE_BIN_PATH
       BUNDLE_GEMFILE
-      BUNDLER_ORIG_MANPATH
       BUNDLER_VERSION
       GEM_HOME
       GEM_PATH

--- a/spec/runtime/with_unbundled_env_spec.rb
+++ b/spec/runtime/with_unbundled_env_spec.rb
@@ -54,6 +54,8 @@ RSpec.describe "Bundler.with_env helpers" do
     end
 
     it "removes variables that bundler added", :ruby_repo do
+      ENV.replace(ENV.to_hash.delete_if {|k, _v| k.start_with?(Bundler::EnvironmentPreserver::BUNDLER_PREFIX) })
+
       original = ruby!('puts ENV.to_a.map {|e| e.join("=") }.sort.join("\n")')
       code = 'puts Bundler.original_env.to_a.map {|e| e.join("=") }.sort.join("\n")'
       bundle_exec_ruby! code.dump

--- a/spec/runtime/with_unbundled_env_spec.rb
+++ b/spec/runtime/with_unbundled_env_spec.rb
@@ -76,11 +76,12 @@ RSpec.describe "Bundler.with_env helpers" do
       expect(last_command.stdboth).not_to include("-rbundler/setup")
     end
 
-    it "should clean up RUBYLIB", :ruby_repo do
+    it "should restore RUBYLIB", :ruby_repo do
       code = "print #{modified_env}['RUBYLIB']"
       ENV["RUBYLIB"] = root.join("lib").to_s + File::PATH_SEPARATOR + "/foo"
+      ENV["BUNDLER_ORIG_RUBYLIB"] = root.join("lib").to_s + File::PATH_SEPARATOR + "/foo-original"
       bundle_exec_ruby! code.dump
-      expect(last_command.stdboth).to include("/foo")
+      expect(last_command.stdboth).to include("/foo-original")
     end
 
     it "should restore the original MANPATH" do

--- a/spec/runtime/with_unbundled_env_spec.rb
+++ b/spec/runtime/with_unbundled_env_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe "Bundler.with_env helpers" do
     end
 
     it "removes variables that bundler added", :ruby_repo do
+      # Simulate bundler has not yet been loaded
       ENV.replace(ENV.to_hash.delete_if {|k, _v| k.start_with?(Bundler::EnvironmentPreserver::BUNDLER_PREFIX) })
 
       original = ruby!('puts ENV.to_a.map {|e| e.join("=") }.sort.join("\n")')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -99,8 +99,8 @@ RSpec.configure do |config|
 
   config.before :suite do
     Spec::Rubygems.setup
-    ENV["RUBYOPT"] = original_env["RUBYOPT"] = "#{ENV["RUBYOPT"]} -r#{Spec::Path.spec_dir}/support/hax.rb"
-    ENV["BUNDLE_SPEC_RUN"] = original_env["BUNDLE_SPEC_RUN"] = "true"
+    ENV["RUBYOPT"] = "#{ENV["RUBYOPT"]} -r#{Spec::Path.spec_dir}/support/hax.rb"
+    ENV["BUNDLE_SPEC_RUN"] = "true"
 
     # Don't wrap output in tests
     ENV["THOR_COLUMNS"] = "10000"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -78,7 +78,7 @@ RSpec.configure do |config|
   config.filter_run_when_matching :focus unless ENV["CI"]
 
   original_wd  = Dir.pwd
-  original_env = ENV.to_hash.delete_if {|k, _v| k.start_with?(Bundler::EnvironmentPreserver::BUNDLER_PREFIX) }
+  original_env = ENV.to_hash
 
   config.expect_with :rspec do |c|
     c.syntax = :expect
@@ -105,7 +105,7 @@ RSpec.configure do |config|
     # Don't wrap output in tests
     ENV["THOR_COLUMNS"] = "10000"
 
-    original_env = ENV.to_hash.delete_if {|k, _v| k.start_with?(Bundler::EnvironmentPreserver::BUNDLER_PREFIX) }
+    original_env = ENV.to_hash
 
     if ENV["BUNDLE_RUBY"]
       FileUtils.cp_r Spec::Path.bindir, File.join(Spec::Path.root, "lib", "exe")


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that the specs were removing some environment variables for every tests, but not all of them, causing problems on some environments (see #7251).

### What was your diagnosis of the problem?

My diagnosis was that we don't really need to do this.

### What is your fix for the problem, implemented in this PR?

My fix is to stop doing it, and fix the very few specs that failed after the change. One of the failures actually led to a bug fix (I think), see 6c27ebb.

### Why did you choose this fix out of the possible options?

I chose this fix because I think it's cleaner than adding a public constant in `lib/` only to fix a problem with the specs, like it's done in #7251.
