### PR TITLE
Fix typo in binstubs documentation

### DIFF
--- a/man/bundle-binstubs.ronn
+++ b/man/bundle-binstubs.ronn
@@ -10,7 +10,7 @@ bundle-binstubs(1) -- Install the binstubs of the listed gems
 Binstubs are scripts that wrap around executables. Bundler creates a
 small Ruby file (a binstub) that loads Bundler, runs the command,
 and puts it into `bin/`. Binstubs are a shortcut-or alternative-
-to always using `bundle exec`. This gives you a file that can by run
+to always using `bundle exec`. This gives you a file that can be run
 directly, and one that will always run the correct gem version
 used by the application.
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

There is a typo in the [binstubs documentation](https://bundler.io/v2.0/man/bundle-binstubs.1.html).

It currently reads 

> This gives you a file that can **by** run directly

It should read 

> This gives you a file that can **be** run directly


![Screen Shot 2019-07-29 at 3 14 24 PM](https://user-images.githubusercontent.com/586779/62079346-2452b180-b214-11e9-84c6-e2661c60eb4a.png)

### What is your fix for the problem, implemented in this PR?

Fix the typo in the RONN file that is used to generate this documentation.