### PR TITLE
Stop printing deprecation messages during specs

### DIFF
--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -134,8 +134,9 @@ module Bundler
 
       return unless bundler_major_version >= major_version && prints_major_deprecations?
       @major_deprecation_ui ||= Bundler::UI::Shell.new("no-color" => true)
-      ui = Bundler.ui.is_a?(@major_deprecation_ui.class) ? Bundler.ui : @major_deprecation_ui
-      ui.warn("[DEPRECATED] #{message}")
+      with_major_deprecation_ui do |ui|
+        ui.warn("[DEPRECATED] #{message}")
+      end
     end
 
     def print_major_deprecations!
@@ -211,6 +212,21 @@ module Bundler
     end
 
   private
+
+    def with_major_deprecation_ui(&block)
+      ui = Bundler.ui
+
+      if ui.is_a?(@major_deprecation_ui.class)
+        yield ui
+      else
+        begin
+          Bundler.ui = @major_deprecation_ui
+          yield Bundler.ui
+        ensure
+          Bundler.ui = ui
+        end
+      end
+    end
 
     def validate_bundle_path
       path_separator = Bundler.rubygems.path_separator


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that that test suite prints some deprecation messages to the screen and I think that's unintented. See for example https://travis-ci.org/bundler/bundler/jobs/568969249.

### What was your diagnosis of the problem?

My diagnosis was that bundler is using a different UI than the one intented sometimes.

### What is your fix for the problem, implemented in this PR?

My fix is to make sure all deprecation messages go through bundler's UI.

### Why did you choose this fix out of the possible options?

I chose this fix because it stops deprecation messages from being interleaved with other output during the specs.