### PR TITLE
Improve default gem activation specs

### DIFF
--- a/spec/bundler/definition_spec.rb
+++ b/spec/bundler/definition_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Bundler::Definition do
         s.add_dependency "rack", "1.0"
       end
 
-      bundle :install, :env => { "DEBUG" => 1 }
+      bundle :install, :env => { "DEBUG" => "1" }
 
       expect(out).to match(/re-resolving dependencies/)
       lockfile_should_be <<-G
@@ -84,7 +84,7 @@ RSpec.describe Bundler::Definition do
         s.add_dependency "rack", "1.0"
       end
 
-      bundle :install, :env => { "DEBUG" => 1 }
+      bundle :install, :env => { "DEBUG" => "1" }
 
       expect(out).to match(/re-resolving dependencies/)
       lockfile_should_be <<-G
@@ -121,7 +121,7 @@ RSpec.describe Bundler::Definition do
         gem "foo", :path => "#{lib_path("foo")}"
       G
 
-      bundle :check, :env => { "DEBUG" => 1 }
+      bundle :check, :env => { "DEBUG" => "1" }
 
       expect(out).to match(/using resolution from the lockfile/)
       lockfile_should_be <<-G
@@ -154,7 +154,7 @@ RSpec.describe Bundler::Definition do
       G
 
       bundle "lock --add-platform java"
-      bundle :check, :env => { "DEBUG" => 1 }
+      bundle :check, :env => { "DEBUG" => "1" }
 
       expect(out).to match(/using resolution from the lockfile/)
       lockfile_should_be <<-G
@@ -181,7 +181,7 @@ RSpec.describe Bundler::Definition do
         gem "foo"
       G
 
-      bundle :check, :env => { "DEBUG" => 1 }
+      bundle :check, :env => { "DEBUG" => "1" }
 
       expect(out).to match(/using resolution from the lockfile/)
       lockfile_should_be <<-G

--- a/spec/bundler/friendly_errors_spec.rb
+++ b/spec/bundler/friendly_errors_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Bundler, "friendly errors" do
         gem "rack"
       G
 
-      bundle :install, :env => { "DEBUG" => true }
+      bundle :install, :env => { "DEBUG" => "true" }
 
       expect(err).to include("Failed to load #{home(".gemrc")}")
       expect(exitstatus).to eq(0) if exitstatus

--- a/spec/commands/binstubs_spec.rb
+++ b/spec/commands/binstubs_spec.rb
@@ -458,7 +458,7 @@ RSpec.describe "bundle binstubs <gem>" do
       G
 
       bundle "config set auto_install 1"
-      bundle "binstubs rack", :env => { "BUNDLE_INSTALL" => 1 }
+      bundle "binstubs rack", :env => { "BUNDLE_INSTALL" => "1" }
       expect(out).not_to include("Installing rack 1.0.0")
     end
   end

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "bundle install with gem sources" do
         gem "rack"
       G
 
-      bundle! :install, :env => { "BUNDLE_PATH__SYSTEM" => true } # can't use install_gemfile since it sets retry
+      bundle! :install, :env => { "BUNDLE_PATH__SYSTEM" => "true" } # can't use install_gemfile since it sets retry
       expect(bundled_app(".bundle")).not_to exist
     end
 

--- a/spec/install/deploy_spec.rb
+++ b/spec/install/deploy_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe "install with --deployment or --frozen" do
       expect(the_bundle).to include_gems "path_gem 1.0"
       FileUtils.rm_r lib_path("path_gem-1.0")
 
-      bundle! :install, forgotten_command_line_options(:path => ".bundle", :without => "development", :deployment => true).merge(:env => { :DEBUG => "1" })
+      bundle! :install, forgotten_command_line_options(:path => ".bundle", :without => "development", :deployment => true).merge(:env => { "DEBUG" => "1" })
       run! "puts :WIN"
       expect(out).to eq("WIN")
     end

--- a/spec/install/gemfile/path_spec.rb
+++ b/spec/install/gemfile/path_spec.rb
@@ -438,7 +438,7 @@ RSpec.describe "bundle install with explicit source paths" do
         gem 'net-ssh', '1.0'
       G
 
-      bundle :check, :env => { "DEBUG" => 1 }
+      bundle :check, :env => { "DEBUG" => "1" }
       expect(out).to match(/using resolution from the lockfile/)
       expect(the_bundle).to include_gems "rack-obama 1.0", "net-ssh 1.0"
     end
@@ -458,7 +458,7 @@ RSpec.describe "bundle install with explicit source paths" do
         gem 'net-ssh', :path => "#{lib_path("omg")}"
       G
 
-      bundle :check, :env => { "DEBUG" => 1 }
+      bundle :check, :env => { "DEBUG" => "1" }
       expect(out).to match(/using resolution from the lockfile/)
       expect(the_bundle).to include_gems "rack-obama 1.0", "net-ssh 1.0"
     end
@@ -653,7 +653,7 @@ RSpec.describe "bundle install with explicit source paths" do
       File.open(lib_path("private_lib/Gemfile"), "w") {|f| f.puts gemfile }
 
       Dir.chdir(lib_path("private_lib")) do
