### PR TITLE
Fix more leaks to default copy of bundler

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -312,7 +312,9 @@ else
   # This will be automated once https://github.com/segiddins/automatiek/pull/3
   # is included in `automatiek` and we start using the new API for vendoring
   # subdependencies.
-
+  # Besides that, we currently cherry-pick changes to use `require_relative`
+  # internally instead of regular `require`. They are pending review at
+  # https://github.com/drbrain/net-http-persistent/pull/106
   desc "Vendor a specific version of net-http-persistent"
   Automatiek::RakeTask.new("net-http-persistent") do |lib|
     lib.download = { :github => "https://github.com/drbrain/net-http-persistent" }

--- a/exe/bundle
+++ b/exe/bundle
@@ -7,7 +7,14 @@ Signal.trap("INT") do
   exit 1
 end
 
-require "bundler"
+base_path = File.expand_path("../lib", __dir__)
+
+if File.exist?(base_path)
+  require_relative "../lib/bundler"
+else
+  require "bundler"
+end
+
 # Check if an older version of bundler is installed
 $LOAD_PATH.each do |path|
   next unless path =~ %r{/bundler-0\.(\d+)} && $1.to_i < 9
@@ -18,9 +25,18 @@ $LOAD_PATH.each do |path|
   abort(err)
 end
 
-require "bundler/friendly_errors"
+if File.exist?(base_path)
+  require_relative "../lib/bundler/friendly_errors"
+else
+  require "bundler/friendly_errors"
+end
+
 Bundler.with_friendly_errors do
-  require "bundler/cli"
+  if File.exist?(base_path)
+    require_relative "../lib/bundler/cli"
+  else
+    require "bundler/cli"
+  end
 
   # Allow any command to use --help flag to show help for that command
   help_flags = %w[--help -h]

--- a/lib/bundler/plugin.rb
+++ b/lib/bundler/plugin.rb
@@ -4,11 +4,11 @@ require_relative "plugin/api"
 
 module Bundler
   module Plugin
-    autoload :DSL,        "bundler/plugin/dsl"
-    autoload :Events,     "bundler/plugin/events"
-    autoload :Index,      "bundler/plugin/index"
-    autoload :Installer,  "bundler/plugin/installer"
-    autoload :SourceList, "bundler/plugin/source_list"
+    autoload :DSL,        File.expand_path("plugin/dsl", __dir__)
+    autoload :Events,     File.expand_path("plugin/events", __dir__)
+    autoload :Index,      File.expand_path("plugin/index", __dir__)
+    autoload :Installer,  File.expand_path("plugin/installer", __dir__)
+    autoload :SourceList, File.expand_path("plugin/source_list", __dir__)
 
     class MalformattedPlugin < PluginError; end
     class UndefinedCommandError < PluginError; end

--- a/lib/bundler/vendor/net-http-persistent/lib/net/http/persistent.rb
+++ b/lib/bundler/vendor/net-http-persistent/lib/net/http/persistent.rb
@@ -1,7 +1,7 @@
 require 'net/http'
 require 'uri'
 require 'cgi' # for escaping
-require 'bundler/vendor/connection_pool/lib/connection_pool'
+require_relative '../../../../connection_pool/lib/connection_pool'
 
 begin
   require 'net/http/pipeline'
@@ -1197,6 +1197,6 @@ application:
 
 end
 
-require 'bundler/vendor/net-http-persistent/lib/net/http/persistent/connection'
-require 'bundler/vendor/net-http-persistent/lib/net/http/persistent/pool'
+require_relative 'persistent/connection'
+require_relative 'persistent/pool'
 

--- a/lib/bundler/vendor/net-http-persistent/lib/net/http/persistent/pool.rb
+++ b/lib/bundler/vendor/net-http-persistent/lib/net/http/persistent/pool.rb
@@ -49,5 +49,5 @@ class Bundler::Persistent::Net::HTTP::Persistent::Pool < Bundler::ConnectionPool
   end
 end
 
-require 'bundler/vendor/net-http-persistent/lib/net/http/persistent/timed_stack_multi'
+require_relative 'timed_stack_multi'
 

