### PR TITLE
Wrap up `bundle cache` migration to current `bundle package`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -130,7 +130,10 @@ namespace :man do
     begin
       Spec::Rubygems.gem_require("ronn")
     rescue Gem::LoadError => e
+      desc "Build the man pages"
       task(:build) { abort "We couln't activate ronn (#{e.requirement}). Try `gem install ronn:'#{e.requirement}'` to be able to build the help pages" }
+
+      desc "Verify man pages are in sync"
       task(:check) { abort "We couln't activate ronn (#{e.requirement}). Try `gem install ronn:'#{e.requirement}'` to be able to build the help pages" }
     else
       directory "man"

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -68,9 +68,7 @@ module Bundler
       version
       Bundler.ui.info "\n"
 
-      primary_commands = ["install", "update",
-                          Bundler.feature_flag.bundler_3_mode? ? "cache" : "package",
-                          "exec", "config", "help"]
+      primary_commands = ["install", "update", "cache", "exec", "config", "help"]
 
       list = self.class.printable_commands(true)
       by_name = list.group_by {|name, _message| name.match(/^bundle (\w+)/)[1] }
@@ -412,7 +410,7 @@ module Bundler
       Outdated.new(options, gems).run
     end
 
-    desc "#{Bundler.feature_flag.bundler_3_mode? ? :cache : :package} [OPTIONS]", "Locks and then caches all of the gems into vendor/cache"
+    desc "cache [OPTIONS]", "Locks and then caches all of the gems into vendor/cache"
     unless Bundler.feature_flag.cache_all?
       method_option "all",  :type => :boolean,
                             :banner => "Include all sources (including path and git)."
@@ -421,24 +419,24 @@ module Bundler
     method_option "cache-path", :type => :string, :banner =>
       "Specify a different cache path than the default (vendor/cache)."
     method_option "gemfile", :type => :string, :banner => "Use the specified gemfile instead of Gemfile"
-    method_option "no-install", :type => :boolean, :banner => "Don't install the gems, only the package."
+    method_option "no-install", :type => :boolean, :banner => "Don't install the gems, only update the cache."
     method_option "no-prune", :type => :boolean, :banner => "Don't remove stale gems from the cache."
     method_option "path", :type => :string, :banner =>
       "Specify a different path than the system default ($BUNDLE_PATH or $GEM_HOME).#{" Bundler will remember this value for future installs on this machine" unless Bundler.feature_flag.forget_cli_options?}"
     method_option "quiet", :type => :boolean, :banner => "Only output warnings and errors."
     method_option "frozen", :type => :boolean, :banner =>
-      "Do not allow the Gemfile.lock to be updated after this package operation's install"
+      "Do not allow the Gemfile.lock to be updated after this bundle cache operation's install"
     long_desc <<-D
-      The package command will copy the .gem files for every gem in the bundle into the
+      The cache command will copy the .gem files for every gem in the bundle into the
       directory ./vendor/cache. If you then check that directory into your source
       control repository, others who check out your source will be able to install the
       bundle without having to download any additional gems.
     D
-    def package
-      require_relative "cli/package"
-      Package.new(options).run
+    def cache
+      require_relative "cli/cache"
+      Cache.new(options).run
     end
-    map %w[cache pack] => :package
+    map %w[package pack] => :cache
 
     desc "exec [OPTIONS]", "Run the command in context of the bundle"
     method_option :keep_file_descriptors, :type => :boolean, :default => false

--- a/lib/bundler/cli/cache.rb
+++ b/lib/bundler/cli/cache.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Bundler
-  class CLI::Package
+  class CLI::Cache
     attr_reader :options
 
     def initialize(options)
@@ -40,7 +40,7 @@ module Bundler
 
       if Bundler.definition.has_local_dependencies? && !Bundler.feature_flag.cache_all?
         Bundler.ui.warn "Your Gemfile contains path and git dependencies. If you want "    \
-          "to package them as well, please pass the --all flag. This will be the default " \
+          "to cache them as well, please pass the --all flag. This will be the default " \
           "on Bundler 3.0."
       end
     end

