### PR TITLE
Unskip quality specs

### DIFF
--- a/spec/support/path.rb
+++ b/spec/support/path.rb
@@ -183,7 +183,7 @@ module Spec
   private
 
     def git_root_dir?
-      root == `git rev-parse --show-toplevel`
+      root.to_s == `git rev-parse --show-toplevel`.chomp
     end
   end
 end

--- a/spec/support/path.rb
+++ b/spec/support/path.rb
@@ -30,23 +30,20 @@ module Spec
     end
 
     def tracked_files
-      if root != `git rev-parse --show-toplevel`
-        skip "not in git working directory"
-      end
+      skip "not in git working directory" unless git_root_dir?
+
       @tracked_files ||= ruby_core? ? `git ls-files -z -- lib/bundler lib/bundler.rb spec/bundler man/bundler*` : `git ls-files -z`
     end
 
     def shipped_files
-      if root != `git rev-parse --show-toplevel`
-        skip "not in git working directory"
-      end
+      skip "not in git working directory" unless git_root_dir?
+
       @shipped_files ||= ruby_core? ? `git ls-files -z -- lib/bundler lib/bundler.rb man/bundler* libexec/bundle*` : `git ls-files -z -- lib man exe CHANGELOG.md LICENSE.md README.md bundler.gemspec`
     end
 
     def lib_tracked_files
-      if root != `git rev-parse --show-toplevel`
-        skip "not in git working directory"
-      end
+      skip "not in git working directory" unless git_root_dir?
+
       @lib_tracked_files ||= ruby_core? ? `git ls-files -z -- lib/bundler lib/bundler.rb` : `git ls-files -z -- lib`
     end
 
@@ -182,5 +179,11 @@ module Spec
     end
 
     extend self
+
+  private
+
+    def git_root_dir?
+      root == `git rev-parse --show-toplevel`
+    end
   end
 end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was after 5003a436765eb50d9208ffdce4bbe46cf0d6d63b backported from ruby-core, quality_specs are no longer run, not even in our repo.

### What was your diagnosis of the problem?

My diagnosis was that the condition to check whether the root folder is a git folder was incorrect.

### What is your fix for the problem, implemented in this PR?

My fix is to correct the condition.