### PR TITLE
Fix version number in release playbook

### DIFF
--- a/doc/playbooks/RELEASING.md
+++ b/doc/playbooks/RELEASING.md
@@ -112,7 +112,7 @@ _anything_ wrong as the release manager.
 #### Branching
 
 Minor releases of the next version start with a new release branch from the
-current state of master: `1-12-stable`, and are immediately followed by a `.pre.0` release.
+current state of master: `1-12-stable`, and are immediately followed by a `.pre.1` release.
 
 Once that `-stable` branch has been cut from `master`, changes for that minor
 release series (1.12) will only be made _intentionally_, via patch releases.


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that I'm about to release bundler, but I'm unsure which one is the right version number.

### What was your diagnosis of the problem?

My diagnosis was that the release playbook is probably wrong, because looking at https://rubygems.org/gems/bundler/versions, we don't really ship `.pre.0`. versions.

### What is your fix for the problem, implemented in this PR?

My fix is to document `.pre.1` as the first prerelease on a minor series, since that's what we usually do.