### PR TITLE
Fix typo's in Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,13 @@
 Bugfixes:
 
   - Fix `bundle clean` trying to delete non-existent directory ([#7340](https://github.com/bundler/bundler/pull/7340))
-  - Fix warnings about keywork argument separation on ruby 2.7 ([#7337](https://github.com/bundler/bundler/pull/7337))
+  - Fix warnings about keyword argument separation on ruby 2.7 ([#7337](https://github.com/bundler/bundler/pull/7337))
 
 ## 2.1.0.pre.1 (August 28, 2019)
 
 One of the biggest changes in bundler 2.1.0 is that deprecations for upcoming
 breaking changes in bundler 3 will be turned on by default. We do this to grab
-feedback and comunicate early to our users the kind of changes we're intending
+feedback and communicate early to our users the kind of changes we're intending
 to ship with bundler 3. See
 [#6965](https://github.com/bundler/bundler/pull/6965).
 
@@ -72,7 +72,7 @@ Bugfixes:
   - Warn about situations where multiple gems provide the same executable ([#7075](https://github.com/bundler/bundler/pull/7075))
   - Ignore `frozen` setting in inline mode ([#7125](https://github.com/bundler/bundler/pull/7125))
   - Fix incorrect "bundler attempted to update GEM but version stayed the same" message when updating git sourced gems ([#6325](https://github.com/bundler/bundler/pull/6325))
-  - Don't check for existance of a writable home directory if `BUNDLE_USER_HOME` is set ([#6885](https://github.com/bundler/bundler/pull/6885))
+  - Don't check for existence of a writable home directory if `BUNDLE_USER_HOME` is set ([#6885](https://github.com/bundler/bundler/pull/6885))
   - Fix error message when server would respond to a bad username/password requiest with a 401 ([#6928](https://github.com/bundler/bundler/pull/6928))
   - Fix `bundle outdated` pluralization when multiple groups are requested ([#7063](https://github.com/bundler/bundler/pull/7063))
   - Fix `bundle install` not updating conservatively when gemspec is changed ([#7143](https://github.com/bundler/bundler/pull/7143))


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problems were typos in the Changelog

### What is your fix for the problem, implemented in this PR?

Fix the typos
