### PR TITLE
Revert "I don't think we need this now"

### DIFF
--- a/spec/bundler/source_spec.rb
+++ b/spec/bundler/source_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Bundler::Source do
         context "with a different version" do
           let(:locked_gem) { double(:locked_gem, :name => "nokogiri", :version => "< 1.5") }
 
-          context "with color" do
+          context "with color", :no_color_tty do
             before do
               allow($stdout).to receive(:tty?).and_return(true)
             end
@@ -83,7 +83,7 @@ RSpec.describe Bundler::Source do
           let(:spec) { double(:spec, :name => "nokogiri", :version => "1.6.1", :platform => rb) }
           let(:locked_gem) { double(:locked_gem, :name => "nokogiri", :version => "1.7.0") }
 
-          context "with color" do
+          context "with color", :no_color_tty do
             before do
               allow($stdout).to receive(:tty?).and_return(true)
             end
@@ -110,7 +110,7 @@ RSpec.describe Bundler::Source do
           let(:spec) { double(:spec, :name => "nokogiri", :version => "1.7.1", :platform => rb) }
           let(:locked_gem) { double(:locked_gem, :name => "nokogiri", :version => "1.7.0") }
 
-          context "with color" do
+          context "with color", :no_color_tty do
             before do
               allow($stdout).to receive(:tty?).and_return(true)
             end

--- a/spec/support/filters.rb
+++ b/spec/support/filters.rb
@@ -39,6 +39,7 @@ RSpec.configure do |config|
   config.filter_run_excluding :git => RequirementChecker.against(git_version)
   config.filter_run_excluding :bundler => RequirementChecker.against(Bundler::VERSION.split(".")[0])
   config.filter_run_excluding :ruby_repo => !ENV["GEM_COMMAND"].nil?
+  config.filter_run_excluding :no_color_tty => Gem.win_platform? || !ENV["GITHUB_ACTION"].nil?
 
   config.filter_run_when_matching :focus unless ENV["CI"]
 end


### PR DESCRIPTION
This reverts commit 36816866581147ba7bd491a2a658ac35a2f03afe.

### What was the end-user problem that led to this PR?

The problem was that in #7401, after I got specs passing against a non-silenced by default UI, I started undoing workarounds that I thought were due to the silent by default UI. 

### What was your diagnosis of the problem?

My diagnosis was that in the case I'm reverting here this is not actually fixed, [as the Azure Pipelines logs confirm](https://dev.azure.com/bundler/bundler/_build/results?buildId=2662&view=ms.vss-test-web.build-test-results-tab&runId=1003360&resultId=101526&paneView=debug).

### What is your fix for the problem, implemented in this PR?

My fix is to unrevert the specific commit that I shouldn't have reverted.
