### PR TITLE
Fix `man:check`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ script: rake spec:travis
 before_script:
   - travis_retry rake -E 'module ::Bundler; VERSION = "0.0.0"; end' override_version
   - travis_retry rake spec:travis:deps
-  - travis_retry rake man:check
+  - rake man:check
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-dist: xenial
+dist: bionic
 script: rake spec:travis
 before_script:
   - travis_retry rake -E 'module ::Bundler; VERSION = "0.0.0"; end' override_version

--- a/Rakefile
+++ b/Rakefile
@@ -46,7 +46,7 @@ namespace :spec do
       # Refresh packages index that the ones we need can be installed
       sh "sudo apt-get update"
       # Install groff so ronn can generate man/help pages
-      sh "sudo apt-get install groff-base -y"
+      sh "sudo apt-get install groff-base=1.22.3-10 -y"
       # Install graphviz so that the viz specs can run
       sh "sudo apt-get install graphviz -y"
 

--- a/Rakefile
+++ b/Rakefile
@@ -196,7 +196,7 @@ namespace :man do
         index << [ronn, File.basename(roff)]
 
         file roff => ["man", ronn] do
-          sh "bin/ronn --roff --pipe #{ronn} > #{roff}"
+          sh "bin/ronn --roff --pipe --date #{Time.now.strftime("%Y-%m-%d")} #{ronn} > #{roff}"
         end
 
         file "#{roff}.txt" => roff do

--- a/Rakefile
+++ b/Rakefile
@@ -233,13 +233,13 @@ namespace :man do
 
       desc "Verify man pages are in sync"
       task :check => :build do
-        sh("git diff --quiet man") do |outcome, _|
+        sh("git diff --quiet --ignore-all-space man") do |outcome, _|
           if outcome
             puts
             puts "Manpages are in sync!"
             puts
           else
-            sh("GIT_PAGER=cat git diff man")
+            sh("GIT_PAGER=cat git diff --ignore-all-space man")
 
             puts
             puts "Man pages are out of sync. Above you can see the diff that got generated from rebuilding them. Please review and commit the results."


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was than `ronn` behaves weird sometimes and updates the month in pages to an old month. This can be seen in #7292, but I've seen it too myself. 

### What is your fix for the problem, implemented in this PR?

My fix is to explicitly pass the current date when generating man pages. This has the disadvantage that the man pages will become out of sync if they haven't been updated for more than a month, because the month will change.

But I'd like to introduce it until I think of a better alternative.
