### PR TITLE
Relax bundler binstub

### DIFF
--- a/lib/bundler/templates/Executable.bundler
+++ b/lib/bundler/templates/Executable.bundler
@@ -61,10 +61,9 @@ m = Module.new do
   end
 
   def bundler_version
-    @bundler_version ||= begin
+    @bundler_version ||=
       env_var_version || cli_arg_version ||
         lockfile_version || "#{Gem::Requirement.default}.a"
-    end
   end
 
   def load_bundler!

--- a/lib/bundler/templates/Executable.bundler
+++ b/lib/bundler/templates/Executable.bundler
@@ -87,7 +87,7 @@ m = Module.new do
       require "bundler/version"
     end
     return if require_error.nil? && Gem::Requirement.new(bundler_requirement).satisfied_by?(Gem::Version.new(Bundler::VERSION))
-    warn "Activating bundler (#{bundler_version}) failed:\n#{gem_error.message}\n\nTo install the version of bundler this project requires, run `gem install bundler -v '#{bundler_version}'`"
+    warn "Activating bundler (#{bundler_requirement}) failed:\n#{gem_error.message}\n\nTo install the version of bundler this project requires, run `gem install bundler -v '#{bundler_requirement}'`"
     exit 42
   end
 

--- a/lib/bundler/templates/Executable.bundler
+++ b/lib/bundler/templates/Executable.bundler
@@ -70,8 +70,7 @@ m = Module.new do
   def load_bundler!
     ENV["BUNDLE_GEMFILE"] ||= gemfile
 
-    # must dup string for RG < 1.8 compatibility
-    activate_bundler(bundler_version.dup)
+    activate_bundler(bundler_version)
   end
 
   def activate_bundler(bundler_version)

