### PR TITLE
Turn on warning mode for specs

### DIFF
--- a/spec/runtime/inline_spec.rb
+++ b/spec/runtime/inline_spec.rb
@@ -88,7 +88,6 @@ RSpec.describe "bundler/inline#gemfile" do
     RUBY
 
     expect(out).to include("Installing activesupport")
-    err.gsub! %r{(.*lib/sinatra/base\.rb:\d+: warning: constant ::Fixnum is deprecated$)}, ""
     err_lines = err.split("\n")
     err_lines.reject!{|line| line =~ /\.rb:\d+: warning: / }
     expect(err_lines).to be_empty

--- a/spec/runtime/inline_spec.rb
+++ b/spec/runtime/inline_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "bundler/inline#gemfile" do
 
     expect(out).to include("Installing activesupport")
     err_lines = err.split("\n")
-    err_lines.reject!{|line| line =~ /\.rb:\d+: warning: / }
+    err_lines.reject!{|line| line =~ /\.rb:\d+: warning: / } unless RUBY_VERSION < "2.7"
     expect(err_lines).to be_empty
     expect(exitstatus).to be_zero if exitstatus
   end

--- a/spec/runtime/inline_spec.rb
+++ b/spec/runtime/inline_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "bundler/inline#gemfile" do
     requires = ["#{lib_dir}/bundler/inline"]
     requires.unshift "#{spec_dir}/support/artifice/" + options.delete(:artifice) if options.key?(:artifice)
     requires = requires.map {|r| "require '#{r}'" }.join("\n")
-    @out = ruby("#{requires}\n\n" + code, options)
+    ruby("#{requires}\n\n" + code, options)
   end
 
   before :each do

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -1027,6 +1027,8 @@ end
 
       ruby <<-RUBY
         require '#{lib_dir}/bundler'
+        bundler_module = class << Bundler; self; end
+        bundler_module.send(:remove_method, :require)
         def Bundler.require(path)
           raise "LOSE"
         end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -174,7 +174,7 @@ module Spec
       env = options.delete(:env) || {}
       ruby = ruby.gsub(/["`\$]/) {|m| "\\#{m}" }
       lib_option = options[:no_lib] ? "" : " -I#{lib_dir}"
-      sys_exec(%(#{Gem.ruby}#{lib_option} -e "#{ruby}"), env)
+      sys_exec(%(#{Gem.ruby}#{lib_option} -w -e "#{ruby}"), env)
     end
     bang :ruby
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that we're missing verbose warnings like the one fixed by #7417.

### What was your diagnosis of the problem?

My diagnosis was that our specs should let us know about this.

### What is your fix for the problem, implemented in this PR?

My fix is to enable warnings from our helpers that shell out, and fix the warnings they print. There's also some unrelated changes here that I'll try to split out once I get this green.

### Why did you choose this fix out of the possible options?

I chose this fix because it makes it so that our specs help us catching these warnings earlier.
