### PR TITLE
Bundler displays a duplicate gem entries warning even if gems only appear once per group

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -128,7 +128,7 @@ module Bundler
         else
           Bundler.ui.warn "Your Gemfile lists the gem #{current.name} (#{current.requirement}) more than once.\n" \
                           "You should probably keep only one of them.\n" \
-                          "Remove any duplicate entries and specify the gem only once (per group).\n" \
+                          "Remove any duplicate entries and specify the gem only once.\n" \
                           "While it's not a problem now, it could cause errors if you change the version of one of them later."
         end
 

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -330,7 +330,7 @@ RSpec.describe "bundle install with gem sources" do
         G
 
         expect(err).to include("Your Gemfile lists the gem rack (>= 0) more than once.")
-        expect(err).to include("Remove any duplicate entries and specify the gem only once (per group).")
+        expect(err).to include("Remove any duplicate entries and specify the gem only once.")
         expect(err).to include("While it's not a problem now, it could cause errors if you change the version of one of them later.")
       end
 
@@ -342,7 +342,7 @@ RSpec.describe "bundle install with gem sources" do
         G
 
         expect(err).to include("Your Gemfile lists the gem rack (= 1.0) more than once.")
-        expect(err).to include("Remove any duplicate entries and specify the gem only once (per group).")
+        expect(err).to include("Remove any duplicate entries and specify the gem only once.")
         expect(err).to include("While it's not a problem now, it could cause errors if you change the version of one of them later.")
       end
     end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

I have a Gemfile where some gems appear in two distinct groups. When I run Bundle, the following warning is displayed:

> Your Gemfile lists the gem #{gem} more than once.
> You should probably keep only one of them.
> Remove any duplicate entries and specify the gem **only once (per group)**.
> While it's not a problem now, it could cause errors if you change the version of one of them later.                                                           

Example Gemfile:
```rb
source "https://rubygems.org"

group :production do
end

group :development do
  gem "rake"
end

group :ci, optional: true do
  gem "rake"
end
```

### What was your diagnosis of the problem?

I think the message is misleading, because it shows even if all gems are specified **only once per group**.

### What is your fix for the problem, implemented in this PR?

I removed the _(per group)_ mention from the warning message in order to prevent confusion.

### Why did you choose this fix out of the possible options?

I chose this fix because it was the simplest way to bring your attention to the problem.

If Bundler's real intent is to allow the same gem to appear in multiple groups, as long as it does not appear more than once per group, then my suggestion is wrong, and instead, the logic around the warning message needs to be fixed.