### PR TITLE
Fix `bunde outdated` regression with groupless dependencies

### DIFF
--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -82,7 +82,7 @@ module Bundler
         next unless gem_outdated || (current_spec.git_version != active_spec.git_version)
 
         dependency = current_dependencies[current_spec.name]
-        groups = nil
+        groups = ""
         if dependency && !options[:parseable]
           groups = dependency.groups.join(", ")
         end
@@ -134,10 +134,10 @@ module Bundler
     end
 
     def header_group_message(groups)
-      if groups
-        "===== #{groups_text("Group", groups)} ====="
-      else
+      if groups.empty?
         "===== Without group ====="
+      else
+        "===== #{groups_text("Group", groups)} ====="
       end
     end
 
@@ -198,7 +198,7 @@ module Bundler
 
       output_message = if options[:parseable]
         spec_outdated_info.to_s
-      elsif options_include_groups || !groups
+      elsif options_include_groups || groups.empty?
         "  * #{spec_outdated_info}"
       else
         "  * #{spec_outdated_info} in #{groups_text("group", groups)}"

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -143,6 +143,39 @@ RSpec.describe "bundle outdated" do
     end
   end
 
+  describe "with --group option and outdated transitive dependencies" do
+    before do
+      update_repo2 do
+        build_gem "bar", %w[2.0.0]
+
+        build_gem "bar_dependant", "7.0" do |s|
+          s.add_dependency "bar", "~> 2.0"
+        end
+      end
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+
+        gem "bar_dependant", '7.0'
+      G
+
+      update_repo2 do
+        build_gem "bar", %w[3.0.0]
+      end
+    end
+
+    it "returns a sorted list of outdated gems" do
+      bundle "outdated --groups"
+
+      expect(out).to include("===== Without group =====")
+      expect(out).to include("bar (newest 3.0.0, installed 2.0.0)")
+
+      # Gem names are one per-line, between "*" and their parenthesized version.
+      gem_list = out.split("\n").map {|g| g[/\* (.*) \(/, 1] }.compact
+      expect(gem_list).to eq(gem_list.sort)
+    end
+  end
+
   describe "with --groups option" do
     before do
       install_gemfile <<-G

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe "bundle outdated" do
       expect(gem_list.size).to eq gems_list_size
     end
 
-    it "not outdated gems" do
+    it "works when the bundle is up to date" do
       bundle "outdated --group"
       expect(out).to include("Bundle up to date!")
     end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that the refactoring in #7365 introduced a regression involving groupless dependencies.

### What was your diagnosis of the problem?

My diagnosis was that `nil` groups were not being properly handled when sorting groups by name, and when this kind of outdated deps would be involved, `bundle outdated` would crash with a backtrace like the following:

```
NoMethodError: undefined method `split' for nil:NilClass
  /home/deivid/Code/bundler/lib/bundler/cli/outdated.rb:105:in `block in run'
  /home/deivid/Code/bundler/lib/bundler/cli/outdated.rb:104:in `each'
  /home/deivid/Code/bundler/lib/bundler/cli/outdated.rb:104:in `run'
  /home/deivid/Code/bundler/lib/bundler/cli.rb:412:in `outdated'
  /home/deivid/Code/bundler/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
  /home/deivid/Code/bundler/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
  /home/deivid/Code/bundler/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
  /home/deivid/Code/bundler/lib/bundler/cli.rb:26:in `dispatch'
  /home/deivid/Code/bundler/lib/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
  /home/deivid/Code/bundler/lib/bundler/cli.rb:17:in `start'
  /home/deivid/Code/bundler/exe/bundle:46:in `block in <main>'
  /home/deivid/Code/bundler/lib/bundler/friendly_errors.rb:123:in `with_friendly_errors'
  /home/deivid/Code/bundler/exe/bundle:34:in `<main>'
```

### What is your fix for the problem, implemented in this PR?

My fix is to consider `nil` groups as empty instead, so that sorting them works.

### Why did you choose this fix out of the possible options?

I chose this fix because it's reasonable simple.
