### PR TITLE
Fix some realworld specs testing nothing

### DIFF
--- a/spec/realworld/edgecases_spec.rb
+++ b/spec/realworld/edgecases_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "real world edgecases", :realworld => true, :sometimes => true do
         raise "Could not find #{name} (#{requirement}) on rubygems.org!\n" \
           "Found specs:\n\#{index.send(:specs).inspect}"
       end
-      "#{name} (\#{rubygem.version})"
+      puts "#{name} (\#{rubygem.version})"
     RUBY
   end
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that this helper was printing nothing to the standard output, so the specs in this file were just checking if lockfiles contained the empty string, which is obviously true. For example,

https://github.com/bundler/bundler/blob/e70643c1be3a4417bd537d7e63470265465e693e/spec/realworld/edgecases_spec.rb#L31

### What was your diagnosis of the problem?

My diagnosis was that the helper needs to actually print the extracted information about the resolved gem, so it can be checked that the lockfile is correct.

### What is your fix for the problem, implemented in this PR?

My fix adds the missing `puts`.