### PR TITLE
Add caller information to some deprecation messages

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -116,7 +116,7 @@ module Bundler
     end
 
     def environment
-      SharedHelpers.major_deprecation 2, "Bundler.environment has been removed in favor of Bundler.load"
+      SharedHelpers.major_deprecation 2, "Bundler.environment has been removed in favor of Bundler.load", :print_caller_location => true
       load
     end
 
@@ -282,7 +282,8 @@ EOF
       Bundler::SharedHelpers.major_deprecation(
         2,
         "`Bundler.clean_env` has been deprecated in favor of `Bundler.unbundled_env`. " \
-        "If you instead want the environment before bundler was originally loaded, use `Bundler.original_env`"
+        "If you instead want the environment before bundler was originally loaded, use `Bundler.original_env`",
+        :print_caller_location => true
       )
 
       unbundled_env
@@ -321,7 +322,8 @@ EOF
       Bundler::SharedHelpers.major_deprecation(
         2,
         "`Bundler.with_clean_env` has been deprecated in favor of `Bundler.with_unbundled_env`. " \
-        "If you instead want the environment before bundler was originally loaded, use `Bundler.with_original_env`"
+        "If you instead want the environment before bundler was originally loaded, use `Bundler.with_original_env`",
+        :print_caller_location => true
       )
 
       with_env(unbundled_env) { yield }
@@ -342,7 +344,8 @@ EOF
       Bundler::SharedHelpers.major_deprecation(
         2,
         "`Bundler.clean_system` has been deprecated in favor of `Bundler.unbundled_system`. " \
-        "If you instead want to run the command in the environment before bundler was originally loaded, use `Bundler.original_system`"
+        "If you instead want to run the command in the environment before bundler was originally loaded, use `Bundler.original_system`",
+        :print_caller_location => true
       )
 
       with_env(unbundled_env) { Kernel.system(*args) }
@@ -363,7 +366,8 @@ EOF
       Bundler::SharedHelpers.major_deprecation(
         2,
         "`Bundler.clean_exec` has been deprecated in favor of `Bundler.unbundled_exec`. " \
-        "If you instead want to exec to a command in the environment before bundler was originally loaded, use `Bundler.original_exec`"
+        "If you instead want to exec to a command in the environment before bundler was originally loaded, use `Bundler.original_exec`",
+        :print_caller_location => true
       )
 
       with_env(unbundled_env) { Kernel.exec(*args) }

--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -124,7 +124,12 @@ module Bundler
       namespace.const_get(constant_name)
     end
 
-    def major_deprecation(major_version, message)
+    def major_deprecation(major_version, message, print_caller_location: false)
+      if print_caller_location
+        caller_location = caller_locations(2, 2).first
+        message = "#{message} (called at #{caller_location.path}:#{caller_location.lineno})"
+      end
+
       bundler_major_version = Bundler.bundler_major_version
       if bundler_major_version > major_version
         require_relative "errors"

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe "major deprecations" do
       it "is deprecated in favor of .unbundled_env", :bundler => "2" do
         expect(deprecations).to include \
           "`Bundler.clean_env` has been deprecated in favor of `Bundler.unbundled_env`. " \
-          "If you instead want the environment before bundler was originally loaded, use `Bundler.original_env`"
+          "If you instead want the environment before bundler was originally loaded, use `Bundler.original_env` " \
+          "(called at -e:1)"
       end
 
       pending "is removed and shows a helpful error message about it", :bundler => "3"
@@ -35,7 +36,8 @@ RSpec.describe "major deprecations" do
       it "is deprecated in favor of .unbundled_env", :bundler => "2" do
         expect(deprecations).to include(
           "`Bundler.with_clean_env` has been deprecated in favor of `Bundler.with_unbundled_env`. " \
-          "If you instead want the environment before bundler was originally loaded, use `Bundler.with_original_env`"
+          "If you instead want the environment before bundler was originally loaded, use `Bundler.with_original_env` " \
+          "(called at -e:1)"
         )
       end
 
@@ -51,7 +53,8 @@ RSpec.describe "major deprecations" do
       it "is deprecated in favor of .unbundled_system", :bundler => "2" do
         expect(deprecations).to include(
           "`Bundler.clean_system` has been deprecated in favor of `Bundler.unbundled_system`. " \
-          "If you instead want to run the command in the environment before bundler was originally loaded, use `Bundler.original_system`"
+          "If you instead want to run the command in the environment before bundler was originally loaded, use `Bundler.original_system` " \
+          "(called at -e:1)"
         )
       end
 
@@ -67,7 +70,8 @@ RSpec.describe "major deprecations" do
       it "is deprecated in favor of .unbundled_exec", :bundler => "2" do
         expect(deprecations).to include(
           "`Bundler.clean_exec` has been deprecated in favor of `Bundler.unbundled_exec`. " \
-          "If you instead want to exec to a command in the environment before bundler was originally loaded, use `Bundler.original_exec`"
+          "If you instead want to exec to a command in the environment before bundler was originally loaded, use `Bundler.original_exec` " \
+          "(called at -e:1)"
         )
       end
 
@@ -81,7 +85,7 @@ RSpec.describe "major deprecations" do
       end
 
       it "is deprecated in favor of .load", :bundler => "2" do
-        expect(deprecations).to include "Bundler.environment has been removed in favor of Bundler.load"
+        expect(deprecations).to include "Bundler.environment has been removed in favor of Bundler.load (called at -e:1)"
       end
 
       pending "is removed and shows a helpful error message about it", :bundler => "3"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that some deprecations mention usage of deprecated methods, but include no information about where the deprecated method is being called.

### What was your diagnosis of the problem?

My diagnosis was that we should include this information with this kind of deprecation messages, to make migration easier.

### What is your fix for the problem, implemented in this PR?

My fix is to add an optional argument to the `major_deprecation` method, to print the location of the deprecated caller.

### Why did you choose this fix out of the possible options?

I chose this fix because it required little code changes.
