### PR TITLE
Fix help with command aliases

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -150,13 +150,14 @@ module Bundler
       "Use the specified gemfile instead of Gemfile"
     method_option "path", :type => :string, :banner =>
       "Specify a different path than the system default ($BUNDLE_PATH or $GEM_HOME).#{" Bundler will remember this value for future installs on this machine" unless Bundler.feature_flag.forget_cli_options?}"
-    map "c" => "check"
     def check
       remembered_flag_deprecation("path")
 
       require_relative "cli/check"
       Check.new(options).run
     end
+
+    map "c" => "check"
 
     desc "remove [GEM [GEM ...]]", "Removes gems from the Gemfile"
     long_desc <<-D
@@ -219,7 +220,6 @@ module Bundler
       "Exclude gems that are part of the specified named group."
     method_option "with", :type => :array, :banner =>
       "Include gems that are part of the specified named group."
-    map "i" => "install"
     def install
       SharedHelpers.major_deprecation(2, "The `--force` option has been renamed to `--redownload`") if ARGV.include?("--force")
 
@@ -232,6 +232,8 @@ module Bundler
         Install.new(options.dup).run
       end
     end
+
+    map "i" => "install"
 
     desc "update [OPTIONS]", "Update the current environment"
     long_desc <<-D
@@ -434,6 +436,7 @@ module Bundler
       require_relative "cli/cache"
       Cache.new(options).run
     end
+
     map %w[package pack] => :cache
 
     desc "exec [OPTIONS]", "Run the command in context of the bundle"
@@ -444,11 +447,12 @@ module Bundler
       bundle exec you can require and call the bundled gems as if they were installed
       into the system wide RubyGems repository.
     D
-    map "e" => "exec"
     def exec(*args)
       require_relative "cli/exec"
       Exec.new(options, args).run
     end
+
+    map "e" => "exec"
 
     desc "config NAME [VALUE]", "Retrieve or set a configuration value"
     long_desc <<-D
@@ -492,6 +496,7 @@ module Bundler
         Bundler.ui.info "Bundler version #{Bundler::VERSION}#{build_info}"
       end
     end
+
     map %w[-v --version] => :version
 
     desc "licenses", "Prints the license of all gems in the bundle"

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -324,7 +324,7 @@ module Bundler
       List.new(options).run
     end
 
-    map %w[ls] => "list"
+    map "ls" => "list"
 
     desc "info GEM [OPTIONS]", "Show information for the given gem"
     method_option "path", :type => :boolean, :banner => "Print full path to gem"

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -9,9 +9,7 @@ module Bundler
     package_name "Bundler"
 
     AUTO_INSTALL_CMDS = %w[show binstubs outdated exec open console licenses clean].freeze
-    PARSEABLE_COMMANDS = %w[
-      check config help exec platform show version
-    ].freeze
+    PARSEABLE_COMMANDS = %w[check config help exec platform show version].freeze
 
     def self.start(*)
       super

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -15,7 +15,7 @@ module Bundler
       "check" => "c",
       "install" => "i",
       "list" => "ls",
-      "exec" => "e",
+      "exec" => ["e", "ex", "exe"],
       "cache" => ["package", "pack"],
       "version" => ["-v", "--version"],
     }.freeze
@@ -696,7 +696,8 @@ module Bundler
     def self.reformatted_help_args(args)
       bundler_commands = all_commands.keys
       help_flags = %w[--help -h]
-      exec_commands = %w[e ex exe exec]
+      exec_commands = ["exec"] + COMMAND_ALIASES["exec"]
+
       help_used = args.index {|a| help_flags.include? a }
       exec_used = args.index {|a| exec_commands.include? a }
       command = args.find {|a| bundler_commands.include? a }

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -11,6 +11,15 @@ module Bundler
     AUTO_INSTALL_CMDS = %w[show binstubs outdated exec open console licenses clean].freeze
     PARSEABLE_COMMANDS = %w[check config help exec platform show version].freeze
 
