### PR TITLE
Give a more clear error when user tries to `bundle open` a default gem

### DIFF
--- a/lib/bundler/cli/open.rb
+++ b/lib/bundler/cli/open.rb
@@ -14,10 +14,10 @@ module Bundler
       editor = [ENV["BUNDLER_EDITOR"], ENV["VISUAL"], ENV["EDITOR"]].find {|e| !e.nil? && !e.empty? }
       return Bundler.ui.info("To open a bundled gem, set $EDITOR or $BUNDLER_EDITOR") unless editor
       return unless spec = Bundler::CLI::Common.select_spec(name, :regex_match)
-      path = spec.full_gem_path
       if spec.default_gem?
         Bundler.ui.info "Unable to open #{name} because it's a default gem, so the directory it would normally be installed to does not exist."
       else
+        path = spec.full_gem_path
         Dir.chdir(path) do
           command = Shellwords.split(editor) + [path]
           Bundler.with_original_env do

--- a/lib/bundler/cli/open.rb
+++ b/lib/bundler/cli/open.rb
@@ -15,11 +15,15 @@ module Bundler
       return Bundler.ui.info("To open a bundled gem, set $EDITOR or $BUNDLER_EDITOR") unless editor
       return unless spec = Bundler::CLI::Common.select_spec(name, :regex_match)
       path = spec.full_gem_path
-      Dir.chdir(path) do
-        command = Shellwords.split(editor) + [path]
-        Bundler.with_original_env do
-          system(*command)
-        end || Bundler.ui.info("Could not run '#{command.join(" ")}'")
+      if spec.default_gem?
+        Bundler.ui.info "Unable to open #{name} because it's a default gem, so the directory it would normally be installed to does not exist."
+      else
+        Dir.chdir(path) do
+          command = Shellwords.split(editor) + [path]
+          Bundler.with_original_env do
+            system(*command)
+          end || Bundler.ui.info("Could not run '#{command.join(" ")}'")
+        end
       end
     end
   end

--- a/spec/commands/open_spec.rb
+++ b/spec/commands/open_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe "bundle open" do
-  before :each do
+  before do
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
       gem "rails"

--- a/spec/commands/open_spec.rb
+++ b/spec/commands/open_spec.rb
@@ -91,4 +91,17 @@ RSpec.describe "bundle open" do
       expect(out).not_to include("BUNDLE_GEMFILE=")
     end
   end
+
+  context "when opening a default gem" do
+    before do
+      install_gemfile <<-G
+        gem "json"
+      G
+    end
+
+    it "throws proper error when trying to open default gem" do
+      bundle "open json", :env => { "EDITOR" => "echo editor", "VISUAL" => "echo visual", "BUNDLER_EDITOR" => "echo bundler_editor" }
+      expect(out).to include("Unable to open json because it's a default gem, so the directory it would normally be installed to does not exist.")
+    end
+  end
 end

--- a/spec/commands/open_spec.rb
+++ b/spec/commands/open_spec.rb
@@ -1,92 +1,94 @@
 # frozen_string_literal: true
 
 RSpec.describe "bundle open" do
