### PR TITLE
Support multiple groups for --without-group and --only-group options …

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -345,8 +345,8 @@ module Bundler
 
     desc "list", "List all gems in the bundle"
     method_option "name-only", :type => :boolean, :banner => "print only the gem names"
-    method_option "only-group", :type => :string, :banner => "print gems from a particular group"
-    method_option "without-group", :type => :string, :banner => "print all gems except from a group"
+    method_option "only-group", :type => :array, :default => [], :banner => "print gems from a given set of groups"
+    method_option "without-group", :type => :array, :default => [], :banner => "print all gems except from a given set of groups"
     method_option "paths", :type => :boolean, :banner => "print the path to each gem in the bundle"
     def list
       require_relative "cli/list"

--- a/lib/bundler/cli/list.rb
+++ b/lib/bundler/cli/list.rb
@@ -4,14 +4,16 @@ module Bundler
   class CLI::List
     def initialize(options)
       @options = options
+      @without_group = options["without-group"].map(&:to_sym)
+      @only_group = options["only-group"].map(&:to_sym)
     end
 
     def run
-      raise InvalidOption, "The `--only-group` and `--without-group` options cannot be used together" if @options["only-group"] && @options["without-group"]
+      raise InvalidOption, "The `--only-group` and `--without-group` options cannot be used together" if @only_group.any? && @without_group.any?
 
       raise InvalidOption, "The `--name-only` and `--paths` options cannot be used together" if @options["name-only"] && @options[:paths]
 
-      specs = if @options["only-group"] || @options["without-group"]
+      specs = if @only_group.any? || @without_group.any?
         filtered_specs_by_groups
       else
         Bundler.load.specs
@@ -32,9 +34,9 @@ module Bundler
   private
 
     def verify_group_exists(groups)
-      raise InvalidOption, "`#{@options["without-group"]}` group could not be found." if @options["without-group"] && !groups.include?(@options["without-group"].to_sym)
-
-      raise InvalidOption, "`#{@options["only-group"]}` group could not be found." if @options["only-group"] && !groups.include?(@options["only-group"].to_sym)
+      (@without_group + @only_group).each do |group|
+        raise InvalidOption, "`#{group}` group could not be found." unless groups.include?(group)
+      end
     end
 
     def filtered_specs_by_groups
@@ -44,10 +46,10 @@ module Bundler
       verify_group_exists(groups)
 
       show_groups =
-        if @options["without-group"]
-          groups.reject {|g| g == @options["without-group"].to_sym }
-        elsif @options["only-group"]
-          groups.select {|g| g == @options["only-group"].to_sym }
+        if @without_group.any?
+          groups.reject {|g| @without_group.include?(g) }
+        elsif @only_group.any?
+          groups.select {|g| @only_group.include?(g) }
         else
           groups
         end.map(&:to_sym)

--- a/man/bundle-list.1
+++ b/man/bundle-list.1
@@ -7,7 +7,7 @@
 \fBbundle\-list\fR \- List all the gems in the bundle
 .
 .SH "SYNOPSIS"
-\fBbundle list\fR [\-\-name\-only] [\-\-paths] [\-\-without\-group=GROUP] [\-\-only\-group=GROUP]
+\fBbundle list\fR [\-\-name\-only] [\-\-paths] [\-\-without\-group=GROUP[ GROUP\.\.\.]] [\-\-only\-group=GROUP[ GROUP\.\.\.]]
 .
 .SH "DESCRIPTION"
 Prints a list of all the gems in the bundle including their version\.
@@ -28,7 +28,7 @@ bundle list \-\-without\-group test
 bundle list \-\-only\-group dev
 .
 .P
-bundle list \-\-only\-group dev \-\-paths
+bundle list \-\-only\-group dev test \-\-paths
 .
 .SH "OPTIONS"
 .
@@ -41,10 +41,10 @@ Print only the name of each gem\.
 Print the path to each gem in the bundle\.
 .
 .TP
-\fB\-\-without\-group\fR
-Print all gems expect from a group\.
+\fB\-\-without\-group=<list>\fR
+A space\-separated list of groups of gems to skip during printing\.
 .
 .TP
-\fB\-\-only\-group\fR
-Print gems from a particular group\.
+\fB\-\-only\-group=<list>\fR
+A space\-separated list of groups of gems to print\.
 

