### PR TITLE
Track changes from ruby core master

### DIFF
--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -2,7 +2,6 @@
 
 require "pathname"
 require "rbconfig"
-require "rubygems"
 
 require_relative "version"
 require_relative "constants"

--- a/spec/bundler/source_spec.rb
+++ b/spec/bundler/source_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Bundler::Source do
         context "with a different version" do
           let(:locked_gem) { double(:locked_gem, :name => "nokogiri", :version => "< 1.5") }
 
-          context "with color", :non_windows do
+          context "with color", :no_color_tty do
             before { Bundler.ui = Bundler::UI::Shell.new }
 
             it "should return a string with the spec name and version and locked spec version" do
@@ -77,7 +77,7 @@ RSpec.describe Bundler::Source do
           let(:spec) { double(:spec, :name => "nokogiri", :version => "1.6.1", :platform => rb) }
           let(:locked_gem) { double(:locked_gem, :name => "nokogiri", :version => "1.7.0") }
 
-          context "with color", :non_windows do
+          context "with color", :no_color_tty do
             before { Bundler.ui = Bundler::UI::Shell.new }
 
             it "should return a string with the locked spec version in yellow" do
@@ -98,7 +98,7 @@ RSpec.describe Bundler::Source do
           let(:spec) { double(:spec, :name => "nokogiri", :version => "1.7.1", :platform => rb) }
           let(:locked_gem) { double(:locked_gem, :name => "nokogiri", :version => "1.7.0") }
 
-          context "with color", :non_windows do
+          context "with color", :no_color_tty do
             before { Bundler.ui = Bundler::UI::Shell.new }
 
             it "should return a string with the locked spec version in green" do

--- a/spec/commands/binstubs_spec.rb
+++ b/spec/commands/binstubs_spec.rb
@@ -264,7 +264,7 @@ RSpec.describe "bundle binstubs <gem>" do
     end
 
     context "when using --shebang" do
-      it "sets the specified shebang for the the binstub" do
+      it "sets the specified shebang for the binstub" do
         install_gemfile <<-G
           source "#{file_uri_for(gem_repo1)}"
           gem "rack"

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "bundle exec" do
     expect(out).to eq("hi")
   end
 
-  it "respects custom process title when loading through ruby" do
+  it "respects custom process title when loading through ruby", :github_action_linux do
     script_that_changes_its_own_title_and_checks_if_picked_up_by_ps_unix_utility = <<~RUBY
       Process.setproctitle("1-2-3-4-5-6-7-8-9-10-11-12-13-14-15-16")
       puts `ps -eo args | grep [1]-2-3-4-5-6-7-8-9-10-11-12-13-14-15-16`

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -299,7 +299,7 @@ RSpec.describe "bundle exec" do
     G
 
     rubylib = ENV["RUBYLIB"]
-    rubylib = rubylib.to_s.split(File::PATH_SEPARATOR).unshift bundler_path
+    rubylib = rubylib.to_s.split(File::PATH_SEPARATOR).unshift bundler_path.to_s
     rubylib = rubylib.uniq.join(File::PATH_SEPARATOR)
 
     bundle "exec 'echo $RUBYLIB'"

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -275,7 +275,8 @@ RSpec.describe "bundle gem" do
     end
 
     it "sets a minimum ruby version" do
-      bundler_gemspec = Bundler::GemHelper.new(File.expand_path("../..", __dir__)).gemspec
+      gemspec_path = ruby_core? ? "../../../lib/bundler" : "../.."
+      bundler_gemspec = Bundler::GemHelper.new(File.expand_path(gemspec_path, __dir__)).gemspec
 
       expect(bundler_gemspec.required_ruby_version).to eq(generated_gemspec.required_ruby_version)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -71,8 +71,8 @@ RSpec.configure do |config|
   config.filter_run_excluding :git => RequirementChecker.against(git_version)
   config.filter_run_excluding :bundler => RequirementChecker.against(Bundler::VERSION.split(".")[0])
   config.filter_run_excluding :ruby_repo => !(ENV["BUNDLE_RUBY"] && ENV["BUNDLE_GEM"]).nil?