-  before do
-    install_gemfile <<-G
-      source "#{file_uri_for(gem_repo1)}"
-      gem "rails"
-    G
-  end
-
-  it "opens the gem with BUNDLER_EDITOR as highest priority" do
-    bundle "open rails", :env => { "EDITOR" => "echo editor", "VISUAL" => "echo visual", "BUNDLER_EDITOR" => "echo bundler_editor" }
-    expect(out).to include("bundler_editor #{default_bundle_path("gems", "rails-2.3.2")}")
-  end
-
-  it "opens the gem with VISUAL as 2nd highest priority" do
-    bundle "open rails", :env => { "EDITOR" => "echo editor", "VISUAL" => "echo visual", "BUNDLER_EDITOR" => "" }
-    expect(out).to include("visual #{default_bundle_path("gems", "rails-2.3.2")}")
-  end
-
-  it "opens the gem with EDITOR as 3rd highest priority" do
-    bundle "open rails", :env => { "EDITOR" => "echo editor", "VISUAL" => "", "BUNDLER_EDITOR" => "" }
-    expect(out).to include("editor #{default_bundle_path("gems", "rails-2.3.2")}")
-  end
-
-  it "complains if no EDITOR is set" do
-    bundle "open rails", :env => { "EDITOR" => "", "VISUAL" => "", "BUNDLER_EDITOR" => "" }
-    expect(out).to eq("To open a bundled gem, set $EDITOR or $BUNDLER_EDITOR")
-  end
-
-  it "complains if gem not in bundle" do
-    bundle "open missing", :env => { "EDITOR" => "echo editor", "VISUAL" => "", "BUNDLER_EDITOR" => "" }
-    expect(err).to match(/could not find gem 'missing'/i)
-  end
-
-  it "does not blow up if the gem to open does not have a Gemfile" do
-    git = build_git "foo"
-    ref = git.ref_for("master", 11)
-
-    install_gemfile <<-G
-      source "#{file_uri_for(gem_repo1)}"
-      gem 'foo', :git => "#{lib_path("foo-1.0")}"
-    G
-
-    bundle "open foo", :env => { "EDITOR" => "echo editor", "VISUAL" => "", "BUNDLER_EDITOR" => "" }
-    expect(out).to match("editor #{default_bundle_path.join("bundler/gems/foo-1.0-#{ref}")}")
-  end
-
-  it "suggests alternatives for similar-sounding gems" do
-    bundle "open Rails", :env => { "EDITOR" => "echo editor", "VISUAL" => "", "BUNDLER_EDITOR" => "" }
-    expect(err).to match(/did you mean rails\?/i)
-  end
-
-  it "opens the gem with short words" do
-    bundle "open rec", :env => { "EDITOR" => "echo editor", "VISUAL" => "echo visual", "BUNDLER_EDITOR" => "echo bundler_editor" }
-
-    expect(out).to include("bundler_editor #{default_bundle_path("gems", "activerecord-2.3.2")}")
-  end
-
-  it "select the gem from many match gems" do
-    env = { "EDITOR" => "echo editor", "VISUAL" => "echo visual", "BUNDLER_EDITOR" => "echo bundler_editor" }
-    bundle "open active", :env => env do |input, _, _|
-      input.puts "2"
+  context "when opening a regular gem" do
+    before do
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gem "rails"
+      G
     end
 
-    expect(out).to match(/bundler_editor #{default_bundle_path('gems', 'activerecord-2.3.2')}\z/)
-  end
-
-  it "allows selecting exit from many match gems" do
-    env = { "EDITOR" => "echo editor", "VISUAL" => "echo visual", "BUNDLER_EDITOR" => "echo bundler_editor" }
-    bundle! "open active", :env => env do |input, _, _|
-      input.puts "0"
+    it "opens the gem with BUNDLER_EDITOR as highest priority" do
+      bundle "open rails", :env => { "EDITOR" => "echo editor", "VISUAL" => "echo visual", "BUNDLER_EDITOR" => "echo bundler_editor" }
+      expect(out).to include("bundler_editor #{default_bundle_path("gems", "rails-2.3.2")}")
     end
-  end
 
-  it "performs an automatic bundle install" do
-    gemfile <<-G
-      source "#{file_uri_for(gem_repo1)}"
-      gem "rails"
-      gem "foo"
-    G
+    it "opens the gem with VISUAL as 2nd highest priority" do
+      bundle "open rails", :env => { "EDITOR" => "echo editor", "VISUAL" => "echo visual", "BUNDLER_EDITOR" => "" }
+      expect(out).to include("visual #{default_bundle_path("gems", "rails-2.3.2")}")
+    end
 
-    bundle "config set auto_install 1"
-    bundle "open rails", :env => { "EDITOR" => "echo editor", "VISUAL" => "", "BUNDLER_EDITOR" => "" }
-    expect(out).to include("Installing foo 1.0")
-  end
+    it "opens the gem with EDITOR as 3rd highest priority" do
+      bundle "open rails", :env => { "EDITOR" => "echo editor", "VISUAL" => "", "BUNDLER_EDITOR" => "" }
+      expect(out).to include("editor #{default_bundle_path("gems", "rails-2.3.2")}")
+    end
 
-  it "opens the editor with a clean env" do
-    bundle "open", :env => { "EDITOR" => "sh -c 'env'", "VISUAL" => "", "BUNDLER_EDITOR" => "" }
-    expect(out).not_to include("BUNDLE_GEMFILE=")
+    it "complains if no EDITOR is set" do
+      bundle "open rails", :env => { "EDITOR" => "", "VISUAL" => "", "BUNDLER_EDITOR" => "" }
+      expect(out).to eq("To open a bundled gem, set $EDITOR or $BUNDLER_EDITOR")
+    end
+
+    it "complains if gem not in bundle" do
+      bundle "open missing", :env => { "EDITOR" => "echo editor", "VISUAL" => "", "BUNDLER_EDITOR" => "" }
+      expect(err).to match(/could not find gem 'missing'/i)
+    end
+
+    it "does not blow up if the gem to open does not have a Gemfile" do
+      git = build_git "foo"
+      ref = git.ref_for("master", 11)
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gem 'foo', :git => "#{lib_path("foo-1.0")}"
+      G
+
+      bundle "open foo", :env => { "EDITOR" => "echo editor", "VISUAL" => "", "BUNDLER_EDITOR" => "" }
+      expect(out).to match("editor #{default_bundle_path.join("bundler/gems/foo-1.0-#{ref}")}")
+    end
+
+    it "suggests alternatives for similar-sounding gems" do
+      bundle "open Rails", :env => { "EDITOR" => "echo editor", "VISUAL" => "", "BUNDLER_EDITOR" => "" }
+      expect(err).to match(/did you mean rails\?/i)
+    end
+
+    it "opens the gem with short words" do
+      bundle "open rec", :env => { "EDITOR" => "echo editor", "VISUAL" => "echo visual", "BUNDLER_EDITOR" => "echo bundler_editor" }
+
+      expect(out).to include("bundler_editor #{default_bundle_path("gems", "activerecord-2.3.2")}")
+    end
+
+    it "select the gem from many match gems" do
+      env = { "EDITOR" => "echo editor", "VISUAL" => "echo visual", "BUNDLER_EDITOR" => "echo bundler_editor" }
+      bundle "open active", :env => env do |input, _, _|
+        input.puts "2"
+      end
+
+      expect(out).to match(/bundler_editor #{default_bundle_path('gems', 'activerecord-2.3.2')}\z/)
+    end
+
+    it "allows selecting exit from many match gems" do
+      env = { "EDITOR" => "echo editor", "VISUAL" => "echo visual", "BUNDLER_EDITOR" => "echo bundler_editor" }
+      bundle! "open active", :env => env do |input, _, _|
+        input.puts "0"
+      end
+    end
+
+    it "performs an automatic bundle install" do
+      gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gem "rails"
+        gem "foo"
+      G
+
+      bundle "config set auto_install 1"
+      bundle "open rails", :env => { "EDITOR" => "echo editor", "VISUAL" => "", "BUNDLER_EDITOR" => "" }
+      expect(out).to include("Installing foo 1.0")
+    end
+
+    it "opens the editor with a clean env" do
+      bundle "open", :env => { "EDITOR" => "sh -c 'env'", "VISUAL" => "", "BUNDLER_EDITOR" => "" }
+      expect(out).not_to include("BUNDLE_GEMFILE=")
+    end
   end
 end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that `bundle open` doesn't currently support opening default gems, but crashes with a very verbose and unclear error when the user tries to do it. 

### What was your diagnosis of the problem?

My diagnosis was that we should give a more clear error in this case.

### What is your fix for the problem, implemented in this PR?

My fix is a rebased and improved version of #4882, that detects the situation and gives a better error. 

### Why did you choose this fix out of the possible options?

I chose this fix because it was already created and it's simpler than adding support for opening default gems, which is more problematic because they can't be pristine'd easily if edited and might not be in a writable location.

Closes #4882.
Fixes #4436.