### PR TITLE
Fix `bundle doctor` command

### DIFF
--- a/lib/bundler/cli/doctor.rb
+++ b/lib/bundler/cli/doctor.rb
@@ -100,7 +100,7 @@ module Bundler
       files_not_readable_or_writable = []
       files_not_rw_and_owned_by_different_user = []
       files_not_owned_by_current_user_but_still_rw = []
-      Find.find(Bundler.home.to_s).each do |f|
+      Find.find(Bundler.bundle_path.to_s).each do |f|
         if !File.writable?(f) || !File.readable?(f)
           if File.stat(f).uid != Process.uid
             files_not_rw_and_owned_by_different_user << f

--- a/spec/commands/doctor_spec.rb
+++ b/spec/commands/doctor_spec.rb
@@ -22,11 +22,17 @@ RSpec.describe "bundle doctor" do
     end
   end
 
+  it "succeeds on a sane installation" do
+    bundle :doctor
+
+    expect(exitstatus).to eq(0)
+  end
+
   context "when all files in home are readable/writable" do
     before(:each) do
       stat = double("stat")
       unwritable_file = double("file")
-      allow(Find).to receive(:find).with(Bundler.home.to_s) { [unwritable_file] }
+      allow(Find).to receive(:find).with(Bundler.bundle_path.to_s) { [unwritable_file] }
       allow(File).to receive(:stat).with(unwritable_file) { stat }
       allow(stat).to receive(:uid) { Process.uid }
       allow(File).to receive(:writable?).with(unwritable_file) { true }
@@ -66,7 +72,7 @@ RSpec.describe "bundle doctor" do
     before(:each) do
       @stat = double("stat")
       @unwritable_file = double("file")
-      allow(Find).to receive(:find).with(Bundler.home.to_s) { [@unwritable_file] }
+      allow(Find).to receive(:find).with(Bundler.bundle_path.to_s) { [@unwritable_file] }
       allow(File).to receive(:stat).with(@unwritable_file) { @stat }
     end
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that `bundle doctor` crashes on very simple usages, like this:

````
$ bundle doctor
The Gemfile's dependencies are satisfied
--- ERROR REPORT TEMPLATE -------------------------------------------------------
# Error Report

## Questions

Please fill out answers to these questions, it'll help us figure out
why things are going wrong.

- **What did you do?**

  I ran the command `/home/deivid/.rbenv/versions/2.6.3/bin/bundle doctor`

- **What did you expect to happen?**

  I expected Bundler to...

- **What happened instead?**

  Instead, what happened was...

- **Have you tried any solutions posted on similar issues in our issue tracker, stack overflow, or google?**

  I tried...

- **Have you read our issues document, https://github.com/bundler/bundler/blob/master/doc/contributing/ISSUES.md?**

  ...

## Backtrace

```
Errno::ENOENT: No such file or directory - /home/deivid/Code/playground/bundler/chcek/.bundle/ruby/2.6.0/bundler
  /home/deivid/.rbenv/versions/2.6.3/lib/ruby/2.6.0/find.rb:43:in `block in find'
  /home/deivid/.rbenv/versions/2.6.3/lib/ruby/2.6.0/find.rb:43:in `collect!'
  /home/deivid/.rbenv/versions/2.6.3/lib/ruby/2.6.0/find.rb:43:in `find'
  /home/deivid/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bundler-2.1.0.pre.1/lib/bundler/cli/doctor.rb:105:in `each'
  /home/deivid/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bundler-2.1.0.pre.1/lib/bundler/cli/doctor.rb:105:in `check_home_permissions'
  /home/deivid/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bundler-2.1.0.pre.1/lib/bundler/cli/doctor.rb:83:in `run'
  /home/deivid/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bundler-2.1.0.pre.1/lib/bundler/cli.rb:652:in `doctor'
  /home/deivid/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bundler-2.1.0.pre.1/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
  /home/deivid/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bundler-2.1.0.pre.1/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
  /home/deivid/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bundler-2.1.0.pre.1/lib/bundler/vendor/thor/lib/thor.rb:387:in `dispatch'
  /home/deivid/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bundler-2.1.0.pre.1/lib/bundler/cli.rb:26:in `dispatch'
  /home/deivid/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bundler-2.1.0.pre.1/lib/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
  /home/deivid/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bundler-2.1.0.pre.1/lib/bundler/cli.rb:17:in `start'
  /home/deivid/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bundler-2.1.0.pre.1/exe/bundle:30:in `block in <top (required)>'
  /home/deivid/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bundler-2.1.0.pre.1/lib/bundler/friendly_errors.rb:123:in `with_friendly_errors'
  /home/deivid/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bundler-2.1.0.pre.1/exe/bundle:22:in `<top (required)>'
  /home/deivid/.rbenv/versions/2.6.3/bin/bundle:23:in `load'
  /home/deivid/.rbenv/versions/2.6.3/bin/bundle:23:in `<main>'
