### PR TITLE
Spec normalizations

### DIFF
--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -236,7 +236,7 @@ RSpec.describe Bundler::SharedHelpers do
     shared_examples_for "ENV['RUBYOPT'] gets set correctly" do
       it "ensures -rbundler/setup is at the beginning of ENV['RUBYOPT']" do
         subject.set_bundle_environment
-        expect(ENV["RUBYOPT"].split(" ")).to start_with("-r#{lib}/bundler/setup")
+        expect(ENV["RUBYOPT"].split(" ")).to start_with("-r#{lib_dir}/bundler/setup")
       end
     end
 

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "bundle exec" do
       else
         require 'tempfile'
         io = Tempfile.new("io-test-fd")
-        args = %W[#{Gem.ruby} -I#{lib} #{bindir.join("bundle")} exec --keep-file-descriptors #{Gem.ruby} #{command.path} \#{io.to_i}]
+        args = %W[#{Gem.ruby} -I#{lib_dir} #{bindir.join("bundle")} exec --keep-file-descriptors #{Gem.ruby} #{command.path} \#{io.to_i}]
         args << { io.to_i => io }
         exec(*args)
       end
@@ -279,7 +279,7 @@ RSpec.describe "bundle exec" do
     G
 
     rubyopt = ENV["RUBYOPT"]
-    rubyopt = "-r#{lib}/bundler/setup #{rubyopt}"
+    rubyopt = "-r#{lib_dir}/bundler/setup #{rubyopt}"
 
     bundle "exec 'echo $RUBYOPT'"
     expect(out).to have_rubyopts(rubyopt)
@@ -294,7 +294,7 @@ RSpec.describe "bundle exec" do
     G
 
     rubylib = ENV["RUBYLIB"]
-    rubylib = rubylib.to_s.split(File::PATH_SEPARATOR).unshift lib.to_s
+    rubylib = rubylib.to_s.split(File::PATH_SEPARATOR).unshift lib_dir.to_s
     rubylib = rubylib.uniq.join(File::PATH_SEPARATOR)
 
     bundle "exec 'echo $RUBYLIB'"

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe "bundle gem" do
   context "when git is not available" do
     # This spec cannot have `git` available in the test env
     before do
-      load_paths = [lib, spec]
+      load_paths = [lib, spec_dir]
       load_path_str = "-I#{load_paths.join(File::PATH_SEPARATOR)}"
 
       sys_exec "#{Gem.ruby} #{load_path_str} #{bindir.join("bundle")} gem #{gem_name}", "PATH" => ""

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe "bundle gem" do
   context "when git is not available" do
     # This spec cannot have `git` available in the test env
     before do
-      load_paths = [lib, spec_dir]
+      load_paths = [lib_dir, spec_dir]
       load_path_str = "-I#{load_paths.join(File::PATH_SEPARATOR)}"
 
       sys_exec "#{Gem.ruby} #{load_path_str} #{bindir.join("bundle")} gem #{gem_name}", "PATH" => ""

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "bundle gem" do
       user = bundleuser
     EOF
     @git_config_location = ENV["GIT_CONFIG"]
-    path = "#{File.expand_path(tmp, File.dirname(__FILE__))}/test_git_config.txt"
+    path = "#{tmp}/test_git_config.txt"
     File.open(path, "w") {|f| f.write(git_config_content) }
     ENV["GIT_CONFIG"] = path
   end

--- a/spec/install/gemfile/groups_spec.rb
+++ b/spec/install/gemfile/groups_spec.rb
@@ -333,7 +333,7 @@ RSpec.describe "bundle install with groups" do
       G
 
       ruby <<-R
-        require "#{lib}/bundler"
+        require "#{lib_dir}/bundler"
         Bundler.setup :default
         Bundler.require :default
         puts RACK

--- a/spec/realworld/dependency_api_spec.rb
+++ b/spec/realworld/dependency_api_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "gemcutter's dependency API", :realworld => true do
       port = find_unused_port
       @server_uri = "http://127.0.0.1:#{port}"
 
-      require File.expand_path("../../support/artifice/endpoint_timeout", __FILE__)
+      require_relative "../support/artifice/endpoint_timeout"
 
       @t = Thread.new do
         server = Rack::Server.start(:app       => EndpointTimeout,

--- a/spec/realworld/double_check_spec.rb
+++ b/spec/realworld/double_check_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "double checking sources", :realworld => true, :sometimes => true
 
     cmd = <<-RUBY
       require "#{lib}/bundler"
-      require "#{spec}/support/artifice/vcr"
+      require "#{spec_dir}/support/artifice/vcr"
       require "#{lib}/bundler/inline"
       gemfile(true) do
         source "https://rubygems.org"

--- a/spec/realworld/double_check_spec.rb
+++ b/spec/realworld/double_check_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "double checking sources", :realworld => true, :sometimes => true
 
     cmd = <<-RUBY
       require "#{lib}/bundler"
-      require #{File.expand_path("../../support/artifice/vcr.rb", __FILE__).dump}
+      require "#{spec}/support/artifice/vcr"
       require "#{lib}/bundler/inline"
       gemfile(true) do
         source "https://rubygems.org"

--- a/spec/realworld/double_check_spec.rb
+++ b/spec/realworld/double_check_spec.rb
@@ -25,9 +25,9 @@ RSpec.describe "double checking sources", :realworld => true, :sometimes => true
     RUBY
 
     cmd = <<-RUBY
-      require "#{lib}/bundler"
+      require "#{lib_dir}/bundler"
       require "#{spec_dir}/support/artifice/vcr"
-      require "#{lib}/bundler/inline"
+      require "#{lib_dir}/bundler/inline"
       gemfile(true) do
         source "https://rubygems.org"
         gem "rails", path: "."

--- a/spec/realworld/edgecases_spec.rb
+++ b/spec/realworld/edgecases_spec.rb
@@ -3,10 +3,10 @@
 RSpec.describe "real world edgecases", :realworld => true, :sometimes => true do
   def rubygems_version(name, requirement)
     ruby! <<-RUBY
-      require #{File.expand_path("../../support/artifice/vcr.rb", __FILE__).dump}
-      require "bundler"
-      require "bundler/source/rubygems/remote"
-      require "bundler/fetcher"
+      require "#{spec}/support/artifice/vcr"
+      require "#{lib}/bundler"
+      require "#{lib}/bundler/source/rubygems/remote"
+      require "#{lib}/bundler/fetcher"
       rubygem = Bundler.ui.silence do
         source = Bundler::Source::Rubygems::Remote.new(URI("https://rubygems.org"))
         fetcher = Bundler::Fetcher.new(source)

--- a/spec/realworld/edgecases_spec.rb
+++ b/spec/realworld/edgecases_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe "real world edgecases", :realworld => true, :sometimes => true do
   def rubygems_version(name, requirement)
     ruby! <<-RUBY
       require "#{spec_dir}/support/artifice/vcr"
-      require "#{lib}/bundler"
-      require "#{lib}/bundler/source/rubygems/remote"
-      require "#{lib}/bundler/fetcher"
+      require "#{lib_dir}/bundler"
+      require "#{lib_dir}/bundler/source/rubygems/remote"
+      require "#{lib_dir}/bundler/fetcher"
       rubygem = Bundler.ui.silence do
         source = Bundler::Source::Rubygems::Remote.new(URI("https://rubygems.org"))
         fetcher = Bundler::Fetcher.new(source)

--- a/spec/realworld/edgecases_spec.rb
+++ b/spec/realworld/edgecases_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe "real world edgecases", :realworld => true, :sometimes => true do
   def rubygems_version(name, requirement)
     ruby! <<-RUBY
-      require "#{spec}/support/artifice/vcr"
+      require "#{spec_dir}/support/artifice/vcr"
       require "#{lib}/bundler"
       require "#{lib}/bundler/source/rubygems/remote"
       require "#{lib}/bundler/fetcher"

--- a/spec/realworld/gemfile_source_header_spec.rb
+++ b/spec/realworld/gemfile_source_header_spec.rb
@@ -37,7 +37,7 @@ private
     @port = find_unused_port
     @server_uri = "http://127.0.0.1:#{@port}"
 
-    require File.expand_path("../../support/artifice/endpoint_mirror_source", __FILE__)
+    require_relative "../support/artifice/endpoint_mirror_source"
 
     @t = Thread.new do
       Rack::Server.start(:app       => EndpointMirrorSource,

--- a/spec/realworld/mirror_probe_spec.rb
+++ b/spec/realworld/mirror_probe_spec.rb
@@ -123,7 +123,7 @@ Could not fetch specs from #{mirror}/
     @server_port = find_unused_port
     @server_uri = "http://#{host}:#{@server_port}"
 
-    require File.expand_path("../../support/artifice/endpoint", __FILE__)
+    require_relative "../support/artifice/endpoint"
 
     @server_thread = Thread.new do
       Rack::Server.start(:app       => Endpoint,

--- a/spec/runtime/gem_tasks_spec.rb
+++ b/spec/runtime/gem_tasks_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "require 'bundler/gem_tasks'" do
     end
     bundled_app("Rakefile").open("w") do |f|
       f.write <<-RAKEFILE
-        $:.unshift("#{lib}")
+        $:.unshift("#{lib_dir}")
         require "bundler/gem_tasks"
       RAKEFILE
     end
@@ -19,7 +19,7 @@ RSpec.describe "require 'bundler/gem_tasks'" do
 
   it "includes the relevant tasks" do
     with_gem_path_as(Spec::Path.base_system_gems.to_s) do
-      sys_exec "#{rake} -T", "RUBYOPT" => "-I#{lib}"
+      sys_exec "#{rake} -T", "RUBYOPT" => "-I#{lib_dir}"
     end
 
     expect(err).to eq("")

--- a/spec/runtime/inline_spec.rb
+++ b/spec/runtime/inline_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe "bundler/inline#gemfile" do
   def script(code, options = {})
-    requires = ["#{lib}/bundler/inline"]
+    requires = ["#{lib_dir}/bundler/inline"]
     requires.unshift File.expand_path("../../support/artifice/" + options.delete(:artifice) + ".rb", __FILE__) if options.key?(:artifice)
     requires = requires.map {|r| "require '#{r}'" }.join("\n")
     @out = ruby("#{requires}\n\n" + code, options)
@@ -97,7 +97,7 @@ RSpec.describe "bundler/inline#gemfile" do
 
   it "lets me use my own ui object" do
     script <<-RUBY, :artifice => "endpoint"
-      require '#{lib}/bundler'
+      require '#{lib_dir}/bundler'
       class MyBundlerUI < Bundler::UI::Silent
         def confirm(msg, newline = nil)
           puts "CONFIRMED!"
@@ -141,7 +141,7 @@ RSpec.describe "bundler/inline#gemfile" do
 
   it "does not mutate the option argument" do
     script <<-RUBY
-      require '#{lib}/bundler'
+      require '#{lib_dir}/bundler'
       options = { :ui => Bundler::UI::Shell.new }
       gemfile(false, options) do
         path "#{lib_path}" do

--- a/spec/runtime/inline_spec.rb
+++ b/spec/runtime/inline_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe "bundler/inline#gemfile" do
   def script(code, options = {})
     requires = ["#{lib_dir}/bundler/inline"]
-    requires.unshift File.expand_path("../../support/artifice/" + options.delete(:artifice) + ".rb", __FILE__) if options.key?(:artifice)
+    requires.unshift "#{spec_dir}/support/artifice/" + options.delete(:artifice) if options.key?(:artifice)
     requires = requires.map {|r| "require '#{r}'" }.join("\n")
     @out = ruby("#{requires}\n\n" + code, options)
   end

--- a/spec/runtime/load_spec.rb
+++ b/spec/runtime/load_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe "Bundler.load" do
       G
 
       ruby! <<-RUBY
-        require "#{lib}/bundler"
+        require "#{lib_dir}/bundler"
         Bundler.setup :default
         Bundler.require :default
         puts RACK

--- a/spec/runtime/require_spec.rb
+++ b/spec/runtime/require_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe "Bundler.require" do
       G
 
       cmd = <<-RUBY
-        require '#{lib}/bundler'
+        require '#{lib_dir}/bundler'
         Bundler.require
       RUBY
       ruby(cmd)

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -1043,7 +1043,7 @@ end
   describe "when Bundler is bundled" do
     it "doesn't blow up" do
       install_gemfile <<-G
-        gem "bundler", :path => "#{File.expand_path("..", lib)}"
+        gem "bundler", :path => "#{root}"
       G
 
       bundle %(exec ruby -e "require 'bundler'; Bundler.setup")

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Bundler.setup" do
       G
 
       ruby <<-RUBY
-        require '#{lib}/bundler'
+        require '#{lib_dir}/bundler'
         Bundler.setup
 
         require 'rack'
@@ -34,7 +34,7 @@ RSpec.describe "Bundler.setup" do
 
     it "doesn't make all groups available" do
       ruby <<-RUBY
-        require '#{lib}/bundler'
+        require '#{lib_dir}/bundler'
         Bundler.setup(:default)
 
         begin
@@ -49,7 +49,7 @@ RSpec.describe "Bundler.setup" do
 
     it "accepts string for group name" do
       ruby <<-RUBY
-        require '#{lib}/bundler'
+        require '#{lib_dir}/bundler'
         Bundler.setup(:default, 'test')
 
         require 'rack'
@@ -61,7 +61,7 @@ RSpec.describe "Bundler.setup" do
 
     it "leaves all groups available if they were already" do
       ruby <<-RUBY
-        require '#{lib}/bundler'
+        require '#{lib_dir}/bundler'
         Bundler.setup
         Bundler.setup(:default)
 
@@ -74,7 +74,7 @@ RSpec.describe "Bundler.setup" do
 
     it "leaves :default available if setup is called twice" do
       ruby <<-RUBY
-        require '#{lib}/bundler'
+        require '#{lib_dir}/bundler'
         Bundler.setup(:default)
         Bundler.setup(:default, :test)
 
@@ -91,7 +91,7 @@ RSpec.describe "Bundler.setup" do
 
     it "handles multiple non-additive invocations" do
       ruby <<-RUBY
-        require '#{lib}/bundler'
+        require '#{lib_dir}/bundler'
         Bundler.setup(:default, :test)
         Bundler.setup(:default)
         require 'rack'
@@ -109,7 +109,7 @@ RSpec.describe "Bundler.setup" do
     def clean_load_path(lp)
       without_bundler_load_path = ruby!("puts $LOAD_PATH").split("\n")
       lp -= without_bundler_load_path
-      lp.map! {|p| p.sub(/^#{Regexp.union system_gem_path.to_s, default_bundle_path.to_s, lib.to_s}/i, "") }
+      lp.map! {|p| p.sub(/^#{Regexp.union system_gem_path.to_s, default_bundle_path.to_s, lib_dir.to_s}/i, "") }
     end
 
     it "puts loaded gems after -I and RUBYLIB", :ruby_repo do
@@ -122,7 +122,7 @@ RSpec.describe "Bundler.setup" do
       ENV["RUBYLIB"] = "rubylib_dir"
 
       ruby <<-RUBY
-        require '#{lib}/bundler'
+        require '#{lib_dir}/bundler'
         Bundler.setup
         puts $LOAD_PATH
       RUBY
@@ -144,7 +144,7 @@ RSpec.describe "Bundler.setup" do
       G
 
       ruby! <<-RUBY
-        require '#{lib}/bundler'
+        require '#{lib_dir}/bundler'
         Bundler.setup
         puts $LOAD_PATH
       RUBY
@@ -172,7 +172,7 @@ RSpec.describe "Bundler.setup" do
       G
 
       ruby! <<-RUBY
-        require '#{lib}/bundler/setup'
+        require '#{lib_dir}/bundler/setup'
         puts $LOAD_PATH
       RUBY
 
@@ -193,7 +193,7 @@ RSpec.describe "Bundler.setup" do
     G
 
     ruby <<-R
-      require '#{lib}/bundler'
+      require '#{lib_dir}/bundler'
 
       begin
         Bundler.setup
@@ -213,7 +213,7 @@ RSpec.describe "Bundler.setup" do
     G
 
     ruby <<-R
-      require '#{lib}/bundler'
+      require '#{lib_dir}/bundler'
 
       Bundler.setup
     R
@@ -236,7 +236,7 @@ RSpec.describe "Bundler.setup" do
     G
 
     ruby <<-R
-      require '#{lib}/bundler'
+      require '#{lib_dir}/bundler'
 
       Bundler.setup
     R
@@ -289,7 +289,7 @@ RSpec.describe "Bundler.setup" do
 
         ENV["BUNDLE_GEMFILE"] = "Gemfile"
         ruby <<-R
-          require '#{lib}/bundler'
+          require '#{lib_dir}/bundler'
 
           begin
             Bundler.setup
@@ -444,7 +444,7 @@ RSpec.describe "Bundler.setup" do
       break_git!
 
       ruby <<-R
-        require '#{lib}/bundler'
+        require '#{lib_dir}/bundler'
 
         begin
           Bundler.setup
@@ -465,7 +465,7 @@ RSpec.describe "Bundler.setup" do
       break_git!
 
       ruby <<-R
-        require "#{lib}/bundler"
+        require "#{lib_dir}/bundler"
 
         begin
           Bundler.setup
@@ -774,7 +774,7 @@ end
         s.class.send(:define_method, :build_extensions) { nil }
       end
 
-      require '#{lib}/bundler'
+      require '#{lib_dir}/bundler'
       gem '#{gem_name}'
 
       puts $LOAD_PATH.count {|path| path =~ /#{gem_name}/} >= 2
@@ -1028,7 +1028,7 @@ end
       bundle "install"
 
       ruby <<-RUBY
-        require '#{lib}/bundler'
+        require '#{lib_dir}/bundler'
         def Bundler.require(path)
           raise "LOSE"
         end
@@ -1083,7 +1083,7 @@ end
     context "is not present" do
       it "does not change the lock" do
         lockfile lock_with(nil)
-        ruby "require '#{lib}/bundler/setup'"
+        ruby "require '#{lib_dir}/bundler/setup'"
         lockfile_should_be lock_with(nil)
       end
     end
@@ -1091,7 +1091,7 @@ end
     context "is newer" do
       it "does not change the lock or warn" do
         lockfile lock_with(Bundler::VERSION.succ)
-        ruby "require '#{lib}/bundler/setup'"
+        ruby "require '#{lib_dir}/bundler/setup'"
         expect(out).to eq("")
         expect(err).to eq("")
         lockfile_should_be lock_with(Bundler::VERSION.succ)
@@ -1101,7 +1101,7 @@ end
     context "is older" do
       it "does not change the lock" do
         lockfile lock_with("1.10.1")
-        ruby "require '#{lib}/bundler/setup'"
+        ruby "require '#{lib_dir}/bundler/setup'"
         lockfile_should_be lock_with("1.10.1")
       end
     end
@@ -1148,14 +1148,14 @@ end
 
     context "is not present" do
       it "does not change the lock" do
-        expect { ruby! "require '#{lib}/bundler/setup'" }.not_to change { lockfile }
+        expect { ruby! "require '#{lib_dir}/bundler/setup'" }.not_to change { lockfile }
       end
     end
 
     context "is newer" do
       let(:ruby_version) { "5.5.5" }
       it "does not change the lock or warn" do
-        expect { ruby! "require '#{lib}/bundler/setup'" }.not_to change { lockfile }
+        expect { ruby! "require '#{lib_dir}/bundler/setup'" }.not_to change { lockfile }
         expect(out).to eq("")
         expect(err).to eq("")
       end
@@ -1164,7 +1164,7 @@ end
     context "is older" do
       let(:ruby_version) { "1.0.0" }
       it "does not change the lock" do
-        expect { ruby! "require '#{lib}/bundler/setup'" }.not_to change { lockfile }
+        expect { ruby! "require '#{lib_dir}/bundler/setup'" }.not_to change { lockfile }
       end
     end
   end
@@ -1173,7 +1173,7 @@ end
     it "does not load Psych" do
       gemfile ""
       ruby <<-RUBY
-        require '#{lib}/bundler/setup'
+        require '#{lib_dir}/bundler/setup'
         puts defined?(Psych::VERSION) ? Psych::VERSION : "undefined"
         require 'psych'
         puts Psych::VERSION
@@ -1186,7 +1186,7 @@ end
     it "does not load openssl" do
       install_gemfile! ""
       ruby! <<-RUBY
-        require "#{lib}/bundler/setup"
+        require "#{lib_dir}/bundler/setup"
         puts defined?(OpenSSL) || "undefined"
         require "openssl"
         puts defined?(OpenSSL) || "undefined"
@@ -1240,7 +1240,7 @@ end
 
       it "activates no gems with -rbundler/setup" do
         install_gemfile! ""
-        ruby! code, :env => { :RUBYOPT => activation_warning_hack_rubyopt + " -r#{lib}/bundler/setup" }
+        ruby! code, :env => { :RUBYOPT => activation_warning_hack_rubyopt + " -r#{lib_dir}/bundler/setup" }
         expect(out).to eq("{}")
       end
 
@@ -1315,7 +1315,7 @@ end
       G
 
       ruby! <<-RUBY
-        require "#{lib}/bundler/setup"
+        require "#{lib_dir}/bundler/setup"
         Object.new.gem "rack"
         puts Gem.loaded_specs["rack"].full_name
       RUBY
@@ -1330,7 +1330,7 @@ end
       G
 
       ruby <<-RUBY
-        require "#{lib}/bundler/setup"
+        require "#{lib_dir}/bundler/setup"
         Object.new.gem "rack"
         puts "FAIL"
       RUBY
@@ -1346,7 +1346,7 @@ end
       G
 
       ruby <<-RUBY
-        require "#{lib}/bundler/setup"
+        require "#{lib_dir}/bundler/setup"
         Object.new.require "rack"
         puts "FAIL"
       RUBY

--- a/spec/runtime/with_unbundled_env_spec.rb
+++ b/spec/runtime/with_unbundled_env_spec.rb
@@ -81,8 +81,8 @@ RSpec.describe "Bundler.with_env helpers" do
 
     it "should restore RUBYLIB", :ruby_repo do
       code = "print #{modified_env}['RUBYLIB']"
-      ENV["RUBYLIB"] = root.join("lib").to_s + File::PATH_SEPARATOR + "/foo"
-      ENV["BUNDLER_ORIG_RUBYLIB"] = root.join("lib").to_s + File::PATH_SEPARATOR + "/foo-original"
+      ENV["RUBYLIB"] = lib_dir.to_s + File::PATH_SEPARATOR + "/foo"
+      ENV["BUNDLER_ORIG_RUBYLIB"] = lib_dir.to_s + File::PATH_SEPARATOR + "/foo-original"
       bundle_exec_ruby! code.dump
       expect(last_command.stdboth).to include("/foo-original")
     end

--- a/spec/runtime/with_unbundled_env_spec.rb
+++ b/spec/runtime/with_unbundled_env_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe "Bundler.with_env helpers" do
     end
 
     it "runs system inside with_original_env" do
-      system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib} -rbundler -e '#{code}'")
+      system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib_dir} -rbundler -e '#{code}'")
       expect($?.exitstatus).to eq(42)
     end
   end
@@ -185,7 +185,7 @@ RSpec.describe "Bundler.with_env helpers" do
     end
 
     it "runs system inside with_clean_env" do
-      system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib} -rbundler -e '#{code}'")
+      system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib_dir} -rbundler -e '#{code}'")
       expect($?.exitstatus).to eq(42)
     end
   end
@@ -200,7 +200,7 @@ RSpec.describe "Bundler.with_env helpers" do
     end
 
     it "runs system inside with_unbundled_env" do
-      system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib} -rbundler -e '#{code}'")
+      system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib_dir} -rbundler -e '#{code}'")
       expect($?.exitstatus).to eq(42)
     end
   end
@@ -221,7 +221,7 @@ RSpec.describe "Bundler.with_env helpers" do
     it "runs exec inside with_original_env" do
       skip "Fork not implemented" if Gem.win_platform?
 
-      system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib} -rbundler -e '#{code}'")
+      system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib_dir} -rbundler -e '#{code}'")
       expect($?.exitstatus).to eq(0)
     end
   end
@@ -242,7 +242,7 @@ RSpec.describe "Bundler.with_env helpers" do
     it "runs exec inside with_clean_env" do
       skip "Fork not implemented" if Gem.win_platform?
 
-      system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib} -rbundler -e '#{code}'")
+      system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib_dir} -rbundler -e '#{code}'")
       expect($?.exitstatus).to eq(1)
     end
   end
