### PR TITLE
Restore the removal of the `--all` flag for `bundle cache` in Bundler 3

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -411,9 +411,10 @@ module Bundler
     end
 
     desc "#{Bundler.feature_flag.bundler_3_mode? ? :cache : :package} [OPTIONS]", "Locks and then caches all of the gems into vendor/cache"
-    method_option "all",  :type => :boolean,
-                          :default => Bundler.feature_flag.cache_all?,
-                          :banner => "Include all sources (including path and git)."
+    unless Bundler.feature_flag.cache_all?
+      method_option "all",  :type => :boolean,
+                            :banner => "Include all sources (including path and git)."
+    end
     method_option "all-platforms", :type => :boolean, :banner => "Include gems for all platforms present in the lockfile, not only the current one"
     method_option "cache-path", :type => :string, :banner =>
       "Specify a different cache path than the default (vendor/cache)."

--- a/lib/bundler/cli/package.rb
+++ b/lib/bundler/cli/package.rb
@@ -34,7 +34,7 @@ module Bundler
     end
 
     def setup_cache_all
-      all = options.fetch(:all, Bundler.feature_flag.bundler_3_mode? || nil)
+      all = options.fetch(:all, Bundler.feature_flag.cache_all? || nil)
 
       Bundler.settings.set_command_option_if_given :cache_all, all
 

--- a/spec/cache/git_spec.rb
+++ b/spec/cache/git_spec.rb
@@ -22,7 +22,8 @@ end
         gem "foo", :git => '#{lib_path("foo-1.0")}'
       G
 
-      bundle cmd, forgotten_command_line_options([:all, :cache_all] => true)
+      bundle "config set cache_all true"
+      bundle cmd
       expect(bundled_app("vendor/cache/foo-1.0-#{ref}")).to exist
       expect(bundled_app("vendor/cache/foo-1.0-#{ref}/.git")).not_to exist
       expect(bundled_app("vendor/cache/foo-1.0-#{ref}/.bundlecache")).to be_file
@@ -40,7 +41,8 @@ end
       G
 
       bundle "install --path vendor/bundle"
-      bundle cmd, forgotten_command_line_options([:all, :cache_all] => true)
+      bundle "config set cache_all true"
+      bundle cmd
 
       expect(bundled_app("vendor/cache/foo-1.0-#{ref}")).to exist
       expect(bundled_app("vendor/cache/foo-1.0-#{ref}/.git")).not_to exist
@@ -56,8 +58,9 @@ end
         gem "foo", :git => '#{lib_path("foo-1.0")}'
       G
 
-      bundle! cmd, forgotten_command_line_options([:all, :cache_all] => true)
-      bundle! cmd, forgotten_command_line_options([:all, :cache_all] => true)
+      bundle "config set cache_all true"
+      bundle! cmd
+      bundle! cmd
 
       expect(out).to include "Updating files in vendor/cache"
       FileUtils.rm_rf lib_path("foo-1.0")
@@ -72,7 +75,8 @@ end
         gem "foo", :git => '#{lib_path("foo-1.0")}'
       G
 
-      bundle cmd, forgotten_command_line_options([:all, :cache_all] => true)
+      bundle "config set cache_all true"
+      bundle cmd
 
       update_git "foo" do |s|
         s.write "lib/foo.rb", "puts :CACHE"
@@ -82,7 +86,8 @@ end
       expect(ref).not_to eq(old_ref)
 
       bundle! "update", :all => true
-      bundle! cmd, forgotten_command_line_options([:all, :cache_all] => true)
+      bundle "config set cache_all true"
+      bundle! cmd
 
       expect(bundled_app("vendor/cache/foo-1.0-#{ref}")).to exist
       expect(bundled_app("vendor/cache/foo-1.0-#{old_ref}")).not_to exist
@@ -100,7 +105,8 @@ end
         gem "foo", :git => '#{lib_path("foo-1.0")}'
       G
 
