### PR TITLE
add 'minitest-spec' test framework option

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -540,7 +540,7 @@ module Bundler
     method_option :ext, :type => :boolean, :default => false, :desc => "Generate the boilerplate for C extension code"
     method_option :mit, :type => :boolean, :desc => "Generate an MIT license file. Set a default with `bundle config set gem.mit true`."
     method_option :test, :type => :string, :lazy_default => "rspec", :aliases => "-t", :banner => "rspec",
-                         :desc => "Generate a test directory for your library, either rspec or minitest. Set a default with `bundle config set gem.test rspec`."
+                         :desc => "Generate tests for your library (rspec/minitest/minitest-spec). Set a default with `bundle config set gem.test rspec`."
     def gem(name)
     end
 

--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -12,6 +12,7 @@ module Bundler
     TEST_FRAMEWORK_VERSIONS = {
       "rspec" => "3.0",
       "minitest" => "5.0",
+      "minitest-spec" => "5.0"
     }.freeze
 
     attr_reader :options, :gem_name, :thor, :name, :target
@@ -97,10 +98,22 @@ module Bundler
             "test/test_helper.rb.tt" => "test/test_helper.rb",
             "test/newgem_test.rb.tt" => "test/#{namespaced_path}_test.rb"
           )
+        when "minitest-spec"
+          templates.merge!(
+            "spec/spec_helper_minitest.rb.tt" => "spec/spec_helper.rb",
+            "spec/newgem_spec_minitest.rb.tt" => "spec/#{namespaced_path}_spec.rb"
+          )
         end
       end
 
-      config[:test_task] = config[:test] == "minitest" ? "test" : "spec"
+      config[:test_task] = case test_framework
+                           when 'minitest'
+                             'test'
+                           when 'minitest-spec'
+                             'spec'
+                           else
+                             'spec'
+                           end
 
       if ask_and_set(:mit, "Do you want to license your code permissively under the MIT license?",
         "This means that any other developer or company will be legally allowed to use your code " \
@@ -199,9 +212,10 @@ module Bundler
 
       if test_framework.nil?
         Bundler.ui.confirm "Do you want to generate tests with your gem?"
-        result = Bundler.ui.ask "Type 'rspec' or 'minitest' to generate those test files now and " \
-          "in the future. rspec/minitest/(none):"
-        if result =~ /rspec|minitest/
+        result = Bundler.ui.ask "Type 'rspec', 'minitest', or " \
+          "'minitest-spec' to generate those test files now and " \
+          "in the future. rspec/minitest/minitest-spec/(none):"
+        if %w(rspec minitest minitest-spec).include? result
           test_framework = result
         else
           test_framework = false

--- a/lib/bundler/templates/newgem/Gemfile.tt
+++ b/lib/bundler/templates/newgem/Gemfile.tt
@@ -8,5 +8,9 @@ gem "rake", "~> 12.0"
 gem "rake-compiler"
 <%- end -%>
 <%- if config[:test] -%>
+<%- if config[:test] == 'minitest-spec' -%>
+gem "minitest", "~> <%= config[:test_framework_version] %>"
+<%- else -%>
 gem "<%= config[:test] %>", "~> <%= config[:test_framework_version] %>"
+<%- end -%>
 <%- end -%>

--- a/lib/bundler/templates/newgem/Rakefile.tt
+++ b/lib/bundler/templates/newgem/Rakefile.tt
@@ -1,13 +1,22 @@
 require "bundler/gem_tasks"
-<% if config[:test] == "minitest" -%>
+<% if config[:test] && config[:test].start_with?("minitest") -%>
 require "rake/testtask"
 
+<% if config[:test] == "minitest" -%>
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList["test/**/*_test.rb"]
 end
-
+<% else %>
+Rake::TestTask.new(:spec) do |t|
+  t.libs << "lib"
+  t.libs << "spec"
+  t.test_files = FileList["spec/**/*_spec.rb"]
+  # Supress `circular require` error messages from minitest
+  # t.warning = false
+end
+<% end %>
 <% elsif config[:test] == "rspec" -%>
 require "rspec/core/rake_task"
 

--- a/lib/bundler/templates/newgem/spec/newgem_spec_minitest.rb.tt
+++ b/lib/bundler/templates/newgem/spec/newgem_spec_minitest.rb.tt
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe <%= config[:constant_name] %> do
+  it "has a version number" do
+    <%= config[:constant_name] %>::VERSION.wont_be :nil?
+  end
+
+  it "does something useful" do
+    false.must_equal true
+  end
+end

--- a/lib/bundler/templates/newgem/spec/spec_helper_minitest.rb.tt
+++ b/lib/bundler/templates/newgem/spec/spec_helper_minitest.rb.tt
@@ -1,0 +1,5 @@
+require "bundler/setup"
+require "<%= config[:namespaced_path] %>"
+
+require 'minitest/spec'
+require 'minitest/autorun'

--- a/man/bundle-gem.ronn
+++ b/man/bundle-gem.ronn
@@ -60,13 +60,13 @@ configuration file using the following names:
   Do not create a `LICENSE.txt` (overrides `--mit` specified in the global
   config).
 
-* `-t`, `--test=minitest`, `--test=rspec`:
+* `-t`, `--test=minitest`, `--test=minitest-spec`, `--test=rspec`:
   Specify the test framework that Bundler should use when generating the
-  project. Acceptable values are `minitest` and `rspec`. The `GEM_NAME.gemspec`
-  will be configured and a skeleton test/spec directory will be created based
-  on this option. If this option is unspecified, an interactive prompt will be
-  displayed and the answer will be saved in Bundler's global config for future
-  `bundle gem` use.
+  project. Acceptable values are `minitest`, `minitest-spec`, and `rspec`. The
+  `GEM_NAME.gemspec` will be configured and a skeleton test/spec directory will
+  be created based on this option. If this option is unspecified, an
+  interactive prompt will be displayed and the answer will be saved in
+  Bundler's global config for future `bundle gem` use.
   If no option is specified, the default testing framework is RSpec.
 
 * `-e`, `--edit[=EDITOR]`:


### PR DESCRIPTION
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was that a minitest spec option wasn't present for `bundle gem --test`, and that I found myself manually converting the `--test=minitest` setup into a spec format.

### What was your diagnosis of the problem?

Seems easy enough to change,, and doesn't add any dependencies.

### What is your fix for the problem, implemented in this PR?

My fix is to add the `--test=minitest-spec` option to the `gem` command.

### Why did you choose this fix out of the possible options?

I chose this fix because it was pretty easy and I was tired of setting up the minitest spec boilerplate.
