### PR TITLE
Add output to bundle info to show the dependent gems

### DIFF
--- a/lib/bundler/cli/info.rb
+++ b/lib/bundler/cli/info.rb
@@ -16,10 +16,11 @@ module Bundler
 
       spec = spec_for_gem(gem_name)
 
-      spec_not_found(gem_name) unless spec
-      return print_gem_path(spec) if @options[:path]
-      print_gem_info(spec)
-      print_gem_dependencies(gem_name)
+      if spec
+        return print_gem_path(spec) if @options[:path]
+        print_gem_info(spec)
+        print_gem_dependencies(gem_name)
+      end
     end
 
   private

--- a/lib/bundler/cli/info.rb
+++ b/lib/bundler/cli/info.rb
@@ -60,8 +60,8 @@ module Bundler
       Bundler.ui.info gem_info
     end
 
-    def print_gem_dependencies(spec)
-      top_level_dependencies = summarize(spec)
+    def print_gem_dependencies(gem_name)
+      top_level_dependencies = summarize(gem_name)
 
       stat_info = String.new
       stat_info << "\tDependents:\n"
@@ -76,13 +76,13 @@ module Bundler
       Bundler.ui.info stat_info
     end
 
-    def summarize(spec)
+    def summarize(gem_name)
       definition = Bundler.definition
       lockfile_contents = definition.to_lock
       parser = Bundler::LockfileParser.new(lockfile_contents)
       @tree = specs_as_tree(parser.specs)
 
-      reverse_dependencies_with_versions(spec)
+      reverse_dependencies_with_versions(gem_name)
     end
 
     def specs_as_tree(specs)
@@ -92,10 +92,10 @@ module Bundler
       end
     end
 
-    def transitive_dependencies(target)
-      raise ArgumentError, "Unknown gem #{target}" unless @tree.key? target
+    def transitive_dependencies(gem_name)
+      raise ArgumentError, "Unknown gem #{gem_name}" unless @tree.key? gem_name
 
-      top_level = @tree[target].dependencies
+      top_level = @tree[gem_name].dependencies
       all_level = top_level + top_level.inject([]) do |arr, dep|
         next arr if dep.name == "bundler"
 
@@ -105,10 +105,10 @@ module Bundler
       all_level.uniq(&:name)
     end
 
-    def reverse_dependencies_with_versions(target)
+    def reverse_dependencies_with_versions(gem_name)
       @tree.map do |name, dep|
         transitive_dependencies(name).map do |transitive_dependency|