--- a/man/bundle-cache.1
+++ b/man/bundle-cache.1
@@ -1,25 +1,25 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-PACKAGE" "1" "October 2019" "" ""
+.TH "BUNDLE\-CACHE" "1" "October 2019" "" ""
 .
 .SH "NAME"
-\fBbundle\-package\fR \- Package your needed \fB\.gem\fR files into your application
+\fBbundle\-cache\fR \- Package your needed \fB\.gem\fR files into your application
 .
 .SH "SYNOPSIS"
-\fBbundle package\fR
+\fBbundle cache\fR
 .
 .SH "DESCRIPTION"
 Copy all of the \fB\.gem\fR files needed to run the application into the \fBvendor/cache\fR directory\. In the future, when running [bundle install(1)][bundle\-install], use the gems in the cache in preference to the ones on \fBrubygems\.org\fR\.
 .
 .SH "GIT AND PATH GEMS"
-The \fBbundle package\fR command can also package \fB:git\fR and \fB:path\fR dependencies besides \.gem files\. This needs to be explicitly enabled via the \fB\-\-all\fR option\. Once used, the \fB\-\-all\fR option will be remembered\.
+The \fBbundle cache\fR command can also package \fB:git\fR and \fB:path\fR dependencies besides \.gem files\. This needs to be explicitly enabled via the \fB\-\-all\fR option\. Once used, the \fB\-\-all\fR option will be remembered\.
 .
 .SH "SUPPORT FOR MULTIPLE PLATFORMS"
 When using gems that have different packages for different platforms, Bundler supports caching of gems for other platforms where the Gemfile has been resolved (i\.e\. present in the lockfile) in \fBvendor/cache\fR\. This needs to be enabled via the \fB\-\-all\-platforms\fR option\. This setting will be remembered in your local bundler configuration\.
 .
 .SH "REMOTE FETCHING"
-By default, if you run \fBbundle install(1)\fR](bundle\-install\.1\.html) after running bundle package(1) \fIbundle\-package\.1\.html\fR, bundler will still connect to \fBrubygems\.org\fR to check whether a platform\-specific gem exists for any of the gems in \fBvendor/cache\fR\.
+By default, if you run \fBbundle install(1)\fR](bundle\-install\.1\.html) after running bundle cache(1) \fIbundle\-cache\.1\.html\fR, bundler will still connect to \fBrubygems\.org\fR to check whether a platform\-specific gem exists for any of the gems in \fBvendor/cache\fR\.
 .
 .P
 For instance, consider this Gemfile(5):
@@ -37,7 +37,7 @@ gem "nokogiri"
 .IP "" 0
 .
 .P
-If you run \fBbundle package\fR under C Ruby, bundler will retrieve the version of \fBnokogiri\fR for the \fB"ruby"\fR platform\. If you deploy to JRuby and run \fBbundle install\fR, bundler is forced to check to see whether a \fB"java"\fR platformed \fBnokogiri\fR exists\.
+If you run \fBbundle cache\fR under C Ruby, bundler will retrieve the version of \fBnokogiri\fR for the \fB"ruby"\fR platform\. If you deploy to JRuby and run \fBbundle install\fR, bundler is forced to check to see whether a \fB"java"\fR platformed \fBnokogiri\fR exists\.
 .
 .P
 Even though the \fBnokogiri\fR gem for the Ruby platform is \fItechnically\fR acceptable on JRuby, it has a C extension that does not run on JRuby\. As a result, bundler will, by default, still connect to \fBrubygems\.org\fR to check whether it has a version of one of your gems more specific to your platform\.
