### PR TITLE
Drop unnecessary `tempfile` require

### DIFF
--- a/lib/bundler/source/git/git_proxy.rb
+++ b/lib/bundler/source/git/git_proxy.rb
@@ -2,7 +2,7 @@
 
 require "open3"
 require "shellwords"
-require "tempfile"
+
 module Bundler
   class Source
     class Git


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The `tempfile` dependency was dropped in [1], but the require was left in there. This could cause gem conflicts because `tempfile` requires `tmpdir` which requires `fileutils`, which loads the default gem instead of our namespaced version, and that could cause fileutils version mismatches and code overriding warnings.

[1]: https://github.com/bundler/bundler/commit/4a37d66f3f222739178d798b30fb135f2429fe45

### What is your fix for the problem, implemented in this PR?

My fix is to drop the unnecessary require.