--- a/lib/bundler/vendored_fileutils.rb
+++ b/lib/bundler/vendored_fileutils.rb
@@ -1,9 +1,4 @@
 # frozen_string_literal: true
 
 module Bundler; end
-if RUBY_VERSION >= "2.4"
-  require_relative "vendor/fileutils/lib/fileutils"
-else
-  # the version we vendor is 2.4+
-  require "fileutils"
-end
+require_relative "vendor/fileutils/lib/fileutils"

--- a/spec/bundler/bundler_spec.rb
+++ b/spec/bundler/bundler_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe Bundler do
       let(:bundler_ui) { Bundler.ui }
       it "should raise a friendly error" do
         allow(File).to receive(:exist?).and_return(true)
-        allow(bundler_fileutils).to receive(:remove_entry_secure).and_raise(ArgumentError)
+        allow(::Bundler::FileUtils).to receive(:remove_entry_secure).and_raise(ArgumentError)
         allow(File).to receive(:world_writable?).and_return(true)
         message = <<EOF
 It is a security vulnerability to allow your home directory to be world-writable, and bundler can not continue.

--- a/spec/bundler/settings_spec.rb
+++ b/spec/bundler/settings_spec.rb
@@ -120,7 +120,7 @@ that would suck --ehhh=oh geez it looks like i might have broken bundler somehow
 
     context "when it's not possible to write to the file" do
       it "raises an PermissionError with explanation" do
-        expect(bundler_fileutils).to receive(:mkdir_p).with(settings.send(:local_config_file).dirname).
+        expect(::Bundler::FileUtils).to receive(:mkdir_p).with(settings.send(:local_config_file).dirname).
           and_raise(Errno::EACCES)
         expect { settings.set_local :frozen, "1" }.
           to raise_error(Bundler::PermissionError, /config/)
@@ -161,7 +161,7 @@ that would suck --ehhh=oh geez it looks like i might have broken bundler somehow
   describe "#set_global" do
     context "when it's not possible to write to the file" do
       it "raises an PermissionError with explanation" do
-        expect(bundler_fileutils).to receive(:mkdir_p).with(settings.send(:global_config_file).dirname).
+        expect(::Bundler::FileUtils).to receive(:mkdir_p).with(settings.send(:global_config_file).dirname).
           and_raise(Errno::EACCES)
         expect { settings.set_global(:frozen, "1") }.
           to raise_error(Bundler::PermissionError, %r{\.bundle/config})

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -843,7 +843,7 @@ __FILE__: #{path.to_s.inspect}
           source "#{file_uri_for(gem_repo1)}"
           gem "rack"
         G
-        bundle "config path vendor/bundler"
+        bundle "config set path vendor/bundler"
         bundle! :install, :system_bundler => true
       end
 

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -837,14 +837,12 @@ __FILE__: #{path.to_s.inspect}
   context "nested bundle exec" do
     context "when bundle in a local path" do
       before do
-        system_gems :bundler
-
         gemfile <<-G
           source "#{file_uri_for(gem_repo1)}"
           gem "rack"
         G
         bundle "config set path vendor/bundler"
-        bundle! :install, :system_bundler => true
+        bundle! :install
       end
 
       it "correctly shells out", :ruby_repo do
@@ -854,7 +852,7 @@ __FILE__: #{path.to_s.inspect}
           puts `bundle exec echo foo`
         RB
         file.chmod(0o777)
-        bundle! "exec #{file}", :system_bundler => true
+        bundle! "exec #{file}"
         expect(out).to eq("foo")
       end
     end

--- a/spec/commands/pristine_spec.rb
+++ b/spec/commands/pristine_spec.rb
@@ -42,8 +42,7 @@ RSpec.describe "bundle pristine", :ruby_repo do
       expect(changes_txt).to_not be_file
     end
 
-    it "does not delete the bundler gem", :rubygems => ">= 2.6.2" do
-      ENV["BUNDLER_SPEC_KEEP_DEFAULT_BUNDLER_GEM"] = "true"
+    it "does not delete the bundler gem" do
       system_gems :bundler
       bundle! "install"
       bundle! "pristine", :system_bundler => true