@@ -49,7 +49,7 @@ This problem is also not limited to the \fB"java"\fR platform\. A similar (commo
 If you know for sure that the gems packaged in \fBvendor/cache\fR are appropriate for the platform you are on, you can run \fBbundle install \-\-local\fR to skip checking for more appropriate gems, and use the ones in \fBvendor/cache\fR\.
 .
 .P
-One way to be sure that you have the right platformed versions of all your gems is to run \fBbundle package\fR on an identical machine and check in the gems\. For instance, you can run \fBbundle package\fR on an identical staging box during your staging process, and check in the \fBvendor/cache\fR before deploying to production\.
+One way to be sure that you have the right platformed versions of all your gems is to run \fBbundle cache\fR on an identical machine and check in the gems\. For instance, you can run \fBbundle cache\fR on an identical staging box during your staging process, and check in the \fBvendor/cache\fR before deploying to production\.
 .
 .P
-By default, bundle package(1) \fIbundle\-package\.1\.html\fR fetches and also installs the gems to the default location\. To package the dependencies to \fBvendor/cache\fR without installing them to the local install location, you can run \fBbundle package \-\-no\-install\fR\.
+By default, bundle cache(1) \fIbundle\-cache\.1\.html\fR fetches and also installs the gems to the default location\. To package the dependencies to \fBvendor/cache\fR without installing them to the local install location, you can run \fBbundle cache \-\-no\-install\fR\.

--- a/man/bundle-cache.1.txt
+++ b/man/bundle-cache.1.txt
@@ -1,12 +1,12 @@
-BUNDLE-PACKAGE(1)					     BUNDLE-PACKAGE(1)
+BUNDLE-CACHE(1) 					       BUNDLE-CACHE(1)
 
 
 
 NAME
-       bundle-package - Package your needed .gem files into your application
+       bundle-cache - Package your needed .gem files into your application
 
 SYNOPSIS
-       bundle package
+       bundle cache
 
 DESCRIPTION
        Copy  all of the .gem files needed to run the application into the ven-
@@ -15,7 +15,7 @@ DESCRIPTION
        the ones on rubygems.org.
 
 GIT AND PATH GEMS
-       The bundle package command can also package :git and :path dependencies
+       The bundle cache command can also package :git and  :path  dependencies
        besides	.gem  files. This needs to be explicitly enabled via the --all
        option. Once used, the --all option will be remembered.
 
@@ -28,9 +28,9 @@ SUPPORT FOR MULTIPLE PLATFORMS
 
 REMOTE FETCHING
        By default, if you run bundle install(1)](bundle-install.1.html)  after
-       running	bundle	package(1)  bundle-package.1.html,  bundler will still
-       connect to rubygems.org to check whether a platform-specific gem exists
-       for any of the gems in vendor/cache.
+       running bundle cache(1) bundle-cache.1.html, bundler will still connect
+       to rubygems.org to check whether a platform-specific gem exists for any
+       of the gems in vendor/cache.
 
        For instance, consider this Gemfile(5):
 
@@ -42,9 +42,9 @@ REMOTE FETCHING
 
 
 
-       If  you run bundle package under C Ruby, bundler will retrieve the ver-
-       sion of nokogiri for the "ruby" platform. If you deploy	to  JRuby  and
-       run  bundle install, bundler is forced to check to see whether a "java"
+       If you run bundle cache under C Ruby, bundler will retrieve the version
+       of nokogiri for the "ruby" platform. If you deploy  to  JRuby  and  run
+       bundle  install,  bundler  is  forced  to check to see whether a "java"
        platformed nokogiri exists.
 
        Even though the nokogiri gem  for  the  Ruby  platform  is  technically
@@ -63,16 +63,16 @@ REMOTE FETCHING
        dor/cache.
 
        One  way  to be sure that you have the right platformed versions of all
-       your gems is to run bundle package on an identical machine and check in
-       the  gems.  For	instance,  you	can run bundle package on an identical
-       staging box during your staging process, and check in the  vendor/cache
+       your gems is to run bundle cache on an identical machine and  check  in
+       the  gems. For instance, you can run bundle cache on an identical stag-
+       ing box during your staging process,  and  check  in  the  vendor/cache
        before deploying to production.
 
-       By  default,  bundle  package(1) bundle-package.1.html fetches and also
+       By  default,  bundle  cache(1)  bundle-cache.1.html  fetches  and  also
        installs the gems to the default location. To package the  dependencies
        to  vendor/cache without installing them to the local install location,
-       you can run bundle package --no-install.
+       you can run bundle cache --no-install.
 
 
 
-				 October 2019		     BUNDLE-PACKAGE(1)
+				 October 2019		       BUNDLE-CACHE(1)

