### PR TITLE
Backport the latest ruby core changes

### DIFF
--- a/lib/bundler/resolver/spec_group.rb
+++ b/lib/bundler/resolver/spec_group.rb
@@ -62,6 +62,7 @@ module Bundler
       end
 
       def eql?(other)
+        return unless other.is_a?(SpecGroup)
         name.eql?(other.name) &&
           version.eql?(other.version) &&
           source.eql?(other.source)

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "bundle exec" do
     expect(out).to eq("hi")
   end
 
-  it "respects custom process title when loading through ruby", :github_action_linux do
+  it "respects custom process title when loading through ruby" do
     script_that_changes_its_own_title_and_checks_if_picked_up_by_ps_unix_utility = <<~'RUBY'
       Process.setproctitle("1-2-3-4-5-6-7-8-9-10-11-12-13-14-15")
       puts `ps -ocommand= -p#{$$}`

--- a/spec/runtime/inline_spec.rb
+++ b/spec/runtime/inline_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe "bundler/inline#gemfile" do
     expect(out).to include("Installing activesupport")
     err.gsub! %r{(.*lib/sinatra/base\.rb:\d+: warning: constant ::Fixnum is deprecated$)}, ""
     err_lines = err.split("\n")
-    err_lines.reject!{|line| line =~ /\.rb:\d+: warning: The last/ }
+    err_lines.reject!{|line| line =~ /\.rb:\d+: warning: / }
     expect(err_lines).to be_empty
     expect(exitstatus).to be_zero if exitstatus
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -71,7 +71,6 @@ RSpec.configure do |config|
   config.filter_run_excluding :bundler => RequirementChecker.against(Bundler::VERSION.split(".")[0])
   config.filter_run_excluding :ruby_repo => !ENV["GEM_COMMAND"].nil?
   config.filter_run_excluding :no_color_tty => Gem.win_platform? || !ENV["GITHUB_ACTION"].nil?
-  config.filter_run_excluding :github_action_linux => !ENV["GITHUB_ACTION"].nil? && (ENV["RUNNER_OS"] == "Linux")
 
   config.filter_run_when_matching :focus unless ENV["CI"]
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The master branch of Bundler with Ruby 2.7 fails some of tests.

### What was your diagnosis of the problem?

It caused by deprecation warnings of Ruby 2.7 and some environmental issues.

### What is your fix for the problem, implemented in this PR?

I fixed them.

* rspec examples of Bundler failed randomly on GitHub Actions of ruby/ruby. We fixed it on `spec_group.rb`
* `github_action_linux` label is no longer required. The current test suite is all green status with GitHub Actions.
* The keyword separation feature warns stub code under the `inline_spec.rb`. I ignore them.

### Why did you choose this fix out of the possible options?


