### PR TITLE
require `rubygems`, not `ubygems` in example

### DIFF
--- a/man/bundle-exec.1
+++ b/man/bundle-exec.1
@@ -155,7 +155,7 @@ You can find a list of all the gems containing gem plugins by running
 .
 .nf
 
-ruby \-rubygems \-e "puts Gem\.find_files(\'rubygems_plugin\.rb\')"
+ruby \-rrubygems \-e "puts Gem\.find_files(\'rubygems_plugin\.rb\')"
 .
 .fi
 .

--- a/man/bundle-exec.1.txt
+++ b/man/bundle-exec.1.txt
@@ -165,7 +165,7 @@ RUBYGEMS PLUGINS
 
 
 
-	   ruby -rubygems -e "puts Gem.find_files('rubygems_plugin.rb')"
+	   ruby -rrubygems -e "puts Gem.find_files('rubygems_plugin.rb')"
 
 
 

--- a/man/bundle-exec.ronn
+++ b/man/bundle-exec.ronn
@@ -145,7 +145,7 @@ their plugins.
 You can find a list of all the gems containing gem plugins
 by running
 
-    ruby -rubygems -e "puts Gem.find_files('rubygems_plugin.rb')"
+    ruby -rrubygems -e "puts Gem.find_files('rubygems_plugin.rb')"
 
 At the very least, you should remove all but the newest
 version of each gem plugin, and also remove all gem plugins


### PR DESCRIPTION
The latter does not work on Ruby 2.6.3.

Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was a broken example in the docs.

### What was your diagnosis of the problem?

Ibid.

### What is your fix for the problem, implemented in this PR?

My fix was to write what was likely intended.

### Why did you choose this fix out of the possible options?

I chose this fix because the solution space is pretty small.
