### PR TITLE
Suppress `Warning: no department given for MutableConstant`

### DIFF
--- a/lib/bundler/gem_helpers.rb
+++ b/lib/bundler/gem_helpers.rb
@@ -2,7 +2,7 @@
 
 module Bundler
   module GemHelpers
-    GENERIC_CACHE = { Gem::Platform::RUBY => Gem::Platform::RUBY } # rubocop:disable MutableConstant
+    GENERIC_CACHE = { Gem::Platform::RUBY => Gem::Platform::RUBY } # rubocop:disable Style/MutableConstant
     GENERICS = [
       [Gem::Platform.new("java"), Gem::Platform.new("java")],
       [Gem::Platform.new("mswin32"), Gem::Platform.new("mswin32")],


### PR DESCRIPTION
This PR suppresses the following `Warning: no department given for MutableConstant`.

```console
% cd path/to/bundler
% bundle exec rubocop -v
0.75.1
% bundle exec rubocop --parallel
(snip)

/Users/koic/src/github.com/bundler/bundler/lib/bundler/gem_helpers.rb:
Warning: no department given for MutableConstant. Run `rubocop -a --only
Migration/DepartmentName` to fix.
```

