### PR TITLE
Add missing `travis_retry`'s to TravisCI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: ruby
 dist: bionic
 script: bin/rake spec:travis
 before_script:
-  - gem install rake:"~> 12.0"
-  - bin/rake override_version
+  - travis_retry gem install rake:"~> 12.0"
+  - travis_retry bin/rake override_version
   - travis_retry bin/rake spec:travis:deps
   - bin/rake man:check
 


### PR DESCRIPTION

### What was the end-user problem that led to this PR?

The problem was that CI failed in #7437 due to a network issue.

### What was your diagnosis of the problem?

My diagnosis was that we should add `travis_retry` in the task that failed and other short tasks that may touch the network.

### What is your fix for the problem, implemented in this PR?

My fix is to do just that.