-      bundle! cmd, forgotten_command_line_options([:all, :cache_all] => true)
+      bundle "config set cache_all true"
+      bundle! cmd
 
       update_git "foo" do |s|
         s.write "lib/foo.rb", "puts :CACHE"
@@ -129,7 +135,8 @@ end
 
       bundle %(config set local.foo #{lib_path("foo-1.0")})
       bundle "install"
-      bundle cmd, forgotten_command_line_options([:all, :cache_all] => true)
+      bundle "config set cache_all true"
+      bundle cmd
 
       expect(bundled_app("vendor/cache/foo-invalid-#{ref}")).to exist
 
@@ -161,7 +168,8 @@ end
       G
 
       ref = git.ref_for("master", 11)
-      bundle cmd, forgotten_command_line_options([:all, :cache_all] => true)
+      bundle "config set cache_all true"
+      bundle cmd
 
       expect(bundled_app("vendor/cache/has_submodule-1.0-#{ref}")).to exist
       expect(bundled_app("vendor/cache/has_submodule-1.0-#{ref}/submodule-1.0")).to exist
@@ -187,7 +195,8 @@ end
         gem "foo", :git => '#{lib_path("foo-1.0")}'
       G
 
-      bundle cmd, forgotten_command_line_options([:all, :cache_all] => true)
+      bundle "config set cache_all true"
+      bundle cmd
       bundle cmd
 
       expect(err).not_to include("Your Gemfile contains path and git dependencies.")
@@ -204,7 +213,8 @@ end
       install_gemfile <<-G
         gem "foo", :git => '#{lib_path("foo-1.0")}'
       G
-      bundle cmd, forgotten_command_line_options([:all, :cache_all] => true)
+      bundle "config set cache_all true"
+      bundle cmd
 
       ref = git.ref_for("master", 11)
       gemspec = bundled_app("vendor/cache/foo-1.0-#{ref}/foo.gemspec").read

--- a/spec/cache/path_spec.rb
+++ b/spec/cache/path_spec.rb
@@ -9,7 +9,8 @@
         gem "foo", :path => '#{bundled_app("lib/foo")}'
       G
 
-      bundle cmd, forgotten_command_line_options([:all, :cache_all] => true)
+      bundle "config set cache_all true"
+      bundle cmd
       expect(bundled_app("vendor/cache/foo-1.0")).not_to exist
       expect(the_bundle).to include_gems "foo 1.0"
     end
@@ -21,7 +22,8 @@
         gem "foo", :path => '#{lib_path("foo-1.0")}'
       G
 
-      bundle cmd, forgotten_command_line_options([:all, :cache_all] => true)
+      bundle "config set cache_all true"
+      bundle cmd
       expect(bundled_app("vendor/cache/foo-1.0")).to exist
       expect(bundled_app("vendor/cache/foo-1.0/.bundlecache")).to be_file
 
@@ -39,7 +41,8 @@
         gem "#{libname}", :path => '#{libpath}'
       G
 
-      bundle cmd, forgotten_command_line_options([:all, :cache_all] => true)
+      bundle "config set cache_all true"
+      bundle cmd
       expect(bundled_app("vendor/cache/#{libname}")).to exist
       expect(bundled_app("vendor/cache/#{libname}/.bundlecache")).to be_file
 
@@ -54,13 +57,14 @@
         gem "foo", :path => '#{lib_path("foo-1.0")}'
       G
 
-      bundle cmd, forgotten_command_line_options([:all, :cache_all] => true)
+      bundle "config set cache_all true"
+      bundle cmd
 
       build_lib "foo" do |s|
         s.write "lib/foo.rb", "puts :CACHE"
       end
 
-      bundle cmd, forgotten_command_line_options([:all, :cache_all] => true)
+      bundle cmd
 
       expect(bundled_app("vendor/cache/foo-1.0")).to exist
       FileUtils.rm_rf lib_path("foo-1.0")
@@ -76,13 +80,14 @@
         gem "foo", :path => '#{lib_path("foo-1.0")}'
       G
 
-      bundle cmd, forgotten_command_line_options([:all, :cache_all] => true)
+      bundle "config set cache_all true"
+      bundle cmd
 
       install_gemfile <<-G
         gem "bar", :path => '#{lib_path("bar-1.0")}'
       G
 
-      bundle cmd, forgotten_command_line_options([:all, :cache_all] => true)
+      bundle cmd
       expect(bundled_app("vendor/cache/bar-1.0")).not_to exist
     end
 
@@ -105,7 +110,8 @@
         gem "foo", :path => '#{lib_path("foo-1.0")}'
       G
 
-      bundle cmd, forgotten_command_line_options([:all, :cache_all] => true)
+      bundle "config set cache_all true"
+      bundle cmd
       build_lib "bar"
 
       install_gemfile <<-G
@@ -124,7 +130,8 @@
         gem "foo", :path => '#{lib_path("foo-1.0")}'
       G
 
-      bundle cmd, forgotten_command_line_options([:all, :cache_all] => true)
+      bundle "config set cache_all true"
+      bundle cmd
       build_lib "baz"
 
       gemfile <<-G

--- a/spec/commands/binstubs_spec.rb
+++ b/spec/commands/binstubs_spec.rb
@@ -301,7 +301,7 @@ RSpec.describe "bundle binstubs <gem>" do
         gem "rails"
       G
 
-      bundle! "binstubs rack", forgotten_command_line_options([:path, :bin] => "exec")
+      bundle! "binstubs rack", :path => "exec"
       bundle! :install
 
       expect(bundled_app("exec/rails")).to exist

--- a/spec/commands/package_spec.rb
+++ b/spec/commands/package_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe "bundle package" do
           gem 'bundler'
         D
 
-        bundle :package, forgotten_command_line_options([:all, :cache_all] => true)
+        bundle "config set cache_all true"
+        bundle :package
 
         expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
         expect(bundled_app("vendor/cache/bundler-0.9.gem")).to_not exist
@@ -54,7 +55,8 @@ RSpec.describe "bundle package" do
             gemspec
           D
 
-          bundle! :package, forgotten_command_line_options([:all, :cache_all] => true)
+          bundle "config set cache_all true"
+          bundle! :package
 
           expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
           expect(bundled_app("vendor/cache/nokogiri-1.4.2.gem")).to exist
@@ -85,7 +87,8 @@ RSpec.describe "bundle package" do
             gemspec
           D
 
-          bundle! :package, forgotten_command_line_options([:all, :cache_all] => true)
+          bundle "config set cache_all true"
+          bundle! :package
 
           expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
           expect(bundled_app("vendor/cache/nokogiri-1.4.2.gem")).to exist
@@ -129,7 +132,8 @@ RSpec.describe "bundle package" do
           gemspec :name => 'mygem_test'
         D
 
-        bundle! :package, forgotten_command_line_options([:all, :cache_all] => true)
+        bundle "config set cache_all true"
+        bundle! :package
 
         expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
         expect(bundled_app("vendor/cache/nokogiri-1.4.2.gem")).to exist

--- a/spec/install/deploy_spec.rb
+++ b/spec/install/deploy_spec.rb
@@ -388,7 +388,9 @@ You have deleted from the Gemfile:
 
       bundle! :install
       expect(the_bundle).to include_gems "foo 1.0"
-      bundle! :package, forgotten_command_line_options([:all, :cache_all] => true)
+
+      bundle "config set cache_all true"
+      bundle! :package
       expect(bundled_app("vendor/cache/foo")).to be_directory
 
       bundle! "install --local"

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -1390,7 +1390,8 @@ In Gemfile:
           gem 'foo'
         end
       G
-      bundle :package, forgotten_command_line_options([:all, :cache_all] => true)
+      bundle "config set cache_all true"
+      bundle :package
       simulate_new_machine
 
       bundle! "install", :env => { "PATH" => "" }

--- a/spec/lock/lockfile_spec.rb
+++ b/spec/lock/lockfile_spec.rb
@@ -620,7 +620,8 @@ RSpec.describe "the lockfile format" do
       gem "foo", :path => "#{lib_path("foo-1.0")}"
     G
 
-    bundle! :package, forgotten_command_line_options([:all, :cache_all] => true)
+    bundle "config set cache_all true"
+    bundle! :package
     bundle! :install, :local => true
 
     lockfile_should_be <<-G

--- a/spec/plugins/source/example_spec.rb
+++ b/spec/plugins/source/example_spec.rb
@@ -145,7 +145,8 @@ RSpec.describe "real source plugins" do
       let(:uri_hash) { Digest(:SHA1).hexdigest(lib_path("a-path-gem-1.0").to_s) }
       it "copies repository to vendor cache and uses it" do
         bundle "install"
-        bundle :cache, forgotten_command_line_options([:all, :cache_all] => true)
+        bundle "config set cache_all true"
+        bundle :cache
 
         expect(bundled_app("vendor/cache/a-path-gem-1.0-#{uri_hash}")).to exist
         expect(bundled_app("vendor/cache/a-path-gem-1.0-#{uri_hash}/.git")).not_to exist
@@ -157,7 +158,8 @@ RSpec.describe "real source plugins" do
 
       it "copies repository to vendor cache and uses it even when installed with bundle --path" do
         bundle! :install, forgotten_command_line_options(:path => "vendor/bundle")
-        bundle! :cache, forgotten_command_line_options([:all, :cache_all] => true)
+        bundle "config set cache_all true"
+        bundle! :cache
 
         expect(bundled_app("vendor/cache/a-path-gem-1.0-#{uri_hash}")).to exist
 
@@ -167,7 +169,8 @@ RSpec.describe "real source plugins" do
 
       it "bundler package copies repository to vendor cache" do
         bundle! :install, forgotten_command_line_options(:path => "vendor/bundle")
-        bundle! :package, forgotten_command_line_options([:all, :cache_all] => true)
+        bundle "config set cache_all true"
+        bundle! :package
 
         expect(bundled_app("vendor/cache/a-path-gem-1.0-#{uri_hash}")).to exist
 
@@ -492,7 +495,8 @@ RSpec.describe "real source plugins" do
           end
         G
 
-        bundle :cache, forgotten_command_line_options([:all, :cache_all] => true)
+        bundle "config set cache_all true"
+        bundle :cache
         expect(bundled_app("vendor/cache/foo-1.0-#{ref}")).to exist
         expect(bundled_app("vendor/cache/foo-1.0-#{ref}/.git")).not_to exist
         expect(bundled_app("vendor/cache/foo-1.0-#{ref}/.bundlecache")).to be_file

--- a/spec/runtime/executable_spec.rb
+++ b/spec/runtime/executable_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe "Running bin/* commands" do
       gem "activesupport"
     G
 
-    bundle! :install, forgotten_command_line_options([:binstubs, :bin] => "bin")
+    bundle! :install, :binstubs => "bin"
 
     gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -158,7 +158,6 @@ module Spec
     def forgotten_command_line_options(options)
       remembered = Bundler::VERSION.split(".", 2).first == "2"
       options = options.map do |k, v|
-        k = Array(k)[remembered ? 0 : -1]
         v = '""' if v && v.to_s.empty?
         [k, v]
       end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that I accidentally restored this flag on Bundler 3 in #7249, but the plan still is to remove it.

### What was your diagnosis of the problem?

My diagnosis was that I need to remove it again.

### What is your fix for the problem, implemented in this PR?

My fix is to remove it.

### Why did you choose this fix out of the possible options?

I chose this fix because it's the original plan and makes sense.
