### PR TITLE
Fix comments and messages to refer to https url

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -260,7 +260,7 @@ module Bundler
       message = <<EOF
 It is a security vulnerability to allow your home directory to be world-writable, and bundler can not continue.
 You should probably consider fixing this issue by running `chmod o-w ~` on *nix.
-Please refer to http://ruby-doc.org/stdlib-2.1.2/libdoc/fileutils/rdoc/FileUtils.html#method-c-remove_entry_secure for details.
+Please refer to https://ruby-doc.org/stdlib-2.1.2/libdoc/fileutils/rdoc/FileUtils.html#method-c-remove_entry_secure for details.
 EOF
       File.world_writable?(path) ? Bundler.ui.warn(message) : raise
       raise PathError, "Please fix the world-writable issue with your #{path} directory"

--- a/lib/bundler/capistrano.rb
+++ b/lib/bundler/capistrano.rb
@@ -2,7 +2,7 @@
 
 require_relative "shared_helpers"
 Bundler::SharedHelpers.major_deprecation 2,
-  "The Bundler task for Capistrano. Please use http://github.com/capistrano/bundler"
+  "The Bundler task for Capistrano. Please use https://github.com/capistrano/bundler"
 
 # Capistrano task for Bundler.
 #
@@ -12,7 +12,7 @@ require_relative "deployment"
 require "capistrano/version"
 
 if defined?(Capistrano::Version) && Gem::Version.new(Capistrano::Version).release >= Gem::Version.new("3.0")
-  raise "For Capistrano 3.x integration, please use http://github.com/capistrano/bundler"
+  raise "For Capistrano 3.x integration, please use https://github.com/capistrano/bundler"
 end
 
 Capistrano::Configuration.instance(:must_exist).load do

--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -190,7 +190,7 @@ module Bundler
       Bundler.ui.error "You have specified a gem name which does not conform to the \n" \
                        "naming guidelines for C extensions. For more information, \n" \
                        "see the 'Extension Naming' section at the following URL:\n" \
-                       "http://guides.rubygems.org/gems-with-extensions/\n"
+                       "https://guides.rubygems.org/gems-with-extensions/\n"
       exit 1
     end
 

--- a/lib/bundler/friendly_errors.rb
+++ b/lib/bundler/friendly_errors.rb
@@ -28,7 +28,7 @@ module Bundler
         Bundler.ui.warn <<-WARN, :wrap => true
           You must recompile Ruby with OpenSSL support or change the sources in your \
           Gemfile from 'https' to 'http'. Instructions for compiling with OpenSSL \
-          using RVM are available at http://rvm.io/packages/openssl.
+          using RVM are available at https://rvm.io/packages/openssl.
         WARN
         Bundler.ui.trace error
       when Interrupt

--- a/lib/bundler/similarity_detector.rb
+++ b/lib/bundler/similarity_detector.rb
@@ -28,7 +28,7 @@ module Bundler
 
   protected
 
-    # http://www.informit.com/articles/article.aspx?p=683059&seqNum=36
+    # https://www.informit.com/articles/article.aspx?p=683059&seqNum=36
     def levenshtein_distance(this, that, ins = 2, del = 2, sub = 1)
       # ins, del, sub are weighted costs
       return nil if this.nil?

--- a/lib/bundler/source/git/git_proxy.rb
+++ b/lib/bundler/source/git/git_proxy.rb
@@ -19,7 +19,7 @@ module Bundler
         def initialize(command)
           msg = String.new
           msg << "Bundler is trying to run a `git #{command}` at runtime. You probably need to run `bundle install`. However, "
-          msg << "this error message could probably be more useful. Please submit a ticket at http://github.com/bundler/bundler/issues "
+          msg << "this error message could probably be more useful. Please submit a ticket at https://github.com/bundler/bundler/issues "
           msg << "with steps to reproduce as well as the following\n\nCALLER: #{caller.join("\n")}"
           super msg
         end

--- a/lib/bundler/templates/newgem/CODE_OF_CONDUCT.md.tt
+++ b/lib/bundler/templates/newgem/CODE_OF_CONDUCT.md.tt
@@ -68,7 +68,7 @@ members of the project's leadership.
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at [http://contributor-covenant.org/version/1/4][version]
+available at [https://contributor-covenant.org/version/1/4][version]
 
-[homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/4/
+[homepage]: https://contributor-covenant.org
+[version]: https://contributor-covenant.org/version/1/4/

--- a/spec/bundler/bundler_spec.rb
+++ b/spec/bundler/bundler_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe Bundler do
         message = <<EOF
 It is a security vulnerability to allow your home directory to be world-writable, and bundler can not continue.
 You should probably consider fixing this issue by running `chmod o-w ~` on *nix.
-Please refer to http://ruby-doc.org/stdlib-2.1.2/libdoc/fileutils/rdoc/FileUtils.html#method-c-remove_entry_secure for details.
+Please refer to https://ruby-doc.org/stdlib-2.1.2/libdoc/fileutils/rdoc/FileUtils.html#method-c-remove_entry_secure for details.
 EOF
         expect(bundler_ui).to receive(:warn).with(message)
         expect { Bundler.send(:rm_rf, bundled_app) }.to raise_error(Bundler::PathError)


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

End-users experience 301 redirect, or unintentionally visit URL with http.

### What was your diagnosis of the problem?

Following are some examples using curl to explain this problem.

```
$ curl -I http://github.com/capistrano/bundler
HTTP/1.1 301 Moved Permanently
Content-length: 0
Location: https://github.com/capistrano/bundler
```
```
$ curl -I http://guides.rubygems.org/gems-with-extensions/
HTTP/1.1 301 Moved Permanently
Content-Type: text/html
Server: GitHub.com
Location: https://guides.rubygems.org/gems-with-extensions/
X-GitHub-Request-Id: 0A1A:1377:32938B:35C160:5D5D5A84
Content-Length: 162
Accept-Ranges: bytes
Date: Wed, 21 Aug 2019 14:51:49 GMT
Via: 1.1 varnish
Age: 0
Connection: keep-alive
X-Served-By: cache-tyo19949-TYO
X-Cache: MISS
X-Cache-Hits: 0
X-Timer: S1566399109.014809,VS0,VE168
Vary: Accept-Encoding
X-Fastly-Request-ID: 9357ee98e56565f92489c8a4e03235ab60eeb27f
```

### What is your fix for the problem, implemented in this PR?

My fix is to replace http URLs with https URLs.

### Why did you choose this fix out of the possible options?

It's because this fix is simple and easy.