--- a/man/bundle-cache.ronn
+++ b/man/bundle-cache.ronn
@@ -1,9 +1,9 @@
-bundle-package(1) -- Package your needed `.gem` files into your application
+bundle-cache(1) -- Package your needed `.gem` files into your application
 ===========================================================================
 
 ## SYNOPSIS
 
-`bundle package`
+`bundle cache`
 
 ## DESCRIPTION
 
@@ -13,7 +13,7 @@ use the gems in the cache in preference to the ones on `rubygems.org`.
 
 ## GIT AND PATH GEMS
 
-The `bundle package` command can also package `:git` and `:path` dependencies
+The `bundle cache` command can also package `:git` and `:path` dependencies
 besides .gem files. This needs to be explicitly enabled via the `--all` option.
 Once used, the `--all` option will be remembered.
 
@@ -28,7 +28,7 @@ bundler configuration.
 ## REMOTE FETCHING
 
 By default, if you run `bundle install(1)`](bundle-install.1.html) after running
-[bundle package(1)](bundle-package.1.html), bundler will still connect to `rubygems.org`
+[bundle cache(1)](bundle-cache.1.html), bundler will still connect to `rubygems.org`
 to check whether a platform-specific gem exists for any of the gems
 in `vendor/cache`.
 
@@ -38,7 +38,7 @@ For instance, consider this Gemfile(5):
 
     gem "nokogiri"
 
-If you run `bundle package` under C Ruby, bundler will retrieve
+If you run `bundle cache` under C Ruby, bundler will retrieve
 the version of `nokogiri` for the `"ruby"` platform. If you deploy
 to JRuby and run `bundle install`, bundler is forced to check to
 see whether a `"java"` platformed `nokogiri` exists.
@@ -60,13 +60,13 @@ are appropriate for the platform you are on, you can run
 gems, and use the ones in `vendor/cache`.
 
 One way to be sure that you have the right platformed versions
-of all your gems is to run `bundle package` on an identical
+of all your gems is to run `bundle cache` on an identical
 machine and check in the gems. For instance, you can run
-`bundle package` on an identical staging box during your
+`bundle cache` on an identical staging box during your
 staging process, and check in the `vendor/cache` before
 deploying to production.
 
-By default, [bundle package(1)](bundle-package.1.html) fetches and also
+By default, [bundle cache(1)](bundle-cache.1.html) fetches and also
 installs the gems to the default location. To package the
 dependencies to `vendor/cache` without installing them to the
-local install location, you can run `bundle package --no-install`.
+local install location, you can run `bundle cache --no-install`.

--- a/man/bundle-package.1
+++ b/man/bundle-package.1
@@ -13,10 +13,10 @@
 Copy all of the \fB\.gem\fR files needed to run the application into the \fBvendor/cache\fR directory\. In the future, when running [bundle install(1)][bundle\-install], use the gems in the cache in preference to the ones on \fBrubygems\.org\fR\.
 .
 .SH "GIT AND PATH GEMS"
-Since Bundler 1\.2, the \fBbundle package\fR command can also package \fB:git\fR and \fB:path\fR dependencies besides \.gem files\. This needs to be explicitly enabled via the \fB\-\-all\fR option\. Once used, the \fB\-\-all\fR option will be remembered\.
+The \fBbundle package\fR command can also package \fB:git\fR and \fB:path\fR dependencies besides \.gem files\. This needs to be explicitly enabled via the \fB\-\-all\fR option\. Once used, the \fB\-\-all\fR option will be remembered\.
 .
 .SH "SUPPORT FOR MULTIPLE PLATFORMS"
-When using gems that have different packages for different platforms, Bundler 1\.8 and newer support caching of gems for other platforms where the Gemfile has been resolved (i\.e\. present in the lockfile) in \fBvendor/cache\fR\. This needs to be enabled via the \fB\-\-all\-platforms\fR option\. This setting will be remembered in your local bundler configuration\.
+When using gems that have different packages for different platforms, Bundler supports caching of gems for other platforms where the Gemfile has been resolved (i\.e\. present in the lockfile) in \fBvendor/cache\fR\. This needs to be enabled via the \fB\-\-all\-platforms\fR option\. This setting will be remembered in your local bundler configuration\.
 .
 .SH "REMOTE FETCHING"
 By default, if you run \fBbundle install(1)\fR](bundle\-install\.1\.html) after running bundle package(1) \fIbundle\-package\.1\.html\fR, bundler will still connect to \fBrubygems\.org\fR to check whether a platform\-specific gem exists for any of the gems in \fBvendor/cache\fR\.

