### PR TITLE
Get some more Windows specs passing

### DIFF
--- a/spec/bundler/definition_spec.rb
+++ b/spec/bundler/definition_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Bundler::Definition do
             rack (1.0.0)
 
         PLATFORMS
-          ruby
+          #{lockfile_platforms}
 
         DEPENDENCIES
           foo!

--- a/spec/commands/add_spec.rb
+++ b/spec/commands/add_spec.rb
@@ -134,6 +134,7 @@ RSpec.describe "bundle add" do
   end
 
   it "shows error message when gem cannot be found" do
+    bundle "config set force_ruby_platform true"
     bundle "add 'werk_it'"
     expect(err).to match("Could not find gem 'werk_it' in")
 

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -524,6 +524,8 @@ RSpec.describe "bundle install with gem sources" do
 
   describe "when requesting a quiet install via --quiet" do
     it "should be quiet" do
+      bundle "config set force_ruby_platform true"
+
       gemfile <<-G
         gem 'rack'
       G

--- a/spec/commands/post_bundle_message_spec.rb
+++ b/spec/commands/post_bundle_message_spec.rb
@@ -101,6 +101,10 @@ RSpec.describe "post bundle message" do
     end
 
     describe "with misspelled or non-existent gem name" do
+      before do
+        bundle "config set force_ruby_platform true"
+      end
+
       it "should report a helpful error message", :bundler => "< 3" do
         install_gemfile <<-G
           source "#{file_uri_for(gem_repo1)}"

--- a/spec/install/bundler_spec.rb
+++ b/spec/install/bundler_spec.rb
@@ -30,6 +30,8 @@ RSpec.describe "bundle install" do
     end
 
     it "causes a conflict if explicitly requesting a different version" do
+      bundle "config set force_ruby_platform true"
+
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
         gem "rails", "3.0"
@@ -89,6 +91,8 @@ RSpec.describe "bundle install" do
     end
 
     it "causes a conflict if child dependencies conflict" do
+      bundle "config set force_ruby_platform true"
+
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
         gem "activemerchant"
@@ -108,6 +112,8 @@ RSpec.describe "bundle install" do
     end
 
     it "causes a conflict if a child dependency conflicts with the Gemfile" do
+      bundle "config set force_ruby_platform true"
+
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
         gem "rails_fail"

--- a/spec/install/gems/flex_spec.rb
+++ b/spec/install/gems/flex_spec.rb
@@ -192,6 +192,8 @@ RSpec.describe "bundle flex_install" do
     end
 
     it "suggests bundle update when the Gemfile requires different versions than the lock" do
+      bundle "config set force_ruby_platform true"
+
       nice_error = <<-E.strip.gsub(/^ {8}/, "")
         Bundler could not find compatible versions for gem "rack":
           In snapshot (Gemfile.lock):

--- a/spec/install/yanked_spec.rb
+++ b/spec/install/yanked_spec.rb
@@ -23,8 +23,8 @@ RSpec.context "when installing a bundle that includes yanked gems" do
     L
 
     install_gemfile <<-G
-        source "#{file_uri_for(gem_repo4)}"
-        gem "foo", "10.0.0"
+      source "#{file_uri_for(gem_repo4)}"
+      gem "foo", "10.0.0"
     G
 
     expect(err).to include("Your bundle is locked to foo (10.0.0)")
@@ -32,8 +32,8 @@ RSpec.context "when installing a bundle that includes yanked gems" do
 
   it "throws the original error when only the Gemfile specifies a gem version that doesn't exist" do
     install_gemfile <<-G
-        source "#{file_uri_for(gem_repo4)}"
-        gem "foo", "10.0.0"
+      source "#{file_uri_for(gem_repo4)}"
+      gem "foo", "10.0.0"
     G
 
     expect(err).not_to include("Your bundle is locked to foo (10.0.0)")
@@ -44,21 +44,21 @@ end
 RSpec.context "when using gem before installing" do
   it "does not suggest the author has yanked the gem" do
     gemfile <<-G
-        source "#{file_uri_for(gem_repo1)}"
-        gem "rack", "0.9.1"
+      source "#{file_uri_for(gem_repo1)}"
+      gem "rack", "0.9.1"
     G
 
     lockfile <<-L
-       GEM
-         remote: #{file_uri_for(gem_repo1)}
-         specs:
-           rack (0.9.1)
+      GEM
+        remote: #{file_uri_for(gem_repo1)}
+        specs:
+          rack (0.9.1)
 
-       PLATFORMS
-         ruby
+      PLATFORMS
+        ruby
 
-       DEPENDENCIES
-         rack (= 0.9.1)
+      DEPENDENCIES
+        rack (= 0.9.1)
     L
 
     bundle :list

--- a/spec/install/yanked_spec.rb
+++ b/spec/install/yanked_spec.rb
@@ -31,6 +31,8 @@ RSpec.context "when installing a bundle that includes yanked gems" do
   end
 
   it "throws the original error when only the Gemfile specifies a gem version that doesn't exist" do
+    bundle "config set force_ruby_platform true"
+
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo4)}"
       gem "foo", "10.0.0"

--- a/spec/other/platform_spec.rb
+++ b/spec/other/platform_spec.rb
@@ -3,9 +3,7 @@
 RSpec.describe "bundle platform" do
   context "without flags" do
     let(:bundle_platform_platforms_string) do
-      platforms = [rb]
-      platforms.unshift(specific_local_platform) if Bundler.feature_flag.bundler_3_mode?
-      platforms.map {|pl| "* #{pl}" }.join("\n")
+      local_platforms.reverse.map {|pl| "* #{pl}" }.join("\n")
     end
 
     it "returns all the output" do

--- a/spec/runtime/with_unbundled_env_spec.rb
+++ b/spec/runtime/with_unbundled_env_spec.rb
@@ -214,6 +214,8 @@ RSpec.describe "Bundler.with_env helpers" do
     end
 
     it "runs exec inside with_original_env" do
+      skip "Fork not implemented" if Gem.win_platform?
+
       lib = File.expand_path("../../lib", __dir__)
       system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib} -rbundler -e '#{code}'")
       expect($?.exitstatus).to eq(0)
@@ -234,6 +236,8 @@ RSpec.describe "Bundler.with_env helpers" do
     end
 
     it "runs exec inside with_clean_env" do
+      skip "Fork not implemented" if Gem.win_platform?
+
       lib = File.expand_path("../../lib", __dir__)
       system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib} -rbundler -e '#{code}'")
       expect($?.exitstatus).to eq(1)
@@ -254,6 +258,8 @@ RSpec.describe "Bundler.with_env helpers" do
     end
 
     it "runs exec inside with_clean_env" do
+      skip "Fork not implemented" if Gem.win_platform?
+
       lib = File.expand_path("../../lib", __dir__)
       system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib} -rbundler -e '#{code}'")
       expect($?.exitstatus).to eq(1)

--- a/spec/update/git_spec.rb
+++ b/spec/update/git_spec.rb
@@ -324,7 +324,7 @@ RSpec.describe "bundle update" do
             rack (1.0.0)
 
         PLATFORMS
-          ruby
+          #{lockfile_platforms}
 
         DEPENDENCIES
           foo!


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that Windows build is still red.

### What was your diagnosis of the problem?

My diagnosis was that some functionality is actually working, but specs need to be adapted, because some error messages include the platform on Windows.

### What is your fix for the problem, implemented in this PR?

My fix is to use `force_ruby_platform` for those specs.

### Why did you choose this fix out of the possible options?

I chose this fix because... I'm not sure, maybe it's better to adapt the error messages to include the platform when run on Windows.