### PR TITLE
Fix bundler/inline warning: method redefined; discarding old root

### DIFF
--- a/lib/bundler/inline.rb
+++ b/lib/bundler/inline.rb
@@ -38,6 +38,8 @@ def gemfile(install = false, options = {}, &gemfile)
   raise ArgumentError, "Unknown options: #{opts.keys.join(", ")}" unless opts.empty?
 
   old_root = Bundler.method(:root)
+  bundler_module = class << Bundler; self; end
+  bundler_module.send(:remove_method, :root)
   def Bundler.root
     Bundler::SharedHelpers.pwd.expand_path
   end
@@ -70,6 +72,8 @@ def gemfile(install = false, options = {}, &gemfile)
     runtime.setup.require
   end
 ensure
-  bundler_module = class << Bundler; self; end
-  bundler_module.send(:define_method, :root, old_root) if old_root
+  if bundler_module
+    bundler_module.send(:remove_method, :root)
+    bundler_module.send(:define_method, :root, old_root)
+  end
 end


### PR DESCRIPTION
Closes #6167