### PR TITLE
Consistenly use the default RSpec formatter

### DIFF
--- a/.azure-pipelines/steps.yml
+++ b/.azure-pipelines/steps.yml
@@ -28,7 +28,7 @@ steps:
   displayName: 'gem install rspec_junit_formatter'
 
 - script: |
-    ruby -r rspec_junit_formatter bin/rspec --format progress --format RspecJunitFormatter -o rspec/bundler-junit-results.xml || exit 0
+    ruby -r rspec_junit_formatter bin/rspec --format RspecJunitFormatter -o rspec/bundler-junit-results.xml || exit 0
   displayName: 'ruby bin/rspec'
 
 - task: PublishTestResults@2

--- a/.rspec
+++ b/.rspec
@@ -1,4 +1,3 @@
---format documentation
 --color
 --warnings
 --require spec_helper

--- a/.rspec_parallel
+++ b/.rspec_parallel
@@ -1,4 +1,3 @@
---format progress
 --format ParallelTests::RSpec::RuntimeLogger --out tmp/parallel_runtime_rspec.log
 --require spec_helper
 --require support/parallel.rb

--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,7 @@ end
 
 desc "Run specs"
 task :spec do
-  sh("bin/rspec --format progress")
+  sh("bin/rspec")
 end
 
 namespace :spec do


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that our default RSpec formatter is `--documentation`, but we're overriding it almost everywhere to use `--progress`.

### What was your diagnosis of the problem?

My diagnosis was that we should probably use the default formatter, since I think we all prefer it.

### What is your fix for the problem, implemented in this PR?

My fix is to do that.