-        bundle :install, :env => { "DEBUG" => 1 }, :artifice => "endpoint"
+        bundle :install, :env => { "DEBUG" => "1" }, :artifice => "endpoint"
         expect(out).to match(%r{^HTTP GET http://localgemserver\.test/api/v1/dependencies\?gems=rack$})
         expect(out).not_to match(/^HTTP GET.*private_lib/)
         expect(the_bundle).to include_gems "private_lib 2.2"

--- a/spec/install/gems/compact_index_spec.rb
+++ b/spec/install/gems/compact_index_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "compact index api" do
       build_gem "Rack", "0.1"
     end
 
-    install_gemfile! <<-G, :artifice => "compact_index", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4 }
+    install_gemfile! <<-G, :artifice => "compact_index", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
       source "#{source_uri}"
       gem "rack", "1.0"
       gem "Rack", "0.1"

--- a/spec/install/gems/resolving_spec.rb
+++ b/spec/install/gems/resolving_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe "bundle install with install-time dependencies" do
           end
         end
 
-        install_gemfile <<-G, :artifice => "compact_index", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo2 }
+        install_gemfile <<-G, :artifice => "compact_index", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo2.to_s }
           ruby "#{RUBY_VERSION}"
           source "http://localgemserver.test/"
           gem 'rack'
@@ -127,7 +127,7 @@ RSpec.describe "bundle install with install-time dependencies" do
           build_gem "foo1", "1.0"
         end
 
-        install_gemfile <<-G, :artifice => "compact_index_rate_limited", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4 }
+        install_gemfile <<-G, :artifice => "compact_index_rate_limited", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
           ruby "#{RUBY_VERSION}"
           source "http://localgemserver.test/"
           gem 'rack'
@@ -153,7 +153,7 @@ RSpec.describe "bundle install with install-time dependencies" do
 
       shared_examples_for "ruby version conflicts" do
         it "raises an error during resolution" do
-          install_gemfile <<-G, :artifice => "compact_index", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo2 }
+          install_gemfile <<-G, :artifice => "compact_index", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo2.to_s }
             source "http://localgemserver.test/"
             ruby #{ruby_requirement}
             gem 'require_ruby'

--- a/spec/install/gems/sudo_spec.rb
+++ b/spec/install/gems/sudo_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe "when using sudo", :sudo => true do
 
     context "when ENV['BUNDLE_SILENCE_ROOT_WARNING'] is set" do
       it "skips the warning" do
-        bundle :install, :sudo => :preserve_env, :env => { "BUNDLE_SILENCE_ROOT_WARNING" => true }
+        bundle :install, :sudo => :preserve_env, :env => { "BUNDLE_SILENCE_ROOT_WARNING" => "true" }
         expect(err).to_not include(warning)
       end
     end

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -1264,7 +1264,7 @@ end
       end
 
       let(:default_gems) do
-        Gem::Specification.select(&:default_gem?).map(&:name)
+        Gem::Specification.select(&:default_gem?).map(&:name).reject {|g| exemptions.include?(g) }
       end
 
       it "activates newer versions of default gems" do
@@ -1273,8 +1273,6 @@ end
             build_gem g, "999999"
           end
         end
-
-        default_gems.reject! {|g| exemptions.include?(g) }
 
         install_gemfile! <<-G
           source "#{file_uri_for(gem_repo4)}"
@@ -1292,8 +1290,6 @@ end
             build_gem g, "0.0.0.a"
           end
         end
-
-        default_gems.reject! {|g| exemptions.include?(g) }
 
         install_gemfile! <<-G
           source "#{file_uri_for(gem_repo4)}"

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -864,7 +864,7 @@ end
       G
 
       Dir.chdir(bundled_app.parent) do
-        run <<-R, :env => { "BUNDLE_GEMFILE" => bundled_app("Gemfile") }
+        run <<-R, :env => { "BUNDLE_GEMFILE" => bundled_app("Gemfile").to_s }
           require 'foo'
         R
       end
@@ -888,7 +888,7 @@ end
       bundle :install
 
       Dir.chdir(bundled_app.parent) do
-        run <<-R, :env => { "BUNDLE_GEMFILE" => bundled_app("Gemfile") }
+        run <<-R, :env => { "BUNDLE_GEMFILE" => bundled_app("Gemfile").to_s }
           require 'foo'
         R
       end
@@ -1246,14 +1246,14 @@ end
 
       it "activates no gems with -rbundler/setup" do
         install_gemfile! ""
-        ruby! code, :env => { :RUBYOPT => activation_warning_hack_rubyopt + " -r#{lib_dir}/bundler/setup" }
+        ruby! code, :env => { "RUBYOPT" => activation_warning_hack_rubyopt + " -r#{lib_dir}/bundler/setup" }
         expect(out).to eq("{}")
       end
 
       it "activates no gems with bundle exec" do
         install_gemfile! ""
         create_file("script.rb", code)
-        bundle! "exec ruby ./script.rb", :env => { :RUBYOPT => activation_warning_hack_rubyopt }
+        bundle! "exec ruby ./script.rb", :env => { "RUBYOPT" => activation_warning_hack_rubyopt }
         expect(out).to eq("{}")
       end
 
@@ -1261,7 +1261,7 @@ end
         install_gemfile! ""
         create_file("script.rb", "#!/usr/bin/env ruby\n\n#{code}")
         FileUtils.chmod(0o777, bundled_app("script.rb"))
-        bundle! "exec ./script.rb", :artifice => nil, :env => { :RUBYOPT => activation_warning_hack_rubyopt }
+        bundle! "exec ./script.rb", :artifice => nil, :env => { "RUBYOPT" => activation_warning_hack_rubyopt }
         expect(out).to eq("{}")
       end
 

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -1264,9 +1264,7 @@ end
       end
 
       let(:default_gems) do
