### PR TITLE
Better info about spec exclusions

### DIFF
--- a/spec/support/requirement_checker.rb
+++ b/spec/support/requirement_checker.rb
@@ -6,6 +6,14 @@ class RequirementChecker < Proc
 
     new do |required|
       !Gem::Requirement.new(required).satisfied_by?(provided)
+    end.tap do |checker|
+      checker.provided = provided
     end
+  end
+
+  attr_accessor :provided
+
+  def inspect
+    "\"!= #{provided}\""
   end
 end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that current tests are very cryptic about the tests that are being excluded:

```
$ bin/rspec 
Run options: exclude {:non_windows=>false, :ruby_repo=>false, :bundler=>#<RequirementChecker:./spec/support/requirement_checker.rb:7>, :git=>#<RequirementChecker:./spec/support/requirement_checker.rb:7>, :rubygems=>#<RequirementChecker:./spec/support/requirement_checker.rb:7>, :ruby=>#<RequirementChecker:./spec/support/requirement_checker.rb:7>, :realworld=>true, :sudo=>true}

Randomized with seed 22209
...
```

### What was your diagnosis of the problem?

My diagnosis was that the `RequirementChecker` class needs a better text representation.

### What is your fix for the problem, implemented in this PR?

My fix is to add an `inspect` method that informs better about the exclusion. Now:

```
$ bin/rspec
Run options: exclude {:non_windows=>false, :ruby_repo=>false, :bundler=>"!= 2", :git=>"!= 2.22.0", :rubygems=>"!= 3.0.4", :ruby=>"!= 2.6.3", :realworld=>true, :sudo=>true}

Randomized with seed 36536
...
```

### Why did you choose this fix out of the possible options?

I chose this fix because it makes it easier to understand what's going on.