### PR TITLE
bundle info prints gem metadata

### DIFF
--- a/lib/bundler/cli/info.rb
+++ b/lib/bundler/cli/info.rb
@@ -50,7 +50,7 @@ module Bundler
     end
 
     def print_gem_info(spec)
-      metadata = spec.respond_to?(:metadata) ? spec.metadata : {}
+      metadata = spec.metadata
       gem_info = String.new
       gem_info << "  * #{spec.name} (#{spec.version}#{spec.git_version})\n"
       gem_info << "\tSummary: #{spec.summary}\n" if spec.summary

--- a/lib/bundler/cli/info.rb
+++ b/lib/bundler/cli/info.rb
@@ -50,10 +50,17 @@ module Bundler
     end
 
     def print_gem_info(spec)
+      metadata = spec.respond_to?(:metadata) ? spec.metadata : {}
       gem_info = String.new
       gem_info << "  * #{spec.name} (#{spec.version}#{spec.git_version})\n"
       gem_info << "\tSummary: #{spec.summary}\n" if spec.summary
       gem_info << "\tHomepage: #{spec.homepage}\n" if spec.homepage
+      gem_info << "\tDocumentation: #{metadata["documentation_uri"]}\n" if metadata.key?("documentation_uri")
+      gem_info << "\tSource Code: #{metadata["source_code_uri"]}\n" if metadata.key?("source_code_uri")
+      gem_info << "\tWiki: #{metadata["wiki_uri"]}\n" if metadata.key?("wiki_uri")
+      gem_info << "\tChangelog: #{metadata["changelog_uri"]}\n" if metadata.key?("changelog_uri")
+      gem_info << "\tBug Tracker: #{metadata["bug_tracker_uri"]}\n" if metadata.key?("bug_tracker_uri")
+      gem_info << "\tMailing List: #{metadata["mailing_list_uri"]}\n" if metadata.key?("mailing_list_uri")
       gem_info << "\tPath: #{spec.full_gem_path}\n"
       gem_info << "\tDefault Gem: yes" if spec.respond_to?(:default_gem?) && spec.default_gem?
       Bundler.ui.info gem_info

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "bundle info" do
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rails"
+        gem "has_metadata"
       G
     end
 
@@ -45,6 +46,22 @@ RSpec.describe "bundle info" do
         bundle "info rdoc"
         expect(out).to include("* rdoc")
         expect(out).to include("Default Gem: yes")
+      end
+    end
+
+    context "given a gem with metadata" do
+      it "prints the gem metadata" do
+        bundle "info has_metadata"
+        expect(out).to include "* has_metadata (1.0)
+\tSummary: This is just a fake gem for testing
+\tHomepage: http://example.com
+\tDocumentation: https://www.example.info/gems/bestgemever/0.0.1
+\tSource Code: https://example.com/user/bestgemever
+\tWiki: https://example.com/user/bestgemever/wiki
+\tChangelog: https://example.com/user/bestgemever/CHANGELOG.md
+\tBug Tracker: https://example.com/user/bestgemever/issues
+\tMailing List: https://groups.example.com/bestgemever
+\tPath: #{default_bundle_path("gems", "has_metadata-1.0")}"
       end
     end
 

--- a/spec/support/builders.rb
+++ b/spec/support/builders.rb
@@ -302,6 +302,18 @@ module Spec
             end
           RUBY
         end
+
+        build_gem "has_metadata" do |s|
+          s.metadata = {
+            "bug_tracker_uri"   => "https://example.com/user/bestgemever/issues",
+            "changelog_uri"     => "https://example.com/user/bestgemever/CHANGELOG.md",
+            "documentation_uri" => "https://www.example.info/gems/bestgemever/0.0.1",
+            "homepage_uri"      => "https://bestgemever.example.io",
+            "mailing_list_uri"  => "https://groups.example.com/bestgemever",
+            "source_code_uri"   => "https://example.com/user/bestgemever",
+            "wiki_uri"          => "https://example.com/user/bestgemever/wiki",
+          }
+        end
       end
     end
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Rubygems has supported [gemspec metadata](https://guides.rubygems.org/specification-reference/#metadata) since version 2.0. I think it'd be great to display this information in response to the `bundle info <gem>` command.

### What is your fix for the problem, implemented in this PR?

Added a check for `metadata`, outputting this extra information if it has been included with the gem release. For example:

```
> bundle info rspec-mocks
  * rspec-mocks (3.8.1)
	Summary: rspec-mocks-3.8.1
	Homepage: https://github.com/rspec/rspec-mocks
	Documentation: https://rspec.info/documentation/
	Source Code: https://github.com/rspec/rspec-mocks
	Changelog: https://github.com/rspec/rspec-mocks/blob/v3.8.1/Changelog.md
	Bug Tracker: https://github.com/rspec/rspec-mocks/issues
	Mailing List: https://groups.google.com/forum/#!forum/rspec
	Path: /opt/asdf/installs/ruby/2.6.5/lib/ruby/gems/2.6.0/gems/rspec-mocks-3.8.1
```

For better readability, we could align the values. However, this would mean a change to the existing info property lines (`Summary`, `Homepage`, `Path` and `Default`). Which would potentially break existing scripts that are coupled to the precise output.

