### PR TITLE
Try out specs against MRI 2.6 + Rubygems 3.0

### DIFF
--- a/.azure-pipelines/steps.yml
+++ b/.azure-pipelines/steps.yml
@@ -2,7 +2,7 @@ steps:
 
 - task: UseRubyVersion@0
   inputs:
-    versionSpec: '= 2.4'
+    versionSpec: '= 2.6'
 
 - script: |
     ruby -v

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,6 +2,8 @@ jobs:
 - job: Windows
   pool:
     vmImage: 'vs2017-win2016'
+  variables:
+    rgv: v3.0.6
   steps:
   - template: .azure-pipelines/steps.yml
   timeoutInMinutes: 0


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that our Azure build was using outdated versions of ruby and rubygems.

### What was your diagnosis of the problem?

My diagnosis was that we should update them.

### What is your fix for the problem, implemented in this PR?

My fix is to update them. With the latest versions, failures go down to 319.
