### PR TITLE
Deprecate `--path` flag to `bundle check` (and related fixes)

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -789,7 +789,7 @@ module Bundler
       Bundler::SharedHelpers.major_deprecation 2,\
         "The `#{flag_name}` flag is deprecated because it relies on being " \
         "remembered accross bundler invokations, which bundler will no longer " \
-        "do in future versions. Instead please use `bundle config #{name} " \
+        "do in future versions. Instead please use `bundle config set #{name} " \
         "'#{value}'`, and stop using this flag"
     end
   end

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -156,6 +156,8 @@ module Bundler
       "Specify a different path than the system default ($BUNDLE_PATH or $GEM_HOME).#{" Bundler will remember this value for future installs on this machine" unless Bundler.feature_flag.forget_cli_options?}"
     map "c" => "check"
     def check
+      remembered_flag_deprecation("path")
+
       require_relative "cli/check"
       Check.new(options).run
     end

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -207,7 +207,7 @@ module Bundler
     method_option "no-prune", :type => :boolean, :banner =>
       "Don't remove stale gems from the cache."
     method_option "path", :type => :string, :banner =>
-      "Specify a different path than the system default ($BUNDLE_PATH or $GEM_HOME). Bundler will remember this value for future installs on this machine"
+      "Specify a different path than the system default ($BUNDLE_PATH or $GEM_HOME).#{" Bundler will remember this value for future installs on this machine" unless Bundler.feature_flag.forget_cli_options?}"
     method_option "quiet", :type => :boolean, :banner =>
       "Only output warnings and errors."
     method_option "shebang", :type => :string, :banner =>
@@ -424,7 +424,7 @@ module Bundler
     method_option "no-install", :type => :boolean, :banner => "Don't install the gems, only the package."
     method_option "no-prune", :type => :boolean, :banner => "Don't remove stale gems from the cache."
     method_option "path", :type => :string, :banner =>
-      "Specify a different path than the system default ($BUNDLE_PATH or $GEM_HOME). Bundler will remember this value for future installs on this machine"
+      "Specify a different path than the system default ($BUNDLE_PATH or $GEM_HOME).#{" Bundler will remember this value for future installs on this machine" unless Bundler.feature_flag.forget_cli_options?}"
     method_option "quiet", :type => :boolean, :banner => "Only output warnings and errors."
     method_option "frozen", :type => :boolean, :banner =>
       "Do not allow the Gemfile.lock to be updated after this package operation's install"

--- a/spec/commands/check_spec.rb
+++ b/spec/commands/check_spec.rb
@@ -239,37 +239,42 @@ RSpec.describe "bundle check" do
   end
 
   context "--path", :bundler => "< 3" do
-    before do
-      gemfile <<-G
-        source "#{file_uri_for(gem_repo1)}"
-        gem "rails"
-      G
-      bundle "install --path vendor/bundle"
+    context "after installing gems in the proper directory" do
+      before do
+        gemfile <<-G
+          source "#{file_uri_for(gem_repo1)}"
+          gem "rails"
+        G
+        bundle "install --path vendor/bundle"
 
-      FileUtils.rm_rf(bundled_app(".bundle"))
+        FileUtils.rm_rf(bundled_app(".bundle"))
+      end
+
+      it "returns success" do
+        bundle! "check --path vendor/bundle"
+        expect(out).to include("The Gemfile's dependencies are satisfied")
+      end
+
+      it "should write to .bundle/config" do
+        bundle "check --path vendor/bundle"
+        bundle! "check"
+      end
     end
 
-    it "returns success" do
-      bundle! "check --path vendor/bundle"
-      expect(out).to include("The Gemfile's dependencies are satisfied")
-    end
+    context "after installing gems on a different directory" do
+      before do
+        install_gemfile <<-G
+          source "#{file_uri_for(gem_repo1)}"
+          gem "rails"
+        G
 
-    it "should write to .bundle/config" do
-      bundle "check --path vendor/bundle"
-      bundle! "check"
-    end
-  end
+        bundle "check --path vendor/bundle"
+      end
 
-  context "--path vendor/bundle after installing gems in the default directory" do
-    it "returns false" do
-      install_gemfile <<-G
-        source "#{file_uri_for(gem_repo1)}"
-        gem "rails"
-      G
-
-      bundle "check --path vendor/bundle"
-      expect(exitstatus).to eq(1) if exitstatus
-      expect(err).to match(/The following gems are missing/)
+      it "returns false" do
+        expect(exitstatus).to eq(1) if exitstatus
+        expect(err).to match(/The following gems are missing/)
+      end
     end
   end
 

--- a/spec/commands/check_spec.rb
+++ b/spec/commands/check_spec.rb
@@ -254,7 +254,7 @@ RSpec.describe "bundle check" do
       expect(out).to include("The Gemfile's dependencies are satisfied")
     end
 
-    it "should write to .bundle/config", :bundler => "< 3" do
+    it "should write to .bundle/config" do
       bundle "check --path vendor/bundle"
       bundle! "check"
     end

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -95,6 +95,28 @@ RSpec.describe "major deprecations" do
     end
   end
 
+  context "bundle check --path" do
+    before do
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gem "rack"
+      G
+
+      bundle "check --path vendor/bundle"
+    end
+
+    it "should print a deprecation warning", :bundler => "2" do
+      expect(deprecations).to include(
+        "The `--path` flag is deprecated because it relies on being " \
+        "remembered accross bundler invokations, which bundler will no " \
+        "longer do in future versions. Instead please use `bundle config set " \
+        "path 'vendor/bundle'`, and stop using this flag"
+      )
+    end
+
+    pending "should fail with a helpful error", :bundler => "3"
+  end
+
   describe "bundle config" do
     describe "old list interface" do
       before do

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -290,7 +290,7 @@ RSpec.describe "major deprecations" do
             "The `#{flag_name}` flag is deprecated because it relies on " \
             "being remembered accross bundler invokations, which bundler " \
             "will no longer do in future versions. Instead please use " \
-            "`bundle config #{name} '#{value}'`, and stop using this flag"
+            "`bundle config set #{name} '#{value}'`, and stop using this flag"
           )
         end
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that this flag should also be deprecated for these commands in preparation for bundler no longer remembering CLI flags.

### What was your diagnosis of the problem?

My diagnosis was that, on bundler 3, the standard use case for `bundle check --path` will no longer work, namely:

```
 $ bundle check --path .bundle
The following gems are missing
 * rake (12.3.3)
Install missing gems with `bundle install`
$ bundle install
Fetching gem metadata from https://rubygems.org/.
Installing rake 12.3.3
Using bundler 2.1.0.pre.1
Bundle complete! 1 Gemfile dependency, 2 gems now installed.
Bundled gems are installed into `./.bundle`
```

In the case of `bundle cache --path`, it has never really work as I expect
So we should deprecate `bundle check --path` and instead use whatever path is configured.

The cache of `bundle cache --path` is not as clear. Currently it does remember the flag for subsequent `bundle install` runs, but it does not change the location where subsequent `bundle cache` or `bundle install` runs save their cache. So I'm not sure how the current behavior is useful.

### What is your fix for the problem, implemented in this PR?

My fix is, pending further discussion on what the expected behavior for `bundle cache` is, to only deprecate `bundle check --path`, and in the case of `bundle cache` I only fixed the option description to not say it remembers the option in bundler 3.

Finally, I added a minor change in the deprecation message to recommend `bundle config set path <path>` instead of `bundle config path <path>`, because the latter is deprecated.

### Why did you choose this fix out of the possible options?

I chose this fix because it's the subset of all this that seemed clearly like the way to go.

Fixes #7300.