### PR TITLE
Fix bundle clean issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.1.0.pre.1
+## 2.1.0.pre.1 (August 28, 2019)
 
 One of the biggest changes in bundler 2.1.0 is that deprecations for upcoming
 breaking changes in bundler 3 will be turned on by default. We do this to grab

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -317,7 +317,7 @@ module Bundler
     end
 
     def spec_git_paths
-      sources.git_sources.map {|s| File.realpath(s.path) }
+      sources.git_sources.map {|s| File.realpath(s.path) if File.exist?(s.path) }.compact
     end
 
     def groups

--- a/spec/commands/clean_spec.rb
+++ b/spec/commands/clean_spec.rb
@@ -25,7 +25,9 @@ RSpec.describe "bundle clean" do
       gem "foo"
     G
 
-    bundle! "install", forgotten_command_line_options(:path => "vendor/bundle", :clean => false)
+    bundle "config set path vendor/bundle"
+    bundle "config set clean false"
+    bundle! "install"
 
     gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -52,7 +54,9 @@ RSpec.describe "bundle clean" do
       gem "foo"
     G
 
-    bundle "install", forgotten_command_line_options(:path => "vendor/bundle", :clean => false)
+    bundle "config set path vendor/bundle"
+    bundle "config set clean false"
+    bundle "install"
 
     gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -80,7 +84,9 @@ RSpec.describe "bundle clean" do
       gem "foo"
     G
 
-    bundle! "install", forgotten_command_line_options(:path => "vendor/bundle", :clean => false)
+    bundle "config set path vendor/bundle"
+    bundle "config set clean false"
+    bundle! "install"
 
     gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -111,8 +117,10 @@ RSpec.describe "bundle clean" do
       end
     G
 
-    bundle "install", forgotten_command_line_options(:path => "vendor/bundle")
-    bundle "install", forgotten_command_line_options(:without => "test_group")
+    bundle "config set path vendor/bundle"
+    bundle "install"
+    bundle "config set without test_group"
+    bundle "install"
     bundle :clean
 
     expect(out).to include("Removing rack (1.0.0)")
@@ -137,7 +145,8 @@ RSpec.describe "bundle clean" do
       end
     G
 
-    bundle "install", forgotten_command_line_options(:path => "vendor/bundle")
+    bundle "config set path vendor/bundle"
+    bundle "install"
 
     bundle :clean
 
@@ -160,7 +169,8 @@ RSpec.describe "bundle clean" do
       end
     G
 
-    bundle "install", forgotten_command_line_options(:path => "vendor/bundle")
+    bundle "config set path vendor/bundle"
+    bundle "install"
 
     gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -200,7 +210,8 @@ RSpec.describe "bundle clean" do
     FileUtils.mkdir_p(bundled_app("real-path"))
     FileUtils.ln_sf(bundled_app("real-path"), bundled_app("symlink-path"))
 
-    bundle "install", forgotten_command_line_options(:path => bundled_app("symlink-path"))
+    bundle "config set path #{bundled_app("symlink-path")}"
+    bundle "install"
 
     bundle :clean
 
@@ -222,7 +233,8 @@ RSpec.describe "bundle clean" do
       end
     G
 
-    bundle! "install", forgotten_command_line_options(:path => "vendor/bundle")
+    bundle "config set path vendor/bundle"
+    bundle! "install"
 
     update_git "foo", :path => lib_path("foo-bar")
     revision2 = revision_for(lib_path("foo-bar"))
@@ -252,7 +264,8 @@ RSpec.describe "bundle clean" do
       gem "activesupport", :git => "#{lib_path("rails")}", :ref => '#{revision}'
     G
 
-    bundle "install", forgotten_command_line_options(:path => "vendor/bundle")
+    bundle "config set path vendor/bundle"
+    bundle "install"
     bundle :clean
     expect(out).to include("")
 
@@ -274,7 +287,9 @@ RSpec.describe "bundle clean" do
         end
       end
     G
-    bundle "install", forgotten_command_line_options(:path => "vendor/bundle", :without => "test")
+    bundle "config set path vendor/bundle"
+    bundle "config set without test"
+    bundle "install"
 
     bundle :clean
 
@@ -295,7 +310,9 @@ RSpec.describe "bundle clean" do
       end
     G
 
-    bundle "install", forgotten_command_line_options(:path => "vendor/bundle", :without => "development")
+    bundle "config set path vendor/bundle"
+    bundle "config set without development"
+    bundle "install"
 
     bundle :clean
     expect(exitstatus).to eq(0) if exitstatus
@@ -324,7 +341,8 @@ RSpec.describe "bundle clean" do
       gem "foo"
     G
 
-    bundle "install", forgotten_command_line_options(:path => "vendor/bundle")
+    bundle "config set path vendor/bundle"
+    bundle "install"
 
     gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -372,7 +390,9 @@ RSpec.describe "bundle clean" do
       gem "thin"
       gem "rack"
     G
-    bundle "install", forgotten_command_line_options(:path => "vendor/bundle", :clean => true)
+    bundle "config set path vendor/bundle"
+    bundle "config set clean false"
+    bundle "install --clean true"
 
     gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -393,7 +413,9 @@ RSpec.describe "bundle clean" do
 
       gem "foo"
     G
