### PR TITLE
Lazily load `open3`

### DIFF
--- a/lib/bundler/source/git/git_proxy.rb
+++ b/lib/bundler/source/git/git_proxy.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "open3"
 require "shellwords"
 
 module Bundler
@@ -243,12 +242,14 @@ module Bundler
         end
 
         def capture_and_filter_stderr(uri, cmd)
+          require "open3"
           return_value, captured_err, status = Open3.capture3(cmd)
           Bundler.ui.warn URICredentialsFilter.credential_filtered_string(captured_err, uri) if uri && !captured_err.empty?
           [return_value, status]
         end
 
         def capture_and_ignore_stderr(cmd)
+          require "open3"
           return_value, _, status = Open3.capture3(cmd)
           [return_value, status]
         end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "open3"
-
 require_relative "command_execution"
 require_relative "the_bundle"
 
@@ -211,6 +209,7 @@ module Spec
 
       env = env.map {|k, v| [k.to_s, v.to_s] }.to_h # convert env keys and values to string
 
+      require "open3"
       Open3.popen3(env, cmd.to_s) do |stdin, stdout, stderr, wait_thr|
         yield stdin, stdout, wait_thr if block_given?
         stdin.close


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was `open3` will be gemified in ruby 2.7, and since we use it inside `bundler`, we might activate a version causing a conflict with the user's choice.

### What was your diagnosis of the problem?

My diagnosis was that only loading it when needed should be better.

### What is your fix for the problem, implemented in this PR?

My fix is to lazily load it.

I expect this PR to fix [some of the errors](https://travis-ci.org/bundler/bundler/jobs/615940817) currently happening in our CI against ruby-head.