@@ -263,7 +263,7 @@ RSpec.describe "Bundler.with_env helpers" do
     it "runs exec inside with_clean_env" do
       skip "Fork not implemented" if Gem.win_platform?
 
-      system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib} -rbundler -e '#{code}'")
+      system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib_dir} -rbundler -e '#{code}'")
       expect($?.exitstatus).to eq(1)
     end
   end

--- a/spec/runtime/with_unbundled_env_spec.rb
+++ b/spec/runtime/with_unbundled_env_spec.rb
@@ -170,7 +170,6 @@ RSpec.describe "Bundler.with_env helpers" do
     end
 
     it "runs system inside with_original_env" do
-      lib = File.expand_path("../../lib", __dir__)
       system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib} -rbundler -e '#{code}'")
       expect($?.exitstatus).to eq(42)
     end
@@ -186,7 +185,6 @@ RSpec.describe "Bundler.with_env helpers" do
     end
 
     it "runs system inside with_clean_env" do
-      lib = File.expand_path("../../lib", __dir__)
       system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib} -rbundler -e '#{code}'")
       expect($?.exitstatus).to eq(42)
     end
@@ -202,7 +200,6 @@ RSpec.describe "Bundler.with_env helpers" do
     end
 
     it "runs system inside with_unbundled_env" do