--- a/spec/install/gemfile/groups_spec.rb
+++ b/spec/install/gemfile/groups_spec.rb
@@ -333,7 +333,7 @@ RSpec.describe "bundle install with groups" do
       G
 
       ruby <<-R
-        require "bundler"
+        require "#{lib}/bundler"
         Bundler.setup :default
         Bundler.require :default
         puts RACK

--- a/spec/plugins/source/example_spec.rb
+++ b/spec/plugins/source/example_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe "real source plugins" do
       build_repo2 do
         build_plugin "bundler-source-mpath" do |s|
           s.write "plugins.rb", <<-RUBY
-            require "bundler/vendored_fileutils"
             require "bundler-source-mpath"
 
             class MPath < Bundler::Plugin::API

--- a/spec/realworld/double_check_spec.rb
+++ b/spec/realworld/double_check_spec.rb
@@ -25,9 +25,9 @@ RSpec.describe "double checking sources", :realworld => true, :sometimes => true
     RUBY
 
     cmd = <<-RUBY
-      require "bundler"
+      require "#{lib}/bundler"
       require #{File.expand_path("../../support/artifice/vcr.rb", __FILE__).dump}
-      require "bundler/inline"
+      require "#{lib}/bundler/inline"
       gemfile(true) do
         source "https://rubygems.org"
         gem "rails", path: "."

--- a/spec/runtime/inline_spec.rb
+++ b/spec/runtime/inline_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe "bundler/inline#gemfile" do
   def script(code, options = {})
-    requires = ["bundler/inline"]
+    requires = ["#{lib}/bundler/inline"]
     requires.unshift File.expand_path("../../support/artifice/" + options.delete(:artifice) + ".rb", __FILE__) if options.key?(:artifice)
     requires = requires.map {|r| "require '#{r}'" }.join("\n")
     @out = ruby("#{requires}\n\n" + code, options)
@@ -96,7 +96,7 @@ RSpec.describe "bundler/inline#gemfile" do
 
   it "lets me use my own ui object" do
     script <<-RUBY, :artifice => "endpoint"
-      require 'bundler'
+      require '#{lib}/bundler'
       class MyBundlerUI < Bundler::UI::Silent
         def confirm(msg, newline = nil)
           puts "CONFIRMED!"
@@ -140,7 +140,7 @@ RSpec.describe "bundler/inline#gemfile" do
 
   it "does not mutate the option argument" do
     script <<-RUBY
-      require 'bundler'
+      require '#{lib}/bundler'
       options = { :ui => Bundler::UI::Shell.new }
       gemfile(false, options) do
         path "#{lib_path}" do

--- a/spec/runtime/load_spec.rb
+++ b/spec/runtime/load_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe "Bundler.load" do
       G
 
       ruby! <<-RUBY
-        require "bundler"
+        require "#{lib}/bundler"
         Bundler.setup :default
         Bundler.require :default
         puts RACK

--- a/spec/runtime/require_spec.rb
+++ b/spec/runtime/require_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe "Bundler.require" do
       G
 
       cmd = <<-RUBY
-        require 'bundler'
+        require '#{lib}/bundler'
         Bundler.require
       RUBY
       ruby(cmd)

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Bundler.setup" do
       G
 
       ruby <<-RUBY
-        require 'bundler'
+        require '#{lib}/bundler'
         Bundler.setup
 
         require 'rack'
@@ -34,7 +34,7 @@ RSpec.describe "Bundler.setup" do
 
     it "doesn't make all groups available" do
       ruby <<-RUBY
-        require 'bundler'
+        require '#{lib}/bundler'
         Bundler.setup(:default)
 
         begin
@@ -49,7 +49,7 @@ RSpec.describe "Bundler.setup" do
 
     it "accepts string for group name" do
       ruby <<-RUBY
-        require 'bundler'
+        require '#{lib}/bundler'
         Bundler.setup(:default, 'test')
 
         require 'rack'
