### PR TITLE
Use the latest rubygems 3.0.6 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,8 @@ env:
   - RGV=master BUNDLER_SPEC_SUB_VERSION=3.0.0
   - RGV=master
   # Test the latest rubygems release with all of our supported rubies
-  - RGV=v3.0.4 BUNDLER_SPEC_SUB_VERSION=3.0.0
-  - RGV=v3.0.4
+  - RGV=v3.0.6 BUNDLER_SPEC_SUB_VERSION=3.0.0
+  - RGV=v3.0.6
 
 jobs:
   include:
@@ -52,7 +52,7 @@ jobs:
       env: RGV=master
       stage: test
     - rvm: 2.3.8
-      env: RGV=v3.0.4
+      env: RGV=v3.0.6
       stage: test
     # Ruby 2.5, Rubygems 2.7
     - rvm: 2.5.5

--- a/Rakefile
+++ b/Rakefile
@@ -51,7 +51,7 @@ namespace :spec do
       sh "sudo apt-get install graphviz -y"
 
       # Install the gems with a consistent version of RubyGems
-      sh "gem update --system 3.0.4"
+      sh "gem update --system 3.0.6"
 
       # Install the other gem deps, etc
       Rake::Task["spec:deps"].invoke
@@ -89,7 +89,7 @@ namespace :spec do
   namespace :rubygems do
     # When editing this list, also edit .travis.yml!
     branches = %w[master]
-    releases = %w[v2.5.2 v2.6.14 v2.7.10 v3.0.4]
+    releases = %w[v2.5.2 v2.6.14 v2.7.10 v3.0.6]
     (branches + releases).each do |rg|
       desc "Run specs with RubyGems #{rg}"
       task rg do


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that [rubygems 3.0.6 was released](https://blog.rubygems.org/2019/08/16/3.0.6-released.html), and we haven't yet tested against it.

### What is your fix for the problem, implemented in this PR?

My fix is to use the new rubygems in CI.