-      lib = File.expand_path("../../lib", __dir__)
       system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib} -rbundler -e '#{code}'")
       expect($?.exitstatus).to eq(42)
     end
@@ -224,7 +221,6 @@ RSpec.describe "Bundler.with_env helpers" do
     it "runs exec inside with_original_env" do
       skip "Fork not implemented" if Gem.win_platform?
 
-      lib = File.expand_path("../../lib", __dir__)
       system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib} -rbundler -e '#{code}'")
       expect($?.exitstatus).to eq(0)
     end
@@ -246,7 +242,6 @@ RSpec.describe "Bundler.with_env helpers" do
     it "runs exec inside with_clean_env" do
       skip "Fork not implemented" if Gem.win_platform?
 
-      lib = File.expand_path("../../lib", __dir__)
       system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib} -rbundler -e '#{code}'")
       expect($?.exitstatus).to eq(1)
     end
@@ -268,7 +263,6 @@ RSpec.describe "Bundler.with_env helpers" do
     it "runs exec inside with_clean_env" do
       skip "Fork not implemented" if Gem.win_platform?
 
-      lib = File.expand_path("../../lib", __dir__)
       system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib} -rbundler -e '#{code}'")
       expect($?.exitstatus).to eq(1)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
-$:.unshift File.expand_path("..", __FILE__)
-$:.unshift File.expand_path("../../lib", __FILE__)
+require_relative "support/path"
+
+$:.unshift Spec::Path.spec_dir.to_s
+$:.unshift Spec::Path.lib_dir.to_s
 
 require "bundler/psyched_yaml"
 require "bundler/vendored_fileutils"
