### PR TITLE
Improve load path order spec

### DIFF
--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe "Bundler.setup" do
     def clean_load_path(lp)
       without_bundler_load_path = ruby!("puts $LOAD_PATH").split("\n")
       lp -= without_bundler_load_path
-      lp.map! {|p| p.sub(/^#{Regexp.union system_gem_path.to_s, default_bundle_path.to_s}/i, "") }
+      lp.map! {|p| p.sub(/^#{Regexp.union system_gem_path.to_s, default_bundle_path.to_s, bundler_path.to_s}/i, "") }
     end
 
     it "puts loaded gems after -I and RUBYLIB", :ruby_repo do
@@ -142,6 +142,8 @@ RSpec.describe "Bundler.setup" do
     end
 
     it "orders the load path correctly when there are dependencies" do
+      system_gems :bundler
+
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rails"
@@ -158,6 +160,7 @@ RSpec.describe "Bundler.setup" do
 
       expect(load_path).to start_with(
         "/gems/rails-2.3.2/lib",
+        "/gems/bundler-#{Bundler::VERSION}/lib",
         "/gems/activeresource-2.3.2/lib",
         "/gems/activerecord-2.3.2/lib",
         "/gems/actionpack-2.3.2/lib",

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -113,12 +113,7 @@ RSpec.describe "Bundler.setup" do
   context "load order" do
     def clean_load_path(lp)
       without_bundler_load_path = ruby!("puts $LOAD_PATH").split("\n")
-      lp = lp - [
-        bundler_path.to_s,
-        bundler_path.join("gems/bundler-#{Bundler::VERSION}/lib").to_s,
-        tmp("rubygems/lib").to_s,
-        root.join("../lib").expand_path.to_s,
-      ] - without_bundler_load_path
+      lp -= without_bundler_load_path
       lp.map! {|p| p.sub(/^#{Regexp.union system_gem_path.to_s, default_bundle_path.to_s}/i, "") }
     end
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was for a while I've had a spec failing locally and that's annoying.

### What was your diagnosis of the problem?

My diagnosis was that if you install a development version of bundler in your system (through `bin/rake install:local`), this spec starts failing with:

``` 
 $ bin/rspec -e "orders the load pa"
Run options: include {:full_description=>/orders\ the\ load\ pa/}

Randomized with seed 55764

Bundler.setup
  load order
$ /home/deivid/.rbenv/versions/2.6.3/bin/ruby \
  -I/home/deivid/Code/bundler/lib:/home/deivid/Code/bundler/spec -rsupport/hax \
  -r/home/deivid/Code/bundler/spec/support/artifice/fail /home/deivid/Code/bundler/exe/bundle \
  install --retry 0
Fetching source index from file:///home/deivid/Code/bundler/tmp/gems/remote1/
Resolving dependencies...
Fetching rake 12.3.2
Installing rake 12.3.2
Fetching activesupport 2.3.2
Installing activesupport 2.3.2
Fetching actionmailer 2.3.2
Installing actionmailer 2.3.2
Fetching actionpack 2.3.2
Installing actionpack 2.3.2
Fetching activerecord 2.3.2
Installing activerecord 2.3.2
Fetching activeresource 2.3.2
Installing activeresource 2.3.2
Using bundler 2.1.0.pre.1
Fetching rails 2.3.2
Installing rails 2.3.2
Bundle complete! 1 Gemfile dependency, 8 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
# $? => 0

$ /home/deivid/.rbenv/versions/2.6.3/bin/ruby -I/home/deivid/Code/bundler/lib -e  \
  <<EOS
          require 'rubygems'
          require 'bundler'
          Bundler.setup
          puts $LOAD_PATH
EOS
/home/deivid/Code/bundler/lib
/home/deivid/.rbenv/rbenv.d/exec/gem-rehash
/home/deivid/Code/bundler/tmp/gems/system/gems/rails-2.3.2/lib
/home/deivid/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bundler-2.1.0.pre.1/lib
/home/deivid/Code/bundler/tmp/gems/system/gems/activeresource-2.3.2/lib
/home/deivid/Code/bundler/tmp/gems/system/gems/activerecord-2.3.2/lib
/home/deivid/Code/bundler/tmp/gems/system/gems/actionpack-2.3.2/lib
/home/deivid/Code/bundler/tmp/gems/system/gems/actionmailer-2.3.2/lib
/home/deivid/Code/bundler/tmp/gems/system/gems/activesupport-2.3.2/lib
/home/deivid/Code/bundler/tmp/gems/system/gems/rake-12.3.2/lib
/home/deivid/.rbenv/versions/2.6.3/lib/ruby/site_ruby/2.6.0
/home/deivid/.rbenv/versions/2.6.3/lib/ruby/site_ruby/2.6.0/x86_64-linux
/home/deivid/.rbenv/versions/2.6.3/lib/ruby/site_ruby
/home/deivid/.rbenv/versions/2.6.3/lib/ruby/vendor_ruby/2.6.0
/home/deivid/.rbenv/versions/2.6.3/lib/ruby/vendor_ruby/2.6.0/x86_64-linux
/home/deivid/.rbenv/versions/2.6.3/lib/ruby/vendor_ruby
/home/deivid/.rbenv/versions/2.6.3/lib/ruby/2.6.0
/home/deivid/.rbenv/versions/2.6.3/lib/ruby/2.6.0/x86_64-linux
# $? => 0

$ /home/deivid/.rbenv/versions/2.6.3/bin/ruby -I/home/deivid/Code/bundler/lib -e puts\ \$LOAD_PATH
/home/deivid/Code/bundler/lib
/home/deivid/.rbenv/rbenv.d/exec/gem-rehash
/home/deivid/.rbenv/versions/2.6.3/lib/ruby/site_ruby/2.6.0
/home/deivid/.rbenv/versions/2.6.3/lib/ruby/site_ruby/2.6.0/x86_64-linux
/home/deivid/.rbenv/versions/2.6.3/lib/ruby/site_ruby
/home/deivid/.rbenv/versions/2.6.3/lib/ruby/vendor_ruby/2.6.0
/home/deivid/.rbenv/versions/2.6.3/lib/ruby/vendor_ruby/2.6.0/x86_64-linux
/home/deivid/.rbenv/versions/2.6.3/lib/ruby/vendor_ruby
/home/deivid/.rbenv/versions/2.6.3/lib/ruby/2.6.0
/home/deivid/.rbenv/versions/2.6.3/lib/ruby/2.6.0/x86_64-linux
# $? => 0
    orders the load path correctly when there are dependencies (FAILED - 1)


Retried examples: 0

Failures:

  1) Bundler.setup load order orders the load path correctly when there are dependencies
     Failure/Error:
       expect(load_path).to start_with(
         "/gems/rails-2.3.2/lib",
         "/gems/activeresource-2.3.2/lib",
         "/gems/activerecord-2.3.2/lib",
         "/gems/actionpack-2.3.2/lib",
         "/gems/actionmailer-2.3.2/lib",
         "/gems/activesupport-2.3.2/lib",
         "/gems/rake-12.3.2/lib"
       )
     
       expected ["/gems/rails-2.3.2/lib", "/home/deivid/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bundler-2.1.0.....3.2/lib", "/gems/actionmailer-2.3.2/lib", "/gems/activesupport-2.3.2/lib", "/gems/rake-12.3.2/lib"] to start with "/gems/rails-2.3.2/lib", "/gems/activeresource-2.3.2/lib", "/gems/activerecord-2.3.2/lib", "/gems/actionpack-2.3.2/lib", "/gems/actionmailer-2.3.2/lib", "/gems/activesupport-2.3.2/lib", and "/gems/rake-12.3.2/lib"
     
       Commands:
       $ /home/deivid/.rbenv/versions/2.6.3/bin/ruby \
         -I/home/deivid/Code/bundler/lib:/home/deivid/Code/bundler/spec -rsupport/hax \
         -r/home/deivid/Code/bundler/spec/support/artifice/fail /home/deivid/Code/bundler/exe/bundle \
         install --retry 0
       Fetching source index from file:///home/deivid/Code/bundler/tmp/gems/remote1/
       Resolving dependencies...
       Fetching rake 12.3.2
       Installing rake 12.3.2
       Fetching activesupport 2.3.2
       Installing activesupport 2.3.2
       Fetching actionmailer 2.3.2
       Installing actionmailer 2.3.2
       Fetching actionpack 2.3.2
       Installing actionpack 2.3.2
       Fetching activerecord 2.3.2
       Installing activerecord 2.3.2
       Fetching activeresource 2.3.2
       Installing activeresource 2.3.2
       Using bundler 2.1.0.pre.1
       Fetching rails 2.3.2
       Installing rails 2.3.2
       Bundle complete! 1 Gemfile dependency, 8 gems now installed.
       Use `bundle info [gemname]` to see where a bundled gem is installed.
       # $? => 0
     
       $ /home/deivid/.rbenv/versions/2.6.3/bin/ruby -I/home/deivid/Code/bundler/lib -e  \
         <<EOS
                 require 'rubygems'
                 require 'bundler'
                 Bundler.setup
                 puts $LOAD_PATH
       EOS
       /home/deivid/Code/bundler/lib
       /home/deivid/.rbenv/rbenv.d/exec/gem-rehash
       /home/deivid/Code/bundler/tmp/gems/system/gems/rails-2.3.2/lib
       /home/deivid/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bundler-2.1.0.pre.1/lib
       /home/deivid/Code/bundler/tmp/gems/system/gems/activeresource-2.3.2/lib
       /home/deivid/Code/bundler/tmp/gems/system/gems/activerecord-2.3.2/lib
       /home/deivid/Code/bundler/tmp/gems/system/gems/actionpack-2.3.2/lib
       /home/deivid/Code/bundler/tmp/gems/system/gems/actionmailer-2.3.2/lib
       /home/deivid/Code/bundler/tmp/gems/system/gems/activesupport-2.3.2/lib
       /home/deivid/Code/bundler/tmp/gems/system/gems/rake-12.3.2/lib
       /home/deivid/.rbenv/versions/2.6.3/lib/ruby/site_ruby/2.6.0
       /home/deivid/.rbenv/versions/2.6.3/lib/ruby/site_ruby/2.6.0/x86_64-linux
       /home/deivid/.rbenv/versions/2.6.3/lib/ruby/site_ruby
       /home/deivid/.rbenv/versions/2.6.3/lib/ruby/vendor_ruby/2.6.0
       /home/deivid/.rbenv/versions/2.6.3/lib/ruby/vendor_ruby/2.6.0/x86_64-linux
       /home/deivid/.rbenv/versions/2.6.3/lib/ruby/vendor_ruby
       /home/deivid/.rbenv/versions/2.6.3/lib/ruby/2.6.0
       /home/deivid/.rbenv/versions/2.6.3/lib/ruby/2.6.0/x86_64-linux
       # $? => 0
     
       $ /home/deivid/.rbenv/versions/2.6.3/bin/ruby -I/home/deivid/Code/bundler/lib -e puts\ \$LOAD_PATH
       /home/deivid/Code/bundler/lib
       /home/deivid/.rbenv/rbenv.d/exec/gem-rehash
       /home/deivid/.rbenv/versions/2.6.3/lib/ruby/site_ruby/2.6.0
       /home/deivid/.rbenv/versions/2.6.3/lib/ruby/site_ruby/2.6.0/x86_64-linux
       /home/deivid/.rbenv/versions/2.6.3/lib/ruby/site_ruby
       /home/deivid/.rbenv/versions/2.6.3/lib/ruby/vendor_ruby/2.6.0
       /home/deivid/.rbenv/versions/2.6.3/lib/ruby/vendor_ruby/2.6.0/x86_64-linux
       /home/deivid/.rbenv/versions/2.6.3/lib/ruby/vendor_ruby
       /home/deivid/.rbenv/versions/2.6.3/lib/ruby/2.6.0
       /home/deivid/.rbenv/versions/2.6.3/lib/ruby/2.6.0/x86_64-linux
       # $? => 0
     # ./spec/runtime/setup_spec.rb:164:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:127:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:96:in `block (2 levels) in <top (required)>'
     # ./spec/support/rubygems_ext.rb:43:in `load'
     # ./spec/support/rubygems_ext.rb:43:in `gem_load'

Finished in 0.82951 seconds (files took 1.17 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/runtime/setup_spec.rb:149 # Bundler.setup load order orders the load path correctly when there are dependencies

Randomized with seed 55764
```

This is because the development version of bundler installed gets activated and that messes up the load path assertion.
 
### What is your fix for the problem, implemented in this PR?

My fix is to build the development bundler gem, install it to `tmp/system` and make sure that version gets activated. And include that in the test assertion.

### Why did you choose this fix out of the possible options?

I chose this fix because it makes the spec independent from the developer's environment.
