### PR TITLE
Use RbConfig::CONFIG directly instead of Gem::ConfigMap.

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -150,7 +150,7 @@ module Bundler
     end
 
     def ruby_scope
-      "#{Bundler.rubygems.ruby_engine}/#{Bundler.rubygems.config_map[:ruby_version]}"
+      "#{Bundler.rubygems.ruby_engine}/#{RbConfig::CONFIG["ruby_version"]}"
     end
 
     def user_home

--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -213,10 +213,6 @@ module Bundler
       Gem::MARSHAL_SPEC_DIR
     end
 
-    def config_map
-      RbConfig::CONFIG
-    end
-
     def clear_paths
       Gem.clear_paths
     end

--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -214,7 +214,7 @@ module Bundler
     end
 
     def config_map
-      Gem::ConfigMap
+      RbConfig::CONFIG
     end
 
     def clear_paths

--- a/spec/support/path.rb
+++ b/spec/support/path.rb
@@ -33,7 +33,7 @@ module Spec
       if Bundler::VERSION.split(".").first.to_i < 3
         system_gem_path(*path)
       else
-        bundled_app(*[".bundle", ENV.fetch("BUNDLER_SPEC_RUBY_ENGINE", Gem.ruby_engine), RbConfig::CONFIG[:ruby_version], *path].compact)
+        bundled_app(*[".bundle", ENV.fetch("BUNDLER_SPEC_RUBY_ENGINE", Gem.ruby_engine), RbConfig::CONFIG["ruby_version"], *path].compact)
       end
     end
 
@@ -52,7 +52,7 @@ module Spec
     end
 
     def vendored_gems(path = nil)
-      bundled_app(*["vendor/bundle", Gem.ruby_engine, RbConfig::CONFIG[:ruby_version], path].compact)
+      bundled_app(*["vendor/bundle", Gem.ruby_engine, RbConfig::CONFIG["ruby_version"], path].compact)
     end
 
     def cached_gem(path)

--- a/spec/support/path.rb
+++ b/spec/support/path.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "pathname"
+require "rbconfig"
 
 module Spec
   module Path
@@ -32,7 +33,7 @@ module Spec
       if Bundler::VERSION.split(".").first.to_i < 3
         system_gem_path(*path)
       else
-        bundled_app(*[".bundle", ENV.fetch("BUNDLER_SPEC_RUBY_ENGINE", Gem.ruby_engine), Gem::ConfigMap[:ruby_version], *path].compact)
+        bundled_app(*[".bundle", ENV.fetch("BUNDLER_SPEC_RUBY_ENGINE", Gem.ruby_engine), RbConfig::CONFIG[:ruby_version], *path].compact)
       end
     end
 
@@ -51,7 +52,7 @@ module Spec
     end
 
     def vendored_gems(path = nil)
-      bundled_app(*["vendor/bundle", Gem.ruby_engine, Gem::ConfigMap[:ruby_version], path].compact)
+      bundled_app(*["vendor/bundle", Gem.ruby_engine, RbConfig::CONFIG[:ruby_version], path].compact)
     end
 
     def cached_gem(path)


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

When we try to remove `Gem::ConfigMap` on rubygems repository, It breaks the bundler examples.

https://github.com/rubygems/rubygems/pull/2848#issuecomment-515726585

### What was your diagnosis of the problem?

Gem::ConfigMap is compatibility code for the old Ruby like 1.8/1.9.

### What is your fix for the problem, implemented in this PR?

Use RbConfig instead of `Gem::ConfigMap` directly. It was always provided after the Ruby 2.x.

