### PR TITLE
Fix `bundle exec`'ing to rubygems being silent

### DIFF
--- a/lib/bundler/cli/exec.rb
+++ b/lib/bundler/cli/exec.rb
@@ -25,12 +25,12 @@ module Bundler
       SharedHelpers.set_bundle_environment
       if bin_path = Bundler.which(cmd)
         if !Bundler.settings[:disable_exec_load] && ruby_shebang?(bin_path)
-          return kernel_load(bin_path, *args)
+          return with_verbose_rubygems { kernel_load(bin_path, *args) }
         end
-        kernel_exec(bin_path, *args)
+        with_verbose_rubygems { kernel_exec(bin_path, *args) }
       else
         # exec using the given command
-        kernel_exec(cmd, *args)
+        with_verbose_rubygems { kernel_exec(cmd, *args) }
       end
     end
 
@@ -88,6 +88,15 @@ module Bundler
 
       first_line = File.open(file, "rb") {|f| f.read(possibilities.map(&:size).max) }
       possibilities.any? {|shebang| first_line.start_with?(shebang) }
+    end
+
+    def with_verbose_rubygems
+      old_ui = Gem::DefaultUserInteraction.ui
+      Gem::DefaultUserInteraction.ui = nil
+
+      yield
+    ensure
+      Gem::DefaultUserInteraction.ui = old_ui
     end
   end
 end

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -55,6 +55,12 @@ RSpec.describe "bundle exec" do
     expect(out).to eq("hi")
   end
 
+  it "works when exec'ing to rubygems" do
+    install_gemfile 'gem "rack"'
+    bundle "exec gem --version"
+    expect(out).to eq(Gem::VERSION)
+  end
+
   it "respects custom process title when loading through ruby" do
     script_that_changes_its_own_title_and_checks_if_picked_up_by_ps_unix_utility = <<~'RUBY'
       Process.setproctitle("1-2-3-4-5-6-7-8-9-10-11-12-13-14-15")


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that #7401 caused a regression where `bundle exec`'ing to rubygems would silence rubygems output.

### What was your diagnosis of the problem?

My diagnosis was that the removal of:
* Code where `Bundler::RGProxy` would be only set conditionally on `Bundler.ui =` not being passed `nil`.
* Code setting `Bundler.ui` to `nil` right before shelling during `bundle exec`.

caused rubygems UI to be silent during `bundle exec gem`.

### What is your fix for the problem, implemented in this PR?

My fix is to explictly "unsilence" rubygems UI before `bundle exec` calls.

### Why did you choose this fix out of the possible options?

I chose this fix because it's more explicit than the previous one.

Fixes #7441.
