### PR TITLE
Simplify setting `Bunder.ui`

### DIFF
--- a/lib/bundler/deployment.rb
+++ b/lib/bundler/deployment.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 require_relative "shared_helpers"
+
+require_relative "../bundler"
+
+Bundler.ui = Bundler::UI::Shell.new
+
 Bundler::SharedHelpers.major_deprecation 2, "Bundler no longer integrates with " \
   "Capistrano, but Capistrano provides its own integration with " \
   "Bundler via the capistrano-bundler gem. Use it instead."

--- a/lib/bundler/setup.rb
+++ b/lib/bundler/setup.rb
@@ -5,8 +5,9 @@ require_relative "shared_helpers"
 if Bundler::SharedHelpers.in_bundle?
   require_relative "../bundler"
 
+  Bundler.ui = Bundler::UI::Shell.new
+
   if STDOUT.tty? || ENV["BUNDLER_FORCE_TTY"]
-    Bundler.ui = Bundler::UI::Shell.new
     begin
       Bundler.setup
     rescue Bundler::BundlerError => e
@@ -24,6 +25,4 @@ if Bundler::SharedHelpers.in_bundle?
   # Add bundler to the load path after disabling system gems
   bundler_lib = File.expand_path("../..", __FILE__)
   $LOAD_PATH.unshift(bundler_lib) unless $LOAD_PATH.include?(bundler_lib)
-
-  Bundler.ui = nil
 end

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -133,10 +133,7 @@ module Bundler
       end
 
       return unless bundler_major_version >= major_version && prints_major_deprecations?
-      @major_deprecation_ui ||= Bundler::UI::Shell.new("no-color" => true)
-      with_major_deprecation_ui do |ui|
-        ui.warn("[DEPRECATED] #{message}")
-      end
+      Bundler.ui.warn("[DEPRECATED] #{message}")
     end
 
     def print_major_deprecations!
@@ -212,21 +209,6 @@ module Bundler
     end
 
   private
-
-    def with_major_deprecation_ui(&block)
-      ui = Bundler.ui
-
-      if ui.is_a?(@major_deprecation_ui.class)
-        yield ui
-      else
-        begin
-          Bundler.ui = @major_deprecation_ui
-          yield Bundler.ui
-        ensure
-          Bundler.ui = ui
-        end
-      end
-    end
 
     def validate_bundle_path
       path_separator = Bundler.rubygems.path_separator

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -11,12 +11,13 @@ RSpec.describe "bundle exec" do
       gem "rack", "1.0.0"
     G
 
+    bundle "install --gemfile CustomGemfile"
     bundle "exec --gemfile CustomGemfile rackup"
     expect(out).to eq("1.0.0")
   end
 
   it "activates the correct gem" do
-    gemfile <<-G
+    install_gemfile <<-G
       gem "rack", "0.9.1"
     G
 
@@ -60,7 +61,7 @@ RSpec.describe "bundle exec" do
       Process.setproctitle("1-2-3-4-5-6-7-8-9-10-11-12-13-14-15-16")
       puts `ps -eo args | grep [1]-2-3-4-5-6-7-8-9-10-11-12-13-14-15-16`
     RUBY
-    create_file "Gemfile"
+    install_gemfile ""
     create_file "a.rb", script_that_changes_its_own_title_and_checks_if_picked_up_by_ps_unix_utility
     bundle "exec ruby a.rb"
     expect(out).to eq("1-2-3-4-5-6-7-8-9-10-11-12-13-14-15-16")

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -16,6 +16,15 @@ RSpec.describe "bundle exec" do
     expect(out).to eq("1.0.0")
   end
 
+  it "resolves automatically without having run `bundle install`" do
+    gemfile <<-G
+      gem "rack", "0.9.1"
+    G
+
+    bundle "exec rackup"
+    expect(out).to include("Resolving dependencies...\n")
+  end
+
   it "activates the correct gem" do
     install_gemfile <<-G
       gem "rack", "0.9.1"

--- a/spec/runtime/executable_spec.rb
+++ b/spec/runtime/executable_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "Running bin/* commands" do
       s.executables = "rackup"
     end
 
-    gemfile <<-G
+    install_gemfile <<-G
       gem "rack", :path => "#{lib_path("rack")}"
     G
 

--- a/spec/runtime/require_spec.rb
+++ b/spec/runtime/require_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Bundler.require" do
       s.write "lib/ten.rb", "puts 'ten'"
     end
 
-    gemfile <<-G
+    install_gemfile <<-G
       path "#{lib_path}" do
         gem "one", :group => :bar, :require => %w[baz qux]
         gem "two"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that https://github.com/bundler/bundler/pull/7294 didn't actually stop the deprecations from being printed during specs.

### What was your diagnosis of the problem?

My diagnosis was that we still need to simplify the UI in order to fix that.

### What is your fix for the problem, implemented in this PR?

My fix tries #7284 again. The reason I closed that one is because I thought it was changing the behaviour because `-rbundler/setup` would start printing deprecations and before they wouldn't be printed. Apparently deprecations/warnings would only be printed when bundler is run directly (see my comment in https://github.com/bundler/bundler/pull/7284#issuecomment-520169497).

However, I actually tried it and the behavior in master is to indeed _print_ deprecations in any case, so what this PR is actually doing is fixing the spec to represent the real behavior, not actually changing the behavior.

Given that, I think this refactoring is fine, and it indeed works for cleaning up the warnings from the specs.