--- a/man/bundle-package.1.txt
+++ b/man/bundle-package.1.txt
@@ -15,21 +15,20 @@ DESCRIPTION
        the ones on rubygems.org.
 
 GIT AND PATH GEMS
-       Since Bundler 1.2, the bundle package command can also package :git and
-       :path  dependencies  besides  .gem  files.  This needs to be explicitly
-       enabled via the --all option. Once  used,  the  --all  option  will  be
-       remembered.
+       The bundle package command can also package :git and :path dependencies
+       besides	.gem  files. This needs to be explicitly enabled via the --all
+       option. Once used, the --all option will be remembered.
 
 SUPPORT FOR MULTIPLE PLATFORMS
-       When  using  gems that have different packages for different platforms,
-       Bundler 1.8 and newer support caching of gems for other platforms where
-       the  Gemfile  has  been resolved (i.e. present in the lockfile) in ven-
-       dor/cache. This needs to be enabled  via  the  --all-platforms  option.
-       This setting will be remembered in your local bundler configuration.
+       When using gems that have different packages for  different  platforms,
+       Bundler	supports caching of gems for other platforms where the Gemfile
+       has been resolved (i.e. present in the lockfile) in vendor/cache.  This
+       needs  to  be enabled via the --all-platforms option. This setting will
+       be remembered in your local bundler configuration.
 
 REMOTE FETCHING
-       By  default, if you run bundle install(1)](bundle-install.1.html) after
-       running bundle package(1)  bundle-package.1.html,  bundler  will  still
+       By default, if you run bundle install(1)](bundle-install.1.html)  after
+       running	bundle	package(1)  bundle-package.1.html,  bundler will still
        connect to rubygems.org to check whether a platform-specific gem exists
        for any of the gems in vendor/cache.
 
@@ -43,35 +42,35 @@ REMOTE FETCHING
 
 
 
-       If you run bundle package under C Ruby, bundler will retrieve the  ver-
-       sion  of  nokogiri  for the "ruby" platform. If you deploy to JRuby and
-       run bundle install, bundler is forced to check to see whether a	"java"
+       If  you run bundle package under C Ruby, bundler will retrieve the ver-
+       sion of nokogiri for the "ruby" platform. If you deploy	to  JRuby  and
+       run  bundle install, bundler is forced to check to see whether a "java"
        platformed nokogiri exists.
 
-       Even  though  the  nokogiri  gem  for  the Ruby platform is technically
-       acceptable on JRuby, it has a C extension that does not run  on	JRuby.
+       Even though the nokogiri gem  for  the  Ruby  platform  is  technically
+       acceptable  on  JRuby, it has a C extension that does not run on JRuby.
        As a result, bundler will, by default, still connect to rubygems.org to
-       check whether it has a version of one of your  gems  more  specific  to
+       check  whether  it  has	a version of one of your gems more specific to
        your platform.
 
-       This  problem  is  also	not  limited to the "java" platform. A similar
+       This problem is also not limited to  the  "java"  platform.  A  similar
        (common) problem can happen when developing on Windows and deploying to
        Linux, or even when developing on OSX and deploying to Linux.
 
-       If  you know for sure that the gems packaged in vendor/cache are appro-
-       priate for the platform you are on, you can run bundle install  --local
-       to  skip  checking  for more appropriate gems, and use the ones in ven-
+       If you know for sure that the gems packaged in vendor/cache are	appro-
+       priate  for the platform you are on, you can run bundle install --local
+       to skip checking for more appropriate gems, and use the	ones  in  ven-
        dor/cache.
 
-       One way to be sure that you have the right platformed versions  of  all
+       One  way  to be sure that you have the right platformed versions of all
        your gems is to run bundle package on an identical machine and check in
-       the gems. For instance, you can run  bundle  package  on  an  identical
-       staging	box during your staging process, and check in the vendor/cache
+       the  gems.  For	instance,  you	can run bundle package on an identical
+       staging box during your staging process, and check in the  vendor/cache
        before deploying to production.
 