-    bundle! "install", forgotten_command_line_options(:path => "vendor/bundle", :clean => true)
+    bundle "config set path vendor/bundle"
+    bundle "config set clean false"
+    bundle "install --clean true"
 
     update_repo2 do
       build_gem "foo", "1.0.1"
@@ -436,7 +458,8 @@ RSpec.describe "bundle clean" do
       gem "thin"
       gem "rack"
     G
-    bundle "install", forgotten_command_line_options(:path => "vendor/bundle")
+    bundle "config set path vendor/bundle"
+    bundle "install"
 
     gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -456,7 +479,8 @@ RSpec.describe "bundle clean" do
 
       gem "foo"
     G
-    bundle! "install", forgotten_command_line_options(:path => "vendor/bundle")
+    bundle "config set path vendor/bundle"
+    bundle! "install"
 
     update_repo2 do
       build_gem "foo", "1.0.1"
@@ -557,7 +581,8 @@ RSpec.describe "bundle clean" do
       gem "foo", :git => "#{lib_path("foo-1.0")}"
     G
 
-    bundle "install", forgotten_command_line_options(:path => "vendor/bundle")
+    bundle "config set path vendor/bundle"
+    bundle "install"
 
     # mimic 7 length git revisions in Gemfile.lock
     gemfile_lock = File.read(bundled_app("Gemfile.lock")).split("\n")
@@ -566,7 +591,8 @@ RSpec.describe "bundle clean" do
     end
     lockfile(bundled_app("Gemfile.lock"), gemfile_lock.join("\n"))
 
-    bundle "install", forgotten_command_line_options(:path => "vendor/bundle")
+    bundle "config set path vendor/bundle"
+    bundle "install"
 
     bundle :clean
 
@@ -616,7 +642,8 @@ RSpec.describe "bundle clean" do
       gem "bar", "1.0", :path => "#{relative_path}"
     G
 
-    bundle "install", forgotten_command_line_options(:path => "vendor/bundle")
+    bundle "config set path vendor/bundle"
+    bundle "install"
     bundle! :clean
   end
 
@@ -628,7 +655,9 @@ RSpec.describe "bundle clean" do
       gem "foo"
     G
 
-    bundle "install", forgotten_command_line_options(:path => "vendor/bundle", :clean => false)
+    bundle "config set path vendor/bundle"
+    bundle "config set clean false"
+    bundle "install"
 
     gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -656,7 +685,9 @@ RSpec.describe "bundle clean" do
       gem "foo"
     G
 
-    bundle "install", forgotten_command_line_options(:path => "vendor/bundle", :clean => false)
+    bundle "config set path vendor/bundle"
+    bundle "config set clean false"
+    bundle "install"
 
     gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -684,7 +715,9 @@ RSpec.describe "bundle clean" do
       gem "foo"
     G
 
-    bundle "install", forgotten_command_line_options(:path => "vendor/bundle", :clean => false)
+    bundle "config set path vendor/bundle"
+    bundle "config set clean false"
+    bundle "install"
     bundle "config set dry_run false"
 
     gemfile <<-G
@@ -714,7 +747,9 @@ RSpec.describe "bundle clean" do
       gem "foo"
     G
 
-    bundle! "install", forgotten_command_line_options(:path => "vendor/bundle", :clean => false)
+    bundle "config set path vendor/bundle"
+    bundle "config set clean false"
+    bundle! "install"
 
     gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -741,7 +776,8 @@ RSpec.describe "bundle clean" do
       gem "very_simple_git_binary", :git => "#{lib_path("very_simple_git_binary-1.0")}", :ref => "#{revision}"
     G
 
-    bundle! "install", forgotten_command_line_options(:path => "vendor/bundle")
+    bundle "config set path vendor/bundle"
+    bundle! "install"
     expect(vendored_gems("bundler/gems/extensions")).to exist
     expect(vendored_gems("bundler/gems/very_simple_git_binary-1.0-#{revision[0..11]}")).to exist
 
@@ -761,7 +797,8 @@ RSpec.describe "bundle clean" do
       gem "simple_binary"
     G
 
-    bundle! "install", forgotten_command_line_options(:path => "vendor/bundle")
+    bundle "config set path vendor/bundle"
+    bundle! "install"
 
     very_simple_binary_extensions_dir =
       Pathname.glob("#{vendored_gems}/extensions/*/*/very_simple_binary-1.0").first
@@ -800,7 +837,8 @@ RSpec.describe "bundle clean" do
       gem "very_simple_git_binary", :git => "#{lib_path("very_simple_git_binary-1.0")}", :ref => "#{revision}"
     G
 
-    bundle! "install", forgotten_command_line_options(:path => "vendor/bundle")
+    bundle "config set path vendor/bundle"
+    bundle! "install"
 
     very_simple_binary_extensions_dir =
       Pathname.glob("#{vendored_gems}/bundler/gems/extensions/*/*/very_simple_git_binary-1.0-#{short_revision}").first


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that `bundle clean` is crashing under some conditions.

### What was your diagnosis of the problem?

My diagnosis was that sometimes (when the bundle includes git sourced gems with extensions), it assumes that some paths exist, but they don't.

### What is your fix for the problem, implemented in this PR?

My fix is to ignore those paths.

### Why did you choose this fix out of the possible options?

I chose this fix because it fixes the issue.

Fixes #7338.