### PR TITLE
Remove junit formatter in Azure for the moment

### DIFF
--- a/.azure-pipelines/steps.yml
+++ b/.azure-pipelines/steps.yml
@@ -24,16 +24,5 @@ steps:
   displayName: 'ruby bin/rake spec:deps'
 
 - script: |
-    gem install --no-document --conservative rspec_junit_formatter
-  displayName: 'gem install rspec_junit_formatter'
-
-- script: |
-    ruby -r rspec_junit_formatter bin/rspec --format RspecJunitFormatter -o rspec/bundler-junit-results.xml || exit 0
+    ruby bin/rspec || exit 0
   displayName: 'ruby bin/rspec'
-
-- task: PublishTestResults@2
-  inputs:
-    testRunner: JUnit
-    testResultsFiles: rspec/bundler-junit-results.xml
-  displayName: Publish test results
-  condition: succeededOrFailed()


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was it's not easy to inspect Windows failures at the moment. Github checks only show a few inline annotations, but we have ~330 failures at the moment.

### What was your diagnosis of the problem?

My diagnosis was that for the moment, regular test output is better.

### What is your fix for the problem, implemented in this PR?

My fix is to remove the junit formatter for the moment.
