### PR TITLE
Enable `Style/UnneededInterpolation` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -798,6 +798,9 @@ Style/TrailingCommaInHashLiteral:
 Style/TrailingMethodEndStatement:
   Enabled: true
 
+Style/UnneededInterpolation:
+  Enabled: true
+
 Style/UnlessElse:
   Enabled: true
 

--- a/lib/bundler/cli/config.rb
+++ b/lib/bundler/cli/config.rb
@@ -114,7 +114,7 @@ module Bundler
         else
           Bundler.ui.confirm "Settings are listed in order of priority. The top value will be used.\n"
           Bundler.settings.all.each do |setting|
-            Bundler.ui.confirm "#{setting}"
+            Bundler.ui.confirm setting
             show_pretty_values_for(setting)
             Bundler.ui.confirm ""
           end

--- a/lib/bundler/env.rb
+++ b/lib/bundler/env.rb
@@ -69,7 +69,7 @@ module Bundler
     end
 
     def self.ruby_version
-      str = String.new("#{RUBY_VERSION}")
+      str = String.new(RUBY_VERSION)
       str << "p#{RUBY_PATCHLEVEL}" if defined? RUBY_PATCHLEVEL
       str << " (#{RUBY_RELEASE_DATE} revision #{RUBY_REVISION}) [#{RUBY_PLATFORM}]"
     end

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -310,7 +310,7 @@ module Bundler
       rubyopt = [ENV["RUBYOPT"]].compact
       setup_require = "-r#{File.expand_path("setup", __dir__)}"
       return if !rubyopt.empty? && rubyopt.first =~ /#{setup_require}/
