### PR TITLE
Undo auto multiplatform

### DIFF
--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -169,8 +169,6 @@ module Bundler
     end
 
     def retrieve_active_spec(definition, current_spec)
-      return unless current_spec.match_platform(Bundler.local_platform)
-
       if strict
         active_spec = definition.find_resolved_spec(current_spec)
       else

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -518,6 +518,10 @@ module Bundler
       raise InvalidOption, "Unable to remove the platform `#{platform}` since the only platforms are #{@platforms.join ", "}"
     end
 
+    def add_current_platform
+      current_platforms.each {|platform| add_platform(platform) }
+    end
+
     def find_resolved_spec(current_spec)
       specs.find_by_name_and_platform(current_spec.name, current_spec.platform)
     end

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -113,7 +113,7 @@ module Bundler
       end
       @unlocking ||= @unlock[:ruby] ||= (!@locked_ruby_version ^ !@ruby_version)
 
-      add_platforms unless Bundler.frozen_bundle?
+      add_current_platform unless Bundler.frozen_bundle?
 
       converge_path_sources_to_gemspec_sources
       @path_changes = converge_paths
@@ -542,12 +542,6 @@ module Bundler
     end
 
   private
-
-    def add_platforms
-      (@dependencies.flat_map(&:expanded_platforms) + current_platforms).uniq.each do |platform|
-        add_platform(platform)
-      end
-    end
 
     def current_platforms
       current_platform = Bundler.local_platform

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -896,7 +896,17 @@ module Bundler
       dependencies.each do |dep|
         dep = Dependency.new(dep, ">= 0") unless dep.respond_to?(:name)
         next if !remote && !dep.current_platform?
-        dep.gem_platforms(sorted_platforms).each do |p|
+        platforms = dep.gem_platforms(sorted_platforms)
+        if platforms.empty? && !Bundler.settings[:disable_platform_warnings]
+          mapped_platforms = dep.expanded_platforms
+          Bundler.ui.warn \
+            "The dependency #{dep} will be unused by any of the platforms Bundler is installing for. " \
+            "Bundler is installing for #{@platforms.join ", "} but the dependency " \
+            "is only for #{mapped_platforms.join ", "}. " \
+            "To add those platforms to the bundle, " \
+            "run `bundle lock --add-platform #{mapped_platforms.join " "}`."
+        end
+        platforms.each do |p|
           deps << DepProxy.new(dep, p) if remote || p == generic_local_platform
         end
       end

--- a/lib/bundler/inline.rb
+++ b/lib/bundler/inline.rb
@@ -58,7 +58,7 @@ def gemfile(install = false, options = {}, &gemfile)
 
     Bundler.ui = ui if install
     if install || missing_specs.call
-      Bundler.settings.temporary(:inline => true) do
+      Bundler.settings.temporary(:inline => true, :disable_platform_warnings => true) do
         installer = Bundler::Installer.install(Bundler.root, definition, :system => true)
         installer.post_install_messages.each do |name, message|
           Bundler.ui.info "Post-install message from #{name}:\n#{message}"

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -24,6 +24,7 @@ module Bundler
       disable_exec_load
       disable_local_branch_check
       disable_multisource
+      disable_platform_warnings
       disable_shared_gems
       disable_version_check
       force_ruby_platform

--- a/man/bundle-config.1
+++ b/man/bundle-config.1
@@ -187,6 +187,9 @@ The following is a list of all configuration keys and their purpose\. You can le
 \fBdisable_multisource\fR (\fBBUNDLE_DISABLE_MULTISOURCE\fR): When set, Gemfiles containing multiple sources will produce errors instead of warnings\. Use \fBbundle config unset disable_multisource\fR to unset\.
 .
 .IP "\(bu" 4
+\fBdisable_platform_warnings\fR (\fBBUNDLE_DISABLE_PLATFORM_WARNINGS\fR): Disable warnings during bundle install when a dependency is unused on the current platform\.
+.
+.IP "\(bu" 4
 \fBdisable_shared_gems\fR (\fBBUNDLE_DISABLE_SHARED_GEMS\fR): Stop Bundler from accessing gems installed to RubyGems\' normal location\.
 .
 .IP "\(bu" 4

--- a/man/bundle-config.1.txt
+++ b/man/bundle-config.1.txt
@@ -213,6 +213,10 @@ LIST OF AVAILABLE KEYS
 	   files containing multiple sources will produce  errors  instead  of
 	   warnings. Use bundle config unset disable_multisource to unset.
 
