### PR TITLE
Lazily load CGI

### DIFF
--- a/lib/bundler/friendly_errors.rb
+++ b/lib/bundler/friendly_errors.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "cgi"
 require_relative "vendored_thor"
 
 module Bundler
@@ -114,6 +113,7 @@ module Bundler
     def issues_url(exception)
       message = exception.message.lines.first.tr(":", " ").chomp
       message = message.split("-").first if exception.is_a?(Errno)
+      require "cgi"
       "https://github.com/bundler/bundler/search?q=" \
         "#{CGI.escape(message)}&type=Issues"
     end


### PR DESCRIPTION


Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was that our ruby-head build is failing in CI.

### What was your diagnosis of the problem?

My diagnosis was that since `cgi` is now a default gem on ruby 2.7, we're getting someunintended activations of the new default gem inside our specs.

### What is your fix for the problem, implemented in this PR?

My fix is to lazily load CGI.