--- a/man/bundle-list.1.txt
+++ b/man/bundle-list.1.txt
@@ -6,8 +6,8 @@ NAME
        bundle-list - List all the gems in the bundle
 
 SYNOPSIS
-       bundle	 list	 [--name-only]	  [--paths]    [--without-group=GROUP]
-       [--only-group=GROUP]
+       bundle  list [--name-only] [--paths] [--without-group=GROUP[ GROUP...]]
+       [--only-group=GROUP[ GROUP...]]
 
 DESCRIPTION
        Prints a list of all the gems in the bundle including their version.
@@ -22,7 +22,7 @@ DESCRIPTION
 
        bundle list --only-group dev
 
-       bundle list --only-group dev --paths
+       bundle list --only-group dev test --paths
 
 OPTIONS
        --name-only
@@ -31,11 +31,12 @@ OPTIONS
        --paths
 	      Print the path to each gem in the bundle.
 
-       --without-group
-	      Print all gems expect from a group.
+       --without-group=<list>
+	      A space-separated list of groups of gems to skip	during	print-
+	      ing.
 
-       --only-group
-	      Print gems from a particular group.
+       --only-group=<list>
+	      A space-separated list of groups of gems to print.
 
 
 

--- a/man/bundle-list.ronn
+++ b/man/bundle-list.ronn
@@ -3,7 +3,7 @@ bundle-list(1) -- List all the gems in the bundle
 
 ## SYNOPSIS
 
-`bundle list` [--name-only] [--paths] [--without-group=GROUP] [--only-group=GROUP]
+`bundle list` [--name-only] [--paths] [--without-group=GROUP[ GROUP...]] [--only-group=GROUP[ GROUP...]]
 
 ## DESCRIPTION
 
@@ -19,7 +19,7 @@ bundle list --without-group test
 
 bundle list --only-group dev
 
-bundle list --only-group dev --paths
+bundle list --only-group dev test --paths
 
 ## OPTIONS
 
@@ -27,7 +27,7 @@ bundle list --only-group dev --paths
   Print only the name of each gem.
 * `--paths`:
   Print the path to each gem in the bundle.
-* `--without-group`:
-  Print all gems expect from a group.
-* `--only-group`:
-  Print gems from a particular group.
+* `--without-group=<list>`:
+  A space-separated list of groups of gems to skip during printing.
+* `--only-group=<list>`:
+  A space-separated list of groups of gems to print.

--- a/spec/commands/list_spec.rb
+++ b/spec/commands/list_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe "bundle list" do
 
         gem "rack"
         gem "rspec", :group => [:test]
+        gem "rails", :group => [:production]
       G
     end
 
@@ -32,6 +33,7 @@ RSpec.describe "bundle list" do
         bundle! "list --without-group test"
 
         expect(out).to include("  * rack (1.0.0)")
+        expect(out).to include("  * rails (2.3.2)")
         expect(out).not_to include("  * rspec (1.2.7)")
       end
     end
@@ -43,6 +45,16 @@ RSpec.describe "bundle list" do
         expect(err).to eq "`random` group could not be found."
       end
     end
+
+    context "when multiple groups" do
+      it "prints the gems not in the specified groups" do
+        bundle! "list --without-group test production"
+
+        expect(out).to include("  * rack (1.0.0)")
+        expect(out).not_to include("  * rails (2.3.2)")
+        expect(out).not_to include("  * rspec (1.2.7)")
+      end
+    end
   end
 
   describe "with only-group option" do
@@ -52,6 +64,7 @@ RSpec.describe "bundle list" do
 
         gem "rack"
         gem "rspec", :group => [:test]
+        gem "rails", :group => [:production]
       G
     end
 
@@ -69,6 +82,16 @@ RSpec.describe "bundle list" do
         bundle "list --only-group random"
 
         expect(err).to eq "`random` group could not be found."
+      end
+    end
+
+    context "when multiple groups" do
+      it "prints the gems in the specified groups" do
+        bundle! "list --only-group default production"
+
+        expect(out).to include("  * rack (1.0.0)")
+        expect(out).to include("  * rails (2.3.2)")
+        expect(out).not_to include("  * rspec (1.2.7)")
       end
     end
   end


### PR DESCRIPTION
This is a reworked version of #6939 
It accepts multiple groups for `--without-group` and `--only-group`.

Closes #6939 