### PR TITLE
Release task improvements

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -187,6 +187,7 @@ namespace :man do
       Spec::Rubygems.gem_require("ronn")
     rescue Gem::LoadError => e
       task(:build) { abort "We couln't activate ronn (#{e.requirement}). Try `gem install ronn:'#{e.requirement}'` to be able to build the help pages" }
+      task(:check) { abort "We couln't activate ronn (#{e.requirement}). Try `gem install ronn:'#{e.requirement}'` to be able to build the help pages" }
     else
       directory "man"
 

--- a/task/release.rake
+++ b/task/release.rake
@@ -4,7 +4,7 @@ require "bundler/gem_tasks"
 task :build => ["build_metadata"] do
   Rake::Task["build_metadata:clean"].tap(&:reenable).real_invoke
 end
-task :release => ["release:verify_docs", "release:verify_files", "release:verify_github", "build_metadata", "release:github"]
+task "release:rubygem_push" => ["release:verify_docs", "release:verify_files", "release:verify_github", "build_metadata", "release:github"]
 
 namespace :release do
   task :verify_docs => :"man:check"

--- a/task/release.rake
+++ b/task/release.rake
@@ -4,7 +4,7 @@ require "bundler/gem_tasks"
 task :build => ["build_metadata"] do
   Rake::Task["build_metadata:clean"].tap(&:reenable).real_invoke
 end
-task :release => ["release:verify_docs", "release:verify_files", "release:verify_github", "build_metadata"]
+task :release => ["release:verify_docs", "release:verify_files", "release:verify_github", "build_metadata", "release:github"]
 
 namespace :release do
   task :verify_docs => :"man:check"
@@ -141,10 +141,6 @@ namespace :release do
                   :body => release_notes(version),
                   :prerelease => version.prerelease?,
                 }
-  end
-
-  task :release do |args|
-    Rake::Task["release:github"].invoke(args.version)
   end
 
   desc "Make a patch release with the PRs from master in the patch milestone"

--- a/task/release.rake
+++ b/task/release.rake
@@ -129,6 +129,7 @@ namespace :release do
     relevant.join("\n").strip
   end
 
+  desc "Push the release to Github releases"
   task :github, :version do |_t, args|
     version = Gem::Version.new(args.version)
     tag = "v#{version}"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was several issues I had when releasing bundler:

* The prerequisites can fail, but the gem is still pushed to rubygems.
* Some error messages could be better.
* The github release is a postrequisite not a prerequisite for the release task.

### What was your diagnosis of the problem?

My diagnosis was that we need to make every prerequisite a prerequisite to the `rubygems:push` task to be really sure the gem is not pushed until every thing else is satisfied.

### What is your fix for the problem, implemented in this PR?

My fix implements that idea, plus other few improvements to the release task.