### PR TITLE
Add `--[no-]git` option to `bundle gem`

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -538,6 +538,7 @@ module Bundler
                          :lazy_default => [ENV["BUNDLER_EDITOR"], ENV["VISUAL"], ENV["EDITOR"]].find {|e| !e.nil? && !e.empty? },
                          :desc => "Open generated gemspec in the specified editor (defaults to $EDITOR or $BUNDLER_EDITOR)"
     method_option :ext, :type => :boolean, :default => false, :desc => "Generate the boilerplate for C extension code"
+    method_option :git, :type => :boolean, :default => true, :desc => "Initialize a git repo inside your library."
     method_option :mit, :type => :boolean, :desc => "Generate an MIT license file. Set a default with `bundle config set gem.mit true`."
     method_option :test, :type => :string, :lazy_default => "rspec", :aliases => "-t", :banner => "rspec",
                          :desc => "Generate a test directory for your library, either rspec or minitest. Set a default with `bundle config set gem.test rspec`."

--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -148,7 +148,7 @@ module Bundler
         end
       end
 
-      if Bundler.git_present?
+      if Bundler.git_present? && options[:git]
         Bundler.ui.info "Initializing git repo in #{target}"
         Dir.chdir(target) do
           `git init`

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -60,6 +60,42 @@ RSpec.describe "bundle gem" do
     end
   end
 
+  describe "git repo initialization" do
+    let(:gem_name) { "test-gem" }
+
+    shared_examples_for "a gem with an initial git repo" do
+      before do
+        execute_bundle_gem(gem_name, flags)
+      end
+      it "generates a gem skeleton with a .git folder" do
+        gem_skeleton_assertions(gem_name)
+        expect(bundled_app("test-gem/.git")).to exist
+      end
+    end
+
+    context "when using the default" do
+      it_behaves_like "a gem with an initial git repo" do
+        let(:flags) { "" }
+      end
+    end
+
+    context "when explicitly passing --git" do
+      it_behaves_like "a gem with an initial git repo" do
+        let(:flags) { "--git" }
+      end
+    end
+
+    context "when passing --no-git" do
+      before do
+        execute_bundle_gem(gem_name, "--no-git")
+      end
+      it "generates a gem skeleton without a .git folder" do
+        gem_skeleton_assertions(gem_name)
+        expect(bundled_app("test-gem/.git")).not_to exist
+      end
+    end
+  end
+
   shared_examples_for "--mit flag" do
     before do
       execute_bundle_gem(gem_name, "--mit")


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that while reproducing #7262, I actually wanted a single git repo, and every subgem source controlled under a single git repository. However, this cannot be done by default.

### What was your diagnosis of the problem?

My diagnosis was that we could add a `--no-git` option to `bundle gem`, so that git repository initialization is skipped. I think this can be specially useful for monorepos.

### What is your fix for the problem, implemented in this PR?

My fix is to implement the flag.

### Why did you choose this fix out of the possible options?

I chose this fix because it's quite simple, and it solves my request.
