### PR TITLE
Bump rspec dependency to 3.8

### DIFF
--- a/spec/support/rubygems_ext.rb
+++ b/spec/support/rubygems_ext.rb
@@ -10,7 +10,7 @@ module Spec
       "automatiek" => "~> 0.2.0",
       "rake" => "~> 12.0",
       "ronn" => "~> 0.7.3",
-      "rspec" => "~> 3.6",
+      "rspec" => "~> 3.8",
       "rubocop" => "= 0.74.0",
       "rubocop-performance" => "= 1.4.0",
     }.freeze


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that tests fail using rspec 3.7 or older.

### What was your diagnosis of the problem?

My diagnosis was that we're using `config.bisect_runner` which is only available from 3.8.

### What is your fix for the problem, implemented in this PR?

My fix is to bump the requirement.