@@ -61,7 +61,7 @@ RSpec.describe "Bundler.setup" do
 
     it "leaves all groups available if they were already" do
       ruby <<-RUBY
-        require 'bundler'
+        require '#{lib}/bundler'
         Bundler.setup
         Bundler.setup(:default)
 
@@ -74,7 +74,7 @@ RSpec.describe "Bundler.setup" do
 
     it "leaves :default available if setup is called twice" do
       ruby <<-RUBY
-        require 'bundler'
+        require '#{lib}/bundler'
         Bundler.setup(:default)
         Bundler.setup(:default, :test)
 
@@ -91,7 +91,7 @@ RSpec.describe "Bundler.setup" do
 
     it "handles multiple non-additive invocations" do
       ruby <<-RUBY
-        require 'bundler'
+        require '#{lib}/bundler'
         Bundler.setup(:default, :test)
         Bundler.setup(:default)
         require 'rack'
@@ -122,7 +122,7 @@ RSpec.describe "Bundler.setup" do
       ENV["RUBYLIB"] = "rubylib_dir"
 
       ruby <<-RUBY
-        require 'bundler'
+        require '#{lib}/bundler'
         Bundler.setup
         puts $LOAD_PATH
       RUBY
@@ -144,7 +144,7 @@ RSpec.describe "Bundler.setup" do
       G
 
       ruby! <<-RUBY
-        require 'bundler'
+        require '#{lib}/bundler'
         Bundler.setup
         puts $LOAD_PATH
       RUBY
@@ -172,7 +172,7 @@ RSpec.describe "Bundler.setup" do
       G
 
       ruby! <<-RUBY
-        require 'bundler/setup'
+        require '#{lib}/bundler/setup'
         puts $LOAD_PATH
       RUBY
 
@@ -193,7 +193,7 @@ RSpec.describe "Bundler.setup" do
     G
 
     ruby <<-R
-      require 'bundler'
+      require '#{lib}/bundler'
 
       begin
         Bundler.setup
@@ -213,7 +213,7 @@ RSpec.describe "Bundler.setup" do
     G
 
     ruby <<-R
-      require 'bundler'
+      require '#{lib}/bundler'
 
       Bundler.setup
     R
@@ -236,7 +236,7 @@ RSpec.describe "Bundler.setup" do
     G
 
     ruby <<-R
-      require 'bundler'
+      require '#{lib}/bundler'
 
       Bundler.setup
     R
@@ -289,7 +289,7 @@ RSpec.describe "Bundler.setup" do
 
         ENV["BUNDLE_GEMFILE"] = "Gemfile"
         ruby <<-R
-          require 'bundler'
+          require '#{lib}/bundler'
 
           begin
             Bundler.setup
@@ -444,7 +444,7 @@ RSpec.describe "Bundler.setup" do
       break_git!
 
       ruby <<-R
-        require 'bundler'
+        require '#{lib}/bundler'
 
         begin
           Bundler.setup
@@ -465,7 +465,7 @@ RSpec.describe "Bundler.setup" do
       break_git!
 
       ruby <<-R
-        require "bundler"
+        require "#{lib}/bundler"
 
         begin
           Bundler.setup
@@ -774,7 +774,7 @@ end
         s.class.send(:define_method, :build_extensions) { nil }
       end
 
