### PR TITLE
More lazy loading and relative requires

### DIFF
--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "vendored_thor" unless defined?(Thor)
 require_relative "../bundler"
 require "shellwords"
 

--- a/spec/install/binstubs_spec.rb
+++ b/spec/install/binstubs_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe "bundle install" do
     it "overrides Gem.bindir" do
       expect(Pathname.new("/usr/bin")).not_to be_writable unless Process.euid == 0
       gemfile <<-G
-        require 'rubygems'
         def Gem.bindir; "/usr/bin"; end
         source "#{file_uri_for(gem_repo1)}"
         gem "rack"

--- a/spec/lock/lockfile_spec.rb
+++ b/spec/lock/lockfile_spec.rb
@@ -1418,7 +1418,6 @@ RSpec.describe "the lockfile format" do
       it "preserves Gemfile.lock \\n line endings" do
         expect do
           ruby <<-RUBY
-                   require 'rubygems'
                    require 'bundler'
                    Bundler.setup
                  RUBY
@@ -1432,7 +1431,6 @@ RSpec.describe "the lockfile format" do
 
         expect do
           ruby <<-RUBY
-                   require 'rubygems'
                    require 'bundler'
                    Bundler.setup
                  RUBY

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -356,7 +356,7 @@ RSpec.describe "major deprecations" do
       G
 
       ruby <<-RUBY
-        require 'bundler'
+        require '#{lib_dir}/bundler'
 
         Bundler.setup
         Bundler.setup

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -356,7 +356,6 @@ RSpec.describe "major deprecations" do
       G
 
       ruby <<-RUBY
-        require 'rubygems'
         require 'bundler'
 
         Bundler.setup

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -358,7 +358,6 @@ RSpec.describe "major deprecations" do
       ruby <<-RUBY
         require 'rubygems'
         require 'bundler'
-        require 'bundler/vendored_thor'
 
         Bundler.setup
         Bundler.setup

--- a/spec/other/platform_spec.rb
+++ b/spec/other/platform_spec.rb
@@ -1086,7 +1086,6 @@ G
       FileUtils.rm(bundled_app("Gemfile.lock"))
 
       ruby <<-R
-        require 'rubygems'
         require 'bundler/setup'
       R
 
@@ -1106,7 +1105,6 @@ G
       FileUtils.rm(bundled_app("Gemfile.lock"))
 
       ruby <<-R
-        require 'rubygems'
         require 'bundler/setup'
       R
 
@@ -1127,7 +1125,6 @@ G
         FileUtils.rm(bundled_app("Gemfile.lock"))
 
         ruby <<-R
-          require 'rubygems'
           require 'bundler/setup'
         R
 
@@ -1148,7 +1145,6 @@ G
       FileUtils.rm(bundled_app("Gemfile.lock"))
 
       ruby <<-R
-        require 'rubygems'
         require 'bundler/setup'
       R
 

--- a/spec/runtime/inline_spec.rb
+++ b/spec/runtime/inline_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe "bundler/inline#gemfile" do
 
   it "has an option for quiet installation" do
     script <<-RUBY, :artifice => "endpoint"
-      require 'bundler'
+      require '#{lib_dir}/bundler/inline'
 
       gemfile(true, :quiet => true) do
         source "https://notaserver.com"

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -985,9 +985,7 @@ end
       build_git "bar", :gemspec => false do |s|
         s.write "lib/bar/version.rb", %(BAR_VERSION = '1.0')
         s.write "bar.gemspec", <<-G
-          lib = File.expand_path('../lib/', __FILE__)
-          $:.unshift lib unless $:.include?(lib)
-          require 'bar/version'
+          require_relative 'lib/bar/version'
 
           Gem::Specification.new do |s|
             s.name        = 'bar'

--- a/spec/support/hax.rb
+++ b/spec/support/hax.rb
@@ -28,7 +28,8 @@ module Gem
 end
 
 if ENV["BUNDLER_SPEC_VERSION"]
-  require "bundler/version"
+  require_relative "path"
+  require "#{Spec::Path.lib_dir}/bundler/version"
 
   module Bundler
     remove_const(:VERSION) if const_defined?(:VERSION)
@@ -37,7 +38,8 @@ if ENV["BUNDLER_SPEC_VERSION"]
 end
 
 if ENV["BUNDLER_SPEC_WINDOWS"] == "true"
-  require "bundler/constants"
+  require_relative "path"
+  require "#{Spec::Path.lib_dir}/bundler/constants"
 
   module Bundler
     remove_const :WINDOWS if defined?(WINDOWS)

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -128,9 +128,10 @@ module Spec
         groups << opts
         @errors = names.map do |name|
           name, version, platform = name.split(/\s+/)
+          require_path = name == "bundler" ? "#{lib_dir}/bundler" : name
           version_const = name == "bundler" ? "Bundler::VERSION" : Spec::Builders.constantize(name)
           begin
-            run! "require '#{name}.rb'; puts #{version_const}", *groups
+            run! "require '#{require_path}.rb'; puts #{version_const}", *groups
           rescue StandardError => e
             next "#{name} is not installed:\n#{indent(e)}"
           end

--- a/spec/support/rubygems_ext.rb
+++ b/spec/support/rubygems_ext.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative "path"
-require "fileutils"
 
 module Spec
   module Rubygems
@@ -50,6 +49,8 @@ module Spec
     end
 
     def setup
+      require "fileutils"
+
       Gem.clear_paths
 
       ENV["BUNDLE_PATH"] = nil


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that testing the latest version of bundler as a vendored copy inside rubygems surfaced some more issues about requiring the wrong code, or activating default gems too early.

### What was your diagnosis of the problem?

My diagnosis was that we should follow similar techniques I've used in other PRs: delay as much as possible requiring default gems, and don't rely on the LOAD_PATH for internal requires.

### What is your fix for the problem, implemented in this PR?

My fix does just that, and also removes a bunch of `require`'s that were not necessary at all.