@@ -20,7 +22,6 @@ require_relative "support/filters"
 require_relative "support/helpers"
 require_relative "support/indexes"
 require_relative "support/matchers"
-require_relative "support/path"
 require_relative "support/parallel"
 require_relative "support/permissions"
 require_relative "support/platforms"

--- a/spec/support/artifice/compact_index.rb
+++ b/spec/support/artifice/compact_index.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../endpoint", __FILE__)
+require_relative "endpoint"
 
 $LOAD_PATH.unshift Dir[base_system_gems.join("gems/compact_index*/lib")].first.to_s
 require "compact_index"

--- a/spec/support/artifice/compact_index_api_missing.rb
+++ b/spec/support/artifice/compact_index_api_missing.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../compact_index", __FILE__)
+require_relative "compact_index"
 
 Artifice.deactivate
 

--- a/spec/support/artifice/compact_index_basic_authentication.rb
+++ b/spec/support/artifice/compact_index_basic_authentication.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../compact_index", __FILE__)
+require_relative "compact_index"
 
 Artifice.deactivate
 

--- a/spec/support/artifice/compact_index_checksum_mismatch.rb
+++ b/spec/support/artifice/compact_index_checksum_mismatch.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../compact_index", __FILE__)
+require_relative "compact_index"
 
 Artifice.deactivate
 

