### PR TITLE
Don't (yet) enable parallelization in CI

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -146,7 +146,9 @@ namespace :spec do
     ENV["BUNDLER_SPEC_PRE_RECORDED"] = "TRUE"
 
     puts "\n\e[1;33m[Travis CI] Running bundler specs against RubyGems #{rg}\e[m\n\n"
-    specs = safe_task { Rake::Task["spec:rubygems:parallel_#{rg}"].invoke }
+    specs = safe_task { Rake::Task["spec:rubygems:#{rg}"].invoke }
+
+    Rake::Task["spec:rubygems:#{rg}"].reenable
 
     puts "\n\e[1;33m[Travis CI] Running bundler sudo specs against RubyGems #{rg}\e[m\n\n"
     sudos = system("sudo -E rake spec:rubygems:#{rg}:sudo")


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that unfortunately #7317 broken rubygems test suite. See https://github.com/rubygems/rubygems/pull/2888.

### What was your diagnosis of the problem?

My diagnosis was that it has some issues.

### What is your fix for the problem, implemented in this PR?

My fix is to not (yet) use it in CI, so we can keep using it locally and investigating these issues without interfering with our CI. In a while we reevaluate how it is working a consider enabling in CI.