-      rubyopt.unshift %(#{setup_require})
+      rubyopt.unshift setup_require
       Bundler::SharedHelpers.set_env "RUBYOPT", rubyopt.join(" ")
     end
 

--- a/spec/bundler/definition_spec.rb
+++ b/spec/bundler/definition_spec.rb
@@ -230,7 +230,7 @@ RSpec.describe Bundler::Definition do
       context "eager unlock" do
         let(:source_list) do
           Bundler::SourceList.new.tap do |source_list|
-            source_list.global_rubygems_source = "#{file_uri_for(gem_repo4)}"
+            source_list.global_rubygems_source = file_uri_for(gem_repo4)
           end
         end
 

--- a/spec/bundler/plugin/installer_spec.rb
+++ b/spec/bundler/plugin/installer_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Bundler::Plugin::Installer do
         end
 
         let(:result) do
-          installer.install(["ga-plugin"], :git => "#{file_uri_for(lib_path("ga-plugin"))}")
+          installer.install(["ga-plugin"], :git => file_uri_for(lib_path("ga-plugin")))
         end
 
         it "returns the installed spec after installing" do
@@ -98,7 +98,7 @@ RSpec.describe Bundler::Plugin::Installer do
 
       context "rubygems plugins" do
         let(:result) do
-          installer.install(["re-plugin"], :source => "#{file_uri_for(gem_repo2)}")
+          installer.install(["re-plugin"], :source => file_uri_for(gem_repo2))
         end
 
         it "returns the installed spec after installing " do
@@ -113,7 +113,7 @@ RSpec.describe Bundler::Plugin::Installer do
 
       context "multiple plugins" do
         let(:result) do
-          installer.install(["re-plugin", "ma-plugin"], :source => "#{file_uri_for(gem_repo2)}")
+          installer.install(["re-plugin", "ma-plugin"], :source => file_uri_for(gem_repo2))
         end
 
         it "returns the installed spec after installing " do

--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Bundler::SharedHelpers do
     end
 
     context ".bundle is global .bundle" do
-      let(:global_rubygems_dir) { Pathname.new("#{bundled_app}") }
+      let(:global_rubygems_dir) { Pathname.new(bundled_app) }
 
       before do
         Dir.mkdir ".bundle"

--- a/spec/cache/git_spec.rb
+++ b/spec/cache/git_spec.rb
@@ -22,7 +22,7 @@ end
         gem "foo", :git => '#{lib_path("foo-1.0")}'
       G
 
-      bundle "#{cmd}", forgotten_command_line_options([:all, :cache_all] => true)
+      bundle cmd, forgotten_command_line_options([:all, :cache_all] => true)
       expect(bundled_app("vendor/cache/foo-1.0-#{ref}")).to exist
       expect(bundled_app("vendor/cache/foo-1.0-#{ref}/.git")).not_to exist
       expect(bundled_app("vendor/cache/foo-1.0-#{ref}/.bundlecache")).to be_file
@@ -40,7 +40,7 @@ end
       G
 
       bundle "install --path vendor/bundle"
-      bundle "#{cmd}", forgotten_command_line_options([:all, :cache_all] => true)
+      bundle cmd, forgotten_command_line_options([:all, :cache_all] => true)
 
       expect(bundled_app("vendor/cache/foo-1.0-#{ref}")).to exist
       expect(bundled_app("vendor/cache/foo-1.0-#{ref}/.git")).not_to exist
@@ -56,8 +56,8 @@ end
         gem "foo", :git => '#{lib_path("foo-1.0")}'
       G
 
-      bundle! "#{cmd}", forgotten_command_line_options([:all, :cache_all] => true)
-      bundle! "#{cmd}", forgotten_command_line_options([:all, :cache_all] => true)
+      bundle! cmd, forgotten_command_line_options([:all, :cache_all] => true)
+      bundle! cmd, forgotten_command_line_options([:all, :cache_all] => true)
 
       expect(out).to include "Updating files in vendor/cache"
       FileUtils.rm_rf lib_path("foo-1.0")
@@ -72,7 +72,7 @@ end
         gem "foo", :git => '#{lib_path("foo-1.0")}'
       G
 
-      bundle "#{cmd}", forgotten_command_line_options([:all, :cache_all] => true)
+      bundle cmd, forgotten_command_line_options([:all, :cache_all] => true)
 
       update_git "foo" do |s|
         s.write "lib/foo.rb", "puts :CACHE"
@@ -82,7 +82,7 @@ end
       expect(ref).not_to eq(old_ref)
 
       bundle! "update", :all => true
-      bundle! "#{cmd}", forgotten_command_line_options([:all, :cache_all] => true)
+      bundle! cmd, forgotten_command_line_options([:all, :cache_all] => true)
 
       expect(bundled_app("vendor/cache/foo-1.0-#{ref}")).to exist
       expect(bundled_app("vendor/cache/foo-1.0-#{old_ref}")).not_to exist
@@ -129,7 +129,7 @@ end
 
       bundle %(config set local.foo #{lib_path("foo-1.0")})
       bundle "install"
-      bundle "#{cmd}", forgotten_command_line_options([:all, :cache_all] => true)
+      bundle cmd, forgotten_command_line_options([:all, :cache_all] => true)
 
       expect(bundled_app("vendor/cache/foo-invalid-#{ref}")).to exist
 
@@ -161,7 +161,7 @@ end
       G
 
       ref = git.ref_for("master", 11)
-      bundle "#{cmd}", forgotten_command_line_options([:all, :cache_all] => true)
+      bundle cmd, forgotten_command_line_options([:all, :cache_all] => true)
 
       expect(bundled_app("vendor/cache/has_submodule-1.0-#{ref}")).to exist
       expect(bundled_app("vendor/cache/has_submodule-1.0-#{ref}/submodule-1.0")).to exist
@@ -175,7 +175,7 @@ end
         gem "foo", :git => '#{lib_path("foo-1.0")}'
       G
 
-      bundle "#{cmd}"
+      bundle cmd
 
       expect(err).to include("Your Gemfile contains path and git dependencies.")
     end

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -299,7 +299,7 @@ RSpec.describe "bundle exec" do
     G
 
     rubylib = ENV["RUBYLIB"]
-    rubylib = "#{rubylib}".split(File::PATH_SEPARATOR).unshift "#{bundler_path}"
+    rubylib = rubylib.to_s.split(File::PATH_SEPARATOR).unshift bundler_path
     rubylib = rubylib.uniq.join(File::PATH_SEPARATOR)
 
     bundle "exec 'echo $RUBYLIB'"

--- a/spec/install/gemfile/sources_spec.rb
+++ b/spec/install/gemfile/sources_spec.rb
@@ -550,8 +550,8 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
     context "and the gemfile changes" do
       it "is still able to find that gem from remote sources" do
-        source_uri = "#{file_uri_for(gem_repo1)}"
-        second_uri = "#{file_uri_for(gem_repo4)}"
+        source_uri = file_uri_for(gem_repo1)
+        second_uri = file_uri_for(gem_repo4)
 
         build_repo4 do
           build_gem "rack", "2.0.1.1.forked"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that sometimes we have some unneeded string interpolations in our code base.

### What was your diagnosis of the problem?

My diagnosis was that we could remove them, because interpolating string variables seems weird and redundant.

### What is your fix for the problem, implemented in this PR?

My fix is to remove the unnecessary interpolations, and enable the corresponding rubocop cop.

### Why did you choose this fix out of the possible options?

I chose this fix because it fixes the current issues and it enforces the style rule from now on. 
