### PR TITLE
Fix documents to refer to URLs with https

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -3,7 +3,7 @@ newPRWelcomeComment: |
 
   We use Travis CI to test and make sure your change works functionally and uses acceptable conventions, you can review the current progress of Travis CI in the PR status window below.
 
-  If you have any questions or concerns that you wish to ask, feel free to leave a comment in this PR or join our #bundler channel on [Slack](http://slack.bundler.io/).
+  If you have any questions or concerns that you wish to ask, feel free to leave a comment in this PR or join our #bundler channel on [Slack](https://slack.bundler.io/).
 
   For more information about contributing to the Bundler project feel free to review our [CONTRIBUTING](https://github.com/bundler/bundler/blob/master/doc/contributing/README.md) guide
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -131,6 +131,6 @@ Sometimes, though, you need to get admins involved. Admins will do their best to
 
 ## Attribution
 
-This Code of Conduct is adapted from the [package.community Code of Conduct], adapted from the [WeAllJS Code of Conduct](https://wealljs.org/code-of-conduct), itself adapted from [Contributor Covenant](http://contributor-covenant.org) version 1.4, available at [http://contributor-covenant.org/version/1/4](http://contributor-covenant.org/version/1/4), as well as the LGBTQ in Technology Slack [Code of Conduct](http://lgbtq.technology/coc.html).
+This Code of Conduct is adapted from the [package.community Code of Conduct], adapted from the [WeAllJS Code of Conduct](https://wealljs.org/code-of-conduct), itself adapted from [Contributor Covenant](https://contributor-covenant.org) version 1.4, available at [https://contributor-covenant.org/version/1/4](https://contributor-covenant.org/version/1/4), as well as the LGBTQ in Technology Slack [Code of Conduct](https://lgbtq.technology/coc.html).
 
-Additional thanks to [Contributor Covenant](http://contributor-covenant.org) for the [default code of conduct](https://github.com/bundler/bundler/blob/master/lib/bundler/templates/newgem/CODE_OF_CONDUCT.md.tt) included in generated gems.
+Additional thanks to [Contributor Covenant](https://contributor-covenant.org) for the [default code of conduct](https://github.com/bundler/bundler/blob/master/lib/bundler/templates/newgem/CODE_OF_CONDUCT.md.tt) included in generated gems.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Version     ](https://img.shields.io/gem/v/bundler.svg?style=flat)](https://rubygems.org/gems/bundler)
 [![Build Status](https://img.shields.io/travis/bundler/bundler/master.svg?style=flat)](https://travis-ci.org/bundler/bundler)
-[![Inline docs ](http://inch-ci.org/github/bundler/bundler.svg?style=flat)](http://inch-ci.org/github/bundler/bundler)
-[![Slack       ](http://bundler-slackin.herokuapp.com/badge.svg)](http://bundler-slackin.herokuapp.com)
+[![Inline docs ](https://inch-ci.org/github/bundler/bundler.svg?style=flat)](https://inch-ci.org/github/bundler/bundler)
+[![Slack       ](https://bundler-slackin.herokuapp.com/badge.svg)](https://bundler-slackin.herokuapp.com)
 
 # Bundler: a gem to bundle gems
 

--- a/doc/contributing/COMMUNITY.md
+++ b/doc/contributing/COMMUNITY.md
@@ -2,7 +2,7 @@
 
 Community is an important part of all we do. If you'd like to be part of the Bundler community, you can jump right in and start helping make Bundler better for everyone who uses it.
 
-It would be tremendously helpful to have more people answering questions about Bundler (and often simply about [RubyGems](https://github.com/rubygems/rubygems) or Ruby itself) in our [issue tracker](https://github.com/bundler/bundler/issues) or on [Stack Overflow](http://stackoverflow.com/questions/tagged/bundler).
+It would be tremendously helpful to have more people answering questions about Bundler (and often simply about [RubyGems](https://github.com/rubygems/rubygems) or Ruby itself) in our [issue tracker](https://github.com/bundler/bundler/issues) or on [Stack Overflow](https://stackoverflow.com/questions/tagged/bundler).
 
 Additional documentation and explanation is always helpful, too. If you have any suggestions for the Bundler website [bundler.io](https://bundler.io), we would absolutely love it if you opened an issue or pull request on the [bundler-site](https://github.com/bundler/bundler-site) repository.
 

--- a/doc/contributing/GETTING_HELP.md
+++ b/doc/contributing/GETTING_HELP.md
@@ -6,6 +6,6 @@ The best ways to get in touch are:
 
 * [Bundler Slack](https://bundler.slack.com).
   * Not a member of the Slack? Join the Bundler team slack [here](https://slack.bundler.io/)!
-* [Bundler mailing list](http://groups.google.com/group/ruby-bundler)
+* [Bundler mailing list](https://groups.google.com/group/ruby-bundler)
 
 You may also find our guide on [filing issues](ISSUES.md) to be helpful as well!

--- a/doc/development/NEW_FEATURES.md
+++ b/doc/development/NEW_FEATURES.md
@@ -3,7 +3,7 @@
 If you would like to add a new feature to Bundler, please follow these steps:
 
   1. [Create an issue](https://github.com/bundler/bundler/issues/new) with the [`feature-request` label](https://github.com/bundler/bundler/labels/type:%20feature-request) to discuss your feature.
-  2. Base your commits on the master branch, since we follow [SemVer](http://semver.org) and don't add new features to old releases.
+  2. Base your commits on the master branch, since we follow [SemVer](https://semver.org) and don't add new features to old releases.
   3. Commit the code and at least one test covering your changes to a feature branch in your fork.
   4. Send us a [pull request](PULL_REQUESTS.md) from your feature branch.
 

--- a/doc/documentation/VISION.md
+++ b/doc/documentation/VISION.md
@@ -5,7 +5,7 @@ Currently, documentation for using Bundler is spread across two places:
 1. built-in `help` (including usage information and man pages)
 2. [Bundler documentation site](https://bundler.io)
 
-Additional documentation about using Bundler to publish gems can also be found on the [RubyGems guides](http://guides.rubygems.org/).
+Additional documentation about using Bundler to publish gems can also be found on the [RubyGems guides](https://guides.rubygems.org/).
 
 ## Goals
 

--- a/doc/playbooks/RELEASING.md
+++ b/doc/playbooks/RELEASING.md
@@ -142,6 +142,6 @@ We :heart: testers, and are big fans of anyone who can run `gem install bundler 
 and try out upcoming releases in their development and staging environments.
 
 There may not always be prereleases or beta versions of Bundler.
-The Bundler team will tweet from the [@bundlerio account](http://twitter.com/bundlerio)
+The Bundler team will tweet from the [@bundlerio account](https://twitter.com/bundlerio)
 when a prerelease or beta version becomes available. You are also always welcome to try
 checking out master and building a gem yourself if you want to try out the latest changes.


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

End-users experience 301 redirect,  or unintentionally visit URL with http and may send email.

### What was your diagnosis of the problem?

I noticed the problem when I was reading codes. Following are some examples using curl to explain this problem.

```
curl -I http://slack.bundler.io/
HTTP/1.1 200 OK
Server: Cowboy
Connection: keep-alive
X-Powered-By: Express
Content-Type: text/html; charset=utf-8
Content-Length: 3726
Etag: W/"3Shz0DQR5y/DyBrYbyUBAQ=="
Date: Fri, 09 Aug 2019 14:16:23 GMT
Via: 1.1 vegur
```
```
curl -I http://contributor-covenant.org
HTTP/1.1 301 Moved Permanently
Cache-Control: public, max-age=0, must-revalidate
Content-Length: 49
Content-Type: text/plain
Date: Sun, 04 Aug 2019 09:47:02 GMT
Location: https://contributor-covenant.org/
Age: 448201
Connection: keep-alive
Server: Netlify
X-NF-Request-ID: 3de60b71-391e-4a6e-8cd4-74a12f217c80-14980829
```

### What is your fix for the problem, implemented in this PR?

My fix is to replace http URLs with https URLs.

### Why did you choose this fix out of the possible options?

It's because this fix is simple and easy.
