### PR TITLE
Fix RGV env variable specified as a path

### DIFF
--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -1056,7 +1056,6 @@ RSpec.describe "bundle install with git sources" do
 
       File.open(lib_path("install_hooks.rb"), "w") do |h|
         h.write <<-H
-          require '#{spec_dir}/support/rubygems'
           Gem.pre_install_hooks << lambda do |inst|
             STDERR.puts "Ran pre-install hook: \#{inst.spec.full_name}"
           end
@@ -1076,7 +1075,6 @@ RSpec.describe "bundle install with git sources" do
 
       File.open(lib_path("install_hooks.rb"), "w") do |h|
         h.write <<-H
-          require '#{spec_dir}/support/rubygems'
           Gem.post_install_hooks << lambda do |inst|
             STDERR.puts "Ran post-install hook: \#{inst.spec.full_name}"
           end
@@ -1096,7 +1094,6 @@ RSpec.describe "bundle install with git sources" do
 
       File.open(lib_path("install_hooks.rb"), "w") do |h|
         h.write <<-H
-          require '#{spec_dir}/support/rubygems'
           Gem.pre_install_hooks << lambda do |inst|
             false
           end

--- a/spec/install/gemfile/path_spec.rb
+++ b/spec/install/gemfile/path_spec.rb
@@ -671,7 +671,6 @@ RSpec.describe "bundle install with explicit source paths" do
 
       File.open(lib_path("install_hooks.rb"), "w") do |h|
         h.write <<-H
-          require '#{spec_dir}/support/rubygems'
           Gem.pre_install_hooks << lambda do |inst|
             STDERR.puts "Ran pre-install hook: \#{inst.spec.full_name}"
           end
@@ -691,7 +690,6 @@ RSpec.describe "bundle install with explicit source paths" do
 
       File.open(lib_path("install_hooks.rb"), "w") do |h|
         h.write <<-H
-          require '#{spec_dir}/support/rubygems'
           Gem.post_install_hooks << lambda do |inst|
             STDERR.puts "Ran post-install hook: \#{inst.spec.full_name}"
           end
@@ -711,7 +709,6 @@ RSpec.describe "bundle install with explicit source paths" do
 
       File.open(lib_path("install_hooks.rb"), "w") do |h|
         h.write <<-H
-          require '#{spec_dir}/support/rubygems'
           Gem.pre_install_hooks << lambda do |inst|
             false
           end

--- a/spec/rubygems/rubygems.rb
+++ b/spec/rubygems/rubygems.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require_relative "../support/rubygems_version_manager"
+
+RubygemsVersionManager.new(ENV["RGV"]).switch
+
+$:.delete("#{Spec::Path.spec_dir}/rubygems")
+
+require "rubygems"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -82,7 +82,7 @@ RSpec.configure do |config|
   config.before :suite do
     require_relative "support/rubygems_ext"
     Spec::Rubygems.setup
-    ENV["RUBYOPT"] = "#{ENV["RUBYOPT"]} -r#{Spec::Path.spec_dir}/support/hax.rb"
+    ENV["RUBYOPT"] = "#{ENV["RUBYOPT"]} -I#{Spec::Path.spec_dir}/rubygems -r#{Spec::Path.spec_dir}/support/hax.rb"
     ENV["BUNDLE_SPEC_RUN"] = "true"
     ENV["BUNDLE_USER_CONFIG"] = ENV["BUNDLE_USER_CACHE"] = ENV["BUNDLE_USER_PLUGIN"] = nil
     ENV["GEMRC"] = nil

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -110,7 +110,6 @@ module Spec
       env["PATH"].gsub!("#{Path.root}/exe", "") if env["PATH"] && system_bundler
 
       requires = options.delete(:requires) || []
-      requires << "support/rubygems"
       requires << "support/hax"
 
       artifice = options.delete(:artifice) do
@@ -144,7 +143,7 @@ module Spec
         end
       end.join
 
-      cmd = "#{sudo} #{Gem.ruby} --disable-gems #{load_path_str} #{requires_str} #{bundle_bin} #{cmd}#{args}"
+      cmd = "#{sudo} #{Gem.ruby} #{load_path_str} #{requires_str} #{bundle_bin} #{cmd}#{args}"
       sys_exec(cmd, env) {|i, o, thr| yield i, o, thr if block_given? }
     end
     bang :bundle

--- a/spec/support/path.rb
+++ b/spec/support/path.rb
@@ -22,7 +22,7 @@ module Spec
     end
 
     def gem_bin
-      @gem_bin ||= ruby_core? ? ENV["GEM_COMMAND"] : "#{Gem.ruby} --disable-gems -r#{spec_dir}/support/rubygems -S gem --backtrace"
+      @gem_bin ||= ruby_core? ? ENV["GEM_COMMAND"] : "#{Gem.ruby} -I#{spec_dir}/rubygems -S gem --backtrace"
     end
 
     def spec_dir

--- a/spec/support/rubygems.rb
+++ b/spec/support/rubygems.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-require_relative "rubygems_version_manager"
-
-RubygemsVersionManager.new(ENV["RGV"]).switch
-
-require "rubygems"

--- a/spec/support/rubygems_ext.rb
+++ b/spec/support/rubygems_ext.rb
@@ -40,7 +40,7 @@ module Spec
     end
 
     def gem_load(gem_name, bin_container)
-      require_relative "rubygems"
+      require_relative "../rubygems/rubygems"
       gem_load_and_activate(gem_name, bin_container)
     end
 

--- a/spec/support/rubygems_version_manager.rb
+++ b/spec/support/rubygems_version_manager.rb
@@ -56,7 +56,7 @@ private
   end
 
   def rubygems_unrequire_needed?
-    defined?(Gem) && Gem::VERSION != target_gem_version
+    defined?(Gem::VERSION) && Gem::VERSION != target_gem_version
   end
 
   def local_copy_switch_needed?


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that using `RGV` (the environment variable we use to select the proper rubygems version to test bundler against) with a path was not quite working.

Setting `RGV` to a path (`RGV=..`) is used in the rubygems repo to test the vendored copy of bundler (that lives at `bundler/` inside that repo) against the checked out copy of the repository.

### What was your diagnosis of the problem?

My diagnosis was that the previous approach to switch the `rubygems` version, namely, reexec'ing with `--disable-gems` and explicitly requiring our "version switching code" was not quite working because nested subprocesses would end up "leaking" to the system copy of `rubygems` again.

### What is your fix for the problem, implemented in this PR?

My fix is to use `RUBYOPT` to configure the path to the rubygems copy that should be used, since I found that even the `require "rubygems"` present's in [ruby's `gem_prelude.rb`](https://github.com/ruby/ruby/blob/c5eb24349a4535948514fe765c3ddb0628d81004/gem_prelude.rb#L1) respects the `-I` option in the `RUBYOPT` env variable.

### Why did you choose this fix out of the possible options?

I chose this fix because it's simpler and works better.
