### PR TITLE
Bump rubocop to 0.74.0

### DIFF
--- a/lib/bundler/friendly_errors.rb
+++ b/lib/bundler/friendly_errors.rb
@@ -5,7 +5,7 @@ require_relative "vendored_thor"
 
 module Bundler
   module FriendlyErrors
-    module_function # rubocop:disable Layout/AccessModifierIndentation
+  module_function
 
     def log_error(error)
       case error

--- a/lib/bundler/uri_credentials_filter.rb
+++ b/lib/bundler/uri_credentials_filter.rb
@@ -2,7 +2,7 @@
 
 module Bundler
   module URICredentialsFilter
-    module_function # rubocop:disable Layout/AccessModifierIndentation
+  module_function
 
     def credential_filtered_uri(uri_to_anonymize)
       return uri_to_anonymize if uri_to_anonymize.nil?

--- a/lib/bundler/yaml_serializer.rb
+++ b/lib/bundler/yaml_serializer.rb
@@ -3,7 +3,7 @@
 module Bundler
   # A stub yaml serializer that can handle only hashes and strings (as of now).
   module YAMLSerializer
-    module_function # rubocop:disable Layout/AccessModifierIndentation
+  module_function
 
     def dump(hash)
       yaml = String.new("---")

--- a/spec/support/rubygems_ext.rb
+++ b/spec/support/rubygems_ext.rb
@@ -11,7 +11,7 @@ module Spec
       "rake" => "~> 12.0",
       "ronn" => "~> 0.7.3",
       "rspec" => "~> 3.6",
-      "rubocop" => "= 0.72.0",
+      "rubocop" => "= 0.74.0",
       "rubocop-performance" => "= 1.4.0",
     }.freeze
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that we are using an outdated rubocop version.

### What was your diagnosis of the problem?

My diagnosis was that we should upgrade, specially because the newest version fixes an issue that made us disable a cop under some situations.

### What is your fix for the problem, implemented in this PR?

My fix is to upgrade rubocop and remove the now unneeded exclusions.
