### PR TITLE
removing multiline gem specifications correctly

### DIFF
--- a/lib/bundler/injector.rb
+++ b/lib/bundler/injector.rb
@@ -180,10 +180,21 @@ module Bundler
     def remove_gems_from_gemfile(gems, gemfile_path)
       patterns = /gem\s+(['"])#{Regexp.union(gems)}\1|gem\s*\((['"])#{Regexp.union(gems)}\2\)/
 
-      # remove lines which match the regex
-      new_gemfile = IO.readlines(gemfile_path).reject {|line| line.match(patterns) }
+      new_gemfile = []
+      multiline_removal = false
+      IO.readlines(gemfile_path).each do |line|
+        if line.match(patterns)
+          multiline_removal = line.rstrip.end_with?(",")
+          # skip lines which match the regex
+          next
+        end
 
-      # remove lone \n and append them with other strings
+        # skip followup lines until line does not end with ','
+        new_gemfile << line unless multiline_removal
+        multiline_removal = line.rstrip.end_with?(",") if multiline_removal
+      end
+
+      # remove line \n and append them with other strings
       new_gemfile.each_with_index do |_line, index|
         if new_gemfile[index + 1] == "\n"
           new_gemfile[index] += new_gemfile[index + 1]

--- a/spec/commands/remove_spec.rb
+++ b/spec/commands/remove_spec.rb
@@ -44,6 +44,30 @@ RSpec.describe "bundle remove" do
           source "#{file_uri_for(gem_repo1)}"
         G
       end
+
+      context "when gem is specified in multiple lines" do
+        it "shows success for removed gem" do
+          gemfile <<-G
+            source '#{file_uri_for(gem_repo1)}'
+
+            gem 'git'
+            gem 'rack',
+                git: 'https://github.com/rack/rack',
+                branch: 'master'
+            gem 'nokogiri'
+          G
+
+          bundle! "remove rack"
+
+          expect(out).to include("rack was removed.")
+          gemfile_should_be <<-G
+            source '#{file_uri_for(gem_repo1)}'
+
+            gem 'git'
+            gem 'nokogiri'
+          G
+        end
+      end
     end
 
     context "when gem is not present in gemfile" do


### PR DESCRIPTION

### What was the end-user problem that led to this PR?

This PR fixes the issue #7431 where gems specified in multiple lines were not removed correctly.

### What was your diagnosis of the problem?

The remove was implemented in a way that the match was only done for a line each. 

### What is your fix for the problem, implemented in this PR?

Now upon line removal it is checked if the gem specification was finished in this line. If there is a trailing `,` comma further lines needs to be removed. 