-       By default, bundle package(1) bundle-package.1.html  fetches  and  also
-       installs  the gems to the default location. To package the dependencies
-       to vendor/cache without installing them to the local install  location,
+       By  default,  bundle  package(1) bundle-package.1.html fetches and also
+       installs the gems to the default location. To package the  dependencies
+       to  vendor/cache without installing them to the local install location,
        you can run bundle package --no-install.
 
 

--- a/man/bundle-package.ronn
+++ b/man/bundle-package.ronn
@@ -13,17 +13,17 @@ use the gems in the cache in preference to the ones on `rubygems.org`.
 
 ## GIT AND PATH GEMS
 
-Since Bundler 1.2, the `bundle package` command can also package `:git` and
-`:path` dependencies besides .gem files. This needs to be explicitly enabled
-via the `--all` option. Once used, the `--all` option will be remembered.
+The `bundle package` command can also package `:git` and `:path` dependencies
+besides .gem files. This needs to be explicitly enabled via the `--all` option.
+Once used, the `--all` option will be remembered.
 
 ## SUPPORT FOR MULTIPLE PLATFORMS
 
 When using gems that have different packages for different platforms, Bundler
-1.8 and newer support caching of gems for other platforms where the Gemfile
-has been resolved (i.e. present in the lockfile) in `vendor/cache`.  This needs
-to be enabled via the `--all-platforms` option. This setting will be remembered
-in your local bundler configuration.
+supports caching of gems for other platforms where the Gemfile has been resolved
+(i.e. present in the lockfile) in `vendor/cache`.  This needs to be enabled via
+the `--all-platforms` option. This setting will be remembered in your local
+bundler configuration.
 
 ## REMOTE FETCHING
 

--- a/man/index.txt
+++ b/man/index.txt
@@ -2,6 +2,7 @@ Gemfile(5)            gemfile.5
 bundle(1)             bundle.1
 bundle-add(1)         bundle-add.1
 bundle-binstubs(1)    bundle-binstubs.1
+bundle-cache(1)       bundle-cache.1
 bundle-check(1)       bundle-check.1
 bundle-clean(1)       bundle-clean.1
 bundle-config(1)      bundle-config.1
@@ -16,7 +17,6 @@ bundle-list(1)        bundle-list.1
 bundle-lock(1)        bundle-lock.1
 bundle-open(1)        bundle-open.1
 bundle-outdated(1)    bundle-outdated.1
-bundle-package(1)     bundle-package.1
 bundle-platform(1)    bundle-platform.1
 bundle-pristine(1)    bundle-pristine.1
 bundle-remove(1)      bundle-remove.1

--- a/spec/cache/cache_path_spec.rb
+++ b/spec/cache/cache_path_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "bundle package" do
 
   context "with --cache-path" do
     it "caches gems at given path" do
-      bundle :package, "cache-path" => "vendor/cache-foo"
+      bundle :cache, "cache-path" => "vendor/cache-foo"
       expect(bundled_app("vendor/cache-foo/rack-1.0.0.gem")).to exist
     end
   end
@@ -18,14 +18,14 @@ RSpec.describe "bundle package" do
   context "with config cache_path" do
     it "caches gems at given path" do
       bundle "config set cache_path vendor/cache-foo"
-      bundle :package
+      bundle :cache
       expect(bundled_app("vendor/cache-foo/rack-1.0.0.gem")).to exist
     end
   end
 
   context "with absolute --cache-path" do
     it "caches gems at given path" do
-      bundle :package, "cache-path" => "/tmp/cache-foo"
+      bundle :cache, "cache-path" => "/tmp/cache-foo"
       expect(bundled_app("/tmp/cache-foo/rack-1.0.0.gem")).to exist
     end
   end

--- a/spec/commands/cache_spec.rb
+++ b/spec/commands/cache_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "bundle package" do
+RSpec.describe "bundle cache" do
   context "with --gemfile" do
     it "finds the gemfile" do
       gemfile bundled_app("NotGemfile"), <<-G
@@ -8,7 +8,7 @@ RSpec.describe "bundle package" do
         gem 'rack'
       G
 
