### PR TITLE
Follow up to `ENV["RGV"]` handling refactor

### DIFF
--- a/spec/support/rubygems_version_manager.rb
+++ b/spec/support/rubygems_version_manager.rb
@@ -110,6 +110,8 @@ private
   end
 
   def resolve_target_gem_version
+    return local_copy_version if env_version_is_path?
+
     return @env_version[1..-1] if @env_version.match(/^v/)
 
     return master_gem_version if @env_version == "master"

--- a/spec/support/rubygems_version_manager.rb
+++ b/spec/support/rubygems_version_manager.rb
@@ -2,9 +2,11 @@
 
 require "pathname"
 require_relative "helpers"
+require_relative "path"
 
 class RubygemsVersionManager
   include Spec::Helpers
+  include Spec::Path
 
   def initialize(env_version)
     @env_version = env_version
@@ -98,7 +100,7 @@ private
   end
 
   def expanded_env_version
-    @expanded_env_version ||= Pathname.new(@env_version).expand_path
+    @expanded_env_version ||= Pathname.new(@env_version).expand_path(root)
   end
 
   def resolve_target_tag_version


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that #7296 broke rubygems CI.

### What was your diagnosis of the problem?

My diagnosis was that the handling of `ENV["RGV"]` when it contains the path of a rubygems checkout instead of a rubygems version (like it happens in the rubygems repo) was incorrect.

### What is your fix for the problem, implemented in this PR?

My fix is to correct the behaviour. I was able to reproduce the CI failures in https://github.com/rubygems/rubygems/pull/2924, and verify they are be fixed by this PR by patching the vendored bundler locally.

Fixes #7363.