### PR TITLE
Consistent lockfiles

### DIFF
--- a/lib/bundler/source/path.rb
+++ b/lib/bundler/source/path.rb
@@ -24,7 +24,12 @@ module Bundler
 
         if options["path"]
           @path = Pathname.new(options["path"])
-          @path = expand(@path) unless @path.relative?
+          expanded_path = expand(@path)
+          @path = if @path.relative?
+            expanded_path.relative_path_from(root_path.expand_path)
+          else
+            expanded_path
+          end
         end
 
         @name    = options["name"]

--- a/lib/bundler/source/path.rb
+++ b/lib/bundler/source/path.rb
@@ -20,7 +20,7 @@ module Bundler
         @allow_cached = false
         @allow_remote = false
 
-        @root_path = options["root_path"] || Bundler.root
+        @root_path = options["root_path"] || root
 
         if options["path"]
           @path = Pathname.new(options["path"])
@@ -136,7 +136,7 @@ module Bundler
 
       def lockfile_path
         return relative_path(original_path) if original_path.absolute?
-        expand(original_path).relative_path_from(Bundler.root)
+        expand(original_path).relative_path_from(root)
       end
 
       def app_cache_path(custom_path = nil)

--- a/spec/install/gemfile/path_spec.rb
+++ b/spec/install/gemfile/path_spec.rb
@@ -370,13 +370,13 @@ RSpec.describe "bundle install with explicit source paths" do
   end
 
   it "works when the path does not have a gemspec but there is a lockfile" do
-    lockfile <<-L
-    PATH
-      remote: vendor/bar
-      specs:
+    lockfile <<~L
+      PATH
+        remote: vendor/bar
+        specs:
 
-    GEM
-      remote: http://rubygems.org
+      GEM
+        remote: http://rubygems.org
     L
 
     in_app_root { FileUtils.mkdir_p("vendor/bar") }

--- a/spec/install/gemfile/path_spec.rb
+++ b/spec/install/gemfile/path_spec.rb
@@ -83,6 +83,50 @@ RSpec.describe "bundle install with explicit source paths" do
     end
   end
 
+  it "sorts paths consistently on install and update when they start with ./" do
+    build_lib "demo", :path => lib_path("demo")
+    build_lib "aaa", :path => lib_path("demo/aaa")
+
+    gemfile = <<-G
+      gemspec
+      gem "aaa", :path => "./aaa"
+    G
+
+    File.open(lib_path("demo/Gemfile"), "w") {|f| f.puts gemfile }
+
+    lockfile = <<~L
+      PATH
+        remote: .
+        specs:
+          demo (1.0)
+
+      PATH
+        remote: aaa
+        specs:
+          aaa (1.0)
+
+      GEM
+        specs:
+
+      PLATFORMS
+        #{lockfile_platforms}
+
+      DEPENDENCIES
+        aaa!
+        demo!
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+
+    Dir.chdir(lib_path("demo")) do
+      bundle :install
+      expect(lib_path("demo/Gemfile.lock")).to have_lockfile(lockfile)
+      bundle :update, :all => true
+      expect(lib_path("demo/Gemfile.lock")).to have_lockfile(lockfile)
+    end
+  end
+
   it "expands paths when comparing locked paths to Gemfile paths" do
     build_lib "foo", :path => bundled_app("foo-1.0")
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that when a Gemfile would specify path sources with paths starting with "./", the generated lockfile would be inconsistent on `bundle install` and `bundle update`.

### What was your diagnosis of the problem?

My diagnosis was that when running `bundle update`, the bundle would be unlocked, and bundler would order the path sources according to the path present in the Gemfile ("./aaa" for example). On the other hand, when running `bundle install`, bundler would read the relative paths from the lockfile, where they are normalized ("aaa" for example).

### What is your fix for the problem, implemented in this PR?

My fix is to normalize relative paths when creating the source list, so that "aaa" is always used over "./aaa".

### Why did you choose this fix out of the possible options?

I chose this fix because it fixes the problem and it's backwards compatible (as in, it doesn't break any specs that assert for specific lockfiles).

Fixes #7262.