-      require 'bundler'
+      require '#{lib}/bundler'
       gem '#{gem_name}'
 
       puts $LOAD_PATH.count {|path| path =~ /#{gem_name}/} >= 2
@@ -1028,7 +1028,7 @@ end
       bundle "install"
 
       ruby <<-RUBY
-        require 'bundler'
+        require '#{lib}/bundler'
         def Bundler.require(path)
           raise "LOSE"
         end
@@ -1083,7 +1083,7 @@ end
     context "is not present" do
       it "does not change the lock" do
         lockfile lock_with(nil)
-        ruby "require 'bundler/setup'"
+        ruby "require '#{lib}/bundler/setup'"
         lockfile_should_be lock_with(nil)
       end
     end
@@ -1091,7 +1091,7 @@ end
     context "is newer" do
       it "does not change the lock or warn" do
         lockfile lock_with(Bundler::VERSION.succ)
-        ruby "require 'bundler/setup'"
+        ruby "require '#{lib}/bundler/setup'"
         expect(out).to eq("")
         expect(err).to eq("")
         lockfile_should_be lock_with(Bundler::VERSION.succ)
@@ -1101,7 +1101,7 @@ end
     context "is older" do
       it "does not change the lock" do
         lockfile lock_with("1.10.1")
-        ruby "require 'bundler/setup'"
+        ruby "require '#{lib}/bundler/setup'"
         lockfile_should_be lock_with("1.10.1")
       end
     end
@@ -1148,14 +1148,14 @@ end
 
     context "is not present" do
       it "does not change the lock" do
-        expect { ruby! "require 'bundler/setup'" }.not_to change { lockfile }
+        expect { ruby! "require '#{lib}/bundler/setup'" }.not_to change { lockfile }
       end
     end
 
     context "is newer" do
       let(:ruby_version) { "5.5.5" }
       it "does not change the lock or warn" do
-        expect { ruby! "require 'bundler/setup'" }.not_to change { lockfile }
+        expect { ruby! "require '#{lib}/bundler/setup'" }.not_to change { lockfile }
         expect(out).to eq("")
         expect(err).to eq("")
       end
@@ -1164,7 +1164,7 @@ end
     context "is older" do
       let(:ruby_version) { "1.0.0" }
       it "does not change the lock" do
-        expect { ruby! "require 'bundler/setup'" }.not_to change { lockfile }
+        expect { ruby! "require '#{lib}/bundler/setup'" }.not_to change { lockfile }
       end
     end
   end
@@ -1173,7 +1173,7 @@ end
     it "does not load Psych" do
       gemfile ""
       ruby <<-RUBY
-        require 'bundler/setup'
+        require '#{lib}/bundler/setup'
         puts defined?(Psych::VERSION) ? Psych::VERSION : "undefined"
         require 'psych'
         puts Psych::VERSION
@@ -1186,7 +1186,7 @@ end
     it "does not load openssl" do
       install_gemfile! ""
       ruby! <<-RUBY
-        require "bundler/setup"
+        require "#{lib}/bundler/setup"
         puts defined?(OpenSSL) || "undefined"
         require "openssl"
         puts defined?(OpenSSL) || "undefined"
@@ -1240,7 +1240,7 @@ end
 
       it "activates no gems with -rbundler/setup" do
         install_gemfile! ""
-        ruby! code, :env => { :RUBYOPT => activation_warning_hack_rubyopt + " -rbundler/setup" }
+        ruby! code, :env => { :RUBYOPT => activation_warning_hack_rubyopt + " -r#{lib}/bundler/setup" }
         expect(out).to eq("{}")
       end
 
@@ -1315,7 +1315,7 @@ end
       G
 
       ruby! <<-RUBY
-        require "bundler/setup"
+        require "#{lib}/bundler/setup"
         Object.new.gem "rack"
         puts Gem.loaded_specs["rack"].full_name
       RUBY
@@ -1330,7 +1330,7 @@ end
       G
 
       ruby <<-RUBY
-        require "bundler/setup"
+        require "#{lib}/bundler/setup"
         Object.new.gem "rack"
         puts "FAIL"
       RUBY
@@ -1346,7 +1346,7 @@ end
       G
 
       ruby <<-RUBY
-        require "bundler/setup"
+        require "#{lib}/bundler/setup"
         Object.new.require "rack"
         puts "FAIL"
       RUBY

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe "Bundler.setup" do
       G
 
       ruby <<-RUBY
-        require 'rubygems'
         require 'bundler'
         Bundler.setup
 
@@ -35,7 +34,6 @@ RSpec.describe "Bundler.setup" do
 
     it "doesn't make all groups available" do
       ruby <<-RUBY
-        require 'rubygems'
         require 'bundler'
         Bundler.setup(:default)
 
@@ -51,7 +49,6 @@ RSpec.describe "Bundler.setup" do
 
     it "accepts string for group name" do
       ruby <<-RUBY
-        require 'rubygems'
         require 'bundler'
         Bundler.setup(:default, 'test')
 
@@ -64,7 +61,6 @@ RSpec.describe "Bundler.setup" do
 
     it "leaves all groups available if they were already" do
       ruby <<-RUBY
-        require 'rubygems'
         require 'bundler'
         Bundler.setup
         Bundler.setup(:default)
@@ -78,7 +74,6 @@ RSpec.describe "Bundler.setup" do
 
     it "leaves :default available if setup is called twice" do
       ruby <<-RUBY
-        require 'rubygems'
         require 'bundler'
         Bundler.setup(:default)
         Bundler.setup(:default, :test)
@@ -127,7 +122,6 @@ RSpec.describe "Bundler.setup" do
       ENV["RUBYLIB"] = "rubylib_dir"
 
       ruby <<-RUBY
-        require 'rubygems'
         require 'bundler'
         Bundler.setup
         puts $LOAD_PATH
@@ -150,7 +144,6 @@ RSpec.describe "Bundler.setup" do
       G
 
       ruby! <<-RUBY
-        require 'rubygems'
         require 'bundler'
         Bundler.setup
         puts $LOAD_PATH
@@ -179,7 +172,6 @@ RSpec.describe "Bundler.setup" do
       G
 
       ruby! <<-RUBY
-        require 'rubygems'
         require 'bundler/setup'
         puts $LOAD_PATH
       RUBY
@@ -201,7 +193,6 @@ RSpec.describe "Bundler.setup" do
     G
 
     ruby <<-R
-      require 'rubygems'
       require 'bundler'
 
       begin
@@ -222,7 +213,6 @@ RSpec.describe "Bundler.setup" do
     G
 
     ruby <<-R
-      require 'rubygems'
       require 'bundler'
 
       Bundler.setup
@@ -246,7 +236,6 @@ RSpec.describe "Bundler.setup" do
     G
 
     ruby <<-R
-      require 'rubygems'
       require 'bundler'
 
       Bundler.setup
@@ -300,7 +289,6 @@ RSpec.describe "Bundler.setup" do
 
         ENV["BUNDLE_GEMFILE"] = "Gemfile"
         ruby <<-R
-          require 'rubygems'
           require 'bundler'
 
           begin
@@ -456,7 +444,6 @@ RSpec.describe "Bundler.setup" do
       break_git!
 
       ruby <<-R
-        require 'rubygems'
         require 'bundler'
 
         begin
@@ -478,7 +465,6 @@ RSpec.describe "Bundler.setup" do
       break_git!
 
       ruby <<-R
-        require "rubygems"
         require "bundler"
 
         begin
@@ -937,8 +923,6 @@ end
 
     it "does not pull in system gems" do
       run <<-R
-        require 'rubygems'
-
         begin;
           require 'rack'
         rescue LoadError
@@ -1221,7 +1205,6 @@ end
 
       let(:activation_warning_hack) { strip_whitespace(<<-RUBY) }
         require #{spec_dir.join("support/hax").to_s.dump}
-        require "rubygems"
 
         if Gem::Specification.instance_methods.map(&:to_sym).include?(:activate)
           Gem::Specification.send(:alias_method, :bundler_spec_activate, :activate)

--- a/spec/runtime/with_unbundled_env_spec.rb
+++ b/spec/runtime/with_unbundled_env_spec.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
 RSpec.describe "Bundler.with_env helpers" do
-  def bundle_exec_ruby!(code)
-    build_bundler_context
-    bundle! "exec '#{Gem.ruby}' -e #{code}"
+  def bundle_exec_ruby!(code, options = {})
+    build_bundler_context options
+    bundle! "exec '#{Gem.ruby}' -e #{code}", options
   end
 
-  def build_bundler_context
+  def build_bundler_context(options = {})
     bundle "config set path vendor/bundle"
     gemfile ""
-    bundle "install"
+    bundle "install", options
   end
 
   describe "Bundler.original_env" do
@@ -75,7 +75,7 @@ RSpec.describe "Bundler.with_env helpers" do
     it "should remove '-rbundler/setup' from RUBYOPT" do
       code = "print #{modified_env}['RUBYOPT']"
       ENV["RUBYOPT"] = "-W2 -rbundler/setup #{ENV["RUBYOPT"]}"
-      bundle_exec_ruby! code.dump
+      bundle_exec_ruby! code.dump, :env => { "BUNDLER_SPEC_DISABLE_DEFAULT_BUNDLER_GEM" => "true" }
       expect(last_command.stdboth).not_to include("-rbundler/setup")
     end
 

--- a/spec/support/artifice/endpoint.rb
+++ b/spec/support/artifice/endpoint.rb
@@ -44,7 +44,7 @@ class Endpoint < Sinatra::Base
     def dependencies_for(gem_names, gem_repo = GEM_REPO)
       return [] if gem_names.nil? || gem_names.empty?
 
-      require "bundler"
+      require "#{Spec::Path.lib}/bundler"
       Bundler::Deprecate.skip_during do
         all_specs = %w[specs.4.8 prerelease_specs.4.8].map do |filename|
           Marshal.load(File.open(gem_repo.join(filename)).read)

--- a/spec/support/artifice/endpoint.rb
+++ b/spec/support/artifice/endpoint.rb
@@ -44,7 +44,6 @@ class Endpoint < Sinatra::Base
     def dependencies_for(gem_names, gem_repo = GEM_REPO)
       return [] if gem_names.nil? || gem_names.empty?
 
-      require "rubygems"
       require "bundler"
       Bundler::Deprecate.skip_during do
         all_specs = %w[specs.4.8 prerelease_specs.4.8].map do |filename|

--- a/spec/support/hax.rb
+++ b/spec/support/hax.rb
@@ -11,7 +11,8 @@ module Gem
   end
   @platforms = [Gem::Platform::RUBY, Gem::Platform.local]
 
-  if defined?(@path_to_default_spec_map) && !ENV["BUNDLER_SPEC_KEEP_DEFAULT_BUNDLER_GEM"]
+  # We only need this hack for rubygems versions without the BundlerVersionFinder
+  if Gem::Version.new(Gem::VERSION) < Gem::Version.new("2.7.0") || ENV["BUNDLER_SPEC_DISABLE_DEFAULT_BUNDLER_GEM"]
     @path_to_default_spec_map.delete_if do |_path, spec|
       spec.name == "bundler"
     end

--- a/spec/support/hax.rb
+++ b/spec/support/hax.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "rubygems"
-
 module Gem
   if version = ENV["BUNDLER_SPEC_RUBYGEMS_VERSION"]
     remove_const(:VERSION) if const_defined?(:VERSION)

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -77,7 +77,7 @@ module Spec
     def run(cmd, *args)
       opts = args.last.is_a?(Hash) ? args.pop : {}
       groups = args.map(&:inspect).join(", ")
-      setup = "require 'bundler' ; Bundler.setup(#{groups})\n"
+      setup = "require '#{lib}/bundler' ; Bundler.setup(#{groups})\n"
       ruby(setup + cmd, opts)
     end
     bang :run

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -593,13 +593,5 @@ module Spec
       end
       port
     end
-
-    def bundler_fileutils
-      if RUBY_VERSION >= "2.4"
-        ::Bundler::FileUtils
-      else
-        ::FileUtils
-      end
-    end
   end
 end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that in some places, it was still possible to end up requiring files in a different copy of bundler (the default copy). I noticed this when I removed a rubygems monkeypatch from the test suite that was preventing the default copy of bundler from being activated when requiring files.

This thing:

https://github.com/bundler/bundler/blob/e1c518363641208429f397170354054b3d28effd/spec/support/hax.rb#L15-L20

### What was your diagnosis of the problem?

My diagnosis was that I should use relative requires wherever they were missing.

### What is your fix for the problem, implemented in this PR?

My fix is to remove the rubygems hack, migrate the rest of the internal requires to be relative, and also introduce some hacks on our specs to make sure we never load the incorrect copy of bundler.

I think this PR should fix the issues in https://github.com/rubygems/rubygems/pull/2863.
