### PR TITLE
Revert "Remove version overriding stuff"

### DIFF
--- a/lib/bundler/version.rb
+++ b/lib/bundler/version.rb
@@ -1,7 +1,23 @@
 # frozen_string_literal: false
 
 module Bundler
-  VERSION = "2.1.0.pre.1".freeze
+  # We're doing this because we might write tests that deal
+  # with other versions of bundler and we are unsure how to
+  # handle this better.
+  VERSION = "2.1.0.pre.1".freeze unless defined?(::Bundler::VERSION)
+
+  def self.overwrite_loaded_gem_version
+    begin
+      require "rubygems"
+    rescue LoadError
+      return
+    end
+    return unless bundler_spec = Gem.loaded_specs["bundler"]
+    return if bundler_spec.version == VERSION
+    bundler_spec.version = Bundler::VERSION
+  end
+  private_class_method :overwrite_loaded_gem_version
+  overwrite_loaded_gem_version
 
   def self.bundler_major_version
     @bundler_major_version ||= VERSION.split(".").first.to_i


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

This reverts commit c675b59e8f7e3b4102cf0e83598b4df23691f209.

c675b59e8f7e3b4102cf0e83598b4df23691f209 was caused by https://travis-ci.org/rubygems/rubygems/jobs/566926815.

### What was your diagnosis of the problem?

I only investigate with bisect.

### What is your fix for the problem, implemented in this PR?

I'm not sure why this change affects with test environment of rubygems with Travis.

### Why did you choose this fix out of the possible options?

@deivid-rodriguez Can we move this hack to only test suite?

