### PR TITLE
Improve binstub specs

### DIFF
--- a/spec/commands/binstubs_spec.rb
+++ b/spec/commands/binstubs_spec.rb
@@ -141,38 +141,61 @@ RSpec.describe "bundle binstubs <gem>" do
       end
 
       context "when a lockfile exists with a locked bundler version" do
-        it "runs the correct version of bundler when the version is newer" do
-          lockfile lockfile.gsub(system_bundler_version, "999.999.999")
-          sys_exec "#{bundled_app("bin/bundle")} install"
-          expect(exitstatus).to eq(42) if exitstatus
-          expect(err).to include("Activating bundler (~> 999.999) failed:").
-            and include("To install the version of bundler this project requires, run `gem install bundler -v '~> 999.999'`")
+        context "and the version is newer" do
+          before do
+            lockfile lockfile.gsub(system_bundler_version, "999.999")
+          end
+
+          it "runs the correct version of bundler" do
+            sys_exec "#{bundled_app("bin/bundle")} install"
+            expect(exitstatus).to eq(42) if exitstatus
+            expect(err).to include("Activating bundler (~> 999.999) failed:").
+              and include("To install the version of bundler this project requires, run `gem install bundler -v '~> 999.999'`")
+          end
         end
 
-        it "runs the correct version of bundler when the version is older and a different major" do
-          simulate_bundler_version "55"
-          lockfile lockfile.gsub(system_bundler_version, "44.0")
-          sys_exec "#{bundled_app("bin/bundle")} install"
-          expect(exitstatus).to eq(42) if exitstatus
-          expect(err).to include("Activating bundler (~> 44.0) failed:").
-            and include("To install the version of bundler this project requires, run `gem install bundler -v '~> 44.0'`")
+        context "and the version is older and a different major" do
+          let(:system_bundler_version) { "55" }
+
+          before do
+            lockfile lockfile.gsub(/BUNDLED WITH\n   .*$/m, "BUNDLED WITH\n   44.0")
+          end
+
+          it "runs the correct version of bundler" do
+            sys_exec "#{bundled_app("bin/bundle")} install"
+            expect(exitstatus).to eq(42) if exitstatus
+            expect(err).to include("Activating bundler (~> 44.0) failed:").
+              and include("To install the version of bundler this project requires, run `gem install bundler -v '~> 44.0'`")
+          end
         end
 
-        it "runs the available version of bundler when the version is older and the same major" do
-          simulate_bundler_version "55.1"
-          lockfile lockfile.gsub(system_bundler_version, "55.0")
-          sys_exec "#{bundled_app("bin/bundle")} install"
-          expect(exitstatus).not_to eq(42) if exitstatus
-          expect(err).not_to include("Activating bundler (~> 55.0) failed:")
+        context "and the version is older and the same major" do
+          let(:system_bundler_version) { "55.1" }
+
+          before do
+            lockfile lockfile.gsub(/BUNDLED WITH\n   .*$/m, "BUNDLED WITH\n   55.0")
+          end
+
+          it "runs the available version of bundler when the version is older and the same major" do
+            sys_exec "#{bundled_app("bin/bundle")} install"
+            expect(exitstatus).not_to eq(42) if exitstatus
+            expect(err).not_to include("Activating bundler (~> 55.0) failed:")
+          end
         end
 
-        it "runs the correct version of bundler when the version is a pre-release" do
-          simulate_bundler_version "55"
-          lockfile lockfile.gsub(system_bundler_version, "2.12.0.a")
-          sys_exec "#{bundled_app("bin/bundle")} install"
-          expect(exitstatus).to eq(42) if exitstatus
-          expect(err).to include("Activating bundler (~> 2.12.a) failed:").
-            and include("To install the version of bundler this project requires, run `gem install bundler -v '~> 2.12.a'`")
+        context "and the version is a pre-releaser" do
+          let(:system_bundler_version) { "55" }
+
+          before do
+            lockfile lockfile.gsub(/BUNDLED WITH\n   .*$/m, "BUNDLED WITH\n   2.12.0.a")
+          end
+
+          it "runs the correct version of bundler when the version is a pre-release" do
+            sys_exec "#{bundled_app("bin/bundle")} install"
+            expect(exitstatus).to eq(42) if exitstatus
+            expect(err).to include("Activating bundler (~> 2.12.a) failed:").
+              and include("To install the version of bundler this project requires, run `gem install bundler -v '~> 2.12.a'`")
+          end
         end
       end
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that I run into some failures when testing rubygems against the latest bundler 2-1-stable branch of bundler.

### What was your diagnosis of the problem?

In certain contexts, the previous approach of overwriting the version constant led into version mismatch issues.

### What is your fix for the problem, implemented in this PR?

Since in this case we are actually testing some rubygems stuff present in the generated binstub, but we don't really care what the bundler gem is actually doing, we can follow the same approach as other specs and install a "dummy" bundler gem to the system gems home used by our specs.

### Why did you choose this fix out of the possible options?

I chose this fix because it still tests the same thing but in a more resilient way, I believe.