+       o   disable_platform_warnings  (BUNDLE_DISABLE_PLATFORM_WARNINGS): Dis-
+	   able warnings during bundle install when a dependency is unused  on
+	   the current platform.
+
        o   disable_shared_gems (BUNDLE_DISABLE_SHARED_GEMS): Stop Bundler from
 	   accessing gems installed to RubyGems' normal location.
 

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -179,6 +179,8 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
    When set, Gemfiles containing multiple sources will produce errors
    instead of warnings.
    Use `bundle config unset disable_multisource` to unset.
+* `disable_platform_warnings` (`BUNDLE_DISABLE_PLATFORM_WARNINGS`):
+   Disable warnings during bundle install when a dependency is unused on the current platform.
 * `disable_shared_gems` (`BUNDLE_DISABLE_SHARED_GEMS`):
    Stop Bundler from accessing gems installed to RubyGems' normal location.
 * `disable_version_check` (`BUNDLE_DISABLE_VERSION_CHECK`):

--- a/spec/install/gemfile/platform_spec.rb
+++ b/spec/install/gemfile/platform_spec.rb
@@ -406,6 +406,25 @@ RSpec.describe "bundle install with platform conditionals" do
          #{Bundler::VERSION}
     L
   end
+
+  context "when disable_platform_warnings is true" do
+    before { bundle! "config set disable_platform_warnings true" }
+
+    it "does not print the warning when a dependency is unused on any platform" do
+      simulate_platform "ruby"
+      simulate_ruby_engine "ruby"
+
+      gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+
+        gem "rack", :platform => [:mingw, :mswin, :x64_mingw, :jruby]
+      G
+
+      bundle! "install"
+
+      expect(out).not_to match(/The dependency (.*) will be unused/)
+    end
+  end
 end
 
 RSpec.describe "when a gem has no architecture" do

--- a/spec/install/gemfile/platform_spec.rb
+++ b/spec/install/gemfile/platform_spec.rb
@@ -372,7 +372,7 @@ RSpec.describe "bundle install with platform conditionals" do
     expect(out).not_to match(/Could not find gem 'some_gem/)
   end
 
-  it "resolves all platforms by default and without warning messages" do
+  it "prints a helpful warning when a dependency is unused on any platform" do
     simulate_platform "ruby"
     simulate_ruby_engine "ruby"
 
@@ -384,27 +384,9 @@ RSpec.describe "bundle install with platform conditionals" do
 
     bundle! "install"
 
-    expect(err).to be_empty
-
-    lockfile_should_be <<-L
-      GEM
-        remote: #{file_uri_for(gem_repo1)}/
-        specs:
-          rack (1.0.0)
-
-      PLATFORMS
-        java
-        ruby
-        x64-mingw32
-        x86-mingw32
-        x86-mswin32
-
-      DEPENDENCIES
-        rack
-
-      BUNDLED WITH
-         #{Bundler::VERSION}
-    L
+    expect(err).to include <<-O.strip
+The dependency #{Gem::Dependency.new("rack", ">= 0")} will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for x86-mingw32, x86-mswin32, x64-mingw32, java. To add those platforms to the bundle, run `bundle lock --add-platform x86-mingw32 x86-mswin32 x64-mingw32 java`.
+    O
   end
 
   context "when disable_platform_warnings is true" do

--- a/spec/runtime/require_spec.rb
+++ b/spec/runtime/require_spec.rb
@@ -425,7 +425,7 @@ RSpec.describe "Bundler.require with platform specific dependencies" do
       source "#{file_uri_for(gem_repo1)}"
 
       platforms :#{not_local_tag} do
-        gem "platform_specific", :require => "omgomg"
+        gem "fail", :require => "omgomg"
       end
 
       gem "rack", "1.0.0"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that since #7215, more Gemfiles are going to fail resolution because of the current issues with multiplatform support, and that we'll be pushing current multiplatform problems into all users because bundler will resolve and lock all platforms included on a Gemfile by default. 

### What was your diagnosis of the problem?

My diagnosis was that we probably need better multiplatform support before we start resolving all platforms by default.

### What is your fix for the problem, implemented in this PR?

My fix is to revert the relevant commits from #7215. I'll try to revisit in the future.

### Why did you choose this fix out of the possible options?

I chose this fix because it goes back to how things were before.

Closes #7315.
