### PR TITLE
Improve `release:prepare_patch` task

### DIFF
--- a/task/release.rake
+++ b/task/release.rake
@@ -182,7 +182,10 @@ namespace :release do
 
     if commits.any? && !system("git", "cherry-pick", "-x", "-m", "1", *commits.map(&:first))
       warn "Opening a new shell to fix the cherry-pick errors"
-      abort unless system("zsh")
+
+      unless system("zsh")
+        abort "Failed to resolve conflicts on a different shell. Resolve conflicts manually and finish the task manually"
+      end
     end
 
     version_file = "lib/bundler/version.rb"

--- a/task/release.rake
+++ b/task/release.rake
@@ -183,7 +183,7 @@ namespace :release do
     if commits.any? && !system("git", "cherry-pick", "-x", "-m", "1", *commits.map(&:first))
       warn "Opening a new shell to fix the cherry-pick errors"
 
-      unless system("zsh")
+      unless system(ENV["SHELL"] || "zsh")
         abort "Failed to resolve conflicts on a different shell. Resolve conflicts manually and finish the task manually"
       end
     end

--- a/task/release.rake
+++ b/task/release.rake
@@ -181,7 +181,7 @@ namespace :release do
     abort "Could not find commits for all PRs" unless commits.size == prs.size
 
     if commits.any? && !system("git", "cherry-pick", "-x", "-m", "1", *commits.map(&:first))
-      warn "Opening a new shell to fix the cherry-pick errors"
+      warn "Opening a new shell to fix the cherry-pick errors. Press Ctrl-D when done to resume the task"
 
       unless system(ENV["SHELL"] || "zsh")
         abort "Failed to resolve conflicts on a different shell. Resolve conflicts manually and finish the task manually"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was some more little issues with the `bin/rake release:prepare_patch` task.

### What is your fix for the problem, implemented in this PR?

My fix is to improve the task with better fallbacks and better informational and error messages.