--- a/spec/support/artifice/compact_index_concurrent_download.rb
+++ b/spec/support/artifice/compact_index_concurrent_download.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../compact_index", __FILE__)
+require_relative "compact_index"
 
 Artifice.deactivate
 

--- a/spec/support/artifice/compact_index_creds_diff_host.rb
+++ b/spec/support/artifice/compact_index_creds_diff_host.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../compact_index", __FILE__)
+require_relative "compact_index"
 
 Artifice.deactivate
 

--- a/spec/support/artifice/compact_index_extra.rb
+++ b/spec/support/artifice/compact_index_extra.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../compact_index", __FILE__)
+require_relative "compact_index"
 
 Artifice.deactivate
 

--- a/spec/support/artifice/compact_index_extra_api.rb
+++ b/spec/support/artifice/compact_index_extra_api.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../compact_index", __FILE__)
+require_relative "compact_index"
 
 Artifice.deactivate
 

--- a/spec/support/artifice/compact_index_extra_api_missing.rb
+++ b/spec/support/artifice/compact_index_extra_api_missing.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../compact_index_extra_api", __FILE__)
+require_relative "compact_index_extra_api"
 
 Artifice.deactivate
 

--- a/spec/support/artifice/compact_index_extra_missing.rb
+++ b/spec/support/artifice/compact_index_extra_missing.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../compact_index_extra", __FILE__)
+require_relative "compact_index_extra"
 
 Artifice.deactivate
 

