### PR TITLE
Remove unneeded CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,8 @@ before_script:
 
 branches:
   only:
-    - master
     - staging
     - trying
-    - /.+-dev$/
-    - /.+-stable$/
 
 cache:
   directories:


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was we're building more stuff than necessary in CI.

### What was your diagnosis of the problem?

My diagnosis was that we don't need to build our protected branches because they are
guaranteed to always be green, and we don't push directly to them.

### What is your fix for the problem, implemented in this PR?

My fix is to remove the relevant branches from TravisCI whitelist.
