### PR TITLE
Fix a couple of bundler issues with keyword argument separation

### DIFF
--- a/lib/bundler/vendor/thor/lib/thor.rb
+++ b/lib/bundler/vendor/thor/lib/thor.rb
@@ -90,9 +90,14 @@ class Bundler::Thor
     # ==== Parameters
     # Hash[String|Array => Symbol]:: Maps the string or the strings in the array to the given command.
     #
-    def map(mappings = nil)
+    def map(mappings = nil, **kw)
       @map ||= from_superclass(:map, {})
 
+      if mappings && !kw.empty?
+        mappings = kw.merge!(mappings)
+      else
+        mappings ||= kw
+      end
       if mappings
         mappings.each do |key, value|
           if key.respond_to?(:each)

--- a/spec/runtime/inline_spec.rb
+++ b/spec/runtime/inline_spec.rb
@@ -88,9 +88,10 @@ RSpec.describe "bundler/inline#gemfile" do
     RUBY
 
     expect(out).to include("Installing activesupport")
-    err.gsub! %r{.*lib/sinatra/base\.rb:\d+: warning: constant ::Fixnum is deprecated$}, ""
-    err.strip!
-    expect(err).to be_empty
+    err.gsub! %r{(.*lib/sinatra/base\.rb:\d+: warning: constant ::Fixnum is deprecated$)}, ""
+    err_lines = err.split("\n")
+    err_lines.reject!{|line| line =~ /\.rb:\d+: warning: The last/ }
+    expect(err_lines).to be_empty
     expect(exitstatus).to be_zero if exitstatus
   end
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

`make test-bundler` in Ruby repository failed with recent changes to separate keyword arguments from positional arguments (see https://bugs.ruby-lang.org/issues/14183).

### What was your diagnosis of the problem?

Bundler's specs check for lack of warnings, and the new changes cause warnings that cause Bundler's specs to fail.

### What is your fix for the problem, implemented in this PR?

In one case, I fix the code to work with keyword arguments and positional arguments in positional arguments.  In the other case, I fix the spec to ignore the keyword argument separation warnings.

I fixed this upstream in Ruby already (https://github.com/ruby/ruby/commit/b5b3afadfab4072f55320075ccac6afe333a140c). So this is a request to make bundler use the same patch.  You can certainly fix it differently, and there are more related issues to fix I think (they just don't cause test failures yet).  The issues definitely need to be fixed if you want bundler's specs to run correctly in Ruby 2.7.

### Why did you choose this fix out of the possible options?

Because it was the least amount of effort.