### PR TITLE
Add "--test=test-unit" option for gem command

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -571,7 +571,7 @@ module Bundler
     method_option :git, :type => :boolean, :default => true, :desc => "Initialize a git repo inside your library."
     method_option :mit, :type => :boolean, :desc => "Generate an MIT license file. Set a default with `bundle config set gem.mit true`."
     method_option :test, :type => :string, :lazy_default => "rspec", :aliases => "-t", :banner => "rspec",
-                         :desc => "Generate a test directory for your library, either rspec or minitest. Set a default with `bundle config set gem.test rspec`."
+                         :desc => "Generate a test directory for your library, among rspec, minitest, or test-unit. Set a default with `bundle config set gem.test rspec`."
     def gem(name)
     end
 

--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -12,6 +12,7 @@ module Bundler
     TEST_FRAMEWORK_VERSIONS = {
       "rspec" => "3.0",
       "minitest" => "5.0",
+      "test-unit" => "3.0",
     }.freeze
 
     attr_reader :options, :gem_name, :thor, :name, :target
@@ -97,10 +98,14 @@ module Bundler
             "test/test_helper.rb.tt" => "test/test_helper.rb",
             "test/newgem_test.rb.tt" => "test/#{namespaced_path}_test.rb"
           )
+        when "test-unit"
+          templates.merge!(
+            "test/test_newgem.rb.tt" => "test/test_#{namespaced_path}.rb"
+          )
         end
       end
 