```

## Environment

```
Bundler       2.1.0.pre.1
  Platforms   ruby, x86_64-linux
Ruby          2.6.3p62 (2019-04-16 revision 67580) [x86_64-linux]
  Full Path   /home/deivid/.rbenv/versions/2.6.3/bin/ruby
  Config Dir  /home/deivid/.rbenv/versions/2.6.3/etc
RubyGems      3.1.0.pre1
  Gem Home    /home/deivid/Code/playground/bundler/chcek/.bundle/ruby/2.6.0
  Gem Path    /home/deivid/Code/playground/bundler/chcek/.bundle/ruby/2.6.0
  User Home   /home/deivid
  User Path   /home/deivid/.gem/ruby/2.6.0
  Bin Dir     /home/deivid/Code/playground/bundler/chcek/.bundle/ruby/2.6.0/bin
Tools         
  Git         2.22.1
  RVM         not installed
  rbenv       rbenv 1.1.2
  chruby      not installed
```

## Bundler Build Metadata

```
Built At          2019-08-15
Git SHA           91f91a1ad
Released Version  false
```

## Bundler settings

```
gem.test
  Set for the current user (/home/deivid/.bundle/config): "rspec"
gem.mit
  Set for the current user (/home/deivid/.bundle/config): true
gem.coc
  Set for the current user (/home/deivid/.bundle/config): true
default_cli_command
  Set for the current user (/home/deivid/.bundle/config): "install"
path_relative_to_cwd
  Set for the current user (/home/deivid/.bundle/config): true
path
  Set for your local app (/home/deivid/Code/playground/bundler/chcek/.bundle/config): ".bundle"
```

## Gemfile

### Gemfile

```ruby
source "https://rubygems.org"

gem "rake", "12.3.2"

gem "byebug", "~> 11.0"
```

### Gemfile.lock

```
GEM
  remote: https://rubygems.org/
  specs:
    byebug (11.0.1)
    rake (12.3.2)

PLATFORMS
  ruby

DEPENDENCIES
  byebug (~> 11.0)
  rake (= 12.3.2)

BUNDLED WITH
   2.1.0.pre.1
```

--- TEMPLATE END ----------------------------------------------------------------

Unfortunately, an unexpected error occurred, and Bundler cannot continue.

First, try this link to see if there are any existing issue reports for this error:
https://github.com/bundler/bundler/search?q=No+such+file+or+directory+-+%2Fhome%2Fdeivid%2FCode%2Fplayground%2Fbundler%2Fchcek%2F.bundle%2Fruby%2F2.6.0%2Fbundler&type=Issues

If there aren't any reports for this error yet, please create copy and paste the report template above into a new issue. Don't forget to anonymize any private data! The new issue form is located at:
https://github.com/bundler/bundler/issues/new
````

### What was your diagnosis of the problem?

My diagnosis was that `Bundler.home` is not the folder this command should use, because that folder is in reality the "home" for git gems and bundler plugins, not the home for the whole bundle. So it sometimes doesn't exist and the command crashes.

### What is your fix for the problem, implemented in this PR?

My fix is to use the proper "home".

### Why did you choose this fix out of the possible options?

I chose this fix because it's better than rescuing the error. It was an unexpected error, so we should fix it.

Fixes #6820 
Closes #6824.