-          next unless transitive_dependency.name == target
+          next unless transitive_dependency.name == gem_name
           {
             :name => dep.name,
             :version => transitive_dependency.requirement.to_s,

--- a/lib/bundler/cli/info.rb
+++ b/lib/bundler/cli/info.rb
@@ -86,8 +86,9 @@ module Bundler
     end
 
     def specs_as_tree(specs)
-      specs.each_with_object({}) do |spec, hash|
+      specs.inject({}) do |hash, spec|
         hash[spec.name] = spec
+        hash
       end
     end
 

--- a/lib/bundler/cli/info.rb
+++ b/lib/bundler/cli/info.rb
@@ -16,10 +16,10 @@ module Bundler
 
       spec = spec_for_gem(gem_name)
 
-      if spec
-        return print_gem_path(spec) if @options[:path]
-        print_gem_info(spec)
-      end
+      spec_not_found(gem_name) unless spec
+      return print_gem_path(spec) if @options[:path]
+      print_gem_info(spec)
+      print_gem_dependencies(gem_name)
     end
 
   private
@@ -57,6 +57,65 @@ module Bundler
       gem_info << "\tPath: #{spec.full_gem_path}\n"
       gem_info << "\tDefault Gem: yes" if spec.respond_to?(:default_gem?) && spec.default_gem?
       Bundler.ui.info gem_info
+    end
+
+    def print_gem_dependencies(spec)
+      top_level_dependencies = summarize(spec)
+
+      stat_info = String.new
+      stat_info << "\tDependents:\n"
+      if top_level_dependencies.count > 0
+        top_level_dependencies.each do |stat_line|
+          stat_info << format("\t\t%s (%s)\n", stat_line[:name], stat_line[:version])
+        end
+      else
+        stat_info << "\t\tNone"
+      end
+
+      Bundler.ui.info stat_info
+    end
+
+    def summarize(spec)
+      definition = Bundler.definition
+      lockfile_contents = definition.to_lock
+      parser = Bundler::LockfileParser.new(lockfile_contents)
+      @tree = specs_as_tree(parser.specs)
+
+      reverse_dependencies_with_versions(spec)
+    end
+
+    def specs_as_tree(specs)
+      specs.each_with_object({}) do |spec, hash|
+        hash[spec.name] = spec
+      end
+    end
+
+    def transitive_dependencies(target)
+      raise ArgumentError, "Unknown gem #{target}" unless @tree.key? target
+
+      top_level = @tree[target].dependencies
+      all_level = top_level + top_level.inject([]) do |arr, dep|
+        next arr if dep.name == "bundler"
+
+        arr + transitive_dependencies(dep.name)
+      end
+
+      all_level.uniq(&:name)
+    end
+
+    def reverse_dependencies_with_versions(target)
+      @tree.map do |name, dep|
+        transitive_dependencies(name).map do |transitive_dependency|
+          next unless transitive_dependency.name == target
+          {
+            :name => dep.name,
+            :version => transitive_dependency.requirement.to_s,
+            :requirement => transitive_dependency.requirement,
+          }
+        end
+      end.flatten.compact.sort do |a, b|
+        a[:requirement].as_list <=> b[:requirement].as_list
+      end
     end
   end
 end

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -9,6 +9,11 @@ RSpec.describe "bundle info" do
       G
     end
 
+    it "prints the gems dependent on the gem in argument" do
+      bundle "info rails"
+      expect(out).to include "\tDependents:\n\t\tNone"
+    end
+
     it "creates a Gemfile.lock when invoked with a gem name" do
       FileUtils.rm("Gemfile.lock")
 

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -5,14 +5,19 @@ RSpec.describe "bundle info" do
     before do
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
-        gem "rake"
         gem "rails"
       G
     end
 
     it "prints the gems dependent on the gem in argument" do
-      bundle "info rake"
-      expect(out).to include "\tDependents:\n\t\trails"
+      bundle "info activesupport"
+      expect(out).to include "\tDependents:\n\t\tactionmailer"
+      expect(out).to include "\n\t\tactionpack"
+    end
+
+    it "prints None on the gem in argument that doesn't have any dependent" do
+      bundle "info rails"
+      expect(out).to include "\t\tNone"
     end
 
     it "creates a Gemfile.lock when invoked with a gem name" do

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "bundle info" do
 
     it "prints the gems dependent on the gem in argument" do
       bundle "info rake"
-      expect(out).to include "\tDependents:\n\t\trails (= 10.0.2)"
+      expect(out).to include "\tDependents:\n\t\trails"
     end
 
     it "creates a Gemfile.lock when invoked with a gem name" do

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -5,13 +5,14 @@ RSpec.describe "bundle info" do
     before do
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
+        gem "rake"
         gem "rails"
       G
     end
 
     it "prints the gems dependent on the gem in argument" do
-      bundle "info rails"
-      expect(out).to include "\tDependents:\n\t\tNone"
+      bundle "info rake"
+      expect(out).to include "\tDependents:\n\t\trails (= 10.0.2)"
     end
 
     it "creates a Gemfile.lock when invoked with a gem name" do


### PR DESCRIPTION
Continuing PR #6893 which has not been updated since the end of April.

Please let me know if there is a better way to continue to work on an existing PR. If granted access, probably it is better to push directly to @ankitkataria's fork. Or if these minor additions are enough to merge this PR, then it is OK also for @ankitkataria to just apply these diffs as another commit on PR #6893 :) 

### What was the end-user problem that led to this PR?

Fixes #6800

- adds functionality to show the dependent gems

### What was your diagnosis of the problem?

My diagnosis was...

### What is your fix for the problem, implemented in this PR?

My fix...

### Why did you choose this fix out of the possible options?

Replicated the functionality from ```bundler-stats``` gem using jmmastey/bundler-stats#1 as a reference as mentioned in the issue