--- a/spec/support/artifice/compact_index_forbidden.rb
+++ b/spec/support/artifice/compact_index_forbidden.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../compact_index", __FILE__)
+require_relative "compact_index"
 
 Artifice.deactivate
 

--- a/spec/support/artifice/compact_index_host_redirect.rb
+++ b/spec/support/artifice/compact_index_host_redirect.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../compact_index", __FILE__)
+require_relative "compact_index"
 
 Artifice.deactivate
 

--- a/spec/support/artifice/compact_index_no_gem.rb
+++ b/spec/support/artifice/compact_index_no_gem.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../compact_index", __FILE__)
+require_relative "compact_index"
 
 Artifice.deactivate
 

--- a/spec/support/artifice/compact_index_partial_update.rb
+++ b/spec/support/artifice/compact_index_partial_update.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../compact_index", __FILE__)
+require_relative "compact_index"
 
 Artifice.deactivate
 

--- a/spec/support/artifice/compact_index_range_not_satisfiable.rb
+++ b/spec/support/artifice/compact_index_range_not_satisfiable.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../compact_index", __FILE__)
+require_relative "compact_index"
 
 Artifice.deactivate
 

--- a/spec/support/artifice/compact_index_rate_limited.rb
+++ b/spec/support/artifice/compact_index_rate_limited.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../compact_index", __FILE__)
+require_relative "compact_index"
 
 Artifice.deactivate
 

--- a/spec/support/artifice/compact_index_redirects.rb
+++ b/spec/support/artifice/compact_index_redirects.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../compact_index", __FILE__)
+require_relative "compact_index"
 
 Artifice.deactivate
 

--- a/spec/support/artifice/compact_index_strict_basic_authentication.rb
+++ b/spec/support/artifice/compact_index_strict_basic_authentication.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../compact_index", __FILE__)
+require_relative "compact_index"
 
 Artifice.deactivate
 

