### PR TITLE
More release fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.1.0.pre.2
+## 2.1.0.pre.2 (September 15, 2019)
 
 Bugfixes:
 

--- a/task/release.rake
+++ b/task/release.rake
@@ -131,7 +131,7 @@ namespace :release do
 
   desc "Push the release to Github releases"
   task :github, :version do |_t, args|
-    version = Gem::Version.new(args.version)
+    version = Gem::Version.new(args.version || bundler_spec.version)
     tag = "v#{version}"
 
     gh_api_post :path => "/repos/bundler/bundler/releases",


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

I just released [2.1.0.pre.2](https://rubygems.org/gems/bundler/versions/2.1.0.pre.2). It went smoother than 2.1.0.pre.1, but I still got an issue where I unintentionally pushed a release named "v" to github releases.

### What was your diagnosis of the problem?

My diagnosis was that the release task by default should use the version in the gemspec for the `release:github` tasks.

### What is your fix for the problem, implemented in this PR?

My fix adds that fallback.

### Why did you choose this fix out of the possible options?

I chose this fix because it does what the user expects when the task is not passed any arguments.
