### PR TITLE
Add initial Bundler::BuildMetadata Spec

### DIFF
--- a/spec/bundler/bundler/build_metadata_spec.rb
+++ b/spec/bundler/bundler/build_metadata_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "bundler"
+require "bundler/build_metadata"
+
+RSpec.describe Bundler::BuildMetadata do
+  describe "#built_at" do
+    it "returns %Y-%m-%d formatted time" do
+      expect(Bundler::BuildMetadata.built_at).to eq Time.now.strftime("%Y-%m-%d")
+    end
+  end
+
+  describe "#release?" do
+    it "returns false as default" do
+      expect(Bundler::BuildMetadata.release?).to be_falsey
+    end
+  end
+
+  describe "#git_commit_sha" do
+    context "if instance valuable is defined" do
+      before do
+        Bundler::BuildMetadata.instance_variable_set(:@git_commit_sha, "foo")
+      end
+
+      after do
+        Bundler::BuildMetadata.remove_instance_variable(:@git_commit_sha)
+      end
+
+      it "returns set value" do
+        expect(Bundler::BuildMetadata.git_commit_sha).to eq "foo"
+      end
+    end
+  end
+
+  describe "#to_h" do
+    subject { Bundler::BuildMetadata.to_h }
+
+    it "returns a hash includes Built At, Git SHA and Released Version" do
+      expect(subject["Built At"]).to eq Time.now.strftime("%Y-%m-%d")
+      expect(subject["Git SHA"]).to be_instance_of(String)
+      expect(subject["Released Version"]).to be_falsey
+    end
+  end
+end


### PR DESCRIPTION
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was there is no spec of `Bundler::BuildMetadata`

### What was your diagnosis of the problem?

My diagnosis was it's better to prepare spec

### What is your fix for the problem, implemented in this PR?

My fix is just adding spec file, has no impact on production codes.

### Why did you choose this fix out of the possible options?

I chose this fix because I saw the code coverage and there is enough space to contribute to this product.