--- a/lib/bundler/templates/Executable.bundler
+++ b/lib/bundler/templates/Executable.bundler
@@ -31,7 +31,7 @@ m = Module.new do
         bundler_version = a
       end
       next unless a =~ /\A--bundler(?:[= ](#{Gem::Version::VERSION_PATTERN}))?\z/
-      bundler_version = $1 || ">= 0.a"
+      bundler_version = $1
       update_index = i
     end
     bundler_version
@@ -63,27 +63,30 @@ m = Module.new do
   def bundler_version
     @bundler_version ||=
       env_var_version || cli_arg_version ||
-        lockfile_version || "#{Gem::Requirement.default}.a"
+        lockfile_version
+  end
+
+  def bundler_requirement
+    return "#{Gem::Requirement.default}.a" unless bundler_version
+
+    Gem::Version.new(bundler_version).approximate_recommendation
   end
 
   def load_bundler!
     ENV["BUNDLE_GEMFILE"] ||= gemfile
 
-    activate_bundler(bundler_version)
+    activate_bundler(bundler_requirement)
   end
 
-  def activate_bundler(bundler_version)
-    if Gem::Version.correct?(bundler_version) && Gem::Version.new(bundler_version).release < Gem::Version.new("2.0")
-      bundler_version = "< 2"
-    end
+  def activate_bundler(bundler_requirement)
     gem_error = activation_error_handling do
-      gem "bundler", bundler_version
+      gem "bundler", bundler_requirement
     end
     return if gem_error.nil?
     require_error = activation_error_handling do
       require "bundler/version"
     end
-    return if require_error.nil? && Gem::Requirement.new(bundler_version).satisfied_by?(Gem::Version.new(Bundler::VERSION))
+    return if require_error.nil? && Gem::Requirement.new(bundler_requirement).satisfied_by?(Gem::Version.new(Bundler::VERSION))
     warn "Activating bundler (#{bundler_version}) failed:\n#{gem_error.message}\n\nTo install the version of bundler this project requires, run `gem install bundler -v '#{bundler_version}'`"
     exit 42
   end

--- a/lib/bundler/templates/Executable.bundler
+++ b/lib/bundler/templates/Executable.bundler
@@ -75,10 +75,10 @@ m = Module.new do
   def load_bundler!
     ENV["BUNDLE_GEMFILE"] ||= gemfile
 
-    activate_bundler(bundler_requirement)
+    activate_bundler
   end
 
-  def activate_bundler(bundler_requirement)
+  def activate_bundler
     gem_error = activation_error_handling do
       gem "bundler", bundler_requirement
     end

--- a/lib/bundler/templates/Executable.bundler
+++ b/lib/bundler/templates/Executable.bundler
@@ -69,7 +69,15 @@ m = Module.new do
   def bundler_requirement
     return "#{Gem::Requirement.default}.a" unless bundler_version
 
-    Gem::Version.new(bundler_version).approximate_recommendation
+    bundler_gem_version = Gem::Version.new(bundler_version)
+
+    requirement = bundler_gem_version.approximate_recommendation
+
+    return requirement unless Gem::Version.new(Gem::VERSION) < Gem::Version.new("2.7.0")
+
+    requirement += ".a" if bundler_gem_version.prerelease?
+
+    requirement
   end
 
   def load_bundler!

--- a/spec/commands/binstubs_spec.rb
+++ b/spec/commands/binstubs_spec.rb
@@ -135,8 +135,8 @@ RSpec.describe "bundle binstubs <gem>" do
         it "runs the correct version of bundler" do
           sys_exec "#{bundled_app("bin/bundle")} install", "BUNDLER_VERSION" => "999.999.999"
           expect(exitstatus).to eq(42) if exitstatus
-          expect(err).to include("Activating bundler (999.999.999) failed:").
-            and include("To install the version of bundler this project requires, run `gem install bundler -v '999.999.999'`")
+          expect(err).to include("Activating bundler (~> 999.999) failed:").
+            and include("To install the version of bundler this project requires, run `gem install bundler -v '~> 999.999'`")
         end
       end
 
@@ -145,8 +145,8 @@ RSpec.describe "bundle binstubs <gem>" do
           lockfile lockfile.gsub(system_bundler_version, "999.999.999")
           sys_exec "#{bundled_app("bin/bundle")} install"
           expect(exitstatus).to eq(42) if exitstatus
-          expect(err).to include("Activating bundler (999.999.999) failed:").
-            and include("To install the version of bundler this project requires, run `gem install bundler -v '999.999.999'`")
+          expect(err).to include("Activating bundler (~> 999.999) failed:").
+            and include("To install the version of bundler this project requires, run `gem install bundler -v '~> 999.999'`")
         end
 
         it "runs the correct version of bundler when the version is older and a different major" do
@@ -154,8 +154,8 @@ RSpec.describe "bundle binstubs <gem>" do
           lockfile lockfile.gsub(system_bundler_version, "44.0")
           sys_exec "#{bundled_app("bin/bundle")} install"
           expect(exitstatus).to eq(42) if exitstatus
-          expect(err).to include("Activating bundler (44.0) failed:").
-            and include("To install the version of bundler this project requires, run `gem install bundler -v '44.0'`")
+          expect(err).to include("Activating bundler (~> 44.0) failed:").
+            and include("To install the version of bundler this project requires, run `gem install bundler -v '~> 44.0'`")
         end
 
         it "runs the available version of bundler when the version is older and the same major" do
@@ -163,7 +163,7 @@ RSpec.describe "bundle binstubs <gem>" do
           lockfile lockfile.gsub(system_bundler_version, "55.0")
           sys_exec "#{bundled_app("bin/bundle")} install"
           expect(exitstatus).not_to eq(42) if exitstatus
-          expect(err).not_to include("Activating bundler (55.0) failed:")
+          expect(err).not_to include("Activating bundler (~> 55.0) failed:")
         end
 
         it "runs the correct version of bundler when the version is a pre-release" do
@@ -171,8 +171,8 @@ RSpec.describe "bundle binstubs <gem>" do
           lockfile lockfile.gsub(system_bundler_version, "2.12.0.a")
           sys_exec "#{bundled_app("bin/bundle")} install"
           expect(exitstatus).to eq(42) if exitstatus
-          expect(err).to include("Activating bundler (2.12.0.a) failed:").
-            and include("To install the version of bundler this project requires, run `gem install bundler -v '2.12.0.a'`")
+          expect(err).to include("Activating bundler (~> 2.12.a) failed:").
+            and include("To install the version of bundler this project requires, run `gem install bundler -v '~> 2.12.a'`")
         end
       end
 
@@ -187,8 +187,8 @@ RSpec.describe "bundle binstubs <gem>" do
         it "calls through to the explicit bundler version" do
           sys_exec "#{bundled_app("bin/bundle")} update --bundler=999.999.999"
           expect(exitstatus).to eq(42) if exitstatus
-          expect(err).to include("Activating bundler (999.999.999) failed:").
-            and include("To install the version of bundler this project requires, run `gem install bundler -v '999.999.999'`")
+          expect(err).to include("Activating bundler (~> 999.999) failed:").
+            and include("To install the version of bundler this project requires, run `gem install bundler -v '~> 999.999'`")
         end
       end
 
@@ -213,8 +213,8 @@ RSpec.describe "bundle binstubs <gem>" do
           it "attempts to load that version" do
             sys_exec bundled_app("bin/rackup").to_s
             expect(exitstatus).to eq(42) if exitstatus
-            expect(err).to include("Activating bundler (999.999.999) failed:").
-              and include("To install the version of bundler this project requires, run `gem install bundler -v '999.999.999'`")
+            expect(err).to include("Activating bundler (~> 999.999) failed:").
+              and include("To install the version of bundler this project requires, run `gem install bundler -v '~> 999.999'`")
           end
         end
       end

--- a/spec/commands/binstubs_spec.rb
+++ b/spec/commands/binstubs_spec.rb
@@ -149,13 +149,21 @@ RSpec.describe "bundle binstubs <gem>" do
             and include("To install the version of bundler this project requires, run `gem install bundler -v '999.999.999'`")
         end
 
-        it "runs the correct version of bundler when the version is older" do
+        it "runs the correct version of bundler when the version is older and a different major" do
           simulate_bundler_version "55"
           lockfile lockfile.gsub(system_bundler_version, "44.0")
           sys_exec "#{bundled_app("bin/bundle")} install"
           expect(exitstatus).to eq(42) if exitstatus
           expect(err).to include("Activating bundler (44.0) failed:").
             and include("To install the version of bundler this project requires, run `gem install bundler -v '44.0'`")
+        end
+
+        it "runs the available version of bundler when the version is older and the same major" do
+          simulate_bundler_version "55.1"
+          lockfile lockfile.gsub(system_bundler_version, "55.0")
+          sys_exec "#{bundled_app("bin/bundle")} install"
+          expect(exitstatus).not_to eq(42) if exitstatus
+          expect(err).not_to include("Activating bundler (55.0) failed:")
         end
 
         it "runs the correct version of bundler when the version is a pre-release" do


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that the logic to select bundler versions was different when bundler is run from a rubygems binstub that when bundler is run from a bundler binstub.

### What was your diagnosis of the problem?

My diagnosis was that we should unify the logic.

### What is your fix for the problem, implemented in this PR?

My fix is to use the same logic implemented in the rubygems version finder, namely, only fail if the major version of bundler does not match.

### Why did you choose this fix out of the possible options?

I chose this fix because it makes things consistent.

Fixes #7243.