-      bundle "package --gemfile=NotGemfile"
+      bundle "cache --gemfile=NotGemfile"
 
       ENV["BUNDLE_GEMFILE"] = "NotGemfile"
       expect(the_bundle).to include_gems "rack 1.0.0"
@@ -25,7 +25,7 @@ RSpec.describe "bundle package" do
         D
 
         bundle "config set cache_all true"
-        bundle :package
+        bundle :cache
 
         expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
         expect(bundled_app("vendor/cache/bundler-0.9.gem")).to_not exist
@@ -56,7 +56,7 @@ RSpec.describe "bundle package" do
           D
 
           bundle "config set cache_all true"
-          bundle! :package
+          bundle! :cache
 
           expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
           expect(bundled_app("vendor/cache/nokogiri-1.4.2.gem")).to exist
@@ -88,7 +88,7 @@ RSpec.describe "bundle package" do
           D
 
           bundle "config set cache_all true"
-          bundle! :package
+          bundle! :cache
 
           expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
           expect(bundled_app("vendor/cache/nokogiri-1.4.2.gem")).to exist
@@ -133,7 +133,7 @@ RSpec.describe "bundle package" do
         D
 
         bundle "config set cache_all true"
-        bundle! :package
+        bundle! :cache
 
         expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
         expect(bundled_app("vendor/cache/nokogiri-1.4.2.gem")).to exist
@@ -152,7 +152,7 @@ RSpec.describe "bundle package" do
         gem 'rack'
       D
 
-      bundle! :package, forgotten_command_line_options(:path => bundled_app("test"))
+      bundle! :cache, forgotten_command_line_options(:path => bundled_app("test"))
 
       expect(the_bundle).to include_gems "rack 1.0.0"
       expect(bundled_app("test/vendor/cache/")).to exist
@@ -166,7 +166,7 @@ RSpec.describe "bundle package" do
         gem 'rack'
       D
 
-      bundle! "package --no-install"
+      bundle! "cache --no-install"
 
       expect(the_bundle).not_to include_gems "rack 1.0.0"
       expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
@@ -178,7 +178,7 @@ RSpec.describe "bundle package" do
         gem 'rack'
       D
 
-      bundle! "package --no-install"
+      bundle! "cache --no-install"
       bundle! "install"
 
       expect(the_bundle).to include_gems "rack 1.0.0"
@@ -190,7 +190,7 @@ RSpec.describe "bundle package" do
         gem "rack", "1.0.0"
       D
 
-      bundle! "package --no-install"
+      bundle! "cache --no-install"
       bundle! "update --all"
 
       expect(the_bundle).to include_gems "rack 1.0.0"
@@ -204,7 +204,7 @@ RSpec.describe "bundle package" do
         gem 'rack', :platforms => :ruby_19
       D
 
-      bundle "package --all-platforms"
+      bundle "cache --all-platforms"
       expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
     end
 
@@ -226,7 +226,7 @@ RSpec.describe "bundle package" do
         end
       G
 
-      bundle! :package, "all-platforms" => true
+      bundle! :cache, "all-platforms" => true
       expect(bundled_app("vendor/cache/weakling-0.0.3.gem")).to exist
       expect(bundled_app("vendor/cache/uninstallable-2.0.gem")).to exist
       expect(the_bundle).to include_gem "rack 1.0"
@@ -247,7 +247,7 @@ RSpec.describe "bundle package" do
       bundle "install"
     end
 
-    subject { bundle :package, forgotten_command_line_options(:frozen => true) }
+    subject { bundle :cache, forgotten_command_line_options(:frozen => true) }
 
     it "tries to install with frozen" do
       bundle! "config set deployment true"
@@ -276,7 +276,7 @@ RSpec.describe "bundle install with gem sources" do
         gem "rack"
       G
 
-      bundle :pack
+      bundle :cache
       simulate_new_machine
       FileUtils.rm_rf gem_repo2
 
@@ -291,7 +291,7 @@ RSpec.describe "bundle install with gem sources" do
         gem "rack"
       G
 
-      bundle! :pack
+      bundle! :cache
       simulate_new_machine
       FileUtils.rm_rf gem_repo2
 
