### PR TITLE
Remove unnecessary bit from `bundler/setup`

### DIFF
--- a/lib/bundler/setup.rb
+++ b/lib/bundler/setup.rb
@@ -21,9 +21,5 @@ if Bundler::SharedHelpers.in_bundle?
     Bundler.setup
   end
 
-  # Add bundler to the load path after disabling system gems
-  bundler_lib = File.expand_path("../..", __FILE__)
-  $LOAD_PATH.unshift(bundler_lib) unless $LOAD_PATH.include?(bundler_lib)
-
   Bundler.ui = nil
 end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

These lines in the `bundler/setup` file are not necessary.

### What was your diagnosis of the problem?

Bundler no longer needs to be in the `$LOAD_PATH` once a version of itself has been loaded.

In any case, the `Metadata` source takes care of adding `bundler` to the index:

https://github.com/bundler/bundler/blob/e70643c1be3a4417bd537d7e63470265465e693e/lib/bundler/source/metadata.rb#L13-L30

and then that spec is added to the resolution here:

https://github.com/bundler/bundler/blob/e70643c1be3a4417bd537d7e63470265465e693e/lib/bundler/definition.rb#L180-L184

And from the resulting set of specs, the LOAD_PATH is setup:

https://github.com/bundler/bundler/blob/e70643c1be3a4417bd537d7e63470265465e693e/lib/bundler/runtime.rb#L25-L38

 So `bundler` will be present in the `$LOAD_PATH` anyways, and the lines being removed here will never be useful.

### What is your fix for the problem, implemented in this PR?

My fix is to remove these lines to make the code easier to follow.