-  config.filter_run_excluding :no_color_tty => Gem.win_platform? || !!ENV["GITHUB_ACTION"]
-  config.filter_run_excluding :github_action_linux => !!ENV["GITHUB_ACTION"] && (ENV["RUNNER_OS"] == "Linux")
+  config.filter_run_excluding :no_color_tty => Gem.win_platform? || !ENV["GITHUB_ACTION"].nil?
+  config.filter_run_excluding :github_action_linux => !ENV["GITHUB_ACTION"].nil? && (ENV["RUNNER_OS"] == "Linux")
 
   config.filter_run_when_matching :focus unless ENV["CI"]
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -72,6 +72,7 @@ RSpec.configure do |config|
   config.filter_run_excluding :bundler => RequirementChecker.against(Bundler::VERSION.split(".")[0])
   config.filter_run_excluding :ruby_repo => !(ENV["BUNDLE_RUBY"] && ENV["BUNDLE_GEM"]).nil?
   config.filter_run_excluding :no_color_tty => Gem.win_platform? || !!ENV["GITHUB_ACTION"]
+  config.filter_run_excluding :github_action_linux => !!ENV["GITHUB_ACTION"] && (ENV["RUNNER_OS"] == "Linux")
 
   config.filter_run_when_matching :focus unless ENV["CI"]
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -71,7 +71,7 @@ RSpec.configure do |config|
   config.filter_run_excluding :git => RequirementChecker.against(git_version)
   config.filter_run_excluding :bundler => RequirementChecker.against(Bundler::VERSION.split(".")[0])
   config.filter_run_excluding :ruby_repo => !(ENV["BUNDLE_RUBY"] && ENV["BUNDLE_GEM"]).nil?
-  config.filter_run_excluding :non_windows => Gem.win_platform?
+  config.filter_run_excluding :non_windows => Gem.win_platform? || ENV["CI"]
 
   config.filter_run_when_matching :focus unless ENV["CI"]
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -100,6 +100,7 @@ RSpec.configure do |config|
     ENV["RUBYOPT"] = "#{ENV["RUBYOPT"]} -r#{Spec::Path.spec_dir}/support/hax.rb"
     ENV["BUNDLE_SPEC_RUN"] = "true"
     ENV["BUNDLE_USER_CONFIG"] = ENV["BUNDLE_USER_CACHE"] = ENV["BUNDLE_USER_PLUGIN"] = nil
+    ENV["GEMRC"] = nil
 
     # Don't wrap output in tests
     ENV["THOR_COLUMNS"] = "10000"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -71,7 +71,7 @@ RSpec.configure do |config|
   config.filter_run_excluding :git => RequirementChecker.against(git_version)
   config.filter_run_excluding :bundler => RequirementChecker.against(Bundler::VERSION.split(".")[0])
   config.filter_run_excluding :ruby_repo => !(ENV["BUNDLE_RUBY"] && ENV["BUNDLE_GEM"]).nil?
-  config.filter_run_excluding :non_windows => Gem.win_platform? || ENV["CI"]
+  config.filter_run_excluding :no_color_tty => Gem.win_platform? || !!ENV["GITHUB_ACTION"]
 
   config.filter_run_when_matching :focus unless ENV["CI"]
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

I'm going to merge https://github.com/bundler/bundler/pull/7274. But the ruby-core source has some of the changes for bundler source.

### What was your diagnosis of the problem?


### What is your fix for the problem, implemented in this PR?

ruby core team fixed them:

* Removed circular require warning at `shared_helper.rb`
* Support test at GitHub Actions, It helps that bundler will migrate Actions from Azure Pipelines too.
* Fixed broken examples at ruby core repository


### Why did you choose this fix out of the possible options?

