### PR TITLE
Remove `:ruby_core` tag for ruby core

### DIFF
--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -75,8 +75,8 @@ module Bundler
 
     def build_gem
       file_name = nil
-      gem = ENV["BUNDLE_GEM"] ? ENV["BUNDLE_GEM"] : "gem"
-      sh(%W[#{gem} build -V #{spec_path}]) do
+      gem = ENV["GEM_COMMAND"] ? ENV["GEM_COMMAND"] : "gem"
+      sh("#{gem} build -V #{spec_path}".shellsplit) do
         file_name = File.basename(built_gem_path)
         SharedHelpers.filesystem_access(File.join(base, "pkg")) {|p| FileUtils.mkdir_p(p) }
         FileUtils.mv(built_gem_path, "pkg")
@@ -87,10 +87,10 @@ module Bundler
 
     def install_gem(built_gem_path = nil, local = false)
       built_gem_path ||= build_gem
-      gem = ENV["BUNDLE_GEM"] ? ENV["BUNDLE_GEM"] : "gem"
-      cmd = %W[#{gem} install #{built_gem_path}]
-      cmd << "--local" if local
-      out, status = sh_with_status(cmd)
+      gem = ENV["GEM_COMMAND"] ? ENV["GEM_COMMAND"] : "gem"
+      cmd = "#{gem} install #{built_gem_path}"
+      cmd += " --local" if local
+      out, status = sh_with_status(cmd.shellsplit)
       unless status.success? && out[/Successfully installed/]
         raise "Couldn't install gem, run `gem install #{built_gem_path}' for more detailed output"
       end

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -268,7 +268,7 @@ module Bundler
       until !File.directory?(current) || current == previous
         if ENV["BUNDLE_SPEC_RUN"]
           # avoid stepping above the tmp directory when testing
-          gemspec = if ENV["BUNDLE_RUBY"] && ENV["BUNDLE_GEM"]
+          gemspec = if ENV["GEM_COMMAND"]
             # for Ruby Core
             "lib/bundler/bundler.gemspec"
           else

--- a/spec/bundler/cli_spec.rb
+++ b/spec/bundler/cli_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "bundle executable" do
 
   it "looks for a binary and executes it if it's named bundler-<task>" do
     File.open(tmp("bundler-testtasks"), "w", 0o755) do |f|
-      ruby = ENV["BUNDLE_RUBY"] || "/usr/bin/env ruby"
+      ruby = ENV["RUBY"] || "/usr/bin/env ruby"
       f.puts "#!#{ruby}\nputs 'Hello, world'\n"
     end
 

--- a/spec/bundler/env_spec.rb
+++ b/spec/bundler/env_spec.rb
@@ -190,11 +190,11 @@ RSpec.describe Bundler::Env do
     end
   end
 
-  describe ".version_of", :ruby_repo do
+  describe ".version_of" do
     let(:parsed_version) { described_class.send(:version_of, "ruby") }
 
     it "strips version of new line characters" do
-      expect(parsed_version).to_not include("\n")
+      expect(parsed_version).to_not end_with("\n")
     end
   end
 end

--- a/spec/bundler/gem_helper_spec.rb
+++ b/spec/bundler/gem_helper_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Bundler::GemHelper do
     end
   end
 
-  context "gem management", :ruby_repo do
+  context "gem management" do
     def mock_confirm_message(message)
       expect(Bundler.ui).to receive(:confirm).with(message)
     end

--- a/spec/bundler/mirror_spec.rb
+++ b/spec/bundler/mirror_spec.rb
@@ -304,7 +304,7 @@ RSpec.describe Bundler::Settings::TCPSocketProbe do
       server.close unless server.closed?
     end
 
-    it "probes the server correctly", :ruby_repo do
+    it "probes the server correctly" do
       with_server_and_mirror do |server, mirror|
         expect(server.closed?).to be_falsey
         expect(probe.replies?(mirror)).to be_truthy

--- a/spec/commands/config_spec.rb
+++ b/spec/commands/config_spec.rb
@@ -389,7 +389,7 @@ E
   end
 
   describe "subcommands" do
-    it "list", :ruby_repo do
+    it "list" do
       bundle! "config list"
       expect(out).to eq "Settings are listed in order of priority. The top value will be used.\nspec_run\nSet via BUNDLE_SPEC_RUN: \"true\""
 

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "bundle exec" do
     expect(out).to eq("1.0.0")
   end
 
-  it "works when running from a random directory", :ruby_repo do
+  it "works when running from a random directory" do
     install_gemfile <<-G
       gem "rack"
     G
@@ -56,14 +56,14 @@ RSpec.describe "bundle exec" do
   end
 
   it "respects custom process title when loading through ruby", :github_action_linux do
-    script_that_changes_its_own_title_and_checks_if_picked_up_by_ps_unix_utility = <<~RUBY
-      Process.setproctitle("1-2-3-4-5-6-7-8-9-10-11-12-13-14-15-16")
-      puts `ps -eo args | grep [1]-2-3-4-5-6-7-8-9-10-11-12-13-14-15-16`
+    script_that_changes_its_own_title_and_checks_if_picked_up_by_ps_unix_utility = <<~'RUBY'
+      Process.setproctitle("1-2-3-4-5-6-7-8-9-10-11-12-13-14-15")
+      puts `ps -ocommand= -p#{$$}`
     RUBY
     create_file "Gemfile"
     create_file "a.rb", script_that_changes_its_own_title_and_checks_if_picked_up_by_ps_unix_utility
     bundle "exec ruby a.rb"
-    expect(out).to eq("1-2-3-4-5-6-7-8-9-10-11-12-13-14-15-16")
+    expect(out).to eq("1-2-3-4-5-6-7-8-9-10-11-12-13-14-15")
   end
 
   it "accepts --verbose" do
@@ -192,7 +192,7 @@ RSpec.describe "bundle exec" do
       it "uses version specified" do
         bundle! "exec irb --version"
 
-        expect(out).to include(specified_irb_version)
+        expect(out).to eq(specified_irb_version)
         expect(err).to be_empty
       end
     end
@@ -222,7 +222,7 @@ RSpec.describe "bundle exec" do
       end
 
       it "uses resolved version" do
-        expect(out).to include(indirect_irb_version)
+        expect(out).to eq(indirect_irb_version)
         expect(err).to be_empty
       end
     end
@@ -336,7 +336,7 @@ RSpec.describe "bundle exec" do
     expect(err).to include("bundler: exec needs a command to run")
   end
 
-  it "raises a helpful error when exec'ing to something outside of the bundle", :ruby_repo do
+  it "raises a helpful error when exec'ing to something outside of the bundle" do
     bundle! "config set clean false" # want to keep the rackup binstub
     install_gemfile! <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -688,7 +688,7 @@ RSpec.describe "bundle exec" do
       it_behaves_like "it runs"
     end
 
-    context "when the file uses the current ruby shebang", :ruby_repo do
+    context "when the file uses the current ruby shebang" do
       let(:shebang) { "#!#{Gem.ruby}" }
       it_behaves_like "it runs"
     end

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe "bundle info" do
     end
   end
 
-  context "with a valid regexp for gem name", :ruby_repo do
+  context "with a valid regexp for gem name" do
     it "presents alternatives" do
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -210,7 +210,7 @@ RSpec.describe "bundle gem" do
     end
   end
 
-  it "generates a valid gemspec", :ruby_repo do
+  it "generates a valid gemspec" do
     in_app_root
     bundle! "gem newgem --bin"
 

--- a/spec/commands/open_spec.rb
+++ b/spec/commands/open_spec.rb
@@ -93,7 +93,17 @@ RSpec.describe "bundle open" do
   end
 
   context "when opening a default gem" do
+    let(:default_gems) do
+      ruby!(<<-RUBY).split("\n")
+        if Gem::Specification.is_a?(Enumerable)
+          puts Gem::Specification.select(&:default_gem?).map(&:name)
+        end
+      RUBY
+    end
+
     before do
+      skip "No default gems available on this test run" if default_gems.empty?
+
       install_gemfile <<-G
         gem "json"
       G

--- a/spec/commands/show_spec.rb
+++ b/spec/commands/show_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
   end
 
   context "with a valid regexp for gem name" do
-    it "presents alternatives", :ruby_repo do
+    it "presents alternatives" do
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rack"

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -1110,7 +1110,7 @@ RSpec.describe "bundle install with git sources" do
   end
 
   context "with an extension" do
-    it "installs the extension", :ruby_repo do
+    it "installs the extension" do
       build_git "foo" do |s|
         s.add_dependency "rake"
         s.extensions << "Rakefile"
@@ -1139,7 +1139,7 @@ RSpec.describe "bundle install with git sources" do
       run! <<-R
         puts $:.grep(/ext/)
       R
-      expect(out).to eq(Pathname.glob(default_bundle_path("bundler/gems/extensions/**/foo-1.0-*")).first.to_s)
+      expect(out).to include(Pathname.glob(default_bundle_path("bundler/gems/extensions/**/foo-1.0-*")).first.to_s)
     end
 
     it "does not use old extension after ref changes", :ruby_repo do
@@ -1204,7 +1204,7 @@ In Gemfile:
       expect(out).not_to include("gem install foo")
     end
 
-    it "does not reinstall the extension", :ruby_repo do
+    it "does not reinstall the extension" do
       build_git "foo" do |s|
         s.add_dependency "rake"
         s.extensions << "Rakefile"
@@ -1245,7 +1245,7 @@ In Gemfile:
       expect(out).to eq(installed_time)
     end
 
-    it "does not reinstall the extension when changing another gem", :ruby_repo do
+    it "does not reinstall the extension when changing another gem" do
       build_git "foo" do |s|
         s.add_dependency "rake"
         s.extensions << "Rakefile"
@@ -1288,7 +1288,7 @@ In Gemfile:
       expect(out).to eq(installed_time)
     end
 
-    it "does reinstall the extension when changing refs", :ruby_repo do
+    it "does reinstall the extension when changing refs" do
       build_git "foo" do |s|
         s.add_dependency "rake"
         s.extensions << "Rakefile"

--- a/spec/install/gems/resolving_spec.rb
+++ b/spec/install/gems/resolving_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe "bundle install with install-time dependencies" do
-  it "installs gems with implicit rake dependencies", :ruby_repo do
+  it "installs gems with implicit rake dependencies" do
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
       gem "with_implicit_rake_dep"
@@ -48,7 +48,7 @@ RSpec.describe "bundle install with install-time dependencies" do
       expect(the_bundle).to include_gems "net_b 1.0"
     end
 
-    it "installs plugins depended on by other plugins", :ruby_repo do
+    it "installs plugins depended on by other plugins" do
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "net_a"
@@ -57,7 +57,7 @@ RSpec.describe "bundle install with install-time dependencies" do
       expect(the_bundle).to include_gems "net_a 1.0", "net_b 1.0"
     end
 
-    it "installs multiple levels of dependencies", :ruby_repo do
+    it "installs multiple levels of dependencies" do
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "net_c"

--- a/spec/quality_es_spec.rb
+++ b/spec/quality_es_spec.rb
@@ -50,11 +50,11 @@ RSpec.describe "La biblioteca si misma" do
     expect(error_messages.compact).to be_well_formed
   end
 
-  it "mantiene la calidad de lenguaje de oraciones usadas en el código fuente", :ruby_repo do
+  it "mantiene la calidad de lenguaje de oraciones usadas en el código fuente" do
     error_messages = []
     exempt = /vendor/
     Dir.chdir(root) do
-      `git ls-files -z -- lib`.split("\x0").each do |filename|
+      lib_tracked_files.split("\x0").each do |filename|
         next if filename =~ exempt
         error_messages << check_for_expendable_words(filename)
         error_messages << check_for_specific_pronouns(filename)

--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -230,10 +230,9 @@ RSpec.describe "The library itself" do
     end
   end
 
-  it "ships the correct set of files", :ruby_repo do
+  it "ships the correct set of files" do
     Dir.chdir(root) do
-      git_list = IO.popen("git ls-files -z", &:read).split("\x0").select {|f| f.match(%r{^(lib|man|exe)/}) }
-      git_list += %w[CHANGELOG.md LICENSE.md README.md bundler.gemspec]
+      git_list = shipped_files.split("\x0")
 
       gem_list = Gem::Specification.load(gemspec.to_s).files
 

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -810,12 +810,12 @@ end
       end
     end
 
-    it "should not remove itself from the LOAD_PATH and require a different copy of 'bundler/setup'", :ruby_repo do
+    it "should not remove itself from the LOAD_PATH and require a different copy of 'bundler/setup'" do
       install_gemfile ""
 
       ruby <<-R, :env => { "GEM_PATH" => symlinked_gem_home }, :no_lib => true
         TracePoint.trace(:class) do |tp|
-          if tp.path.include?("bundler") && !tp.path.start_with?("#{File.expand_path("../..", __dir__)}")
+          if tp.path.include?("bundler") && !tp.path.start_with?("#{root}")
             puts "OMG. Defining a class from another bundler at \#{tp.path}:\#{tp.lineno}"
           end
         end

--- a/spec/runtime/with_unbundled_env_spec.rb
+++ b/spec/runtime/with_unbundled_env_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Bundler.with_env helpers" do
       end
     end
 
-    it "works with nested bundle exec invocations", :ruby_repo do
+    it "works with nested bundle exec invocations" do
       create_file("exe.rb", <<-'RB')
         count = ARGV.first.to_i
         exit if count < 0

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -69,7 +69,7 @@ RSpec.configure do |config|
   config.filter_run_excluding :rubygems => RequirementChecker.against(Gem::VERSION)
   config.filter_run_excluding :git => RequirementChecker.against(git_version)
   config.filter_run_excluding :bundler => RequirementChecker.against(Bundler::VERSION.split(".")[0])
-  config.filter_run_excluding :ruby_repo => !(ENV["BUNDLE_RUBY"] && ENV["BUNDLE_GEM"]).nil?
+  config.filter_run_excluding :ruby_repo => !ENV["GEM_COMMAND"].nil?
   config.filter_run_excluding :no_color_tty => Gem.win_platform? || !ENV["GITHUB_ACTION"].nil?
   config.filter_run_excluding :github_action_linux => !ENV["GITHUB_ACTION"].nil? && (ENV["RUNNER_OS"] == "Linux")
 
@@ -87,12 +87,12 @@ RSpec.configure do |config|
   end
 
   config.around :each do |example|
-    if ENV["BUNDLE_RUBY"]
+    if ENV["RUBY"]
       orig_ruby = Gem.ruby
-      Gem.ruby = ENV["BUNDLE_RUBY"]
+      Gem.ruby = ENV["RUBY"]
     end
     example.run
-    Gem.ruby = orig_ruby if ENV["BUNDLE_RUBY"]
+    Gem.ruby = orig_ruby if ENV["RUBY"]
   end
 
   config.before :suite do
@@ -107,7 +107,7 @@ RSpec.configure do |config|
 
     original_env = ENV.to_hash
 
-    if ENV["BUNDLE_RUBY"]
+    if ENV["RUBY"]
       FileUtils.cp_r Spec::Path.bindir, File.join(Spec::Path.root, "lib", "exe")
     end
   end
@@ -138,7 +138,7 @@ RSpec.configure do |config|
   end
 
   config.after :suite do
-    if ENV["BUNDLE_RUBY"]
+    if ENV["RUBY"]
       FileUtils.rm_rf File.join(Spec::Path.root, "lib", "exe")
     end
   end

--- a/spec/support/builders.rb
+++ b/spec/support/builders.rb
@@ -557,7 +557,7 @@ module Spec
             "#!/usr/bin/env ruby\n"
           end
           @spec.files << executable
-          write executable, "#{shebang}require '#{@name}' ; puts #{Builders.constantize(@name)}"
+          write executable, "#{shebang}require_relative '../lib/#{@name}' ; puts #{Builders.constantize(@name)}"
         end
       end
 

--- a/spec/support/hax.rb
+++ b/spec/support/hax.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 module Gem
+  def self.ruby=(ruby)
+    @ruby = ruby
+  end
+
+  if ENV["RUBY"]
+    Gem.ruby = ENV["RUBY"]
+  end
+
   if version = ENV["BUNDLER_SPEC_RUBYGEMS_VERSION"]
     remove_const(:VERSION) if const_defined?(:VERSION)
     VERSION = version

--- a/spec/support/path.rb
+++ b/spec/support/path.rb
@@ -22,7 +22,7 @@ module Spec
     end
 
     def gem_bin
-      @gem_bin ||= ruby_core? ? ENV["BUNDLE_GEM"] : "#{Gem.ruby} -S gem --backtrace"
+      @gem_bin ||= ruby_core? ? ENV["GEM_COMMAND"] : "#{Gem.ruby} -S gem --backtrace"
     end
 
     def spec_dir
@@ -30,7 +30,11 @@ module Spec
     end
 
     def tracked_files
-      @tracked_files ||= ruby_core? ? `git ls-files -z -- lib/bundler lib/bundler.rb spec/bundler` : `git ls-files -z`
+      @tracked_files ||= ruby_core? ? `git ls-files -z -- lib/bundler lib/bundler.rb spec/bundler man/bundler*` : `git ls-files -z`
+    end
+
+    def shipped_files
+      @shipped_files ||= ruby_core? ? `git ls-files -z -- lib/bundler lib/bundler.rb man/bundler* libexec/bundle*` : `git ls-files -z -- lib man exe CHANGELOG.md LICENSE.md README.md bundler.gemspec`
     end
 
     def lib_tracked_files
@@ -161,7 +165,7 @@ module Spec
       @ruby_core ||= nil
 
       if @ruby_core.nil?
-        @ruby_core = true & (ENV["BUNDLE_RUBY"] && ENV["BUNDLE_GEM"])
+        @ruby_core = true & ENV["GEM_COMMAND"]
       else
         @ruby_core
       end


### PR DESCRIPTION
This pull request is backported from https://github.com/ruby/ruby/pull/2380