### PR TITLE
Make 'bundle add' cache newly added gems when needed

### DIFF
--- a/lib/bundler/cli/add.rb
+++ b/lib/bundler/cli/add.rb
@@ -21,6 +21,7 @@ module Bundler
 
     def perform_bundle_install
       Installer.install(Bundler.root, Bundler.definition)
+      Bundler.load.cache if Bundler.app_cache.exist?
     end
 
     def inject_dependencies

--- a/spec/commands/add_spec.rb
+++ b/spec/commands/add_spec.rb
@@ -239,4 +239,13 @@ RSpec.describe "bundle add" do
       expect(err).not_to include("You may also need to change the version requirement specified in the Gemfile if it's too restrictive")
     end
   end
+
+  describe "when a gem is added and cache exists" do
+    it "caches all new dependencies added for the specified gem" do
+      bundle! :cache
+
+      bundle "add 'rack' --version=1.0.0"
+      expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
+    end
+  end
 end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that when calling `bundle add` with cache_all as true, I have to call an additional `bundle install` to vendor gems.

### What was your diagnosis of the problem?

My diagnosis was that a call to Bundler.load.cache was missing. For example Bundler::CLI::Update does the same after installing gems.

### What is your fix for the problem, implemented in this PR?

My fix was to call Bundler.load.cache when `Bundler.app_cache.exist? ` 

### Why did you choose this fix out of the possible options?

I chose this fix because it looks like this makes the behavior consistent with other commands.

I should also say that, as this is my first PR here, I'm not sure that this is the best solution, and it seems an easy fix for #7384. 