### PR TITLE
Pass `env` as a parameter to `sys_exec`

### DIFF
--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -172,10 +172,10 @@ module Spec
     end
 
     def ruby(ruby, options = {})
-      env = (options.delete(:env) || {}).map {|k, v| "#{k}='#{v}' " }.join
+      env = options.delete(:env) || {}
       ruby = ruby.gsub(/["`\$]/) {|m| "\\#{m}" }
       lib_option = options[:no_lib] ? "" : " -I#{lib_dir}"
-      sys_exec(%(#{env}#{Gem.ruby}#{lib_option} -e "#{ruby}"))
+      sys_exec(%(#{Gem.ruby}#{lib_option} -e "#{ruby}"), env)
     end
     bang :ruby
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that Windows has trouble with commands of the form `BUNDLE_FROZEN=true bundle install`.

### What was your diagnosis of the problem?

My diagnosis was that we should use `Open3.popen3` explicit `env` argument instead of passing a command line that has environment variables in the front.

### What is your fix for the problem, implemented in this PR?

My fix is to do just that. This is a follow up to #7011, but specifically for the `ruby` test helper. I expect this to fix some more Windows failures.