### PR TITLE
Fix typo in comment: attibutes -> attributes

### DIFF
--- a/lib/bundler/plugin/api/source.rb
+++ b/lib/bundler/plugin/api/source.rb
@@ -196,7 +196,7 @@ module Bundler
         # This shall check if two source object represent the same source.
         #
         # The comparison shall take place only on the attribute that can be
-        # inferred from the options passed from Gemfile and not on attibutes
+        # inferred from the options passed from Gemfile and not on attributes
         # that are used to pin down the gem to specific version (e.g. Git
         # sources should compare on branch and tag but not on commit hash)
         #


### PR DESCRIPTION
Let me skip answering questions in the pull request template since it's obviously just fixing a typo!