@@ -304,7 +304,7 @@ RSpec.describe "bundle install with gem sources" do
         source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
-      bundle :pack
+      bundle :cache
 
       build_gem "rack", "1.0.0", :path => bundled_app("vendor/cache") do |s|
         s.write "lib/rack.rb", "raise 'omg'"
@@ -321,7 +321,7 @@ RSpec.describe "bundle install with gem sources" do
           source "#{file_uri_for(gem_repo1)}"
           gem "platform_specific"
         G
-        bundle :pack
+        bundle :cache
       end
 
       simulate_new_machine

--- a/spec/install/deploy_spec.rb
+++ b/spec/install/deploy_spec.rb
@@ -390,7 +390,7 @@ You have deleted from the Gemfile:
       expect(the_bundle).to include_gems "foo 1.0"
 
       bundle "config set cache_all true"
-      bundle! :package
+      bundle! :cache
       expect(bundled_app("vendor/cache/foo")).to be_directory
 
       bundle! "install --local"

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -1391,7 +1391,7 @@ In Gemfile:
         end
       G
       bundle "config set cache_all true"
-      bundle :package
+      bundle :cache
       simulate_new_machine
 
       bundle! "install", :env => { "PATH" => "" }

--- a/spec/install/gemfile/sources_spec.rb
+++ b/spec/install/gemfile/sources_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
       end
 
       it "can cache and deploy" do
-        bundle! :package
+        bundle! :cache
 
         expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
         expect(bundled_app("vendor/cache/rack-obama-1.0.gem")).to exist

--- a/spec/lock/lockfile_spec.rb
+++ b/spec/lock/lockfile_spec.rb
@@ -621,7 +621,7 @@ RSpec.describe "the lockfile format" do
     G
 
     bundle "config set cache_all true"
-    bundle! :package
+    bundle! :cache
     bundle! :install, :local => true
 
     lockfile_should_be <<-G

--- a/spec/other/platform_spec.rb
+++ b/spec/other/platform_spec.rb
@@ -781,7 +781,7 @@ G
         #{ruby_version_correct}
       G
 
-      bundle :pack
+      bundle :cache
       expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
     end
 
@@ -794,7 +794,7 @@ G
           #{ruby_version_correct_engineless}
         G
 
-        bundle :pack
+        bundle :cache
         expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
       end
     end
@@ -806,7 +806,7 @@ G
         #{ruby_version_incorrect}
       G
 
-      bundle :pack
+      bundle :cache
       should_be_ruby_version_incorrect
     end
 
@@ -817,7 +817,7 @@ G
         #{engine_incorrect}
       G
 
-      bundle :pack
+      bundle :cache
       should_be_engine_incorrect
     end
 
@@ -829,7 +829,7 @@ G
           #{engine_version_incorrect}
         G
 
-        bundle :pack
+        bundle :cache
         should_be_engine_version_incorrect
       end
     end
@@ -842,7 +842,7 @@ G
         #{patchlevel_incorrect}
       G
 
-      bundle :pack
+      bundle :cache
       should_be_patchlevel_incorrect
     end
   end

--- a/spec/plugins/source/example_spec.rb
+++ b/spec/plugins/source/example_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe "real source plugins" do
       it "bundler package copies repository to vendor cache" do
         bundle! :install, forgotten_command_line_options(:path => "vendor/bundle")
         bundle "config set cache_all true"
-        bundle! :package
+        bundle! :cache
 
         expect(bundled_app("vendor/cache/a-path-gem-1.0-#{uri_hash}")).to exist
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that after https://github.com/bundler/bundler/pull/7249, we added the current `bundle package` functionality to the current `bundle cache` command, so that these commands are now aliases of each other.

The initial plan was to do this in a more careful manner but we concluded that this was only _adding_ functionality to `bundle cache`, so not backwards incompatible.

We still need to wrap up the original plan, where `bundle cache` is the preferred command.

### What is your fix for the problem, implemented in this PR?

My fix is to migrate docs, tests and help text to use `bundle cache`, and to remove duplicated specs for `bundle cache` and `bundle package`, since they are testing the exact same code.