-      config[:test_task] = config[:test] == "minitest" ? "test" : "spec"
+      config[:test_task] = config[:test] == "minitest" || config[:test] == "test-unit" ? "test" : "spec"
 
       if ask_and_set(:mit, "Do you want to license your code permissively under the MIT license?",
         "This means that any other developer or company will be legally allowed to use your code " \
@@ -199,9 +204,9 @@ module Bundler
 
       if test_framework.nil?
         Bundler.ui.confirm "Do you want to generate tests with your gem?"
-        result = Bundler.ui.ask "Type 'rspec' or 'minitest' to generate those test files now and " \
-          "in the future. rspec/minitest/(none):"
-        if result =~ /rspec|minitest/
+        result = Bundler.ui.ask "Type 'rspec' or 'minitest' or 'test-unit' to generate those test files now and " \
+          "in the future. rspec/minitest/test-unit/(none):"
+        if result =~ /rspec|minitest|test-unit/
           test_framework = result
         else
           test_framework = false

--- a/lib/bundler/templates/newgem/Rakefile.tt
+++ b/lib/bundler/templates/newgem/Rakefile.tt
@@ -1,11 +1,15 @@
 require "bundler/gem_tasks"
-<% if config[:test] == "minitest" -%>
+<% if config[:test] == "minitest" || config[:test] == "test-unit" -%>
 require "rake/testtask"
 
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.libs << "lib"
+<% if config[:test] == "minitest" -%>
   t.test_files = FileList["test/**/*_test.rb"]
+<% else -%>
+  t.test_files = FileList["test/**/test_*.rb"]
+<% end -%>
 end
 
 <% elsif config[:test] == "rspec" -%>

--- a/lib/bundler/templates/newgem/test/test_newgem.rb.tt
+++ b/lib/bundler/templates/newgem/test/test_newgem.rb.tt
@@ -1,0 +1,14 @@
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+require "<%= config[:namespaced_path] %>"
+
+require "test/unit"
+
+class Test<%= config[:constant_name] %> < Test::Unit::TestCase
+  def test_that_it_has_a_version_number
+    refute_nil ::<%= config[:constant_name] %>::VERSION
+  end
+
+  def test_it_does_something_useful
+    assert false
+  end
+end

--- a/man/bundle-gem.1
+++ b/man/bundle-gem.1
@@ -64,8 +64,8 @@ Add an MIT license to a \fBLICENSE\.txt\fR file in the root of the generated pro
 Do not create a \fBLICENSE\.txt\fR (overrides \fB\-\-mit\fR specified in the global config)\.
 .
 .TP
-\fB\-t\fR, \fB\-\-test=minitest\fR, \fB\-\-test=rspec\fR
-Specify the test framework that Bundler should use when generating the project\. Acceptable values are \fBminitest\fR and \fBrspec\fR\. The \fBGEM_NAME\.gemspec\fR will be configured and a skeleton test/spec directory will be created based on this option\. If this option is unspecified, an interactive prompt will be displayed and the answer will be saved in Bundler\'s global config for future \fBbundle gem\fR use\. If no option is specified, the default testing framework is RSpec\.
+\fB\-t\fR, \fB\-\-test=minitest\fR, \fB\-\-test=rspec\fR, \fB\-\-test=test\-unit\fR
+Specify the test framework that Bundler should use when generating the project\. Acceptable values are \fBminitest\fR, \fBrspec\fR, and \fBtest\-unit\fR\. The \fBGEM_NAME\.gemspec\fR will be configured and a skeleton test/spec directory will be created based on this option\. If this option is unspecified, an interactive prompt will be displayed and the answer will be saved in Bundler\'s global config for future \fBbundle gem\fR use\. If no option is specified, the default testing framework is RSpec\.
 .
 .TP
 \fB\-e\fR, \fB\-\-edit[=EDITOR]\fR

--- a/man/bundle-gem.1.txt
+++ b/man/bundle-gem.1.txt
@@ -65,15 +65,15 @@ OPTIONS
 	      Do not create a LICENSE.txt (overrides --mit  specified  in  the
 	      global config).
 
-       -t, --test=minitest, --test=rspec
+       -t, --test=minitest, --test=rspec, --test=test-unit
 	      Specify the test framework that Bundler should use when generat-
-	      ing the project. Acceptable values are minitest and  rspec.  The
-	      GEM_NAME.gemspec	will  be  configured  and a skeleton test/spec
-	      directory will be created based on this option. If  this	option
-	      is  unspecified, an interactive prompt will be displayed and the
-	      answer will be saved in Bundler's global config for future  bun-
-	      dle  gem	use.  If  no  option is specified, the default testing
-	      framework is RSpec.
+	      ing the project. Acceptable  values  are	minitest,  rspec,  and
+	      test-unit.  The GEM_NAME.gemspec will be configured and a skele-
+	      ton test/spec directory will be created based on this option. If
+	      this  option  is unspecified, an interactive prompt will be dis-
+	      played and the answer will be saved in Bundler's	global	config
+	      for  future  bundle  gem use. If no option is specified, the de-
+	      fault testing framework is RSpec.
 
        -e, --edit[=EDITOR]
 	      Open the resulting GEM_NAME.gemspec in EDITOR,  or  the  default

--- a/man/bundle-gem.ronn
+++ b/man/bundle-gem.ronn
@@ -60,13 +60,13 @@ configuration file using the following names:
   Do not create a `LICENSE.txt` (overrides `--mit` specified in the global
   config).
 
-* `-t`, `--test=minitest`, `--test=rspec`:
+* `-t`, `--test=minitest`, `--test=rspec`, `--test=test-unit`:
   Specify the test framework that Bundler should use when generating the
-  project. Acceptable values are `minitest` and `rspec`. The `GEM_NAME.gemspec`
-  will be configured and a skeleton test/spec directory will be created based
-  on this option. If this option is unspecified, an interactive prompt will be
-  displayed and the answer will be saved in Bundler's global config for future
-  `bundle gem` use.
+  project. Acceptable values are `minitest`, `rspec`, and `test-unit`. The
+  `GEM_NAME.gemspec` will be configured and a skeleton test/spec directory
+  will be created based on this option. If this option is unspecified, an
+  interactive prompt will be displayed and the answer will be saved in
+  Bundler's global config for future `bundle gem` use.
   If no option is specified, the default testing framework is RSpec.
 
 * `-e`, `--edit[=EDITOR]`:


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that the `bundle gem --test` option supported only "minitest" and "rspec", not "test-unit".

### What was your diagnosis of the problem?

My diagnosis was that the lack of "test-unit" was very unfortunate.  It is only one test framework gem that is bundled to the ruby distribution.

### What is your fix for the problem, implemented in this PR?

My fix is to add "--test=test-unit" option for `bundle gem` command.  I implemented it based on the implementation of "--test=minitest".  It creates "test/test_newgem.rb" (test-unit style) instead of "test/newgem_test.rb" (mnitest style).  It also tweaks Rakefile and gemspec files appropriately.

### Why did you choose this fix out of the possible options?

I chose this fix because I couldn't come up with other options.