--- a/spec/support/artifice/compact_index_wrong_dependencies.rb
+++ b/spec/support/artifice/compact_index_wrong_dependencies.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../compact_index", __FILE__)
+require_relative "compact_index"
 
 Artifice.deactivate
 

--- a/spec/support/artifice/compact_index_wrong_gem_checksum.rb
+++ b/spec/support/artifice/compact_index_wrong_gem_checksum.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../compact_index", __FILE__)
+require_relative "compact_index"
 
 Artifice.deactivate
 

--- a/spec/support/artifice/endopint_marshal_fail_basic_authentication.rb
+++ b/spec/support/artifice/endopint_marshal_fail_basic_authentication.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../endpoint_marshal_fail", __FILE__)
+require_relative "endpoint_marshal_fail"
 
 Artifice.deactivate
 

--- a/spec/support/artifice/endpoint.rb
+++ b/spec/support/artifice/endpoint.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require File.expand_path("../../path.rb", __FILE__)
-require Spec::Path.root.join("lib/bundler/deprecate")
+require Spec::Path.lib_dir.join("bundler/deprecate")
 include Spec::Path
 
 $LOAD_PATH.unshift(*Dir[Spec::Path.base_system_gems.join("gems/{artifice,mustermann,rack,tilt,sinatra}-*/lib")].map(&:to_s))

--- a/spec/support/artifice/endpoint.rb
+++ b/spec/support/artifice/endpoint.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../path.rb", __FILE__)
+require_relative "../path"
 require Spec::Path.lib_dir.join("bundler/deprecate")
 include Spec::Path
 

--- a/spec/support/artifice/endpoint.rb
+++ b/spec/support/artifice/endpoint.rb
@@ -44,7 +44,7 @@ class Endpoint < Sinatra::Base
     def dependencies_for(gem_names, gem_repo = GEM_REPO)
       return [] if gem_names.nil? || gem_names.empty?
 
-      require "#{Spec::Path.lib}/bundler"
+      require "#{Spec::Path.lib_dir}/bundler"
       Bundler::Deprecate.skip_during do
         all_specs = %w[specs.4.8 prerelease_specs.4.8].map do |filename|
           Marshal.load(File.open(gem_repo.join(filename)).read)

--- a/spec/support/artifice/endpoint_500.rb
+++ b/spec/support/artifice/endpoint_500.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../path.rb", __FILE__)
+require_relative "../path"
 include Spec::Path
 
 $LOAD_PATH.unshift(*Dir[Spec::Path.base_system_gems.join("gems/{artifice,mustermann,rack,tilt,sinatra}-*/lib")].map(&:to_s))

--- a/spec/support/artifice/endpoint_api_forbidden.rb
+++ b/spec/support/artifice/endpoint_api_forbidden.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../endpoint", __FILE__)
+require_relative "endpoint"
 
 Artifice.deactivate
 

--- a/spec/support/artifice/endpoint_api_missing.rb
+++ b/spec/support/artifice/endpoint_api_missing.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../endpoint", __FILE__)
+require_relative "endpoint"
 
 Artifice.deactivate
 

--- a/spec/support/artifice/endpoint_basic_authentication.rb
+++ b/spec/support/artifice/endpoint_basic_authentication.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../endpoint", __FILE__)
+require_relative "endpoint"
 
 Artifice.deactivate
 

--- a/spec/support/artifice/endpoint_creds_diff_host.rb
+++ b/spec/support/artifice/endpoint_creds_diff_host.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../endpoint", __FILE__)
+require_relative "endpoint"
 
 Artifice.deactivate
 

--- a/spec/support/artifice/endpoint_extra.rb
+++ b/spec/support/artifice/endpoint_extra.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../endpoint", __FILE__)
+require_relative "endpoint"
 
 Artifice.deactivate
 

--- a/spec/support/artifice/endpoint_extra_api.rb
+++ b/spec/support/artifice/endpoint_extra_api.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../endpoint", __FILE__)
+require_relative "endpoint"
 
 Artifice.deactivate
 

--- a/spec/support/artifice/endpoint_extra_missing.rb
+++ b/spec/support/artifice/endpoint_extra_missing.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../endpoint_extra", __FILE__)
+require_relative "endpoint_extra"
 
 Artifice.deactivate
 

--- a/spec/support/artifice/endpoint_fallback.rb
+++ b/spec/support/artifice/endpoint_fallback.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../endpoint", __FILE__)
+require_relative "endpoint"
 
 Artifice.deactivate
 

--- a/spec/support/artifice/endpoint_host_redirect.rb
+++ b/spec/support/artifice/endpoint_host_redirect.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../endpoint", __FILE__)
+require_relative "endpoint"
 
 Artifice.deactivate
 

--- a/spec/support/artifice/endpoint_marshal_fail.rb
+++ b/spec/support/artifice/endpoint_marshal_fail.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../endpoint_fallback", __FILE__)
+require_relative "endpoint_fallback"
 
 Artifice.deactivate
 

--- a/spec/support/artifice/endpoint_mirror_source.rb
+++ b/spec/support/artifice/endpoint_mirror_source.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../endpoint", __FILE__)
+require_relative "endpoint"
 
 class EndpointMirrorSource < Endpoint
   get "/gems/:id" do

--- a/spec/support/artifice/endpoint_redirect.rb
+++ b/spec/support/artifice/endpoint_redirect.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../endpoint", __FILE__)
+require_relative "endpoint"
 
 Artifice.deactivate
 

