### PR TITLE
Properly avoid readline crashes when running specs on Windows

### DIFF
--- a/.azure-pipelines/steps.yml
+++ b/.azure-pipelines/steps.yml
@@ -10,12 +10,6 @@ steps:
   displayName: 'ruby -v + ridk version'
 
 - script: |
-    mkdir tmp
-    cd tmp
-    mkdir home
-  displayName: 'work around readline crash (for https://github.com/bundler/bundler/issues/6902)'
-
-- script: |
     bash .azure-pipelines\patch_readline.sh
   displayName: 'patch local readline implementation (for https://github.com/bundler/bundler/issues/6907)'
 

--- a/spec/support/rubygems_ext.rb
+++ b/spec/support/rubygems_ext.rb
@@ -67,6 +67,9 @@ module Spec
         manifest_path.open("w") {|f| f << manifest.join }
       end
 
+      FileUtils.mkdir_p(Path.home)
+      FileUtils.mkdir_p(Path.tmpdir)
+
       ENV["HOME"] = Path.home.to_s
       ENV["TMPDIR"] = Path.tmpdir.to_s
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that specs cannot be run on windows unless you add the ugly workaround currently included in the azure pipelines config.

### What was your diagnosis of the problem?

My diagnosis was that the `tmp/tmpdir` and `tmp/home` folder (which act as `ENV["HOME"]` and `ENV["TMPDIR"]` for our specs) are emptied in an `around(:each)` hook, but there's some stuff going before that and after `ENV["HOME"]` and `ENV["TMPDIR"]` are set (on a `before(:suite)` hook) that might require the folders they point to to exist.

This is the case of rb-readline, used on Windows:

https://github.com/ConnorAtherton/rb-readline/blob/9fba246073f78831b7c7129c76cc07d8476a8892/lib/rbreadline.rb#L1096

or any bundler's code that uses `Bundler.user_home`:

https://github.com/bundler/bundler/blob/f83412ae8cda9c933b8cf33ec2abfb78a408daab/lib/bundler.rb#L227

For example, running `rm -rf tmp/ && bin/rspec ./spec/other/major_deprecation_spec.rb:368` prints a warning about this that it's fixed by this PR:

```
$ rm -rf tmp/ && bin/rspec ./spec/other/major_deprecation_spec.rb:368 

Randomized with seed 1955

(... stuff ...)

`/home/deivid/Code/bundler/tmp/1/home` is not a directory.
Bundler will use `/tmp/bundler/home/deivid' as your home directory temporarily.
.

Retried examples: 0


Finished in 5.26 seconds (files took 0.17927 seconds to load)
1 example, 0 failures

Randomized with seed 1955
```

### What is your fix for the problem, implemented in this PR?

My fix is to create the folders as soon as the environment variables are set.

### Why did you choose this fix out of the possible options?

I chose this fix because it's more general that a workaround living on a specific CI config.

Fixes #6902.