-        ruby!(<<-RUBY).split("\n")
-          puts Gem::Specification.select(&:default_gem?).map(&:name)
-        RUBY
+        Gem::Specification.select(&:default_gem?).map(&:name)
       end
 
       it "activates newer versions of default gems" do

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -1265,9 +1265,7 @@ end
 
       let(:default_gems) do
         ruby!(<<-RUBY).split("\n")
-          if Gem::Specification.is_a?(Enumerable)
-            puts Gem::Specification.select(&:default_gem?).map(&:name)
-          end
+          puts Gem::Specification.select(&:default_gem?).map(&:name)
         RUBY
       end
 

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -1276,7 +1276,7 @@ end
             gem "#{g}", "999999"
           G
 
-          expect(the_bundle).to include_gem("#{g} 999999")
+          expect(the_bundle).to include_gem("#{g} 999999", :env => { "RUBYOPT" => activation_warning_hack_rubyopt })
         end
 
         it "activates older versions of #{g}" do
@@ -1291,7 +1291,7 @@ end
             gem "#{g}", "0.0.0.a"
           G
 
-          expect(the_bundle).to include_gem("#{g} 0.0.0.a")
+          expect(the_bundle).to include_gem("#{g} 0.0.0.a", :env => { "RUBYOPT" => activation_warning_hack_rubyopt })
         end
       end
     end

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -1218,7 +1218,7 @@ end
             unless #{exemptions.inspect}.include?(name)
               warn '-' * 80
               warn "activating \#{full_name}"
-              warn *caller
+              warn(*caller)
               warn '*' * 80
             end
             bundler_spec_activate

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -1212,17 +1212,15 @@ end
       let(:activation_warning_hack) { strip_whitespace(<<-RUBY) }
         require #{spec_dir.join("support/hax").to_s.dump}
 
-        if Gem::Specification.instance_methods.map(&:to_sym).include?(:activate)
-          Gem::Specification.send(:alias_method, :bundler_spec_activate, :activate)
-          Gem::Specification.send(:define_method, :activate) do
-            unless #{exemptions.inspect}.include?(name)
-              warn '-' * 80
-              warn "activating \#{full_name}"
-              warn(*caller)
-              warn '*' * 80
-            end
-            bundler_spec_activate
+        Gem::Specification.send(:alias_method, :bundler_spec_activate, :activate)
+        Gem::Specification.send(:define_method, :activate) do
+          unless #{exemptions.inspect}.include?(name)
+            warn '-' * 80
+            warn "activating \#{full_name}"
+            warn(*caller)
+            warn '*' * 80
           end
+          bundler_spec_activate
         end
       RUBY
 

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -207,8 +207,6 @@ module Spec
     def sys_exec(cmd, env = {})
       command_execution = CommandExecution.new(cmd.to_s, Dir.pwd)
 
-      env = env.map {|k, v| [k.to_s, v.to_s] }.to_h # convert env keys and values to string
-
       require "open3"
       Open3.popen3(env, cmd.to_s) do |stdin, stdout, stderr, wait_thr|
         yield stdin, stdout, wait_thr if block_given?

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -23,9 +23,7 @@ module Spec
       define_method("#{method}!") do |*args, &blk|
         send(method, *args, &blk).tap do
           unless last_command.success?
-            raise RuntimeError,
-              "Invoking #{method}!(#{args.map(&:inspect).join(", ")}) failed:\n#{last_command.stdboth}",
-              caller.drop_while {|bt| bt.start_with?(__FILE__) }
+            raise "Invoking #{method}!(#{args.map(&:inspect).join(", ")}) failed:\n#{last_command.stdboth}"
           end
         end
       end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The original problem was that currently we are having some issues because ruby-core gemified some libraries that we use inside bundler. We shouldn't use default gems during `bundler/setup` because activating them might cause activation conflicts later on if the user has chosen a different version of the default gem from the one that's selected by default.

The good news is that we have some nice specs that check that we never activate default gems, and they've been very useful lately for detecting this kind of breakage.

The bad news is that some of these specs usually fail with really verbose error messages that make it difficult to find the root cause of the problems.

### What was your diagnosis of the problem?

My diagnosis was that we could improve these specs to give better errors.

### What is your fix for the problem, implemented in this PR?

My fix is to improve the specs with several tweaks, the main ones being:

* Split them into one spec per default gem, so that when a default gem is unintentionally activated by bundler, only that spec fails, and with a reasonably concise error message.

* Add a "gem activation hack" to the specs so that when a default gem is activated by `bundler/setup`, we get the exact location of where the activation happened.

As an example, up to know, running `bin/rspec ./spec/runtime/setup_spec.rb -e "activates older versions"` against current ruby-head (ruby/ruby@4325f080862b36a3e3ddee472169f65758612ad3) and current rubygems (rubygems/rubygems@15ac911c686f68e1985bf700a053a84c46443e1d) leads to:

<details>
  <summary>The following error message before this patch (1664 lines)</summary>

