### PR TITLE
Freeze time to avoid failures at midnight

### DIFF
--- a/spec/bundler/build_metadata_spec.rb
+++ b/spec/bundler/build_metadata_spec.rb
@@ -4,9 +4,14 @@ require "bundler"
 require "bundler/build_metadata"
 
 RSpec.describe Bundler::BuildMetadata do
+  before do
+    allow(Time).to receive(:now).and_return(Time.at(0))
+    Bundler::BuildMetadata.instance_variable_set(:@built_at, nil)
+  end
+
   describe "#built_at" do
     it "returns %Y-%m-%d formatted time" do
-      expect(Bundler::BuildMetadata.built_at).to eq Time.now.strftime("%Y-%m-%d")
+      expect(Bundler::BuildMetadata.built_at).to eq "1970-01-01"
     end
   end
 
@@ -36,7 +41,7 @@ RSpec.describe Bundler::BuildMetadata do
     subject { Bundler::BuildMetadata.to_h }
 
     it "returns a hash includes Built At, Git SHA and Released Version" do
-      expect(subject["Built At"]).to eq Time.now.strftime("%Y-%m-%d")
+      expect(subject["Built At"]).to eq "1970-01-01"
       expect(subject["Git SHA"]).to be_instance_of(String)
       expect(subject["Released Version"]).to be_falsey
     end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was it will potentially fail if tests are executed around midnight

### What was your diagnosis of the problem?

My diagnosis was it should freeze time when executing spec

### What is your fix for the problem, implemented in this PR?

My fix is mocking `Time.now` when executing `Bundler::BuildMetadata` specs

### Why did you choose this fix out of the possible options?

I chose this fix because it doesn't have effects on other specs.
