### PR TITLE
Remove old rubies stuff no longer needed

### DIFF
--- a/lib/bundler/cli/exec.rb
+++ b/lib/bundler/cli/exec.rb
@@ -13,7 +13,7 @@ module Bundler
       @cmd = args.shift
       @args = args
 
-      if Bundler.current_ruby.ruby_2? && !Bundler.current_ruby.jruby?
+      if !Bundler.current_ruby.jruby?
         @args << { :close_others => !options.keep_file_descriptors? }
       elsif options.keep_file_descriptors?
         Bundler.ui.warn "Ruby version #{RUBY_VERSION} defaults to keeping non-standard file descriptors on Kernel#exec."

--- a/lib/bundler/spec_set.rb
+++ b/lib/bundler/spec_set.rb
@@ -162,11 +162,7 @@ module Bundler
     end
 
     def extract_circular_gems(error)
-      if Bundler.current_ruby.mri? && Bundler.current_ruby.on_19?
-        error.message.scan(/(\w+) \([^)]/).flatten
-      else
-        error.message.scan(/@name="(.*?)"/).flatten
-      end
+      error.message.scan(/@name="(.*?)"/).flatten
     end
 
     def lookup

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe Bundler::Dsl do
     end
   end
 
-  describe "Runtime errors", :unless => Bundler.current_ruby.on_18? do
+  describe "Runtime errors" do
     it "will raise a Bundler::GemfileError" do
       gemfile "raise RuntimeError, 'foo'"
       expect { Bundler::Dsl.evaluate(bundled_app("Gemfile"), nil, true) }.

--- a/spec/quality_es_spec.rb
+++ b/spec/quality_es_spec.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-if defined?(Encoding) && Encoding.default_external.name != "UTF-8"
-  # An approximation of ruby -E UTF-8, since it works on 1.8.7
-  Encoding.default_external = Encoding.find("UTF-8")
-end
-
 RSpec.describe "La biblioteca si misma" do
   def check_for_expendable_words(filename)
     failing_line_message = []

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -66,7 +66,6 @@ RSpec.configure do |config|
 
   git_version = Bundler::Source::Git::GitProxy.new(nil, nil, nil).version
 
-  config.filter_run_excluding :ruby => RequirementChecker.against(RUBY_VERSION)
   config.filter_run_excluding :rubygems => RequirementChecker.against(Gem::VERSION)
   config.filter_run_excluding :git => RequirementChecker.against(git_version)
   config.filter_run_excluding :bundler => RequirementChecker.against(Bundler::VERSION.split(".")[0])


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that was still some code specific to old rubies we no longer support.

### What is your fix for the problem, implemented in this PR?

My fix is to remove that code.