```
Randomized with seed 15961
F

Retried examples: 0


Failures:

  1) Bundler.setup with gemified standard libraries default gem activation activates older versions of default gems
     Failure/Error: expect(the_bundle).to include_gems(*default_gems.map {|g| "#{g} 0.0.0.a" })

       expected the bundle to include gems "benchmark 0.0.0.a", "bigdecimal 0.0.0.a", "cgi 0.0.0.a", "csv 0.0.0.a", "date 0.0.0.a", "delegate 0.0.0.a", "e2mmap 0.0.0.a", "etc 0.0.0.a", "fcntl 0.0.0.a", "fiddle 0.0.0.a", "fileutils 0.0.0.a", "forwardable 0.0.0.a", "gdbm 0.0.0.a", "getoptlong 0.0.0.a", "io-console 0.0.0.a", "ipaddr 0.0.0.a", "irb 0.0.0.a", "json 0.0.0.a", "logger 0.0.0.a", "matrix 0.0.0.a", "mutex_m 0.0.0.a", "net-pop 0.0.0.a", "net-smtp 0.0.0.a", "observer 0.0.0.a", "open3 0.0.0.a", "openssl 0.0.0.a", "ostruct 0.0.0.a", "prime 0.0.0.a", "pstore 0.0.0.a", "psych 0.0.0.a", "racc 0.0.0.a", "rdoc 0.0.0.a", "readline 0.0.0.a", "readline-ext 0.0.0.a", "reline 0.0.0.a", "rexml 0.0.0.a", "rss 0.0.0.a", "sdbm 0.0.0.a", "singleton 0.0.0.a", "stringio 0.0.0.a", "strscan 0.0.0.a", "timeout 0.0.0.a", "tracer 0.0.0.a", "uri 0.0.0.a", "webrick 0.0.0.a", "yaml 0.0.0.a", and "zlib 0.0.0.a" but:
           benchmark is not installed:
               Invoking run!("require 'benchmark.rb'; puts BENCHMARK", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           bigdecimal is not installed:
               Invoking run!("require 'bigdecimal.rb'; puts BIGDECIMAL", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           cgi is not installed:
               Invoking run!("require 'cgi.rb'; puts CGI", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           csv is not installed:
               Invoking run!("require 'csv.rb'; puts CSV", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           date is not installed:
               Invoking run!("require 'date.rb'; puts DATE", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           delegate is not installed:
               Invoking run!("require 'delegate.rb'; puts DELEGATE", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           e2mmap is not installed:
               Invoking run!("require 'e2mmap.rb'; puts E2MMAP", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           etc is not installed:
               Invoking run!("require 'etc.rb'; puts ETC", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           fcntl is not installed:
               Invoking run!("require 'fcntl.rb'; puts FCNTL", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           fiddle is not installed:
               Invoking run!("require 'fiddle.rb'; puts FIDDLE", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           fileutils is not installed:
               Invoking run!("require 'fileutils.rb'; puts FILEUTILS", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           forwardable is not installed:
               Invoking run!("require 'forwardable.rb'; puts FORWARDABLE", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           gdbm is not installed:
               Invoking run!("require 'gdbm.rb'; puts GDBM", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           getoptlong is not installed:
               Invoking run!("require 'getoptlong.rb'; puts GETOPTLONG", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           io-console is not installed:
               Invoking run!("require 'io-console.rb'; puts IOCONSOLE", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           ipaddr is not installed:
               Invoking run!("require 'ipaddr.rb'; puts IPADDR", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           irb is not installed:
               Invoking run!("require 'irb.rb'; puts IRB", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           json is not installed:
               Invoking run!("require 'json.rb'; puts JSON", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           logger is not installed:
               Invoking run!("require 'logger.rb'; puts LOGGER", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           matrix is not installed:
               Invoking run!("require 'matrix.rb'; puts MATRIX", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           mutex_m is not installed:
               Invoking run!("require 'mutex_m.rb'; puts MUTEX_M", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           net-pop is not installed:
               Invoking run!("require 'net-pop.rb'; puts NETPOP", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           net-smtp is not installed:
               Invoking run!("require 'net-smtp.rb'; puts NETSMTP", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           observer is not installed:
               Invoking run!("require 'observer.rb'; puts OBSERVER", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           open3 is not installed:
               Invoking run!("require 'open3.rb'; puts OPEN3", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           openssl is not installed:
               Invoking run!("require 'openssl.rb'; puts OPENSSL", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           ostruct is not installed:
               Invoking run!("require 'ostruct.rb'; puts OSTRUCT", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           prime is not installed:
               Invoking run!("require 'prime.rb'; puts PRIME", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           pstore is not installed:
               Invoking run!("require 'pstore.rb'; puts PSTORE", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           psych is not installed:
               Invoking run!("require 'psych.rb'; puts PSYCH", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           racc is not installed:
               Invoking run!("require 'racc.rb'; puts RACC", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           rdoc is not installed:
               Invoking run!("require 'rdoc.rb'; puts RDOC", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           readline is not installed:
               Invoking run!("require 'readline.rb'; puts READLINE", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           readline-ext is not installed:
               Invoking run!("require 'readline-ext.rb'; puts READLINEEXT", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           reline is not installed:
               Invoking run!("require 'reline.rb'; puts RELINE", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           rexml is not installed:
               Invoking run!("require 'rexml.rb'; puts REXML", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           rss is not installed:
               Invoking run!("require 'rss.rb'; puts RSS", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           sdbm is not installed:
               Invoking run!("require 'sdbm.rb'; puts SDBM", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           singleton is not installed:
               Invoking run!("require 'singleton.rb'; puts SINGLETON", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           stringio is not installed:
               Invoking run!("require 'stringio.rb'; puts STRINGIO", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           strscan is not installed:
               Invoking run!("require 'strscan.rb'; puts STRSCAN", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           timeout is not installed:
               Invoking run!("require 'timeout.rb'; puts TIMEOUT", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           tracer is not installed:
               Invoking run!("require 'tracer.rb'; puts TRACER", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           uri is not installed:
               Invoking run!("require 'uri.rb'; puts URI", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           webrick is not installed:
               Invoking run!("require 'webrick.rb'; puts WEBRICK", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           yaml is not installed:
               Invoking run!("require 'yaml.rb'; puts YAML", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'
           zlib is not installed:
               Invoking run!("require 'zlib.rb'; puts ZLIB", {}) failed:
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'

       Commands:
       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
                   if Gem::Specification.is_a?(Enumerable)
                     puts Gem::Specification.select(&:default_gem?).map(&:name)
                   end
       EOS
       benchmark
       bigdecimal
       bundler
       cgi
       csv
       date
       delegate
       e2mmap
       etc
       fcntl
       fiddle
       fileutils
       forwardable
       gdbm
       getoptlong
       io-console
       ipaddr
       irb
       json
       logger
       matrix
       mutex_m
       net-pop
       net-smtp
       observer
       open3
       openssl
       ostruct
       prime
       pstore
       psych
       racc
       rdoc
       readline
       readline-ext
       reline
       rexml
       rss
       sdbm
       singleton
       stringio
       strscan
       timeout
       tracer
       uri
       webrick
       yaml
       zlib
       # $? => 0

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/spec/rubygems -S gem \
         --backtrace generate_index
       Generating Marshal quick index gemspecs for 49 gems
       .................................................
       Complete
       Generated Marshal quick index gemspecs: 0.009s
       Generating specs index
       Generated specs index: 0.000s
       Generating latest specs index
       Generated latest specs index: 0.000s
       Generating prerelease specs index
       Generated prerelease specs index: 0.000s
       Compressing indices
       Compressed indices: 0.000s
       # $? => 0

       $ /home/deivid/.rbenv/versions/master/bin/ruby \
         -I/home/deivid/Code/bundler/lib:/home/deivid/Code/bundler/spec -rsupport/hax \
         -rsupport/artifice/fail /home/deivid/Code/bundler/exe/bundle install --retry 0
       Fetching source index from file:///home/deivid/Code/bundler/tmp/1/gems/remote4/
       Resolving dependencies...
       Fetching benchmark 0.0.0.a
       Installing benchmark 0.0.0.a
       Fetching bigdecimal 0.0.0.a
       Installing bigdecimal 0.0.0.a
       Using bundler 2.1.0.pre.3
       Fetching cgi 0.0.0.a
       Installing cgi 0.0.0.a
       Fetching csv 0.0.0.a
       Installing csv 0.0.0.a
       Fetching date 0.0.0.a
       Installing date 0.0.0.a
       Fetching delegate 0.0.0.a
       Installing delegate 0.0.0.a
       Fetching e2mmap 0.0.0.a
       Installing e2mmap 0.0.0.a
       Fetching etc 0.0.0.a
       Installing etc 0.0.0.a
       Fetching fcntl 0.0.0.a
       Installing fcntl 0.0.0.a
       Fetching fiddle 0.0.0.a
       Installing fiddle 0.0.0.a
       Fetching fileutils 0.0.0.a
       Installing fileutils 0.0.0.a
       Fetching forwardable 0.0.0.a
       Installing forwardable 0.0.0.a
       Fetching gdbm 0.0.0.a
       Installing gdbm 0.0.0.a
       Fetching getoptlong 0.0.0.a
       Installing getoptlong 0.0.0.a
       Fetching io-console 0.0.0.a
       Installing io-console 0.0.0.a
       Fetching ipaddr 0.0.0.a
       Installing ipaddr 0.0.0.a
       Fetching irb 0.0.0.a
       Installing irb 0.0.0.a
       Fetching json 0.0.0.a
       Installing json 0.0.0.a
       Fetching logger 0.0.0.a
       Installing logger 0.0.0.a
       Fetching matrix 0.0.0.a
       Installing matrix 0.0.0.a
       Fetching mutex_m 0.0.0.a
       Installing mutex_m 0.0.0.a
       Fetching net-pop 0.0.0.a
       Installing net-pop 0.0.0.a
       Fetching net-smtp 0.0.0.a
       Installing net-smtp 0.0.0.a
       Fetching observer 0.0.0.a
       Installing observer 0.0.0.a
       Fetching open3 0.0.0.a
       Installing open3 0.0.0.a
       Fetching openssl 0.0.0.a
       Installing openssl 0.0.0.a
       Fetching ostruct 0.0.0.a
       Installing ostruct 0.0.0.a
       Fetching prime 0.0.0.a
       Installing prime 0.0.0.a
       Fetching pstore 0.0.0.a
       Installing pstore 0.0.0.a
       Fetching psych 0.0.0.a
       Installing psych 0.0.0.a
       Fetching racc 0.0.0.a
       Installing racc 0.0.0.a
       Fetching rdoc 0.0.0.a
       Installing rdoc 0.0.0.a
       Fetching readline 0.0.0.a
       Installing readline 0.0.0.a
       Fetching readline-ext 0.0.0.a
       Installing readline-ext 0.0.0.a
       Fetching reline 0.0.0.a
       Installing reline 0.0.0.a
       Fetching rexml 0.0.0.a
       Installing rexml 0.0.0.a
       Fetching rss 0.0.0.a
       Installing rss 0.0.0.a
       Fetching sdbm 0.0.0.a
       Installing sdbm 0.0.0.a
       Fetching singleton 0.0.0.a
       Installing singleton 0.0.0.a
       Fetching stringio 0.0.0.a
       Installing stringio 0.0.0.a
       Fetching strscan 0.0.0.a
       Installing strscan 0.0.0.a
       Fetching timeout 0.0.0.a
       Installing timeout 0.0.0.a
       Fetching tracer 0.0.0.a
       Installing tracer 0.0.0.a
       Fetching uri 0.0.0.a
       Installing uri 0.0.0.a
       Fetching webrick 0.0.0.a
       Installing webrick 0.0.0.a
       Fetching yaml 0.0.0.a
       Installing yaml 0.0.0.a
       Fetching zlib 0.0.0.a
       Installing zlib 0.0.0.a
       Bundle complete! 47 Gemfile dependencies, 48 gems now installed.
       Use `bundle info [gemname]` to see where a bundled gem is installed.
       # $? => 0

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'benchmark.rb'; puts BENCHMARK
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'bigdecimal.rb'; puts BIGDECIMAL
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'cgi.rb'; puts CGI
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'csv.rb'; puts CSV
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'date.rb'; puts DATE
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'delegate.rb'; puts DELEGATE
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'e2mmap.rb'; puts E2MMAP
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'etc.rb'; puts ETC
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'fcntl.rb'; puts FCNTL
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'fiddle.rb'; puts FIDDLE
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'fileutils.rb'; puts FILEUTILS
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'forwardable.rb'; puts FORWARDABLE
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'gdbm.rb'; puts GDBM
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'getoptlong.rb'; puts GETOPTLONG
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'io-console.rb'; puts IOCONSOLE
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'ipaddr.rb'; puts IPADDR
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'irb.rb'; puts IRB
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'json.rb'; puts JSON
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'logger.rb'; puts LOGGER
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'matrix.rb'; puts MATRIX
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'mutex_m.rb'; puts MUTEX_M
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'net-pop.rb'; puts NETPOP
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'net-smtp.rb'; puts NETSMTP
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'observer.rb'; puts OBSERVER
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'open3.rb'; puts OPEN3
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'openssl.rb'; puts OPENSSL
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'ostruct.rb'; puts OSTRUCT
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'prime.rb'; puts PRIME
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'pstore.rb'; puts PSTORE
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'psych.rb'; puts PSYCH
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'racc.rb'; puts RACC
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'rdoc.rb'; puts RDOC
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'readline.rb'; puts READLINE
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'readline-ext.rb'; puts READLINEEXT
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'reline.rb'; puts RELINE
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'rexml.rb'; puts REXML
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'rss.rb'; puts RSS
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'sdbm.rb'; puts SDBM
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'singleton.rb'; puts SINGLETON
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'stringio.rb'; puts STRINGIO
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'strscan.rb'; puts STRSCAN
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'timeout.rb'; puts TIMEOUT
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'tracer.rb'; puts TRACER
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'uri.rb'; puts URI
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'webrick.rb'; puts WEBRICK
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'yaml.rb'; puts YAML
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'zlib.rb'; puts ZLIB
       EOS
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1
     # ./spec/runtime/setup_spec.rb:1311:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:111:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:111:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:78:in `block (2 levels) in <top (required)>'
     # ./spec/support/rubygems_ext.rb:85:in `load'
     # ./spec/support/rubygems_ext.rb:85:in `gem_load_and_activate'
     # ./spec/support/rubygems_ext.rb:43:in `gem_load'