--- a/spec/support/artifice/endpoint_strict_basic_authentication.rb
+++ b/spec/support/artifice/endpoint_strict_basic_authentication.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../endpoint", __FILE__)
+require_relative "endpoint"
 
 Artifice.deactivate
 

--- a/spec/support/artifice/endpoint_timeout.rb
+++ b/spec/support/artifice/endpoint_timeout.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../endpoint_fallback", __FILE__)
+require_relative "endpoint_fallback"
 
 Artifice.deactivate
 

--- a/spec/support/artifice/vcr.rb
+++ b/spec/support/artifice/vcr.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 require "net/http"
+require_relative "../path"
 
-CASSETTE_PATH = File.expand_path("../vcr_cassettes", __FILE__)
+CASSETTE_PATH = "#{Spec::Path.spec_dir}/support/artifice/vcr_cassettes"
 CASSETTE_NAME = ENV.fetch("BUNDLER_SPEC_VCR_CASSETTE_NAME") { "realworld" }
 
 class BundlerVCRHTTP < Net::HTTP

--- a/spec/support/artifice/windows.rb
+++ b/spec/support/artifice/windows.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../path.rb", __FILE__)
+require_relative "../path"
 include Spec::Path
 
 $LOAD_PATH.unshift(*Dir[Spec::Path.base_system_gems.join("gems/{artifice,mustermann,rack,tilt,sinatra}-*/lib")].map(&:to_s))

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -121,7 +121,7 @@ module Spec
         end
       end
       if artifice
-        requires << File.expand_path("../artifice/#{artifice}", __FILE__)
+        requires << "support/artifice/#{artifice}"
       end
 
       requires_str = requires.map {|r| "-r#{r}" }.join(" ")

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -96,10 +96,6 @@ module Spec
       run(cmd, *args)
     end
 
-    def spec
-      spec_dir.to_s
-    end
-
     def bundle(cmd, options = {})
       with_sudo = options.delete(:sudo)
       sudo = with_sudo == :preserve_env ? "sudo -E" : "sudo" if with_sudo
@@ -132,7 +128,7 @@ module Spec
 
       load_path = []
       load_path << lib unless system_bundler
-      load_path << spec
+      load_path << spec_dir
       load_path_str = "-I#{load_path.join(File::PATH_SEPARATOR)}"
 
       args = options.map do |k, v|

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -78,7 +78,7 @@ module Spec
     def run(cmd, *args)
       opts = args.last.is_a?(Hash) ? args.pop : {}
       groups = args.map(&:inspect).join(", ")
-      setup = "require '#{lib}/bundler' ; Bundler.ui.silence { Bundler.setup(#{groups}) }\n"
+      setup = "require '#{lib_dir}/bundler' ; Bundler.ui.silence { Bundler.setup(#{groups}) }\n"
       ruby(setup + cmd, opts)
     end
     bang :run
@@ -127,7 +127,7 @@ module Spec
       requires_str = requires.map {|r| "-r#{r}" }.join(" ")
 
       load_path = []
-      load_path << lib unless system_bundler
+      load_path << lib_dir unless system_bundler
       load_path << spec_dir
       load_path_str = "-I#{load_path.join(File::PATH_SEPARATOR)}"
 
@@ -174,7 +174,7 @@ module Spec
     def ruby(ruby, options = {})
       env = (options.delete(:env) || {}).map {|k, v| "#{k}='#{v}' " }.join
       ruby = ruby.gsub(/["`\$]/) {|m| "\\#{m}" }
-      lib_option = options[:no_lib] ? "" : " -I#{lib}"
+      lib_option = options[:no_lib] ? "" : " -I#{lib_dir}"
       sys_exec(%(#{env}#{Gem.ruby}#{lib_option} -e "#{ruby}"))
     end
     bang :ruby
@@ -191,7 +191,7 @@ module Spec
 
     def gembin(cmd)
       old = ENV["RUBYOPT"]
-      ENV["RUBYOPT"] = "#{ENV["RUBYOPT"]} -I#{lib}"
+      ENV["RUBYOPT"] = "#{ENV["RUBYOPT"]} -I#{lib_dir}"
       cmd = bundled_app("bin/#{cmd}") unless cmd.to_s.include?("/")
       sys_exec(cmd.to_s)
     ensure

--- a/spec/support/path.rb
+++ b/spec/support/path.rb
@@ -131,7 +131,7 @@ module Spec
       tmp("libs", *args)
     end
 
-    def lib
+    def lib_dir
       root.join("lib")
     end
 

--- a/spec/support/rubygems_version_manager.rb
+++ b/spec/support/rubygems_version_manager.rb
@@ -85,7 +85,7 @@ private
   def resolve_local_copy_path
     return expanded_env_version if env_version_is_path?
 
-    rubygems_path = Pathname.new("../../tmp/rubygems").expand_path(__dir__)
+    rubygems_path = root.join("tmp/rubygems")
 
     unless rubygems_path.directory?
       rubygems_path.parent.mkpath


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that I saw some room for improvement in our specs and I couldn't help myself :)

### What is your fix for the problem, implemented in this PR?

Essentially, the idea of this PR is to avoid using `__FILE__` or other folder-structure specific constructs to look for files, and instead use our helpers ìn `spec/support/path.rb`. The idea is that the helpers in this file are aware that `bundler` specs can be run from ruby-core or the upstream repo, and the folder structure is different for both.

Also, the PR normalizes some naming, some duplicated helpers, and the way we require files from specs.