+    COMMAND_ALIASES = {
+      "check" => "c",
+      "install" => "i",
+      "list" => "ls",
+      "exec" => "e",
+      "cache" => ["package", "pack"],
+      "version" => ["-v", "--version"],
+    }.freeze
+
     def self.start(*)
       super
     rescue Exception => e # rubocop:disable Lint/RescueException
@@ -25,6 +34,10 @@ module Bundler
         i.send(:print_command)
         i.send(:warn_on_outdated_bundler)
       end
+    end
+
+    def self.aliases_for(command_name)
+      COMMAND_ALIASES.slice(command_name).invert
     end
 
     def initialize(*args)
@@ -157,7 +170,7 @@ module Bundler
       Check.new(options).run
     end
 
-    map "c" => "check"
+    map aliases_for("check")
 
     desc "remove [GEM [GEM ...]]", "Removes gems from the Gemfile"
     long_desc <<-D
@@ -233,7 +246,7 @@ module Bundler
       end
     end
 
-    map "i" => "install"
+    map aliases_for("install")
 
     desc "update [OPTIONS]", "Update the current environment"
     long_desc <<-D
@@ -326,7 +339,7 @@ module Bundler
       List.new(options).run
     end
 
-    map "ls" => "list"
+    map aliases_for("list")
 
     desc "info GEM [OPTIONS]", "Show information for the given gem"
     method_option "path", :type => :boolean, :banner => "Print full path to gem"
@@ -437,7 +450,7 @@ module Bundler
       Cache.new(options).run
     end
 
-    map %w[package pack] => :cache
+    map aliases_for("cache")
 
     desc "exec [OPTIONS]", "Run the command in context of the bundle"
     method_option :keep_file_descriptors, :type => :boolean, :default => false
@@ -452,7 +465,7 @@ module Bundler
       Exec.new(options, args).run
     end
 
-    map "e" => "exec"
+    map aliases_for("exec")
 
     desc "config NAME [VALUE]", "Retrieve or set a configuration value"
     long_desc <<-D
@@ -497,7 +510,7 @@ module Bundler
       end
     end
 
-    map %w[-v --version] => :version
+    map aliases_for("version")
 
     desc "licenses", "Prints the license of all gems in the bundle"
     def licenses

--- a/spec/bundler/cli_spec.rb
+++ b/spec/bundler/cli_spec.rb
@@ -27,6 +27,56 @@ RSpec.describe "bundle executable" do
     expect(out).to eq("Hello, world")
   end
 
+  describe "aliases" do
+    it "aliases e to exec" do
+      bundle "e --help"
+
+      expect(out).to include("BUNDLE-EXEC")
+    end
+
+    it "aliases ex to exec" do
+      bundle "ex --help"
+
+      expect(out).to include("BUNDLE-EXEC")
+    end
+
+    it "aliases exe to exec" do
+      bundle "exe --help"
+
+      expect(out).to include("BUNDLE-EXEC")
+    end
+
+    it "aliases c to check" do
+      bundle "c --help"
+
+      expect(out).to include("BUNDLE-CHECK")
+    end
+
+    it "aliases i to install" do
+      bundle "i --help"
+
+      expect(out).to include("BUNDLE-INSTALL")
+    end
+
+    it "aliases ls to list" do
+      bundle "ls --help"
+
+      expect(out).to include("BUNDLE-LIST")
+    end
+
+    it "aliases package to cache" do
+      bundle "package --help"
+
+      expect(out).to include("BUNDLE-CACHE")
+    end
+
+    it "aliases pack to cache" do
+      bundle "pack --help"
+
+      expect(out).to include("BUNDLE-CACHE")
+    end
+  end
+
   context "with no arguments" do
     it "prints a concise help message", :bundler => "3" do
       bundle! ""


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that the output of `bundle help install` and `bundle install --help` was inconstent with `bundle i --help`, and the same issue with all of the other command aliases. 

### What was your diagnosis of the problem?

My diagnosis was that the command reformatting so that `bundle <cmd> --help` "redirects" to `bundle help <cmd>` was ignoring command aliases.

### What is your fix for the problem, implemented in this PR?

My fix is to make this logic aware of command aliases.