Finished in 8.37 seconds (files took 0.15614 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/runtime/setup_spec.rb:1295 # Bundler.setup with gemified standard libraries default gem activation activates older versions of default gems

Randomized with seed 15961
```
</details>

<details>
  <summary>A much more concise output after this patch (232 lines), without duplicate errors, with the location of the uri activation, and also surfacing another problem with the "delegate" default gem</summary>

```

Randomized with seed 50536
..........................F.............F......

Retried examples: 0


Failures:

  1) Bundler.setup with gemified standard libraries default gem activation activates older versions of uri
     Failure/Error: expect(the_bundle).to include_gem("#{g} 0.0.0.a", :env => { "RUBYOPT" => activation_warning_hack_rubyopt })

       expected the bundle to include gem "uri 0.0.0.a" and {} but:
           uri is not installed:
               Invoking run!("require 'uri.rb'; puts URI", {}) failed:
               --------------------------------------------------------------------------------
               activating uri-0.10.0
               /home/deivid/Code/bundler/tmp/rubygems/lib/rubygems/core_ext/kernel_gem.rb:68:in `block in gem'
               /home/deivid/Code/bundler/tmp/rubygems/lib/rubygems/core_ext/kernel_gem.rb:68:in `synchronize'
               /home/deivid/Code/bundler/tmp/rubygems/lib/rubygems/core_ext/kernel_gem.rb:68:in `gem'
               /home/deivid/Code/bundler/tmp/rubygems/lib/rubygems/core_ext/kernel_require.rb:80:in `require'
               /home/deivid/Code/bundler/lib/bundler/settings.rb:3:in `<top (required)>'
               /home/deivid/Code/bundler/tmp/rubygems/lib/rubygems/core_ext/kernel_require.rb:92:in `require'
               /home/deivid/Code/bundler/tmp/rubygems/lib/rubygems/core_ext/kernel_require.rb:92:in `require'
               /home/deivid/Code/bundler/lib/bundler.rb:318:in `settings'
               /home/deivid/Code/bundler/lib/bundler.rb:100:in `configured_bundle_path'
               /home/deivid/Code/bundler/lib/bundler.rb:456:in `use_system_gems?'
               /home/deivid/Code/bundler/lib/bundler.rb:646:in `configure_gem_path'
               /home/deivid/Code/bundler/lib/bundler.rb:639:in `configure_gem_home_and_path'
               /home/deivid/Code/bundler/lib/bundler.rb:82:in `configure'
               /home/deivid/Code/bundler/lib/bundler.rb:195:in `definition'
               /home/deivid/Code/bundler/lib/bundler.rb:144:in `setup'
               -e:1:in `block in <main>'
               /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
               /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
               -e:1:in `<main>'
               ********************************************************************************
               /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
                   from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
                   from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
                   from -e:1:in `block in <main>'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
                   from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
                   from -e:1:in `<main>'

       Commands:
       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/spec/rubygems -S gem \
         --backtrace generate_index
       Generating Marshal quick index gemspecs for 2 gems
       ..
       Complete
       Generated Marshal quick index gemspecs: 0.001s
       Generating specs index
       Generated specs index: 0.000s
       Generating latest specs index
       Generated latest specs index: 0.000s
       Generating prerelease specs index
       Generated prerelease specs index: 0.000s
       Compressing indices
       Compressed indices: 0.000s
       # $? => 0

       $ /home/deivid/.rbenv/versions/master/bin/ruby \
         -I/home/deivid/Code/bundler/lib:/home/deivid/Code/bundler/spec -rsupport/hax \
         -rsupport/artifice/fail /home/deivid/Code/bundler/exe/bundle install --retry 0
       Fetching source index from file:///home/deivid/Code/bundler/tmp/1/gems/remote4/
       Resolving dependencies...
       Using bundler 2.1.0.pre.3
       Fetching uri 0.0.0.a
       Installing uri 0.0.0.a
       Bundle complete! 1 Gemfile dependency, 2 gems now installed.
       Use `bundle info [gemname]` to see where a bundled gem is installed.
       # $? => 0

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'uri.rb'; puts URI
       EOS
       --------------------------------------------------------------------------------
       activating uri-0.10.0
       /home/deivid/Code/bundler/tmp/rubygems/lib/rubygems/core_ext/kernel_gem.rb:68:in `block in gem'
       /home/deivid/Code/bundler/tmp/rubygems/lib/rubygems/core_ext/kernel_gem.rb:68:in `synchronize'
       /home/deivid/Code/bundler/tmp/rubygems/lib/rubygems/core_ext/kernel_gem.rb:68:in `gem'
       /home/deivid/Code/bundler/tmp/rubygems/lib/rubygems/core_ext/kernel_require.rb:80:in `require'
       /home/deivid/Code/bundler/lib/bundler/settings.rb:3:in `<top (required)>'
       /home/deivid/Code/bundler/tmp/rubygems/lib/rubygems/core_ext/kernel_require.rb:92:in `require'
       /home/deivid/Code/bundler/tmp/rubygems/lib/rubygems/core_ext/kernel_require.rb:92:in `require'
       /home/deivid/Code/bundler/lib/bundler.rb:318:in `settings'
       /home/deivid/Code/bundler/lib/bundler.rb:100:in `configured_bundle_path'
       /home/deivid/Code/bundler/lib/bundler.rb:456:in `use_system_gems?'
       /home/deivid/Code/bundler/lib/bundler.rb:646:in `configure_gem_path'
       /home/deivid/Code/bundler/lib/bundler.rb:639:in `configure_gem_home_and_path'
       /home/deivid/Code/bundler/lib/bundler.rb:82:in `configure'
       /home/deivid/Code/bundler/lib/bundler.rb:195:in `definition'
       /home/deivid/Code/bundler/lib/bundler.rb:144:in `setup'
       -e:1:in `block in <main>'
       /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       -e:1:in `<main>'
       ********************************************************************************
       /home/deivid/Code/bundler/lib/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.0.0.a. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:31:in `block in setup'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/spec_set.rb:147:in `each'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `map'
       	from /home/deivid/Code/bundler/lib/bundler/runtime.rb:26:in `setup'
       	from /home/deivid/Code/bundler/lib/bundler.rb:150:in `setup'
       	from -e:1:in `block in <main>'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       	from /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       	from -e:1:in `<main>'
       # $? => 1
     # ./spec/runtime/setup_spec.rb:1294:in `block (5 levels) in <top (required)>'
     # ./spec/spec_helper.rb:111:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:111:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:78:in `block (2 levels) in <top (required)>'
     # ./spec/support/rubygems_ext.rb:85:in `load'
     # ./spec/support/rubygems_ext.rb:85:in `gem_load_and_activate'
     # ./spec/support/rubygems_ext.rb:43:in `gem_load'

  2) Bundler.setup with gemified standard libraries default gem activation activates older versions of delegate
     Failure/Error: expect(the_bundle).to include_gem("#{g} 0.0.0.a", :env => { "RUBYOPT" => activation_warning_hack_rubyopt })

       expected the bundle to include gem "delegate 0.0.0.a" and {} but:
           delegate is not installed:
               Invoking run!("require 'delegate.rb'; puts DELEGATE", {}) failed:
               --------------------------------------------------------------------------------
               activating uri-0.10.0
               /home/deivid/Code/bundler/tmp/rubygems/lib/rubygems/core_ext/kernel_gem.rb:68:in `block in gem'
               /home/deivid/Code/bundler/tmp/rubygems/lib/rubygems/core_ext/kernel_gem.rb:68:in `synchronize'
               /home/deivid/Code/bundler/tmp/rubygems/lib/rubygems/core_ext/kernel_gem.rb:68:in `gem'
               /home/deivid/Code/bundler/tmp/rubygems/lib/rubygems/core_ext/kernel_require.rb:80:in `require'
               /home/deivid/Code/bundler/lib/bundler/settings.rb:3:in `<top (required)>'
               /home/deivid/Code/bundler/tmp/rubygems/lib/rubygems/core_ext/kernel_require.rb:92:in `require'
               /home/deivid/Code/bundler/tmp/rubygems/lib/rubygems/core_ext/kernel_require.rb:92:in `require'
               /home/deivid/Code/bundler/lib/bundler.rb:318:in `settings'
               /home/deivid/Code/bundler/lib/bundler.rb:100:in `configured_bundle_path'
               /home/deivid/Code/bundler/lib/bundler.rb:456:in `use_system_gems?'
               /home/deivid/Code/bundler/lib/bundler.rb:646:in `configure_gem_path'
               /home/deivid/Code/bundler/lib/bundler.rb:639:in `configure_gem_home_and_path'
               /home/deivid/Code/bundler/lib/bundler.rb:82:in `configure'
               /home/deivid/Code/bundler/lib/bundler.rb:195:in `definition'
               /home/deivid/Code/bundler/lib/bundler.rb:144:in `setup'
               -e:1:in `block in <main>'
               /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
               /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
               -e:1:in `<main>'
               ********************************************************************************
               -e:2:in `<main>': uninitialized constant DELEGATE (NameError)

       Commands:
       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/spec/rubygems -S gem \
         --backtrace generate_index
       Generating Marshal quick index gemspecs for 2 gems
       ..
       Complete
       Generated Marshal quick index gemspecs: 0.001s
       Generating specs index
       Generated specs index: 0.000s
       Generating latest specs index
       Generated latest specs index: 0.000s
       Generating prerelease specs index
       Generated prerelease specs index: 0.000s
       Compressing indices
       Compressed indices: 0.000s
       # $? => 0

       $ /home/deivid/.rbenv/versions/master/bin/ruby \
         -I/home/deivid/Code/bundler/lib:/home/deivid/Code/bundler/spec -rsupport/hax \
         -rsupport/artifice/fail /home/deivid/Code/bundler/exe/bundle install --retry 0
       Fetching source index from file:///home/deivid/Code/bundler/tmp/1/gems/remote4/
       Resolving dependencies...
       Using bundler 2.1.0.pre.3
       Fetching delegate 0.0.0.a
       Installing delegate 0.0.0.a
       Bundle complete! 1 Gemfile dependency, 2 gems now installed.
       Use `bundle info [gemname]` to see where a bundled gem is installed.
       # $? => 0

       $ /home/deivid/.rbenv/versions/master/bin/ruby -I/home/deivid/Code/bundler/lib -w -e  \
         <<EOS
         require '/home/deivid/Code/bundler/lib/bundler' ; Bundler.ui.silence { Bundler.setup() }
         require 'delegate.rb'; puts DELEGATE
       EOS
       --------------------------------------------------------------------------------
       activating uri-0.10.0
       /home/deivid/Code/bundler/tmp/rubygems/lib/rubygems/core_ext/kernel_gem.rb:68:in `block in gem'
       /home/deivid/Code/bundler/tmp/rubygems/lib/rubygems/core_ext/kernel_gem.rb:68:in `synchronize'
       /home/deivid/Code/bundler/tmp/rubygems/lib/rubygems/core_ext/kernel_gem.rb:68:in `gem'
       /home/deivid/Code/bundler/tmp/rubygems/lib/rubygems/core_ext/kernel_require.rb:80:in `require'
       /home/deivid/Code/bundler/lib/bundler/settings.rb:3:in `<top (required)>'
       /home/deivid/Code/bundler/tmp/rubygems/lib/rubygems/core_ext/kernel_require.rb:92:in `require'
       /home/deivid/Code/bundler/tmp/rubygems/lib/rubygems/core_ext/kernel_require.rb:92:in `require'
       /home/deivid/Code/bundler/lib/bundler.rb:318:in `settings'
       /home/deivid/Code/bundler/lib/bundler.rb:100:in `configured_bundle_path'
       /home/deivid/Code/bundler/lib/bundler.rb:456:in `use_system_gems?'
       /home/deivid/Code/bundler/lib/bundler.rb:646:in `configure_gem_path'
       /home/deivid/Code/bundler/lib/bundler.rb:639:in `configure_gem_home_and_path'
       /home/deivid/Code/bundler/lib/bundler.rb:82:in `configure'
       /home/deivid/Code/bundler/lib/bundler.rb:195:in `definition'
       /home/deivid/Code/bundler/lib/bundler.rb:144:in `setup'
       -e:1:in `block in <main>'
       /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:136:in `with_level'
       /home/deivid/Code/bundler/lib/bundler/ui/shell.rb:88:in `silence'
       -e:1:in `<main>'
       ********************************************************************************
       -e:2:in `<main>': uninitialized constant DELEGATE (NameError)
       # $? => 1
     # ./spec/runtime/setup_spec.rb:1294:in `block (5 levels) in <top (required)>'
     # ./spec/spec_helper.rb:111:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:111:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:78:in `block (2 levels) in <top (required)>'
     # ./spec/support/rubygems_ext.rb:85:in `load'
     # ./spec/support/rubygems_ext.rb:85:in `gem_load_and_activate'
     # ./spec/support/rubygems_ext.rb:43:in `gem_load'

Finished in 25.2 seconds (files took 0.16231 seconds to load)
47 examples, 2 failures

Failed examples:

rspec ./spec/runtime/setup_spec.rb[1:31:3:91] # Bundler.setup with gemified standard libraries default gem activation activates older versions of uri
rspec ./spec/runtime/setup_spec.rb[1:31:3:15] # Bundler.setup with gemified standard libraries default gem activation activates older versions of delegate

Randomized with seed 50536

```
</details>

### Why did you choose this fix out of the possible options?

I chose this fix because it will make it easier to fix current and future breakage of unintentional activation of default gems.