### PR TITLE
Fix incorrect sectioning in `gemfile` man page

### DIFF
--- a/man/gemfile.5.ronn
+++ b/man/gemfile.5.ronn
@@ -310,8 +310,7 @@ Git repositories support a number of additional options.
 
   * `branch`, `tag`, and `ref`:
     You `MUST` only specify at most one of these options. The default
-    is `:branch => "master"`
-  * For example:
+    is `:branch => "master"`.  For example:
 
       git "https://github.com/rails/rails.git", :branch => "5-0-stable" do
 

--- a/man/gemfile.5.ronn
+++ b/man/gemfile.5.ronn
@@ -312,11 +312,11 @@ Git repositories support a number of additional options.
     You `MUST` only specify at most one of these options. The default
     is `:branch => "master"`.  For example:
 
-      git "https://github.com/rails/rails.git", :branch => "5-0-stable" do
+      gem "rails", :git => "https://github.com/rails/rails.git", :branch => "5-0-stable"
 
-      git "https://github.com/rails/rails.git", :tag => "v5.0.0" do
+      gem "rails", :git => "https://github.com/rails/rails.git", :tag => "v5.0.0"
 
-      git "https://github.com/rails/rails.git", :ref => "4aded" do
+      gem "rails", :git => "https://github.com/rails/rails.git", :ref => "4aded"
 
   * `submodules`:
     For reference, a [git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules)


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that Gemfile's man page has incorrect syntax in the section where examples for `:ref`, `:tag` and `:branch` are given.

### What was your diagnosis of the problem?

My diagnosis was that the section was incorrect since the examples were listed as a separate section. Also, the syntax seems incorrect, since building the docs with [ronn-ng]() (something I've been experimenting with lately) gives the following error:

```
$ bin/rake man/gemfile.5
/home/deivid/.rbenv/versions/2.6.3/bin/ruby -S ronn --roff --pipe man/gemfile.5.ronn > man/gemfile.5
warn: unrecognized inline tag: ["p"]
warn: unrecognized inline tag: ["p"]
warn: unrecognized inline tag: ["p"]
man/gemfile.5 ran for   0.000305   0.000038   0.317832 (  0.317939)
```

### What is your fix for the problem, implemented in this PR?

My fix is to correct the syntax. The comparison of the rendered man page is:

#### `bundle help gemfile` (before)

```
   (...)
       branch, tag, and ref
              You MUST only specify at most one of these options. The default is :branch => "master"

       For example:

       submodules
              For  reference,  a  git  submodule https://git-scm.com/book/en/v2/Git-Tools-Submodules lets you have another git repository within a subfolder of your
              repository. Specify :submodules => true to cause bundler to expand any submodules included in the git repository
   (...)
```

#### `bundle help gemfile` (after)

```
   (...)
       branch, tag, and ref
              You MUST only specify at most one of these options. The default is :branch => "master". For example:

              git "https://github.com/rails/rails.git", :branch => "5-0-stable" do

              git "https://github.com/rails/rails.git", :tag => "v5.0.0" do

              git "https://github.com/rails/rails.git", :ref => "4aded" do

       submodules
              For  reference,  a  git  submodule https://git-scm.com/book/en/v2/Git-Tools-Submodules lets you have another git repository within a subfolder of your
              repository. Specify :submodules => true to cause bundler to expand any submodules included in the git repository
   (...)
```

### Why did you choose this fix out of the possible options?

I chose this fix because it seems like the right thing to do.
