### PR TITLE
Use the standard RUBY_ENGINE_VERSION instead of JRUBY_VERSION

### DIFF
--- a/lib/bundler/ruby_version.rb
+++ b/lib/bundler/ruby_version.rb
@@ -103,18 +103,8 @@ module Bundler
 
     def self.system
       ruby_engine = RUBY_ENGINE.dup
-      # :sob: mocking RUBY_VERSION breaks stuff on 1.8.7
       ruby_version = ENV.fetch("BUNDLER_SPEC_RUBY_VERSION") { RUBY_VERSION }.dup
-      ruby_engine_version = case ruby_engine
-                            when "ruby"
-                              ruby_version
-                            when "rbx"
-                              Rubinius::VERSION.dup
-                            when "jruby"
-                              JRUBY_VERSION.dup
-                            else
-                              RUBY_ENGINE_VERSION.dup
-      end
+      ruby_engine_version = RUBY_ENGINE_VERSION.dup
       patchlevel = RUBY_PATCHLEVEL.to_s
 
       @ruby_version ||= RubyVersion.new(ruby_version, patchlevel, ruby_engine, ruby_engine_version)

--- a/spec/bundler/ruby_version_spec.rb
+++ b/spec/bundler/ruby_version_spec.rb
@@ -427,7 +427,7 @@ RSpec.describe "Bundler::RubyVersion and its subclasses" do
 
       describe "#engine" do
         before { stub_const("RUBY_ENGINE", "jruby") }
-        before { stub_const("JRUBY_VERSION", "2.1.1") }
+        before { stub_const("RUBY_ENGINE_VERSION", "2.1.1") }
 
         it "should return a copy of the value of RUBY_ENGINE" do
           expect(subject.engine).to eq("jruby")
@@ -438,37 +438,37 @@ RSpec.describe "Bundler::RubyVersion and its subclasses" do
       describe "#engine_version" do
         context "engine is ruby" do
           before do
-            stub_const("RUBY_VERSION", "2.2.4")
+            stub_const("RUBY_ENGINE_VERSION", "2.2.4")
             stub_const("RUBY_ENGINE", "ruby")
           end
 
-          it "should return a copy of the value of RUBY_VERSION" do
+          it "should return a copy of the value of RUBY_ENGINE_VERSION" do
             expect(bundler_system_ruby_version.engine_versions).to eq(["2.2.4"])
-            expect(bundler_system_ruby_version.engine_versions.first).to_not be(RUBY_VERSION)
+            expect(bundler_system_ruby_version.engine_versions.first).to_not be(RUBY_ENGINE_VERSION)
           end
         end
 
         context "engine is rbx" do
           before do
             stub_const("RUBY_ENGINE", "rbx")
-            stub_const("Rubinius::VERSION", "2.0.0")
+            stub_const("RUBY_ENGINE_VERSION", "2.0.0")
           end
 
-          it "should return a copy of the value of Rubinius::VERSION" do
+          it "should return a copy of the value of RUBY_ENGINE_VERSION" do
             expect(bundler_system_ruby_version.engine_versions).to eq(["2.0.0"])
-            expect(bundler_system_ruby_version.engine_versions.first).to_not be(Rubinius::VERSION)
+            expect(bundler_system_ruby_version.engine_versions.first).to_not be(RUBY_ENGINE_VERSION)
           end
         end
 
         context "engine is jruby" do
           before do
             stub_const("RUBY_ENGINE", "jruby")
-            stub_const("JRUBY_VERSION", "2.1.1")
+            stub_const("RUBY_ENGINE_VERSION", "2.1.1")
           end
 
-          it "should return a copy of the value of JRUBY_VERSION" do
+          it "should return a copy of the value of RUBY_ENGINE_VERSION" do
             expect(subject.engine_versions).to eq(["2.1.1"])
-            expect(bundler_system_ruby_version.engine_versions.first).to_not be(JRUBY_VERSION)
+            expect(bundler_system_ruby_version.engine_versions.first).to_not be(RUBY_ENGINE_VERSION)
           end
         end
 

--- a/spec/support/hax.rb
+++ b/spec/support/hax.rb
@@ -53,9 +53,7 @@ class Object
     remove_const :RUBY_ENGINE
     RUBY_ENGINE = ENV["BUNDLER_SPEC_RUBY_ENGINE"]
 
-    if RUBY_ENGINE == "jruby"
-      remove_const :JRUBY_VERSION if defined?(JRUBY_VERSION)
-      JRUBY_VERSION = ENV["BUNDLER_SPEC_RUBY_ENGINE_VERSION"]
-    end
+    remove_const :RUBY_ENGINE_VERSION
+    RUBY_ENGINE_VERSION = ENV["BUNDLER_SPEC_RUBY_ENGINE_VERSION"]
   end
 end

--- a/spec/support/platforms.rb
+++ b/spec/support/platforms.rb
@@ -71,16 +71,7 @@ module Spec
     def local_engine_version
       return ENV["BUNDLER_SPEC_RUBY_ENGINE_VERSION"] if ENV["BUNDLER_SPEC_RUBY_ENGINE_VERSION"]
 
-      case local_ruby_engine
-      when "ruby"
-        RUBY_VERSION
-      when "rbx"
-        Rubinius::VERSION
-      when "jruby"
-        JRUBY_VERSION
-      else
-        RUBY_ENGINE_VERSION
-      end
+      RUBY_ENGINE_VERSION
     end
 
     def not_local_engine_version


### PR DESCRIPTION
* RUBY_ENGINE and RUBY_ENGINE_VERSION are defined on every modern Ruby.
* There is no such constant as TRUFFLERUBY_VERSION or RBX_VERSION.

This blocks https://github.com/rubygems/rubygems/pull/2797.
Also see https://github.com/rubygems/rubygems/pull/2864