### PR TITLE
Enable retries on flaky spec

### DIFF
--- a/spec/realworld/double_check_spec.rb
+++ b/spec/realworld/double_check_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "double checking sources", :realworld => true do
+RSpec.describe "double checking sources", :realworld => true, :sometimes => true do
   it "finds already-installed gems" do
     create_file("rails.gemspec", <<-RUBY)
       Gem::Specification.new do |s|


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that master is unstable right now, and build fails a number of times. That makes merging PRs annoying because they have to be retried many times.

### What was your diagnosis of the problem?

I'm currently investigating what's going on and found the first root cause. Sometimes specs end up falling back to the old dependency API, and we have no recorded cassettes for those request, so specs fail because those never recorded specs are not allowed to be performed. I'm now invetigating the cause for that and I have a hypothesis: previous specs are sometimes messing up the test user home, and that's why we're falling back.

I yet need to validate this hypothesis and find a fix, but I discovered that we have a mechanism in place for retrying failed specs.

### What is your fix for the problem, implemented in this PR?

My fix is to enable the mechanism for the time being to reduce flakyness of our CI and unblock other PRs

### Why did you choose this fix out of the possible options?

I chose this fix because I don't want other finished PRs to have to wait for me fixing this, or to have to be retried many times so that they can be merged.
