### PR TITLE
Switch to double quotes to match rest of file

### DIFF
--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -1,4 +1,4 @@
-require_relative 'lib/<%=config[:namespaced_path]%>/version'
+require_relative "lib/<%=config[:namespaced_path]%>/version"
 
 Gem::Specification.new do |spec|
   spec.name          = <%= config[:name].inspect %>
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+  spec.files         = Dir.chdir(File.expand_path("..", __FILE__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
   spec.bindir        = "exe"


### PR DESCRIPTION
### What was your diagnosis of the problem?

It is common to prefer double quotes, unless single quotes are needed.  It is also generally preferred to use a consistent quote style (whether double quotes or single quotes).

### What is your fix for the problem, implemented in this PR?

Switch the anomalous single quotes to double quotes.
