### PR TITLE
Vendor `uri` library

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -268,6 +268,14 @@ else
       sublib.prefix = "Bundler"
       sublib.vendor_lib = "lib/bundler/vendor/connection_pool"
     end
+
+    lib.dependency("uri") do |sublib|
+      sublib.version = "master"
+      sublib.download = { :github => "https://github.com/ruby/uri" }
+      sublib.namespace = "URI"
+      sublib.prefix = "Bundler"
+      sublib.vendor_lib = "lib/bundler/vendor/uri"
+    end
   end
 end
 

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -784,7 +784,7 @@ module Bundler
       return unless SharedHelpers.md5_available?
 
       latest = Fetcher::CompactIndex.
-               new(nil, Source::Rubygems::Remote.new(URI("https://rubygems.org")), nil).
+               new(nil, Source::Rubygems::Remote.new(Bundler::URI("https://rubygems.org")), nil).
                send(:compact_index_client).
                instance_variable_get(:@cache).
                dependencies("bundler").

--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -97,7 +97,7 @@ module Bundler
       spec -= [nil, "ruby", ""]
       spec_file_name = "#{spec.join "-"}.gemspec"
 
-      uri = URI.parse("#{remote_uri}#{Gem::MARSHAL_SPEC_DIR}#{spec_file_name}.rz")
+      uri = Bundler::URI.parse("#{remote_uri}#{Gem::MARSHAL_SPEC_DIR}#{spec_file_name}.rz")
       if uri.scheme == "file"
         path = Bundler.rubygems.correct_for_windows_path(uri.path)
         Bundler.load_marshal Bundler.rubygems.inflate(Gem.read_binary(path))
@@ -244,7 +244,7 @@ module Bundler
 
         con = PersistentHTTP.new :name => "bundler", :proxy => :ENV
         if gem_proxy = Bundler.rubygems.configuration[:http_proxy]
-          con.proxy = URI.parse(gem_proxy) if gem_proxy != :no_proxy
+          con.proxy = Bundler::URI.parse(gem_proxy) if gem_proxy != :no_proxy
         end
 
         if remote_uri.scheme == "https"

--- a/lib/bundler/fetcher/downloader.rb
+++ b/lib/bundler/fetcher/downloader.rb
@@ -21,7 +21,7 @@ module Bundler
         when Net::HTTPSuccess, Net::HTTPNotModified
           response
         when Net::HTTPRedirection
-          new_uri = URI.parse(response["location"])
+          new_uri = Bundler::URI.parse(response["location"])
           if new_uri.host == uri.host
             new_uri.user = uri.user
             new_uri.password = uri.password

--- a/lib/bundler/fetcher/index.rb
+++ b/lib/bundler/fetcher/index.rb
@@ -28,7 +28,7 @@ module Bundler
         spec -= [nil, "ruby", ""]
         spec_file_name = "#{spec.join "-"}.gemspec"
 
-        uri = URI.parse("#{remote_uri}#{Gem::MARSHAL_SPEC_DIR}#{spec_file_name}.rz")
+        uri = Bundler::URI.parse("#{remote_uri}#{Gem::MARSHAL_SPEC_DIR}#{spec_file_name}.rz")
         if uri.scheme == "file"
           path = Bundler.rubygems.correct_for_windows_path(uri.path)
           Bundler.load_marshal Bundler.rubygems.inflate(Gem.read_binary(path))

--- a/lib/bundler/lazy_specification.rb
+++ b/lib/bundler/lazy_specification.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "uri"
 require_relative "match_platform"
 
 module Bundler

--- a/lib/bundler/mirror.rb
+++ b/lib/bundler/mirror.rb
@@ -47,7 +47,7 @@ module Bundler
 
       def fetch_valid_mirror_for(uri)
         downcased = uri.to_s.downcase
-        mirror = @mirrors[downcased] || @mirrors[URI(downcased).host] || Mirror.new(uri)
+        mirror = @mirrors[downcased] || @mirrors[Bundler::URI(downcased).host] || Mirror.new(uri)
         mirror.validate!(@prober)
         mirror = Mirror.new(uri) unless mirror.valid?
         mirror
@@ -74,7 +74,7 @@ module Bundler
         @uri = if uri.nil?
           nil
         else
-          URI(uri.to_s)
+          Bundler::URI(uri.to_s)
         end
         @valid = nil
       end
@@ -126,7 +126,7 @@ module Bundler
         if uri == "all"
           @all = true
         else
-          @uri = URI(uri).absolute? ? Settings.normalize_uri(uri) : uri
+          @uri = Bundler::URI(uri).absolute? ? Settings.normalize_uri(uri) : uri
         end
         @value = value
       end

--- a/lib/bundler/plugin/api/source.rb
+++ b/lib/bundler/plugin/api/source.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "uri"
-
 module Bundler
   module Plugin
     class API

--- a/lib/bundler/plugin/api/source.rb
+++ b/lib/bundler/plugin/api/source.rb
@@ -106,7 +106,7 @@ module Bundler
         def install_path
           @install_path ||=
             begin
-              base_name = File.basename(URI.parse(uri).normalize.path)
+              base_name = File.basename(Bundler::URI.parse(uri).normalize.path)
 
               gem_install_dir.join("#{base_name}-#{uri_hash[0..11]}")
             end
@@ -168,7 +168,7 @@ module Bundler
         #
         # This is used by `app_cache_path`
         def app_cache_dirname
-          base_name = File.basename(URI.parse(uri).normalize.path)
+          base_name = File.basename(Bundler::URI.parse(uri).normalize.path)
           "#{base_name}-#{uri_hash}"
         end
 

--- a/lib/bundler/remote_specification.rb
+++ b/lib/bundler/remote_specification.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "uri"
-
 module Bundler
   # Represents a lazily loaded gem specification, where the full specification
   # is on the source server in rubygems' "quick" index. The proxy object is to

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -151,8 +151,8 @@ module Bundler
 
     def mirror_for(uri)
       if uri.is_a?(String)
-        require "uri"
-        uri = URI(uri)
+        require_relative "vendored_uri"
+        uri = Bundler::URI(uri)
       end
 
       gem_mirrors.for(uri.to_s).uri
@@ -423,8 +423,8 @@ module Bundler
         suffix = $3
       end
       uri = "#{uri}/" unless uri.end_with?("/")
-      require "uri"
-      uri = URI(uri)
+      require_relative "vendored_uri"
+      uri = Bundler::URI(uri)
       unless uri.absolute?
         raise ArgumentError, format("Gem sources must be absolute. You provided '%s'.", uri)
       end

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -150,8 +150,11 @@ module Bundler
     end
 
     def mirror_for(uri)
-      require "uri"
-      uri = URI(uri) unless uri.is_a?(URI)
+      if uri.is_a?(String)
+        require "uri"
+        uri = URI(uri)
+      end
+
       gem_mirrors.for(uri.to_s).uri
     end
 

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "uri"
-
 module Bundler
   class Settings
     autoload :Mirror,  File.expand_path("mirror", __dir__)
@@ -152,6 +150,7 @@ module Bundler
     end
 
     def mirror_for(uri)
+      require "uri"
       uri = URI(uri.to_s) unless uri.is_a?(URI)
       gem_mirrors.for(uri.to_s).uri
     end
@@ -421,6 +420,7 @@ module Bundler
         suffix = $3
       end
       uri = "#{uri}/" unless uri.end_with?("/")
+      require "uri"
       uri = URI(uri)
       unless uri.absolute?
         raise ArgumentError, format("Gem sources must be absolute. You provided '%s'.", uri)

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -151,7 +151,7 @@ module Bundler
 
     def mirror_for(uri)
       require "uri"
-      uri = URI(uri.to_s) unless uri.is_a?(URI)
+      uri = URI(uri) unless uri.is_a?(URI)
       gem_mirrors.for(uri.to_s).uri
     end
 

--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -284,7 +284,7 @@ module Bundler
         if uri =~ %r{^\w+://(\w+@)?}
           # Downcase the domain component of the URI
           # and strip off a trailing slash, if one is present
-          input = URI.parse(uri).normalize.to_s.sub(%r{/$}, "")
+          input = Bundler::URI.parse(uri).normalize.to_s.sub(%r{/$}, "")
         else
           # If there is no URI scheme, assume it is an ssh/git URI
           input = uri

--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -282,7 +282,6 @@ module Bundler
 
       def uri_hash
         if uri =~ %r{^\w+://(\w+@)?}
-          require "uri"
           # Downcase the domain component of the URI
           # and strip off a trailing slash, if one is present
           input = URI.parse(uri).normalize.to_s.sub(%r{/$}, "")

--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative "../vendored_fileutils"
-require "uri"
 
 module Bundler
   class Source
@@ -283,6 +282,7 @@ module Bundler
 
       def uri_hash
         if uri =~ %r{^\w+://(\w+@)?}
+          require "uri"
           # Downcase the domain component of the URI
           # and strip off a trailing slash, if one is present
           input = URI.parse(uri).normalize.to_s.sub(%r{/$}, "")

--- a/lib/bundler/source/git/git_proxy.rb
+++ b/lib/bundler/source/git/git_proxy.rb
@@ -217,7 +217,7 @@ module Bundler
         # Adds credentials to the URI as Fetcher#configured_uri_for does
         def configured_uri_for(uri)
           if /https?:/ =~ uri
-            remote = URI(uri)
+            remote = Bundler::URI(uri)
             config_auth = Bundler.settings[remote.to_s] || Bundler.settings[remote.host]
             remote.userinfo ||= config_auth
             remote.to_s

--- a/lib/bundler/source/rubygems.rb
+++ b/lib/bundler/source/rubygems.rb
@@ -327,10 +327,10 @@ module Bundler
       def normalize_uri(uri)
         uri = uri.to_s
         uri = "#{uri}/" unless uri =~ %r{/$}
-        require "uri"
-        uri = URI(uri)
+        require_relative "../vendored_uri"
+        uri = Bundler::URI(uri)
         raise ArgumentError, "The source must be an absolute URI. For example:\n" \
-          "source 'https://rubygems.org'" if !uri.absolute? || (uri.is_a?(URI::HTTP) && uri.host.nil?)
+          "source 'https://rubygems.org'" if !uri.absolute? || (uri.is_a?(Bundler::URI::HTTP) && uri.host.nil?)
         uri
       end
 

--- a/lib/bundler/source/rubygems.rb
+++ b/lib/bundler/source/rubygems.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "uri"
 require "rubygems/user_interaction"
 
 module Bundler
@@ -328,6 +327,7 @@ module Bundler
       def normalize_uri(uri)
         uri = uri.to_s
         uri = "#{uri}/" unless uri =~ %r{/$}
+        require "uri"
         uri = URI(uri)
         raise ArgumentError, "The source must be an absolute URI. For example:\n" \
           "source 'https://rubygems.org'" if !uri.absolute? || (uri.is_a?(URI::HTTP) && uri.host.nil?)

--- a/lib/bundler/source/rubygems/remote.rb
+++ b/lib/bundler/source/rubygems/remote.rb
@@ -48,7 +48,7 @@ module Bundler
           end
 
           uri
-        rescue URI::InvalidComponentError
+        rescue Bundler::URI::InvalidComponentError
           error_message = "Please CGI escape your usernames and passwords before " \
                           "setting them for authentication."
           raise HTTPError.new(error_message)

--- a/lib/bundler/uri_credentials_filter.rb
+++ b/lib/bundler/uri_credentials_filter.rb
@@ -7,8 +7,11 @@ module Bundler
     def credential_filtered_uri(uri_to_anonymize)
       return uri_to_anonymize if uri_to_anonymize.nil?
       uri = uri_to_anonymize.dup
-      require "uri"
-      uri = URI(uri) unless uri.is_a?(URI)
+      if uri.is_a?(String)
+        require "uri"
+        uri = URI(uri)
+      end
+
       if uri.userinfo
         # oauth authentication
         if uri.password == "x-oauth-basic" || uri.password == "x"
@@ -18,8 +21,8 @@ module Bundler
         end
         uri.password = nil
       end
-      return uri if uri_to_anonymize.is_a?(URI)
       return uri.to_s if uri_to_anonymize.is_a?(String)
+      uri
     rescue URI::InvalidURIError # uri is not canonical uri scheme
       uri
     end

--- a/lib/bundler/uri_credentials_filter.rb
+++ b/lib/bundler/uri_credentials_filter.rb
@@ -8,7 +8,7 @@ module Bundler
       return uri_to_anonymize if uri_to_anonymize.nil?
       uri = uri_to_anonymize.dup
       require "uri"
-      uri = URI(uri.to_s) unless uri.is_a?(URI)
+      uri = URI(uri) unless uri.is_a?(URI)
       if uri.userinfo
         # oauth authentication
         if uri.password == "x-oauth-basic" || uri.password == "x"

--- a/lib/bundler/uri_credentials_filter.rb
+++ b/lib/bundler/uri_credentials_filter.rb
@@ -8,8 +8,8 @@ module Bundler
       return uri_to_anonymize if uri_to_anonymize.nil?
       uri = uri_to_anonymize.dup
       if uri.is_a?(String)
-        require "uri"
-        uri = URI(uri)
+        require_relative "vendored_uri"
+        uri = Bundler::URI(uri)
       end
 
       if uri.userinfo
@@ -23,7 +23,7 @@ module Bundler
       end
       return uri.to_s if uri_to_anonymize.is_a?(String)
       uri
-    rescue URI::InvalidURIError # uri is not canonical uri scheme
+    rescue Bundler::URI::InvalidURIError # uri is not canonical uri scheme
       uri
     end
 

--- a/lib/bundler/uri_credentials_filter.rb
+++ b/lib/bundler/uri_credentials_filter.rb
@@ -7,6 +7,7 @@ module Bundler
     def credential_filtered_uri(uri_to_anonymize)
       return uri_to_anonymize if uri_to_anonymize.nil?
       uri = uri_to_anonymize.dup
+      require "uri"
       uri = URI(uri.to_s) unless uri.is_a?(URI)
       if uri.userinfo
         # oauth authentication

--- a/lib/bundler/vendor/net-http-persistent/lib/net/http/persistent.rb
+++ b/lib/bundler/vendor/net-http-persistent/lib/net/http/persistent.rb
@@ -1,5 +1,5 @@
 require 'net/http'
-require 'uri'
+require_relative '../../../../uri/lib/uri'
 require 'cgi' # for escaping
 require_relative '../../../../connection_pool/lib/connection_pool'
 
@@ -31,7 +31,7 @@ autoload :OpenSSL, 'openssl'
 #
 #   require 'bundler/vendor/net-http-persistent/lib/net/http/persistent'
 #
-#   uri = URI 'http://example.com/awesome/web/service'
+#   uri = Bundler::URI 'http://example.com/awesome/web/service'
 #
 #   http = Bundler::Persistent::Net::HTTP::Persistent.new name: 'my_app_name'
 #
@@ -48,17 +48,17 @@ autoload :OpenSSL, 'openssl'
 #   post = Net::HTTP::Post.new post_uri.path
 #   post.set_form_data 'some' => 'cool data'
 #
-#   # perform the POST, the URI is always required
+#   # perform the POST, the Bundler::URI is always required
 #   response http.request post_uri, post
 #
 # Note that for GET, HEAD and other requests that do not have a body you want
-# to use URI#request_uri not URI#path.  The request_uri contains the query
+# to use Bundler::URI#request_uri not Bundler::URI#path.  The request_uri contains the query
 # params which are sent in the body for other requests.
 #
 # == SSL
 #
 # SSL connections are automatically created depending upon the scheme of the
-# URI.  SSL connections are automatically verified against the default
+# Bundler::URI.  SSL connections are automatically verified against the default
 # certificate store for your computer.  You can override this by changing
 # verify_mode or by specifying an alternate cert_store.
 #
@@ -81,7 +81,7 @@ autoload :OpenSSL, 'openssl'
 # == Proxies
 #
 # A proxy can be set through #proxy= or at initialization time by providing a
-# second argument to ::new.  The proxy may be the URI of the proxy server or
+# second argument to ::new.  The proxy may be the Bundler::URI of the proxy server or
 # <code>:ENV</code> which will consult environment variables.
 #
 # See #proxy= and #proxy_from_env for details.
@@ -150,7 +150,7 @@ autoload :OpenSSL, 'openssl'
 #
 #   require 'bundler/vendor/net-http-persistent/lib/net/http/persistent'
 #
-#   uri = URI 'http://example.com/awesome/web/service'
+#   uri = Bundler::URI 'http://example.com/awesome/web/service'
 #   post_uri = uri + 'create'
 #
 #   http = Bundler::Persistent::Net::HTTP::Persistent.new name: 'my_app_name'
@@ -249,7 +249,7 @@ class Bundler::Persistent::Net::HTTP::Persistent
   # NOTE:  This may not work on ruby > 1.9.
 
   def self.detect_idle_timeout uri, max = 10
-    uri = URI uri unless URI::Generic === uri
+    uri = Bundler::URI uri unless Bundler::URI::Generic === uri
     uri += '/'
 
     req = Net::HTTP::Head.new uri.request_uri
@@ -513,13 +513,13 @@ class Bundler::Persistent::Net::HTTP::Persistent
   # required currently, but highly recommended.  Your library name should be
   # good enough.  This parameter will be required in a future version.
   #
-  # +proxy+ may be set to a URI::HTTP or :ENV to pick up proxy options from
+  # +proxy+ may be set to a Bundler::URI::HTTP or :ENV to pick up proxy options from
   # the environment.  See proxy_from_env for details.
   #
-  # In order to use a URI for the proxy you may need to do some extra work
-  # beyond URI parsing if the proxy requires a password:
+  # In order to use a Bundler::URI for the proxy you may need to do some extra work
+  # beyond Bundler::URI parsing if the proxy requires a password:
   #
-  #   proxy = URI 'http://proxy.example'
+  #   proxy = Bundler::URI 'http://proxy.example'
   #   proxy.user     = 'AzureDiamond'
   #   proxy.password = 'hunter2'
   #
@@ -566,7 +566,7 @@ class Bundler::Persistent::Net::HTTP::Persistent
     @verify_mode        = nil
     @cert_store         = nil
 
-    @generation         = 0 # incremented when proxy URI changes
+    @generation         = 0 # incremented when proxy Bundler::URI changes
 
     if HAVE_OPENSSL then
       @verify_mode        = OpenSSL::SSL::VERIFY_PEER
@@ -688,14 +688,14 @@ class Bundler::Persistent::Net::HTTP::Persistent
   end
 
   ##
-  # URI::escape wrapper
+  # Bundler::URI::escape wrapper
 
   def escape str
     CGI.escape str if str
   end
 
   ##
-  # URI::unescape wrapper
+  # Bundler::URI::unescape wrapper
 
   def unescape str
     CGI.unescape str if str
@@ -803,12 +803,12 @@ class Bundler::Persistent::Net::HTTP::Persistent
   alias key= private_key=
 
   ##
-  # Sets the proxy server.  The +proxy+ may be the URI of the proxy server,
+  # Sets the proxy server.  The +proxy+ may be the Bundler::URI of the proxy server,
   # the symbol +:ENV+ which will read the proxy from the environment or nil to
   # disable use of a proxy.  See #proxy_from_env for details on setting the
   # proxy from the environment.
   #
-  # If the proxy URI is set after requests have been made, the next request
+  # If the proxy Bundler::URI is set after requests have been made, the next request
   # will shut-down and re-open all connections.
   #
   # The +no_proxy+ query parameter can be used to specify hosts which shouldn't
@@ -819,9 +819,9 @@ class Bundler::Persistent::Net::HTTP::Persistent
   def proxy= proxy
     @proxy_uri = case proxy
                  when :ENV      then proxy_from_env
-                 when URI::HTTP then proxy
+                 when Bundler::URI::HTTP then proxy
                  when nil       then # ignore
-                 else raise ArgumentError, 'proxy must be :ENV or a URI::HTTP'
+                 else raise ArgumentError, 'proxy must be :ENV or a Bundler::URI::HTTP'
                  end
 
     @no_proxy.clear
@@ -846,13 +846,13 @@ class Bundler::Persistent::Net::HTTP::Persistent
   end
 
   ##
-  # Creates a URI for an HTTP proxy server from ENV variables.
+  # Creates a Bundler::URI for an HTTP proxy server from ENV variables.
   #
   # If +HTTP_PROXY+ is set a proxy will be returned.
   #
-  # If +HTTP_PROXY_USER+ or +HTTP_PROXY_PASS+ are set the URI is given the
+  # If +HTTP_PROXY_USER+ or +HTTP_PROXY_PASS+ are set the Bundler::URI is given the
   # indicated user and password unless HTTP_PROXY contains either of these in
-  # the URI.
+  # the Bundler::URI.
   #
   # The +NO_PROXY+ ENV variable can be used to specify hosts which shouldn't
   # be reached via proxy; if set it should be a comma separated list of
@@ -868,7 +868,7 @@ class Bundler::Persistent::Net::HTTP::Persistent
 
     return nil if env_proxy.nil? or env_proxy.empty?
 
-    uri = URI normalize_uri env_proxy
+    uri = Bundler::URI normalize_uri env_proxy
 
     env_no_proxy = ENV['no_proxy'] || ENV['NO_PROXY']
 
@@ -951,7 +951,7 @@ class Bundler::Persistent::Net::HTTP::Persistent
     retried      = false
     bad_response = false
 
-    uri      = URI uri
+    uri      = Bundler::URI uri
     req      = request_setup req || uri
     response = nil
 
@@ -1024,13 +1024,13 @@ class Bundler::Persistent::Net::HTTP::Persistent
   end
 
   ##
-  # Creates a GET request if +req_or_uri+ is a URI and adds headers to the
+  # Creates a GET request if +req_or_uri+ is a Bundler::URI and adds headers to the
   # request.
   #
   # Returns the request.
 
   def request_setup req_or_uri # :nodoc:
-    req = if URI === req_or_uri then
+    req = if Bundler::URI === req_or_uri then
             Net::HTTP::Get.new req_or_uri.request_uri
           else
             req_or_uri

--- a/lib/bundler/vendor/uri/lib/uri.rb
+++ b/lib/bundler/vendor/uri/lib/uri.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: false
+# Bundler::URI is a module providing classes to handle Uniform Resource Identifiers
+# (RFC2396[http://tools.ietf.org/html/rfc2396]).
+#
+# == Features
+#
+# * Uniform way of handling URIs.
+# * Flexibility to introduce custom Bundler::URI schemes.
+# * Flexibility to have an alternate Bundler::URI::Parser (or just different patterns
+#   and regexp's).
+#
+# == Basic example
+#
+#   require 'bundler/vendor/uri/lib/uri'
+#
+#   uri = Bundler::URI("http://foo.com/posts?id=30&limit=5#time=1305298413")
+#   #=> #<Bundler::URI::HTTP http://foo.com/posts?id=30&limit=5#time=1305298413>
+#
+#   uri.scheme    #=> "http"
+#   uri.host      #=> "foo.com"
+#   uri.path      #=> "/posts"
+#   uri.query     #=> "id=30&limit=5"
+#   uri.fragment  #=> "time=1305298413"
+#
+#   uri.to_s      #=> "http://foo.com/posts?id=30&limit=5#time=1305298413"
+#
+# == Adding custom URIs
+#
+#   module Bundler::URI
+#     class RSYNC < Generic
+#       DEFAULT_PORT = 873
+#     end
+#     @@schemes['RSYNC'] = RSYNC
+#   end
+#   #=> Bundler::URI::RSYNC
+#
+#   Bundler::URI.scheme_list
+#   #=> {"FILE"=>Bundler::URI::File, "FTP"=>Bundler::URI::FTP, "HTTP"=>Bundler::URI::HTTP,
+#   #    "HTTPS"=>Bundler::URI::HTTPS, "LDAP"=>Bundler::URI::LDAP, "LDAPS"=>Bundler::URI::LDAPS,
+#   #    "MAILTO"=>Bundler::URI::MailTo, "RSYNC"=>Bundler::URI::RSYNC}
+#
+#   uri = Bundler::URI("rsync://rsync.foo.com")
+#   #=> #<Bundler::URI::RSYNC rsync://rsync.foo.com>
+#
+# == RFC References
+#
+# A good place to view an RFC spec is http://www.ietf.org/rfc.html.
+#
+# Here is a list of all related RFC's:
+# - RFC822[http://tools.ietf.org/html/rfc822]
+# - RFC1738[http://tools.ietf.org/html/rfc1738]
+# - RFC2255[http://tools.ietf.org/html/rfc2255]
+# - RFC2368[http://tools.ietf.org/html/rfc2368]
+# - RFC2373[http://tools.ietf.org/html/rfc2373]
+# - RFC2396[http://tools.ietf.org/html/rfc2396]
+# - RFC2732[http://tools.ietf.org/html/rfc2732]
+# - RFC3986[http://tools.ietf.org/html/rfc3986]
+#
+# == Class tree
+#
+# - Bundler::URI::Generic (in uri/generic.rb)
+#   - Bundler::URI::File - (in uri/file.rb)
+#   - Bundler::URI::FTP - (in uri/ftp.rb)
+#   - Bundler::URI::HTTP - (in uri/http.rb)
+#     - Bundler::URI::HTTPS - (in uri/https.rb)
+#   - Bundler::URI::LDAP - (in uri/ldap.rb)
+#     - Bundler::URI::LDAPS - (in uri/ldaps.rb)
+#   - Bundler::URI::MailTo - (in uri/mailto.rb)
+# - Bundler::URI::Parser - (in uri/common.rb)
+# - Bundler::URI::REGEXP - (in uri/common.rb)
+#   - Bundler::URI::REGEXP::PATTERN - (in uri/common.rb)
+# - Bundler::URI::Util - (in uri/common.rb)
+# - Bundler::URI::Escape - (in uri/common.rb)
+# - Bundler::URI::Error - (in uri/common.rb)
+#   - Bundler::URI::InvalidURIError - (in uri/common.rb)
+#   - Bundler::URI::InvalidComponentError - (in uri/common.rb)
+#   - Bundler::URI::BadURIError - (in uri/common.rb)
+#
+# == Copyright Info
+#
+# Author:: Akira Yamada <akira@ruby-lang.org>
+# Documentation::
+#   Akira Yamada <akira@ruby-lang.org>
+#   Dmitry V. Sabanin <sdmitry@lrn.ru>
+#   Vincent Batts <vbatts@hashbangbash.com>
+# License::
+#  Copyright (c) 2001 akira yamada <akira@ruby-lang.org>
+#  You can redistribute it and/or modify it under the same term as Ruby.
+# Revision:: $Id$
+#
+
+module Bundler::URI
+end
+
+require_relative 'uri/version'
+require_relative 'uri/common'
+require_relative 'uri/generic'
+require_relative 'uri/file'
+require_relative 'uri/ftp'
+require_relative 'uri/http'
+require_relative 'uri/https'
+require_relative 'uri/ldap'
+require_relative 'uri/ldaps'
+require_relative 'uri/mailto'

--- a/lib/bundler/vendor/uri/lib/uri/common.rb
+++ b/lib/bundler/vendor/uri/lib/uri/common.rb
@@ -1,0 +1,744 @@
+# frozen_string_literal: true
+#--
+# = uri/common.rb
+#
+# Author:: Akira Yamada <akira@ruby-lang.org>
+# Revision:: $Id$
+# License::
+#   You can redistribute it and/or modify it under the same term as Ruby.
+#
+# See Bundler::URI for general documentation
+#
+
+require_relative "rfc2396_parser"
+require_relative "rfc3986_parser"
+
+module Bundler::URI
+  REGEXP = RFC2396_REGEXP
+  Parser = RFC2396_Parser
+  RFC3986_PARSER = RFC3986_Parser.new
+
+  # Bundler::URI::Parser.new
+  DEFAULT_PARSER = Parser.new
+  DEFAULT_PARSER.pattern.each_pair do |sym, str|
+    unless REGEXP::PATTERN.const_defined?(sym)
+      REGEXP::PATTERN.const_set(sym, str)
+    end
+  end
+  DEFAULT_PARSER.regexp.each_pair do |sym, str|
+    const_set(sym, str)
+  end
+
+  module Util # :nodoc:
+    def make_components_hash(klass, array_hash)
+      tmp = {}
+      if array_hash.kind_of?(Array) &&
+          array_hash.size == klass.component.size - 1
+        klass.component[1..-1].each_index do |i|
+          begin
+            tmp[klass.component[i + 1]] = array_hash[i].clone
+          rescue TypeError
+            tmp[klass.component[i + 1]] = array_hash[i]
+          end
+        end
+
+      elsif array_hash.kind_of?(Hash)
+        array_hash.each do |key, value|
+          begin
+            tmp[key] = value.clone
+          rescue TypeError
+            tmp[key] = value
+          end
+        end
+      else
+        raise ArgumentError,
+          "expected Array of or Hash of components of #{klass} (#{klass.component[1..-1].join(', ')})"
+      end
+      tmp[:scheme] = klass.to_s.sub(/\A.*::/, '').downcase
+
+      return tmp
+    end
+    module_function :make_components_hash
+  end
+
+  # Module for escaping unsafe characters with codes.
+  module Escape
+    #
+    # == Synopsis
+    #
+    #   Bundler::URI.escape(str [, unsafe])
+    #
+    # == Args
+    #
+    # +str+::
+    #   String to replaces in.
+    # +unsafe+::
+    #   Regexp that matches all symbols that must be replaced with codes.
+    #   By default uses <tt>UNSAFE</tt>.
+    #   When this argument is a String, it represents a character set.
+    #
+    # == Description
+    #
+    # Escapes the string, replacing all unsafe characters with codes.
+    #
+    # This method is obsolete and should not be used. Instead, use
+    # CGI.escape, Bundler::URI.encode_www_form or Bundler::URI.encode_www_form_component
+    # depending on your specific use case.
+    #
+    # == Usage
+    #
+    #   require 'bundler/vendor/uri/lib/uri'
+    #
+    #   enc_uri = Bundler::URI.escape("http://example.com/?a=\11\15")
+    #   # => "http://example.com/?a=%09%0D"
+    #
+    #   Bundler::URI.unescape(enc_uri)
+    #   # => "http://example.com/?a=\t\r"
+    #
+    #   Bundler::URI.escape("@?@!", "!?")
+    #   # => "@%3F@%21"
+    #
+    def escape(*arg)
+      warn "Bundler::URI.escape is obsolete", uplevel: 1
+      DEFAULT_PARSER.escape(*arg)
+    end
+    alias encode escape
+    #
+    # == Synopsis
+    #
+    #   Bundler::URI.unescape(str)
+    #
+    # == Args
+    #
+    # +str+::
+    #   String to unescape.
+    #
+    # == Description
+    #
+    # This method is obsolete and should not be used. Instead, use
+    # CGI.unescape, Bundler::URI.decode_www_form or Bundler::URI.decode_www_form_component
+    # depending on your specific use case.
+    #
+    # == Usage
+    #
+    #   require 'bundler/vendor/uri/lib/uri'
+    #
+    #   enc_uri = Bundler::URI.escape("http://example.com/?a=\11\15")
+    #   # => "http://example.com/?a=%09%0D"
+    #
+    #   Bundler::URI.unescape(enc_uri)
+    #   # => "http://example.com/?a=\t\r"
+    #
+    def unescape(*arg)
+      warn "Bundler::URI.unescape is obsolete", uplevel: 1
+      DEFAULT_PARSER.unescape(*arg)
+    end
+    alias decode unescape
+  end # module Escape
+
+  extend Escape
+  include REGEXP
+
+  @@schemes = {}
+  # Returns a Hash of the defined schemes.
+  def self.scheme_list
+    @@schemes
+  end
+
+  #
+  # Base class for all Bundler::URI exceptions.
+  #
+  class Error < StandardError; end
+  #
+  # Not a Bundler::URI.
+  #
+  class InvalidURIError < Error; end
+  #
+  # Not a Bundler::URI component.
+  #
+  class InvalidComponentError < Error; end
+  #
+  # Bundler::URI is valid, bad usage is not.
+  #
+  class BadURIError < Error; end
+
+  #
+  # == Synopsis
+  #
+  #   Bundler::URI::split(uri)
+  #
+  # == Args
+  #
+  # +uri+::
+  #   String with Bundler::URI.
+  #
+  # == Description
+  #
+  # Splits the string on following parts and returns array with result:
+  #
+  # * Scheme
+  # * Userinfo
+  # * Host
+  # * Port
+  # * Registry
+  # * Path
+  # * Opaque
+  # * Query
+  # * Fragment
+  #
+  # == Usage
+  #
+  #   require 'bundler/vendor/uri/lib/uri'
+  #
+  #   Bundler::URI.split("http://www.ruby-lang.org/")
+  #   # => ["http", nil, "www.ruby-lang.org", nil, nil, "/", nil, nil, nil]
+  #
+  def self.split(uri)
+    RFC3986_PARSER.split(uri)
+  end
+
+  #
+  # == Synopsis
+  #
+  #   Bundler::URI::parse(uri_str)
+  #
+  # == Args
+  #
+  # +uri_str+::
+  #   String with Bundler::URI.
+  #
+  # == Description
+  #
+  # Creates one of the Bundler::URI's subclasses instance from the string.
+  #
+  # == Raises
+  #
+  # Bundler::URI::InvalidURIError::
+  #   Raised if Bundler::URI given is not a correct one.
+  #
+  # == Usage
+  #
+  #   require 'bundler/vendor/uri/lib/uri'
+  #
+  #   uri = Bundler::URI.parse("http://www.ruby-lang.org/")
+  #   # => #<Bundler::URI::HTTP http://www.ruby-lang.org/>
+  #   uri.scheme
+  #   # => "http"
+  #   uri.host
+  #   # => "www.ruby-lang.org"
+  #
+  # It's recommended to first ::escape the provided +uri_str+ if there are any
+  # invalid Bundler::URI characters.
+  #
+  def self.parse(uri)
+    RFC3986_PARSER.parse(uri)
+  end
+
+  #
+  # == Synopsis
+  #
+  #   Bundler::URI::join(str[, str, ...])
+  #
+  # == Args
+  #
+  # +str+::
+  #   String(s) to work with, will be converted to RFC3986 URIs before merging.
+  #
+  # == Description
+  #
+  # Joins URIs.
+  #
+  # == Usage
+  #
+  #   require 'bundler/vendor/uri/lib/uri'
+  #
+  #   Bundler::URI.join("http://example.com/","main.rbx")
+  #   # => #<Bundler::URI::HTTP http://example.com/main.rbx>
+  #
+  #   Bundler::URI.join('http://example.com', 'foo')
+  #   # => #<Bundler::URI::HTTP http://example.com/foo>
+  #
+  #   Bundler::URI.join('http://example.com', '/foo', '/bar')
+  #   # => #<Bundler::URI::HTTP http://example.com/bar>
+  #
+  #   Bundler::URI.join('http://example.com', '/foo', 'bar')
+  #   # => #<Bundler::URI::HTTP http://example.com/bar>
+  #
+  #   Bundler::URI.join('http://example.com', '/foo/', 'bar')
+  #   # => #<Bundler::URI::HTTP http://example.com/foo/bar>
+  #
+  def self.join(*str)
+    RFC3986_PARSER.join(*str)
+  end
+
+  #
+  # == Synopsis
+  #
+  #   Bundler::URI::extract(str[, schemes][,&blk])
+  #
+  # == Args
+  #
+  # +str+::
+  #   String to extract URIs from.
+  # +schemes+::
+  #   Limit Bundler::URI matching to specific schemes.
+  #
+  # == Description
+  #
+  # Extracts URIs from a string. If block given, iterates through all matched URIs.
+  # Returns nil if block given or array with matches.
+  #
+  # == Usage
+  #
+  #   require "bundler/vendor/uri/lib/uri"
+  #
+  #   Bundler::URI.extract("text here http://foo.example.org/bla and here mailto:test@example.com and here also.")
+  #   # => ["http://foo.example.com/bla", "mailto:test@example.com"]
+  #
+  def self.extract(str, schemes = nil, &block)
+    warn "Bundler::URI.extract is obsolete", uplevel: 1 if $VERBOSE
+    DEFAULT_PARSER.extract(str, schemes, &block)
+  end
+
+  #
+  # == Synopsis
+  #
+  #   Bundler::URI::regexp([match_schemes])
+  #
+  # == Args
+  #
+  # +match_schemes+::
+  #   Array of schemes. If given, resulting regexp matches to URIs
+  #   whose scheme is one of the match_schemes.
+  #
+  # == Description
+  #
+  # Returns a Regexp object which matches to Bundler::URI-like strings.
+  # The Regexp object returned by this method includes arbitrary
+  # number of capture group (parentheses).  Never rely on it's number.
+  #
+  # == Usage
+  #
+  #   require 'bundler/vendor/uri/lib/uri'
+  #
+  #   # extract first Bundler::URI from html_string
+  #   html_string.slice(Bundler::URI.regexp)
+  #
+  #   # remove ftp URIs
+  #   html_string.sub(Bundler::URI.regexp(['ftp']), '')
+  #
+  #   # You should not rely on the number of parentheses
+  #   html_string.scan(Bundler::URI.regexp) do |*matches|
+  #     p $&
+  #   end
+  #
+  def self.regexp(schemes = nil)
+    warn "Bundler::URI.regexp is obsolete", uplevel: 1 if $VERBOSE
+    DEFAULT_PARSER.make_regexp(schemes)
+  end
+
+  TBLENCWWWCOMP_ = {} # :nodoc:
+  256.times do |i|
+    TBLENCWWWCOMP_[-i.chr] = -('%%%02X' % i)
+  end
+  TBLENCWWWCOMP_[' '] = '+'
+  TBLENCWWWCOMP_.freeze
+  TBLDECWWWCOMP_ = {} # :nodoc:
+  256.times do |i|
+    h, l = i>>4, i&15
+    TBLDECWWWCOMP_[-('%%%X%X' % [h, l])] = -i.chr
+    TBLDECWWWCOMP_[-('%%%x%X' % [h, l])] = -i.chr
+    TBLDECWWWCOMP_[-('%%%X%x' % [h, l])] = -i.chr
+    TBLDECWWWCOMP_[-('%%%x%x' % [h, l])] = -i.chr
+  end
+  TBLDECWWWCOMP_['+'] = ' '
+  TBLDECWWWCOMP_.freeze
+
+  # Encodes given +str+ to URL-encoded form data.
+  #
+  # This method doesn't convert *, -, ., 0-9, A-Z, _, a-z, but does convert SP
+  # (ASCII space) to + and converts others to %XX.
+  #
+  # If +enc+ is given, convert +str+ to the encoding before percent encoding.
+  #
+  # This is an implementation of
+  # http://www.w3.org/TR/2013/CR-html5-20130806/forms.html#url-encoded-form-data.
+  #
+  # See Bundler::URI.decode_www_form_component, Bundler::URI.encode_www_form.
+  def self.encode_www_form_component(str, enc=nil)
+    str = str.to_s.dup
+    if str.encoding != Encoding::ASCII_8BIT
+      if enc && enc != Encoding::ASCII_8BIT
+        str.encode!(Encoding::UTF_8, invalid: :replace, undef: :replace)
+        str.encode!(enc, fallback: ->(x){"&##{x.ord};"})
+      end
+      str.force_encoding(Encoding::ASCII_8BIT)
+    end
+    str.gsub!(/[^*\-.0-9A-Z_a-z]/, TBLENCWWWCOMP_)
+    str.force_encoding(Encoding::US_ASCII)
+  end
+
+  # Decodes given +str+ of URL-encoded form data.
+  #
+  # This decodes + to SP.
+  #
+  # See Bundler::URI.encode_www_form_component, Bundler::URI.decode_www_form.
+  def self.decode_www_form_component(str, enc=Encoding::UTF_8)
+    raise ArgumentError, "invalid %-encoding (#{str})" if /%(?!\h\h)/ =~ str
+    str.b.gsub(/\+|%\h\h/, TBLDECWWWCOMP_).force_encoding(enc)
+  end
+
+  # Generates URL-encoded form data from given +enum+.
+  #
+  # This generates application/x-www-form-urlencoded data defined in HTML5
+  # from given an Enumerable object.
+  #
+  # This internally uses Bundler::URI.encode_www_form_component(str).
+  #
+  # This method doesn't convert the encoding of given items, so convert them
+  # before calling this method if you want to send data as other than original
+  # encoding or mixed encoding data. (Strings which are encoded in an HTML5
+  # ASCII incompatible encoding are converted to UTF-8.)
+  #
+  # This method doesn't handle files.  When you send a file, use
+  # multipart/form-data.
+  #
+  # This refers http://url.spec.whatwg.org/#concept-urlencoded-serializer
+  #
+  #    Bundler::URI.encode_www_form([["q", "ruby"], ["lang", "en"]])
+  #    #=> "q=ruby&lang=en"
+  #    Bundler::URI.encode_www_form("q" => "ruby", "lang" => "en")
+  #    #=> "q=ruby&lang=en"
+  #    Bundler::URI.encode_www_form("q" => ["ruby", "perl"], "lang" => "en")
+  #    #=> "q=ruby&q=perl&lang=en"
+  #    Bundler::URI.encode_www_form([["q", "ruby"], ["q", "perl"], ["lang", "en"]])
+  #    #=> "q=ruby&q=perl&lang=en"
+  #
+  # See Bundler::URI.encode_www_form_component, Bundler::URI.decode_www_form.
+  def self.encode_www_form(enum, enc=nil)
+    enum.map do |k,v|
+      if v.nil?
+        encode_www_form_component(k, enc)
+      elsif v.respond_to?(:to_ary)
+        v.to_ary.map do |w|
+          str = encode_www_form_component(k, enc)
+          unless w.nil?
+            str << '='
+            str << encode_www_form_component(w, enc)
+          end
+        end.join('&')
+      else
+        str = encode_www_form_component(k, enc)
+        str << '='
+        str << encode_www_form_component(v, enc)
+      end
+    end.join('&')
+  end
+
+  # Decodes URL-encoded form data from given +str+.
+  #
+  # This decodes application/x-www-form-urlencoded data
+  # and returns an array of key-value arrays.
+  #
+  # This refers http://url.spec.whatwg.org/#concept-urlencoded-parser,
+  # so this supports only &-separator, and doesn't support ;-separator.
+  #
+  #    ary = Bundler::URI.decode_www_form("a=1&a=2&b=3")
+  #    ary                   #=> [['a', '1'], ['a', '2'], ['b', '3']]
+  #    ary.assoc('a').last   #=> '1'
+  #    ary.assoc('b').last   #=> '3'
+  #    ary.rassoc('a').last  #=> '2'
+  #    Hash[ary]             #=> {"a"=>"2", "b"=>"3"}
+  #
+  # See Bundler::URI.decode_www_form_component, Bundler::URI.encode_www_form.
+  def self.decode_www_form(str, enc=Encoding::UTF_8, separator: '&', use__charset_: false, isindex: false)
+    raise ArgumentError, "the input of #{self.name}.#{__method__} must be ASCII only string" unless str.ascii_only?
+    ary = []
+    return ary if str.empty?
+    enc = Encoding.find(enc)
+    str.b.each_line(separator) do |string|
+      string.chomp!(separator)
+      key, sep, val = string.partition('=')
+      if isindex
+        if sep.empty?
+          val = key
+          key = +''
+        end
+        isindex = false
+      end
+
+      if use__charset_ and key == '_charset_' and e = get_encoding(val)
+        enc = e
+        use__charset_ = false
+      end
+
+      key.gsub!(/\+|%\h\h/, TBLDECWWWCOMP_)
+      if val
+        val.gsub!(/\+|%\h\h/, TBLDECWWWCOMP_)
+      else
+        val = +''
+      end
+
+      ary << [key, val]
+    end
+    ary.each do |k, v|
+      k.force_encoding(enc)
+      k.scrub!
+      v.force_encoding(enc)
+      v.scrub!
+    end
+    ary
+  end
+
+  private
+=begin command for WEB_ENCODINGS_
+  curl https://encoding.spec.whatwg.org/encodings.json|
+  ruby -rjson -e 'H={}
+  h={
+    "shift_jis"=>"Windows-31J",
+    "euc-jp"=>"cp51932",
+    "iso-2022-jp"=>"cp50221",
+    "x-mac-cyrillic"=>"macCyrillic",
+  }
+  JSON($<.read).map{|x|x["encodings"]}.flatten.each{|x|
+    Encoding.find(n=h.fetch(n=x["name"].downcase,n))rescue next
+    x["labels"].each{|y|H[y]=n}
+  }
+  puts "{"
+  H.each{|k,v|puts %[  #{k.dump}=>#{v.dump},]}
+  puts "}"
+'
+=end
+  WEB_ENCODINGS_ = {
+    "unicode-1-1-utf-8"=>"utf-8",
+    "utf-8"=>"utf-8",
+    "utf8"=>"utf-8",
+    "866"=>"ibm866",
+    "cp866"=>"ibm866",
+    "csibm866"=>"ibm866",
+    "ibm866"=>"ibm866",
+    "csisolatin2"=>"iso-8859-2",
+    "iso-8859-2"=>"iso-8859-2",
+    "iso-ir-101"=>"iso-8859-2",
+    "iso8859-2"=>"iso-8859-2",
+    "iso88592"=>"iso-8859-2",
+    "iso_8859-2"=>"iso-8859-2",
+    "iso_8859-2:1987"=>"iso-8859-2",
+    "l2"=>"iso-8859-2",
+    "latin2"=>"iso-8859-2",
+    "csisolatin3"=>"iso-8859-3",
+    "iso-8859-3"=>"iso-8859-3",
+    "iso-ir-109"=>"iso-8859-3",
+    "iso8859-3"=>"iso-8859-3",
+    "iso88593"=>"iso-8859-3",
+    "iso_8859-3"=>"iso-8859-3",
+    "iso_8859-3:1988"=>"iso-8859-3",
+    "l3"=>"iso-8859-3",
+    "latin3"=>"iso-8859-3",
+    "csisolatin4"=>"iso-8859-4",
+    "iso-8859-4"=>"iso-8859-4",
+    "iso-ir-110"=>"iso-8859-4",
+    "iso8859-4"=>"iso-8859-4",
+    "iso88594"=>"iso-8859-4",
+    "iso_8859-4"=>"iso-8859-4",
+    "iso_8859-4:1988"=>"iso-8859-4",
+    "l4"=>"iso-8859-4",
+    "latin4"=>"iso-8859-4",
+    "csisolatincyrillic"=>"iso-8859-5",
+    "cyrillic"=>"iso-8859-5",
+    "iso-8859-5"=>"iso-8859-5",
+    "iso-ir-144"=>"iso-8859-5",
+    "iso8859-5"=>"iso-8859-5",
+    "iso88595"=>"iso-8859-5",
+    "iso_8859-5"=>"iso-8859-5",
+    "iso_8859-5:1988"=>"iso-8859-5",
+    "arabic"=>"iso-8859-6",
+    "asmo-708"=>"iso-8859-6",
+    "csiso88596e"=>"iso-8859-6",
+    "csiso88596i"=>"iso-8859-6",
+    "csisolatinarabic"=>"iso-8859-6",
+    "ecma-114"=>"iso-8859-6",
+    "iso-8859-6"=>"iso-8859-6",
+    "iso-8859-6-e"=>"iso-8859-6",
+    "iso-8859-6-i"=>"iso-8859-6",
+    "iso-ir-127"=>"iso-8859-6",
+    "iso8859-6"=>"iso-8859-6",
+    "iso88596"=>"iso-8859-6",
+    "iso_8859-6"=>"iso-8859-6",
+    "iso_8859-6:1987"=>"iso-8859-6",
+    "csisolatingreek"=>"iso-8859-7",
+    "ecma-118"=>"iso-8859-7",
+    "elot_928"=>"iso-8859-7",
+    "greek"=>"iso-8859-7",
+    "greek8"=>"iso-8859-7",
+    "iso-8859-7"=>"iso-8859-7",
+    "iso-ir-126"=>"iso-8859-7",
+    "iso8859-7"=>"iso-8859-7",
+    "iso88597"=>"iso-8859-7",
+    "iso_8859-7"=>"iso-8859-7",
+    "iso_8859-7:1987"=>"iso-8859-7",
+    "sun_eu_greek"=>"iso-8859-7",
+    "csiso88598e"=>"iso-8859-8",
+    "csisolatinhebrew"=>"iso-8859-8",
+    "hebrew"=>"iso-8859-8",
+    "iso-8859-8"=>"iso-8859-8",
+    "iso-8859-8-e"=>"iso-8859-8",
+    "iso-ir-138"=>"iso-8859-8",
+    "iso8859-8"=>"iso-8859-8",
+    "iso88598"=>"iso-8859-8",
+    "iso_8859-8"=>"iso-8859-8",
+    "iso_8859-8:1988"=>"iso-8859-8",
+    "visual"=>"iso-8859-8",
+    "csisolatin6"=>"iso-8859-10",
+    "iso-8859-10"=>"iso-8859-10",
+    "iso-ir-157"=>"iso-8859-10",
+    "iso8859-10"=>"iso-8859-10",
+    "iso885910"=>"iso-8859-10",
+    "l6"=>"iso-8859-10",
+    "latin6"=>"iso-8859-10",
+    "iso-8859-13"=>"iso-8859-13",
+    "iso8859-13"=>"iso-8859-13",
+    "iso885913"=>"iso-8859-13",
+    "iso-8859-14"=>"iso-8859-14",
+    "iso8859-14"=>"iso-8859-14",
+    "iso885914"=>"iso-8859-14",
+    "csisolatin9"=>"iso-8859-15",
+    "iso-8859-15"=>"iso-8859-15",
+    "iso8859-15"=>"iso-8859-15",
+    "iso885915"=>"iso-8859-15",
+    "iso_8859-15"=>"iso-8859-15",
+    "l9"=>"iso-8859-15",
+    "iso-8859-16"=>"iso-8859-16",
+    "cskoi8r"=>"koi8-r",
+    "koi"=>"koi8-r",
+    "koi8"=>"koi8-r",
+    "koi8-r"=>"koi8-r",
+    "koi8_r"=>"koi8-r",
+    "koi8-ru"=>"koi8-u",
+    "koi8-u"=>"koi8-u",
+    "dos-874"=>"windows-874",
+    "iso-8859-11"=>"windows-874",
+    "iso8859-11"=>"windows-874",
+    "iso885911"=>"windows-874",
+    "tis-620"=>"windows-874",
+    "windows-874"=>"windows-874",
+    "cp1250"=>"windows-1250",
+    "windows-1250"=>"windows-1250",
+    "x-cp1250"=>"windows-1250",
+    "cp1251"=>"windows-1251",
+    "windows-1251"=>"windows-1251",
+    "x-cp1251"=>"windows-1251",
+    "ansi_x3.4-1968"=>"windows-1252",
+    "ascii"=>"windows-1252",
+    "cp1252"=>"windows-1252",
+    "cp819"=>"windows-1252",
+    "csisolatin1"=>"windows-1252",
+    "ibm819"=>"windows-1252",
+    "iso-8859-1"=>"windows-1252",
+    "iso-ir-100"=>"windows-1252",
+    "iso8859-1"=>"windows-1252",
+    "iso88591"=>"windows-1252",
+    "iso_8859-1"=>"windows-1252",
+    "iso_8859-1:1987"=>"windows-1252",
+    "l1"=>"windows-1252",
+    "latin1"=>"windows-1252",
+    "us-ascii"=>"windows-1252",
+    "windows-1252"=>"windows-1252",
+    "x-cp1252"=>"windows-1252",
+    "cp1253"=>"windows-1253",
+    "windows-1253"=>"windows-1253",
+    "x-cp1253"=>"windows-1253",
+    "cp1254"=>"windows-1254",
+    "csisolatin5"=>"windows-1254",
+    "iso-8859-9"=>"windows-1254",
+    "iso-ir-148"=>"windows-1254",
+    "iso8859-9"=>"windows-1254",
+    "iso88599"=>"windows-1254",
+    "iso_8859-9"=>"windows-1254",
+    "iso_8859-9:1989"=>"windows-1254",
+    "l5"=>"windows-1254",
+    "latin5"=>"windows-1254",
+    "windows-1254"=>"windows-1254",
+    "x-cp1254"=>"windows-1254",
+    "cp1255"=>"windows-1255",
+    "windows-1255"=>"windows-1255",
+    "x-cp1255"=>"windows-1255",
+    "cp1256"=>"windows-1256",
+    "windows-1256"=>"windows-1256",
+    "x-cp1256"=>"windows-1256",
+    "cp1257"=>"windows-1257",
+    "windows-1257"=>"windows-1257",
+    "x-cp1257"=>"windows-1257",
+    "cp1258"=>"windows-1258",
+    "windows-1258"=>"windows-1258",
+    "x-cp1258"=>"windows-1258",
+    "x-mac-cyrillic"=>"macCyrillic",
+    "x-mac-ukrainian"=>"macCyrillic",
+    "chinese"=>"gbk",
+    "csgb2312"=>"gbk",
+    "csiso58gb231280"=>"gbk",
+    "gb2312"=>"gbk",
+    "gb_2312"=>"gbk",
+    "gb_2312-80"=>"gbk",
+    "gbk"=>"gbk",
+    "iso-ir-58"=>"gbk",
+    "x-gbk"=>"gbk",
+    "gb18030"=>"gb18030",
+    "big5"=>"big5",
+    "big5-hkscs"=>"big5",
+    "cn-big5"=>"big5",
+    "csbig5"=>"big5",
+    "x-x-big5"=>"big5",
+    "cseucpkdfmtjapanese"=>"cp51932",
+    "euc-jp"=>"cp51932",
+    "x-euc-jp"=>"cp51932",
+    "csiso2022jp"=>"cp50221",
+    "iso-2022-jp"=>"cp50221",
+    "csshiftjis"=>"Windows-31J",
+    "ms932"=>"Windows-31J",
+    "ms_kanji"=>"Windows-31J",
+    "shift-jis"=>"Windows-31J",
+    "shift_jis"=>"Windows-31J",
+    "sjis"=>"Windows-31J",
+    "windows-31j"=>"Windows-31J",
+    "x-sjis"=>"Windows-31J",
+    "cseuckr"=>"euc-kr",
+    "csksc56011987"=>"euc-kr",
+    "euc-kr"=>"euc-kr",
+    "iso-ir-149"=>"euc-kr",
+    "korean"=>"euc-kr",
+    "ks_c_5601-1987"=>"euc-kr",
+    "ks_c_5601-1989"=>"euc-kr",
+    "ksc5601"=>"euc-kr",
+    "ksc_5601"=>"euc-kr",
+    "windows-949"=>"euc-kr",
+    "utf-16be"=>"utf-16be",
+    "utf-16"=>"utf-16le",
+    "utf-16le"=>"utf-16le",
+  } # :nodoc:
+
+  # :nodoc:
+  # return encoding or nil
+  # http://encoding.spec.whatwg.org/#concept-encoding-get
+  def self.get_encoding(label)
+    Encoding.find(WEB_ENCODINGS_[label.to_str.strip.downcase]) rescue nil
+  end
+end # module Bundler::URI
+
+module Bundler
+
+  #
+  # Returns +uri+ converted to an Bundler::URI object.
+  #
+  def URI(uri)
+    if uri.is_a?(Bundler::URI::Generic)
+      uri
+    elsif uri = String.try_convert(uri)
+      Bundler::URI.parse(uri)
+    else
+      raise ArgumentError,
+        "bad argument (expected Bundler::URI object or Bundler::URI string)"
+    end
+  end
+  module_function :URI
+end

--- a/lib/bundler/vendor/uri/lib/uri/file.rb
+++ b/lib/bundler/vendor/uri/lib/uri/file.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require_relative 'generic'
+
+module Bundler::URI
+
+  #
+  # The "file" Bundler::URI is defined by RFC8089.
+  #
+  class File < Generic
+    # A Default port of nil for Bundler::URI::File.
+    DEFAULT_PORT = nil
+
+    #
+    # An Array of the available components for Bundler::URI::File.
+    #
+    COMPONENT = [
+      :scheme,
+      :host,
+      :path
+    ].freeze
+
+    #
+    # == Description
+    #
+    # Creates a new Bundler::URI::File object from components, with syntax checking.
+    #
+    # The components accepted are +host+ and +path+.
+    #
+    # The components should be provided either as an Array, or as a Hash
+    # with keys formed by preceding the component names with a colon.
+    #
+    # If an Array is used, the components must be passed in the
+    # order <code>[host, path]</code>.
+    #
+    # Examples:
+    #
+    #     require 'bundler/vendor/uri/lib/uri'
+    #
+    #     uri1 = Bundler::URI::File.build(['host.example.com', '/path/file.zip'])
+    #     uri1.to_s  # => "file://host.example.com/path/file.zip"
+    #
+    #     uri2 = Bundler::URI::File.build({:host => 'host.example.com',
+    #       :path => '/ruby/src'})
+    #     uri2.to_s  # => "file://host.example.com/ruby/src"
+    #
+    def self.build(args)
+      tmp = Util::make_components_hash(self, args)
+      super(tmp)
+    end
+
+    # Protected setter for the host component +v+.
+    #
+    # See also Bundler::URI::Generic.host=.
+    #
+    def set_host(v)
+      v = "" if v.nil? || v == "localhost"
+      @host = v
+    end
+
+    # do nothing
+    def set_port(v)
+    end
+
+    # raise InvalidURIError
+    def check_userinfo(user)
+      raise Bundler::URI::InvalidURIError, "can not set userinfo for file Bundler::URI"
+    end
+
+    # raise InvalidURIError
+    def check_user(user)
+      raise Bundler::URI::InvalidURIError, "can not set user for file Bundler::URI"
+    end
+
+    # raise InvalidURIError
+    def check_password(user)
+      raise Bundler::URI::InvalidURIError, "can not set password for file Bundler::URI"
+    end
+
+    # do nothing
+    def set_userinfo(v)
+    end
+
+    # do nothing
+    def set_user(v)
+    end
+
+    # do nothing
+    def set_password(v)
+    end
+  end
+
+  @@schemes['FILE'] = File
+end

--- a/lib/bundler/vendor/uri/lib/uri/ftp.rb
+++ b/lib/bundler/vendor/uri/lib/uri/ftp.rb
@@ -1,0 +1,267 @@
+# frozen_string_literal: false
+# = uri/ftp.rb
+#
+# Author:: Akira Yamada <akira@ruby-lang.org>
+# License:: You can redistribute it and/or modify it under the same term as Ruby.
+# Revision:: $Id$
+#
+# See Bundler::URI for general documentation
+#
+
+require_relative 'generic'
+
+module Bundler::URI
+
+  #
+  # FTP Bundler::URI syntax is defined by RFC1738 section 3.2.
+  #
+  # This class will be redesigned because of difference of implementations;
+  # the structure of its path. draft-hoffman-ftp-uri-04 is a draft but it
+  # is a good summary about the de facto spec.
+  # http://tools.ietf.org/html/draft-hoffman-ftp-uri-04
+  #
+  class FTP < Generic
+    # A Default port of 21 for Bundler::URI::FTP.
+    DEFAULT_PORT = 21
+
+    #
+    # An Array of the available components for Bundler::URI::FTP.
+    #
+    COMPONENT = [
+      :scheme,
+      :userinfo, :host, :port,
+      :path, :typecode
+    ].freeze
+
+    #
+    # Typecode is "a", "i", or "d".
+    #
+    # * "a" indicates a text file (the FTP command was ASCII)
+    # * "i" indicates a binary file (FTP command IMAGE)
+    # * "d" indicates the contents of a directory should be displayed
+    #
+    TYPECODE = ['a', 'i', 'd'].freeze
+
+    # Typecode prefix ";type=".
+    TYPECODE_PREFIX = ';type='.freeze
+
+    def self.new2(user, password, host, port, path,
+                  typecode = nil, arg_check = true) # :nodoc:
+      # Do not use this method!  Not tested.  [Bug #7301]
+      # This methods remains just for compatibility,
+      # Keep it undocumented until the active maintainer is assigned.
+      typecode = nil if typecode.size == 0
+      if typecode && !TYPECODE.include?(typecode)
+        raise ArgumentError,
+          "bad typecode is specified: #{typecode}"
+      end
+
+      # do escape
+
+      self.new('ftp',
+               [user, password],
+               host, port, nil,
+               typecode ? path + TYPECODE_PREFIX + typecode : path,
+               nil, nil, nil, arg_check)
+    end
+
+    #
+    # == Description
+    #
+    # Creates a new Bundler::URI::FTP object from components, with syntax checking.
+    #
+    # The components accepted are +userinfo+, +host+, +port+, +path+, and
+    # +typecode+.
+    #
+    # The components should be provided either as an Array, or as a Hash
+    # with keys formed by preceding the component names with a colon.
+    #
+    # If an Array is used, the components must be passed in the
+    # order <code>[userinfo, host, port, path, typecode]</code>.
+    #
+    # If the path supplied is absolute, it will be escaped in order to
+    # make it absolute in the Bundler::URI.
+    #
+    # Examples:
+    #
+    #     require 'bundler/vendor/uri/lib/uri'
+    #
+    #     uri1 = Bundler::URI::FTP.build(['user:password', 'ftp.example.com', nil,
+    #       '/path/file.zip', 'i'])
+    #     uri1.to_s  # => "ftp://user:password@ftp.example.com/%2Fpath/file.zip;type=i"
+    #
+    #     uri2 = Bundler::URI::FTP.build({:host => 'ftp.example.com',
+    #       :path => 'ruby/src'})
+    #     uri2.to_s  # => "ftp://ftp.example.com/ruby/src"
+    #
+    def self.build(args)
+
+      # Fix the incoming path to be generic URL syntax
+      # FTP path  ->  URL path
+      # foo/bar       /foo/bar
+      # /foo/bar      /%2Ffoo/bar
+      #
+      if args.kind_of?(Array)
+        args[3] = '/' + args[3].sub(/^\//, '%2F')
+      else
+        args[:path] = '/' + args[:path].sub(/^\//, '%2F')
+      end
+
+      tmp = Util::make_components_hash(self, args)
+
+      if tmp[:typecode]
+        if tmp[:typecode].size == 1
+          tmp[:typecode] = TYPECODE_PREFIX + tmp[:typecode]
+        end
+        tmp[:path] << tmp[:typecode]
+      end
+
+      return super(tmp)
+    end
+
+    #
+    # == Description
+    #
+    # Creates a new Bundler::URI::FTP object from generic URL components with no
+    # syntax checking.
+    #
+    # Unlike build(), this method does not escape the path component as
+    # required by RFC1738; instead it is treated as per RFC2396.
+    #
+    # Arguments are +scheme+, +userinfo+, +host+, +port+, +registry+, +path+,
+    # +opaque+, +query+, and +fragment+, in that order.
+    #
+    def initialize(scheme,
+                   userinfo, host, port, registry,
+                   path, opaque,
+                   query,
+                   fragment,
+                   parser = nil,
+                   arg_check = false)
+      raise InvalidURIError unless path
+      path = path.sub(/^\//,'')
+      path.sub!(/^%2F/,'/')
+      super(scheme, userinfo, host, port, registry, path, opaque,
+            query, fragment, parser, arg_check)
+      @typecode = nil
+      if tmp = @path.index(TYPECODE_PREFIX)
+        typecode = @path[tmp + TYPECODE_PREFIX.size..-1]
+        @path = @path[0..tmp - 1]
+
+        if arg_check
+          self.typecode = typecode
+        else
+          self.set_typecode(typecode)
+        end
+      end
+    end
+
+    # typecode accessor.
+    #
+    # See Bundler::URI::FTP::COMPONENT.
+    attr_reader :typecode
+
+    # Validates typecode +v+,
+    # returns +true+ or +false+.
+    #
+    def check_typecode(v)
+      if TYPECODE.include?(v)
+        return true
+      else
+        raise InvalidComponentError,
+          "bad typecode(expected #{TYPECODE.join(', ')}): #{v}"
+      end
+    end
+    private :check_typecode
+
+    # Private setter for the typecode +v+.
+    #
+    # See also Bundler::URI::FTP.typecode=.
+    #
+    def set_typecode(v)
+      @typecode = v
+    end
+    protected :set_typecode
+
+    #
+    # == Args
+    #
+    # +v+::
+    #    String
+    #
+    # == Description
+    #
+    # Public setter for the typecode +v+
+    # (with validation).
+    #
+    # See also Bundler::URI::FTP.check_typecode.
+    #
+    # == Usage
+    #
+    #   require 'bundler/vendor/uri/lib/uri'
+    #
+    #   uri = Bundler::URI.parse("ftp://john@ftp.example.com/my_file.img")
+    #   #=> #<Bundler::URI::FTP ftp://john@ftp.example.com/my_file.img>
+    #   uri.typecode = "i"
+    #   uri
+    #   #=> #<Bundler::URI::FTP ftp://john@ftp.example.com/my_file.img;type=i>
+    #
+    def typecode=(typecode)
+      check_typecode(typecode)
+      set_typecode(typecode)
+      typecode
+    end
+
+    def merge(oth) # :nodoc:
+      tmp = super(oth)
+      if self != tmp
+        tmp.set_typecode(oth.typecode)
+      end
+
+      return tmp
+    end
+
+    # Returns the path from an FTP Bundler::URI.
+    #
+    # RFC 1738 specifically states that the path for an FTP Bundler::URI does not
+    # include the / which separates the Bundler::URI path from the Bundler::URI host. Example:
+    #
+    # <code>ftp://ftp.example.com/pub/ruby</code>
+    #
+    # The above Bundler::URI indicates that the client should connect to
+    # ftp.example.com then cd to pub/ruby from the initial login directory.
+    #
+    # If you want to cd to an absolute directory, you must include an
+    # escaped / (%2F) in the path. Example:
+    #
+    # <code>ftp://ftp.example.com/%2Fpub/ruby</code>
+    #
+    # This method will then return "/pub/ruby".
+    #
+    def path
+      return @path.sub(/^\//,'').sub(/^%2F/,'/')
+    end
+
+    # Private setter for the path of the Bundler::URI::FTP.
+    def set_path(v)
+      super("/" + v.sub(/^\//, "%2F"))
+    end
+    protected :set_path
+
+    # Returns a String representation of the Bundler::URI::FTP.
+    def to_s
+      save_path = nil
+      if @typecode
+        save_path = @path
+        @path = @path + TYPECODE_PREFIX + @typecode
+      end
+      str = super
+      if @typecode
+        @path = save_path
+      end
+
+      return str
+    end
+  end
+  @@schemes['FTP'] = FTP
+end

--- a/lib/bundler/vendor/uri/lib/uri/generic.rb
+++ b/lib/bundler/vendor/uri/lib/uri/generic.rb
@@ -1,0 +1,1568 @@
+# frozen_string_literal: true
+
+# = uri/generic.rb
+#
+# Author:: Akira Yamada <akira@ruby-lang.org>
+# License:: You can redistribute it and/or modify it under the same term as Ruby.
+# Revision:: $Id$
+#
+# See Bundler::URI for general documentation
+#
+
+require_relative 'common'
+autoload :IPSocket, 'socket'
+autoload :IPAddr, 'ipaddr'
+
+module Bundler::URI
+
+  #
+  # Base class for all Bundler::URI classes.
+  # Implements generic Bundler::URI syntax as per RFC 2396.
+  #
+  class Generic
+    include Bundler::URI
+
+    #
+    # A Default port of nil for Bundler::URI::Generic.
+    #
+    DEFAULT_PORT = nil
+
+    #
+    # Returns default port.
+    #
+    def self.default_port
+      self::DEFAULT_PORT
+    end
+
+    #
+    # Returns default port.
+    #
+    def default_port
+      self.class.default_port
+    end
+
+    #
+    # An Array of the available components for Bundler::URI::Generic.
+    #
+    COMPONENT = [
+      :scheme,
+      :userinfo, :host, :port, :registry,
+      :path, :opaque,
+      :query,
+      :fragment
+    ].freeze
+
+    #
+    # Components of the Bundler::URI in the order.
+    #
+    def self.component
+      self::COMPONENT
+    end
+
+    USE_REGISTRY = false # :nodoc:
+
+    def self.use_registry # :nodoc:
+      self::USE_REGISTRY
+    end
+
+    #
+    # == Synopsis
+    #
+    # See ::new.
+    #
+    # == Description
+    #
+    # At first, tries to create a new Bundler::URI::Generic instance using
+    # Bundler::URI::Generic::build. But, if exception Bundler::URI::InvalidComponentError is raised,
+    # then it does Bundler::URI::Escape.escape all Bundler::URI components and tries again.
+    #
+    def self.build2(args)
+      begin
+        return self.build(args)
+      rescue InvalidComponentError
+        if args.kind_of?(Array)
+          return self.build(args.collect{|x|
+            if x.is_a?(String)
+              DEFAULT_PARSER.escape(x)
+            else
+              x
+            end
+          })
+        elsif args.kind_of?(Hash)
+          tmp = {}
+          args.each do |key, value|
+            tmp[key] = if value
+                DEFAULT_PARSER.escape(value)
+              else
+                value
+              end
+          end
+          return self.build(tmp)
+        end
+      end
+    end
+
+    #
+    # == Synopsis
+    #
+    # See ::new.
+    #
+    # == Description
+    #
+    # Creates a new Bundler::URI::Generic instance from components of Bundler::URI::Generic
+    # with check.  Components are: scheme, userinfo, host, port, registry, path,
+    # opaque, query, and fragment. You can provide arguments either by an Array or a Hash.
+    # See ::new for hash keys to use or for order of array items.
+    #
+    def self.build(args)
+      if args.kind_of?(Array) &&
+          args.size == ::Bundler::URI::Generic::COMPONENT.size
+        tmp = args.dup
+      elsif args.kind_of?(Hash)
+        tmp = ::Bundler::URI::Generic::COMPONENT.collect do |c|
+          if args.include?(c)
+            args[c]
+          else
+            nil
+          end
+        end
+      else
+        component = self.class.component rescue ::Bundler::URI::Generic::COMPONENT
+        raise ArgumentError,
+        "expected Array of or Hash of components of #{self.class} (#{component.join(', ')})"
+      end
+
+      tmp << nil
+      tmp << true
+      return self.new(*tmp)
+    end
+
+    #
+    # == Args
+    #
+    # +scheme+::
+    #   Protocol scheme, i.e. 'http','ftp','mailto' and so on.
+    # +userinfo+::
+    #   User name and password, i.e. 'sdmitry:bla'.
+    # +host+::
+    #   Server host name.
+    # +port+::
+    #   Server port.
+    # +registry+::
+    #   Registry of naming authorities.
+    # +path+::
+    #   Path on server.
+    # +opaque+::
+    #   Opaque part.
+    # +query+::
+    #   Query data.
+    # +fragment+::
+    #   Part of the Bundler::URI after '#' character.
+    # +parser+::
+    #   Parser for internal use [Bundler::URI::DEFAULT_PARSER by default].
+    # +arg_check+::
+    #   Check arguments [false by default].
+    #
+    # == Description
+    #
+    # Creates a new Bundler::URI::Generic instance from ``generic'' components without check.
+    #
+    def initialize(scheme,
+                   userinfo, host, port, registry,
+                   path, opaque,
+                   query,
+                   fragment,
+                   parser = DEFAULT_PARSER,
+                   arg_check = false)
+      @scheme = nil
+      @user = nil
+      @password = nil
+      @host = nil
+      @port = nil
+      @path = nil
+      @query = nil
+      @opaque = nil
+      @fragment = nil
+      @parser = parser == DEFAULT_PARSER ? nil : parser
+
+      if arg_check
+        self.scheme = scheme
+        self.userinfo = userinfo
+        self.hostname = host
+        self.port = port
+        self.path = path
+        self.query = query
+        self.opaque = opaque
+        self.fragment = fragment
+      else
+        self.set_scheme(scheme)
+        self.set_userinfo(userinfo)
+        self.set_host(host)
+        self.set_port(port)
+        self.set_path(path)
+        self.query = query
+        self.set_opaque(opaque)
+        self.fragment=(fragment)
+      end
+      if registry
+        raise InvalidURIError,
+          "the scheme #{@scheme} does not accept registry part: #{registry} (or bad hostname?)"
+      end
+
+      @scheme&.freeze
+      self.set_path('') if !@path && !@opaque # (see RFC2396 Section 5.2)
+      self.set_port(self.default_port) if self.default_port && !@port
+    end
+
+    #
+    # Returns the scheme component of the Bundler::URI.
+    #
+    #   Bundler::URI("http://foo/bar/baz").scheme #=> "http"
+    #
+    attr_reader :scheme
+
+    # Returns the host component of the Bundler::URI.
+    #
+    #   Bundler::URI("http://foo/bar/baz").host #=> "foo"
+    #
+    # It returns nil if no host component exists.
+    #
+    #   Bundler::URI("mailto:foo@example.org").host #=> nil
+    #
+    # The component does not contain the port number.
+    #
+    #   Bundler::URI("http://foo:8080/bar/baz").host #=> "foo"
+    #
+    # Since IPv6 addresses are wrapped with brackets in URIs,
+    # this method returns IPv6 addresses wrapped with brackets.
+    # This form is not appropriate to pass to socket methods such as TCPSocket.open.
+    # If unwrapped host names are required, use the #hostname method.
+    #
+    #   Bundler::URI("http://[::1]/bar/baz").host     #=> "[::1]"
+    #   Bundler::URI("http://[::1]/bar/baz").hostname #=> "::1"
+    #
+    attr_reader :host
+
+    # Returns the port component of the Bundler::URI.
+    #
+    #   Bundler::URI("http://foo/bar/baz").port      #=> 80
+    #   Bundler::URI("http://foo:8080/bar/baz").port #=> 8080
+    #
+    attr_reader :port
+
+    def registry # :nodoc:
+      nil
+    end
+
+    # Returns the path component of the Bundler::URI.
+    #
+    #   Bundler::URI("http://foo/bar/baz").path #=> "/bar/baz"
+    #
+    attr_reader :path
+
+    # Returns the query component of the Bundler::URI.
+    #
+    #   Bundler::URI("http://foo/bar/baz?search=FooBar").query #=> "search=FooBar"
+    #
+    attr_reader :query
+
+    # Returns the opaque part of the Bundler::URI.
+    #
+    #   Bundler::URI("mailto:foo@example.org").opaque #=> "foo@example.org"
+    #   Bundler::URI("http://foo/bar/baz").opaque     #=> nil
+    #
+    # The portion of the path that does not make use of the slash '/'.
+    # The path typically refers to an absolute path or an opaque part.
+    # (See RFC2396 Section 3 and 5.2.)
+    #
+    attr_reader :opaque
+
+    # Returns the fragment component of the Bundler::URI.
+    #
+    #   Bundler::URI("http://foo/bar/baz?search=FooBar#ponies").fragment #=> "ponies"
+    #
+    attr_reader :fragment
+
+    # Returns the parser to be used.
+    #
+    # Unless a Bundler::URI::Parser is defined, DEFAULT_PARSER is used.
+    #
+    def parser
+      if !defined?(@parser) || !@parser
+        DEFAULT_PARSER
+      else
+        @parser || DEFAULT_PARSER
+      end
+    end
+
+    # Replaces self by other Bundler::URI object.
+    #
+    def replace!(oth)
+      if self.class != oth.class
+        raise ArgumentError, "expected #{self.class} object"
+      end
+
+      component.each do |c|
+        self.__send__("#{c}=", oth.__send__(c))
+      end
+    end
+    private :replace!
+
+    #
+    # Components of the Bundler::URI in the order.
+    #
+    def component
+      self.class.component
+    end
+
+    #
+    # Checks the scheme +v+ component against the Bundler::URI::Parser Regexp for :SCHEME.
+    #
+    def check_scheme(v)
+      if v && parser.regexp[:SCHEME] !~ v
+        raise InvalidComponentError,
+          "bad component(expected scheme component): #{v}"
+      end
+
+      return true
+    end
+    private :check_scheme
+
+    # Protected setter for the scheme component +v+.
+    #
+    # See also Bundler::URI::Generic.scheme=.
+    #
+    def set_scheme(v)
+      @scheme = v&.downcase
+    end
+    protected :set_scheme
+
+    #
+    # == Args
+    #
+    # +v+::
+    #    String
+    #
+    # == Description
+    #
+    # Public setter for the scheme component +v+
+    # (with validation).
+    #
+    # See also Bundler::URI::Generic.check_scheme.
+    #
+    # == Usage
+    #
+    #   require 'bundler/vendor/uri/lib/uri'
+    #
+    #   uri = Bundler::URI.parse("http://my.example.com")
+    #   uri.scheme = "https"
+    #   uri.to_s  #=> "https://my.example.com"
+    #
+    def scheme=(v)
+      check_scheme(v)
+      set_scheme(v)
+      v
+    end
+
+    #
+    # Checks the +user+ and +password+.
+    #
+    # If +password+ is not provided, then +user+ is
+    # split, using Bundler::URI::Generic.split_userinfo, to
+    # pull +user+ and +password.
+    #
+    # See also Bundler::URI::Generic.check_user, Bundler::URI::Generic.check_password.
+    #
+    def check_userinfo(user, password = nil)
+      if !password
+        user, password = split_userinfo(user)
+      end
+      check_user(user)
+      check_password(password, user)
+
+      return true
+    end
+    private :check_userinfo
+
+    #
+    # Checks the user +v+ component for RFC2396 compliance
+    # and against the Bundler::URI::Parser Regexp for :USERINFO.
+    #
+    # Can not have a registry or opaque component defined,
+    # with a user component defined.
+    #
+    def check_user(v)
+      if @opaque
+        raise InvalidURIError,
+          "can not set user with opaque"
+      end
+
+      return v unless v
+
+      if parser.regexp[:USERINFO] !~ v
+        raise InvalidComponentError,
+          "bad component(expected userinfo component or user component): #{v}"
+      end
+
+      return true
+    end
+    private :check_user
+
+    #
+    # Checks the password +v+ component for RFC2396 compliance
+    # and against the Bundler::URI::Parser Regexp for :USERINFO.
+    #
+    # Can not have a registry or opaque component defined,
+    # with a user component defined.
+    #
+    def check_password(v, user = @user)
+      if @opaque
+        raise InvalidURIError,
+          "can not set password with opaque"
+      end
+      return v unless v
+
+      if !user
+        raise InvalidURIError,
+          "password component depends user component"
+      end
+
+      if parser.regexp[:USERINFO] !~ v
+        raise InvalidComponentError,
+          "bad password component"
+      end
+
+      return true
+    end
+    private :check_password
+
+    #
+    # Sets userinfo, argument is string like 'name:pass'.
+    #
+    def userinfo=(userinfo)
+      if userinfo.nil?
+        return nil
+      end
+      check_userinfo(*userinfo)
+      set_userinfo(*userinfo)
+      # returns userinfo
+    end
+
+    #
+    # == Args
+    #
+    # +v+::
+    #    String
+    #
+    # == Description
+    #
+    # Public setter for the +user+ component
+    # (with validation).
+    #
+    # See also Bundler::URI::Generic.check_user.
+    #
+    # == Usage
+    #
+    #   require 'bundler/vendor/uri/lib/uri'
+    #
+    #   uri = Bundler::URI.parse("http://john:S3nsit1ve@my.example.com")
+    #   uri.user = "sam"
+    #   uri.to_s  #=> "http://sam:V3ry_S3nsit1ve@my.example.com"
+    #
+    def user=(user)
+      check_user(user)
+      set_user(user)
+      # returns user
+    end
+
+    #
+    # == Args
+    #
+    # +v+::
+    #    String
+    #
+    # == Description
+    #
+    # Public setter for the +password+ component
+    # (with validation).
+    #
+    # See also Bundler::URI::Generic.check_password.
+    #
+    # == Usage
+    #
+    #   require 'bundler/vendor/uri/lib/uri'
+    #
+    #   uri = Bundler::URI.parse("http://john:S3nsit1ve@my.example.com")
+    #   uri.password = "V3ry_S3nsit1ve"
+    #   uri.to_s  #=> "http://john:V3ry_S3nsit1ve@my.example.com"
+    #
+    def password=(password)
+      check_password(password)
+      set_password(password)
+      # returns password
+    end
+
+    # Protected setter for the +user+ component, and +password+ if available
+    # (with validation).
+    #
+    # See also Bundler::URI::Generic.userinfo=.
+    #
+    def set_userinfo(user, password = nil)
+      unless password
+        user, password = split_userinfo(user)
+      end
+      @user     = user
+      @password = password if password
+
+      [@user, @password]
+    end
+    protected :set_userinfo
+
+    # Protected setter for the user component +v+.
+    #
+    # See also Bundler::URI::Generic.user=.
+    #
+    def set_user(v)
+      set_userinfo(v, @password)
+      v
+    end
+    protected :set_user
+
+    # Protected setter for the password component +v+.
+    #
+    # See also Bundler::URI::Generic.password=.
+    #
+    def set_password(v)
+      @password = v
+      # returns v
+    end
+    protected :set_password
+
+    # Returns the userinfo +ui+ as <code>[user, password]</code>
+    # if properly formatted as 'user:password'.
+    def split_userinfo(ui)
+      return nil, nil unless ui
+      user, password = ui.split(':', 2)
+
+      return user, password
+    end
+    private :split_userinfo
+
+    # Escapes 'user:password' +v+ based on RFC 1738 section 3.1.
+    def escape_userpass(v)
+      parser.escape(v, /[@:\/]/o) # RFC 1738 section 3.1 #/
+    end
+    private :escape_userpass
+
+    # Returns the userinfo, either as 'user' or 'user:password'.
+    def userinfo
+      if @user.nil?
+        nil
+      elsif @password.nil?
+        @user
+      else
+        @user + ':' + @password
+      end
+    end
+
+    # Returns the user component.
+    def user
+      @user
+    end
+
+    # Returns the password component.
+    def password
+      @password
+    end
+
+    #
+    # Checks the host +v+ component for RFC2396 compliance
+    # and against the Bundler::URI::Parser Regexp for :HOST.
+    #
+    # Can not have a registry or opaque component defined,
+    # with a host component defined.
+    #
+    def check_host(v)
+      return v unless v
+
+      if @opaque
+        raise InvalidURIError,
+          "can not set host with registry or opaque"
+      elsif parser.regexp[:HOST] !~ v
+        raise InvalidComponentError,
+          "bad component(expected host component): #{v}"
+      end
+
+      return true
+    end
+    private :check_host
+
+    # Protected setter for the host component +v+.
+    #
+    # See also Bundler::URI::Generic.host=.
+    #
+    def set_host(v)
+      @host = v
+    end
+    protected :set_host
+
+    #
+    # == Args
+    #
+    # +v+::
+    #    String
+    #
+    # == Description
+    #
+    # Public setter for the host component +v+
+    # (with validation).
+    #
+    # See also Bundler::URI::Generic.check_host.
+    #
+    # == Usage
+    #
+    #   require 'bundler/vendor/uri/lib/uri'
+    #
+    #   uri = Bundler::URI.parse("http://my.example.com")
+    #   uri.host = "foo.com"
+    #   uri.to_s  #=> "http://foo.com"
+    #
+    def host=(v)
+      check_host(v)
+      set_host(v)
+      v
+    end
+
+    # Extract the host part of the Bundler::URI and unwrap brackets for IPv6 addresses.
+    #
+    # This method is the same as Bundler::URI::Generic#host except
+    # brackets for IPv6 (and future IP) addresses are removed.
+    #
+    #   uri = Bundler::URI("http://[::1]/bar")
+    #   uri.hostname      #=> "::1"
+    #   uri.host          #=> "[::1]"
+    #
+    def hostname
+      v = self.host
+      /\A\[(.*)\]\z/ =~ v ? $1 : v
+    end
+
+    # Sets the host part of the Bundler::URI as the argument with brackets for IPv6 addresses.
+    #
+    # This method is the same as Bundler::URI::Generic#host= except
+    # the argument can be a bare IPv6 address.
+    #
+    #   uri = Bundler::URI("http://foo/bar")
+    #   uri.hostname = "::1"
+    #   uri.to_s  #=> "http://[::1]/bar"
+    #
+    # If the argument seems to be an IPv6 address,
+    # it is wrapped with brackets.
+    #
+    def hostname=(v)
+      v = "[#{v}]" if /\A\[.*\]\z/ !~ v && /:/ =~ v
+      self.host = v
+    end
+
+    #
+    # Checks the port +v+ component for RFC2396 compliance
+    # and against the Bundler::URI::Parser Regexp for :PORT.
+    #
+    # Can not have a registry or opaque component defined,
+    # with a port component defined.
+    #
+    def check_port(v)
+      return v unless v
+
+      if @opaque
+        raise InvalidURIError,
+          "can not set port with registry or opaque"
+      elsif !v.kind_of?(Integer) && parser.regexp[:PORT] !~ v
+        raise InvalidComponentError,
+          "bad component(expected port component): #{v.inspect}"
+      end
+
+      return true
+    end
+    private :check_port
+
+    # Protected setter for the port component +v+.
+    #
+    # See also Bundler::URI::Generic.port=.
+    #
+    def set_port(v)
+      v = v.empty? ? nil : v.to_i unless !v || v.kind_of?(Integer)
+      @port = v
+    end
+    protected :set_port
+
+    #
+    # == Args
+    #
+    # +v+::
+    #    String
+    #
+    # == Description
+    #
+    # Public setter for the port component +v+
+    # (with validation).
+    #
+    # See also Bundler::URI::Generic.check_port.
+    #
+    # == Usage
+    #
+    #   require 'bundler/vendor/uri/lib/uri'
+    #
+    #   uri = Bundler::URI.parse("http://my.example.com")
+    #   uri.port = 8080
+    #   uri.to_s  #=> "http://my.example.com:8080"
+    #
+    def port=(v)
+      check_port(v)
+      set_port(v)
+      port
+    end
+
+    def check_registry(v) # :nodoc:
+      raise InvalidURIError, "can not set registry"
+    end
+    private :check_registry
+
+    def set_registry(v) #:nodoc:
+      raise InvalidURIError, "can not set registry"
+    end
+    protected :set_registry
+
+    def registry=(v)
+      raise InvalidURIError, "can not set registry"
+    end
+
+    #
+    # Checks the path +v+ component for RFC2396 compliance
+    # and against the Bundler::URI::Parser Regexp
+    # for :ABS_PATH and :REL_PATH.
+    #
+    # Can not have a opaque component defined,
+    # with a path component defined.
+    #
+    def check_path(v)
+      # raise if both hier and opaque are not nil, because:
+      # absoluteURI   = scheme ":" ( hier_part | opaque_part )
+      # hier_part     = ( net_path | abs_path ) [ "?" query ]
+      if v && @opaque
+        raise InvalidURIError,
+          "path conflicts with opaque"
+      end
+
+      # If scheme is ftp, path may be relative.
+      # See RFC 1738 section 3.2.2, and RFC 2396.
+      if @scheme && @scheme != "ftp"
+        if v && v != '' && parser.regexp[:ABS_PATH] !~ v
+          raise InvalidComponentError,
+            "bad component(expected absolute path component): #{v}"
+        end
+      else
+        if v && v != '' && parser.regexp[:ABS_PATH] !~ v &&
+           parser.regexp[:REL_PATH] !~ v
+          raise InvalidComponentError,
+            "bad component(expected relative path component): #{v}"
+        end
+      end
+
+      return true
+    end
+    private :check_path
+
+    # Protected setter for the path component +v+.
+    #
+    # See also Bundler::URI::Generic.path=.
+    #
+    def set_path(v)
+      @path = v
+    end
+    protected :set_path
+
+    #
+    # == Args
+    #
+    # +v+::
+    #    String
+    #
+    # == Description
+    #
+    # Public setter for the path component +v+
+    # (with validation).
+    #
+    # See also Bundler::URI::Generic.check_path.
+    #
+    # == Usage
+    #
+    #   require 'bundler/vendor/uri/lib/uri'
+    #
+    #   uri = Bundler::URI.parse("http://my.example.com/pub/files")
+    #   uri.path = "/faq/"
+    #   uri.to_s  #=> "http://my.example.com/faq/"
+    #
+    def path=(v)
+      check_path(v)
+      set_path(v)
+      v
+    end
+
+    #
+    # == Args
+    #
+    # +v+::
+    #    String
+    #
+    # == Description
+    #
+    # Public setter for the query component +v+.
+    #
+    # == Usage
+    #
+    #   require 'bundler/vendor/uri/lib/uri'
+    #
+    #   uri = Bundler::URI.parse("http://my.example.com/?id=25")
+    #   uri.query = "id=1"
+    #   uri.to_s  #=> "http://my.example.com/?id=1"
+    #
+    def query=(v)
+      return @query = nil unless v
+      raise InvalidURIError, "query conflicts with opaque" if @opaque
+
+      x = v.to_str
+      v = x.dup if x.equal? v
+      v.encode!(Encoding::UTF_8) rescue nil
+      v.delete!("\t\r\n")
+      v.force_encoding(Encoding::ASCII_8BIT)
+      raise InvalidURIError, "invalid percent escape: #{$1}" if /(%\H\H)/n.match(v)
+      v.gsub!(/(?!%\h\h|[!$-&(-;=?-_a-~])./n.freeze){'%%%02X' % $&.ord}
+      v.force_encoding(Encoding::US_ASCII)
+      @query = v
+    end
+
+    #
+    # Checks the opaque +v+ component for RFC2396 compliance and
+    # against the Bundler::URI::Parser Regexp for :OPAQUE.
+    #
+    # Can not have a host, port, user, or path component defined,
+    # with an opaque component defined.
+    #
+    def check_opaque(v)
+      return v unless v
+
+      # raise if both hier and opaque are not nil, because:
+      # absoluteURI   = scheme ":" ( hier_part | opaque_part )
+      # hier_part     = ( net_path | abs_path ) [ "?" query ]
+      if @host || @port || @user || @path  # userinfo = @user + ':' + @password
+        raise InvalidURIError,
+          "can not set opaque with host, port, userinfo or path"
+      elsif v && parser.regexp[:OPAQUE] !~ v
+        raise InvalidComponentError,
+          "bad component(expected opaque component): #{v}"
+      end
+
+      return true
+    end
+    private :check_opaque
+
+    # Protected setter for the opaque component +v+.
+    #
+    # See also Bundler::URI::Generic.opaque=.
+    #
+    def set_opaque(v)
+      @opaque = v
+    end
+    protected :set_opaque
+
+    #
+    # == Args
+    #
+    # +v+::
+    #    String
+    #
+    # == Description
+    #
+    # Public setter for the opaque component +v+
+    # (with validation).
+    #
+    # See also Bundler::URI::Generic.check_opaque.
+    #
+    def opaque=(v)
+      check_opaque(v)
+      set_opaque(v)
+      v
+    end
+
+    #
+    # Checks the fragment +v+ component against the Bundler::URI::Parser Regexp for :FRAGMENT.
+    #
+    #
+    # == Args
+    #
+    # +v+::
+    #    String
+    #
+    # == Description
+    #
+    # Public setter for the fragment component +v+
+    # (with validation).
+    #
+    # == Usage
+    #
+    #   require 'bundler/vendor/uri/lib/uri'
+    #
+    #   uri = Bundler::URI.parse("http://my.example.com/?id=25#time=1305212049")
+    #   uri.fragment = "time=1305212086"
+    #   uri.to_s  #=> "http://my.example.com/?id=25#time=1305212086"
+    #
+    def fragment=(v)
+      return @fragment = nil unless v
+
+      x = v.to_str
+      v = x.dup if x.equal? v
+      v.encode!(Encoding::UTF_8) rescue nil
+      v.delete!("\t\r\n")
+      v.force_encoding(Encoding::ASCII_8BIT)
+      v.gsub!(/(?!%\h\h|[!-~])./n){'%%%02X' % $&.ord}
+      v.force_encoding(Encoding::US_ASCII)
+      @fragment = v
+    end
+
+    #
+    # Returns true if Bundler::URI is hierarchical.
+    #
+    # == Description
+    #
+    # Bundler::URI has components listed in order of decreasing significance from left to right,
+    # see RFC3986 https://tools.ietf.org/html/rfc3986 1.2.3.
+    #
+    # == Usage
+    #
+    #   require 'bundler/vendor/uri/lib/uri'
+    #
+    #   uri = Bundler::URI.parse("http://my.example.com/")
+    #   uri.hierarchical?
+    #   #=> true
+    #   uri = Bundler::URI.parse("mailto:joe@example.com")
+    #   uri.hierarchical?
+    #   #=> false
+    #
+    def hierarchical?
+      if @path
+        true
+      else
+        false
+      end
+    end
+
+    #
+    # Returns true if Bundler::URI has a scheme (e.g. http:// or https://) specified.
+    #
+    def absolute?
+      if @scheme
+        true
+      else
+        false
+      end
+    end
+    alias absolute absolute?
+
+    #
+    # Returns true if Bundler::URI does not have a scheme (e.g. http:// or https://) specified.
+    #
+    def relative?
+      !absolute?
+    end
+
+    #
+    # Returns an Array of the path split on '/'.
+    #
+    def split_path(path)
+      path.split("/", -1)
+    end
+    private :split_path
+
+    #
+    # Merges a base path +base+, with relative path +rel+,
+    # returns a modified base path.
+    #
+    def merge_path(base, rel)
+
+      # RFC2396, Section 5.2, 5)
+      # RFC2396, Section 5.2, 6)
+      base_path = split_path(base)
+      rel_path  = split_path(rel)
+
+      # RFC2396, Section 5.2, 6), a)
+      base_path << '' if base_path.last == '..'
+      while i = base_path.index('..')
+        base_path.slice!(i - 1, 2)
+      end
+
+      if (first = rel_path.first) and first.empty?
+        base_path.clear
+        rel_path.shift
+      end
+
+      # RFC2396, Section 5.2, 6), c)
+      # RFC2396, Section 5.2, 6), d)
+      rel_path.push('') if rel_path.last == '.' || rel_path.last == '..'
+      rel_path.delete('.')
+
+      # RFC2396, Section 5.2, 6), e)
+      tmp = []
+      rel_path.each do |x|
+        if x == '..' &&
+            !(tmp.empty? || tmp.last == '..')
+          tmp.pop
+        else
+          tmp << x
+        end
+      end
+
+      add_trailer_slash = !tmp.empty?
+      if base_path.empty?
+        base_path = [''] # keep '/' for root directory
+      elsif add_trailer_slash
+        base_path.pop
+      end
+      while x = tmp.shift
+        if x == '..'
+          # RFC2396, Section 4
+          # a .. or . in an absolute path has no special meaning
+          base_path.pop if base_path.size > 1
+        else
+          # if x == '..'
+          #   valid absolute (but abnormal) path "/../..."
+          # else
+          #   valid absolute path
+          # end
+          base_path << x
+          tmp.each {|t| base_path << t}
+          add_trailer_slash = false
+          break
+        end
+      end
+      base_path.push('') if add_trailer_slash
+
+      return base_path.join('/')
+    end
+    private :merge_path
+
+    #
+    # == Args
+    #
+    # +oth+::
+    #    Bundler::URI or String
+    #
+    # == Description
+    #
+    # Destructive form of #merge.
+    #
+    # == Usage
+    #
+    #   require 'bundler/vendor/uri/lib/uri'
+    #
+    #   uri = Bundler::URI.parse("http://my.example.com")
+    #   uri.merge!("/main.rbx?page=1")
+    #   uri.to_s  # => "http://my.example.com/main.rbx?page=1"
+    #
+    def merge!(oth)
+      t = merge(oth)
+      if self == t
+        nil
+      else
+        replace!(t)
+        self
+      end
+    end
+
+    #
+    # == Args
+    #
+    # +oth+::
+    #    Bundler::URI or String
+    #
+    # == Description
+    #
+    # Merges two URIs.
+    #
+    # == Usage
+    #
+    #   require 'bundler/vendor/uri/lib/uri'
+    #
+    #   uri = Bundler::URI.parse("http://my.example.com")
+    #   uri.merge("/main.rbx?page=1")
+    #   # => "http://my.example.com/main.rbx?page=1"
+    #
+    def merge(oth)
+      rel = parser.send(:convert_to_uri, oth)
+
+      if rel.absolute?
+        #raise BadURIError, "both Bundler::URI are absolute" if absolute?
+        # hmm... should return oth for usability?
+        return rel
+      end
+
+      unless self.absolute?
+        raise BadURIError, "both Bundler::URI are relative"
+      end
+
+      base = self.dup
+
+      authority = rel.userinfo || rel.host || rel.port
+
+      # RFC2396, Section 5.2, 2)
+      if (rel.path.nil? || rel.path.empty?) && !authority && !rel.query
+        base.fragment=(rel.fragment) if rel.fragment
+        return base
+      end
+
+      base.query = nil
+      base.fragment=(nil)
+
+      # RFC2396, Section 5.2, 4)
+      if !authority
+        base.set_path(merge_path(base.path, rel.path)) if base.path && rel.path
+      else
+        # RFC2396, Section 5.2, 4)
+        base.set_path(rel.path) if rel.path
+      end
+
+      # RFC2396, Section 5.2, 7)
+      base.set_userinfo(rel.userinfo) if rel.userinfo
+      base.set_host(rel.host)         if rel.host
+      base.set_port(rel.port)         if rel.port
+      base.query = rel.query       if rel.query
+      base.fragment=(rel.fragment) if rel.fragment
+
+      return base
+    end # merge
+    alias + merge
+
+    # :stopdoc:
+    def route_from_path(src, dst)
+      case dst
+      when src
+        # RFC2396, Section 4.2
+        return ''
+      when %r{(?:\A|/)\.\.?(?:/|\z)}
+        # dst has abnormal absolute path,
+        # like "/./", "/../", "/x/../", ...
+        return dst.dup
+      end
+
+      src_path = src.scan(%r{[^/]*/})
+      dst_path = dst.scan(%r{[^/]*/?})
+
+      # discard same parts
+      while !dst_path.empty? && dst_path.first == src_path.first
+        src_path.shift
+        dst_path.shift
+      end
+
+      tmp = dst_path.join
+
+      # calculate
+      if src_path.empty?
+        if tmp.empty?
+          return './'
+        elsif dst_path.first.include?(':') # (see RFC2396 Section 5)
+          return './' + tmp
+        else
+          return tmp
+        end
+      end
+
+      return '../' * src_path.size + tmp
+    end
+    private :route_from_path
+    # :startdoc:
+
+    # :stopdoc:
+    def route_from0(oth)
+      oth = parser.send(:convert_to_uri, oth)
+      if self.relative?
+        raise BadURIError,
+          "relative Bundler::URI: #{self}"
+      end
+      if oth.relative?
+        raise BadURIError,
+          "relative Bundler::URI: #{oth}"
+      end
+
+      if self.scheme != oth.scheme
+        return self, self.dup
+      end
+      rel = Bundler::URI::Generic.new(nil, # it is relative Bundler::URI
+                             self.userinfo, self.host, self.port,
+                             nil, self.path, self.opaque,
+                             self.query, self.fragment, parser)
+
+      if rel.userinfo != oth.userinfo ||
+          rel.host.to_s.downcase != oth.host.to_s.downcase ||
+          rel.port != oth.port
+
+        if self.userinfo.nil? && self.host.nil?
+          return self, self.dup
+        end
+
+        rel.set_port(nil) if rel.port == oth.default_port
+        return rel, rel
+      end
+      rel.set_userinfo(nil)
+      rel.set_host(nil)
+      rel.set_port(nil)
+
+      if rel.path && rel.path == oth.path
+        rel.set_path('')
+        rel.query = nil if rel.query == oth.query
+        return rel, rel
+      elsif rel.opaque && rel.opaque == oth.opaque
+        rel.set_opaque('')
+        rel.query = nil if rel.query == oth.query
+        return rel, rel
+      end
+
+      # you can modify `rel', but can not `oth'.
+      return oth, rel
+    end
+    private :route_from0
+    # :startdoc:
+
+    #
+    # == Args
+    #
+    # +oth+::
+    #    Bundler::URI or String
+    #
+    # == Description
+    #
+    # Calculates relative path from oth to self.
+    #
+    # == Usage
+    #
+    #   require 'bundler/vendor/uri/lib/uri'
+    #
+    #   uri = Bundler::URI.parse('http://my.example.com/main.rbx?page=1')
+    #   uri.route_from('http://my.example.com')
+    #   #=> #<Bundler::URI::Generic /main.rbx?page=1>
+    #
+    def route_from(oth)
+      # you can modify `rel', but can not `oth'.
+      begin
+        oth, rel = route_from0(oth)
+      rescue
+        raise $!.class, $!.message
+      end
+      if oth == rel
+        return rel
+      end
+
+      rel.set_path(route_from_path(oth.path, self.path))
+      if rel.path == './' && self.query
+        # "./?foo" -> "?foo"
+        rel.set_path('')
+      end
+
+      return rel
+    end
+
+    alias - route_from
+
+    #
+    # == Args
+    #
+    # +oth+::
+    #    Bundler::URI or String
+    #
+    # == Description
+    #
+    # Calculates relative path to oth from self.
+    #
+    # == Usage
+    #
+    #   require 'bundler/vendor/uri/lib/uri'
+    #
+    #   uri = Bundler::URI.parse('http://my.example.com')
+    #   uri.route_to('http://my.example.com/main.rbx?page=1')
+    #   #=> #<Bundler::URI::Generic /main.rbx?page=1>
+    #
+    def route_to(oth)
+      parser.send(:convert_to_uri, oth).route_from(self)
+    end
+
+    #
+    # Returns normalized Bundler::URI.
+    #
+    #   require 'bundler/vendor/uri/lib/uri'
+    #
+    #   Bundler::URI("HTTP://my.EXAMPLE.com").normalize
+    #   #=> #<Bundler::URI::HTTP http://my.example.com/>
+    #
+    # Normalization here means:
+    #
+    # * scheme and host are converted to lowercase,
+    # * an empty path component is set to "/".
+    #
+    def normalize
+      uri = dup
+      uri.normalize!
+      uri
+    end
+
+    #
+    # Destructive version of #normalize.
+    #
+    def normalize!
+      if path&.empty?
+        set_path('/')
+      end
+      if scheme && scheme != scheme.downcase
+        set_scheme(self.scheme.downcase)
+      end
+      if host && host != host.downcase
+        set_host(self.host.downcase)
+      end
+    end
+
+    #
+    # Constructs String from Bundler::URI.
+    #
+    def to_s
+      str = ''.dup
+      if @scheme
+        str << @scheme
+        str << ':'
+      end
+
+      if @opaque
+        str << @opaque
+      else
+        if @host || %w[file postgres].include?(@scheme)
+          str << '//'
+        end
+        if self.userinfo
+          str << self.userinfo
+          str << '@'
+        end
+        if @host
+          str << @host
+        end
+        if @port && @port != self.default_port
+          str << ':'
+          str << @port.to_s
+        end
+        str << @path
+        if @query
+          str << '?'
+          str << @query
+        end
+      end
+      if @fragment
+        str << '#'
+        str << @fragment
+      end
+      str
+    end
+
+    #
+    # Compares two URIs.
+    #
+    def ==(oth)
+      if self.class == oth.class
+        self.normalize.component_ary == oth.normalize.component_ary
+      else
+        false
+      end
+    end
+
+    def hash
+      self.component_ary.hash
+    end
+
+    def eql?(oth)
+      self.class == oth.class &&
+      parser == oth.parser &&
+      self.component_ary.eql?(oth.component_ary)
+    end
+
+=begin
+
+--- Bundler::URI::Generic#===(oth)
+
+=end
+#    def ===(oth)
+#      raise NotImplementedError
+#    end
+
+=begin
+=end
+
+
+    # Returns an Array of the components defined from the COMPONENT Array.
+    def component_ary
+      component.collect do |x|
+        self.send(x)
+      end
+    end
+    protected :component_ary
+
+    # == Args
+    #
+    # +components+::
+    #    Multiple Symbol arguments defined in Bundler::URI::HTTP.
+    #
+    # == Description
+    #
+    # Selects specified components from Bundler::URI.
+    #
+    # == Usage
+    #
+    #   require 'bundler/vendor/uri/lib/uri'
+    #
+    #   uri = Bundler::URI.parse('http://myuser:mypass@my.example.com/test.rbx')
+    #   uri.select(:userinfo, :host, :path)
+    #   # => ["myuser:mypass", "my.example.com", "/test.rbx"]
+    #
+    def select(*components)
+      components.collect do |c|
+        if component.include?(c)
+          self.send(c)
+        else
+          raise ArgumentError,
+            "expected of components of #{self.class} (#{self.class.component.join(', ')})"
+        end
+      end
+    end
+
+    def inspect
+      "#<#{self.class} #{self}>"
+    end
+
+    #
+    # == Args
+    #
+    # +v+::
+    #    Bundler::URI or String
+    #
+    # == Description
+    #
+    # Attempts to parse other Bundler::URI +oth+,
+    # returns [parsed_oth, self].
+    #
+    # == Usage
+    #
+    #   require 'bundler/vendor/uri/lib/uri'
+    #
+    #   uri = Bundler::URI.parse("http://my.example.com")
+    #   uri.coerce("http://foo.com")
+    #   #=> [#<Bundler::URI::HTTP http://foo.com>, #<Bundler::URI::HTTP http://my.example.com>]
+    #
+    def coerce(oth)
+      case oth
+      when String
+        oth = parser.parse(oth)
+      else
+        super
+      end
+
+      return oth, self
+    end
+
+    # Returns a proxy Bundler::URI.
+    # The proxy Bundler::URI is obtained from environment variables such as http_proxy,
+    # ftp_proxy, no_proxy, etc.
+    # If there is no proper proxy, nil is returned.
+    #
+    # If the optional parameter +env+ is specified, it is used instead of ENV.
+    #
+    # Note that capitalized variables (HTTP_PROXY, FTP_PROXY, NO_PROXY, etc.)
+    # are examined, too.
+    #
+    # But http_proxy and HTTP_PROXY is treated specially under CGI environment.
+    # It's because HTTP_PROXY may be set by Proxy: header.
+    # So HTTP_PROXY is not used.
+    # http_proxy is not used too if the variable is case insensitive.
+    # CGI_HTTP_PROXY can be used instead.
+    def find_proxy(env=ENV)
+      raise BadURIError, "relative Bundler::URI: #{self}" if self.relative?
+      name = self.scheme.downcase + '_proxy'
+      proxy_uri = nil
+      if name == 'http_proxy' && env.include?('REQUEST_METHOD') # CGI?
+        # HTTP_PROXY conflicts with *_proxy for proxy settings and
+        # HTTP_* for header information in CGI.
+        # So it should be careful to use it.
+        pairs = env.reject {|k, v| /\Ahttp_proxy\z/i !~ k }
+        case pairs.length
+        when 0 # no proxy setting anyway.
+          proxy_uri = nil
+        when 1
+          k, _ = pairs.shift
+          if k == 'http_proxy' && env[k.upcase] == nil
+            # http_proxy is safe to use because ENV is case sensitive.
+            proxy_uri = env[name]
+          else
+            proxy_uri = nil
+          end
+        else # http_proxy is safe to use because ENV is case sensitive.
+          proxy_uri = env.to_hash[name]
+        end
+        if !proxy_uri
+          # Use CGI_HTTP_PROXY.  cf. libwww-perl.
+          proxy_uri = env["CGI_#{name.upcase}"]
+        end
+      elsif name == 'http_proxy'
+        unless proxy_uri = env[name]
+          if proxy_uri = env[name.upcase]
+            warn 'The environment variable HTTP_PROXY is discouraged.  Use http_proxy.', uplevel: 1
+          end
+        end
+      else
+        proxy_uri = env[name] || env[name.upcase]
+      end
+
+      if proxy_uri.nil? || proxy_uri.empty?
+        return nil
+      end
+
+      if self.hostname
+        begin
+          addr = IPSocket.getaddress(self.hostname)
+          return nil if /\A127\.|\A::1\z/ =~ addr
+        rescue SocketError
+        end
+      end
+
+      name = 'no_proxy'
+      if no_proxy = env[name] || env[name.upcase]
+        return nil unless Bundler::URI::Generic.use_proxy?(self.hostname, addr, self.port, no_proxy)
+      end
+      Bundler::URI.parse(proxy_uri)
+    end
+
+    def self.use_proxy?(hostname, addr, port, no_proxy) # :nodoc:
+      hostname = hostname.downcase
+      dothostname = ".#{hostname}"
+      no_proxy.scan(/([^:,\s]+)(?::(\d+))?/) {|p_host, p_port|
+        if !p_port || port == p_port.to_i
+          if p_host.start_with?('.')
+            return false if hostname.end_with?(p_host.downcase)
+          else
+            return false if dothostname.end_with?(".#{p_host.downcase}")
+          end
+          if addr
+            begin
+              return false if IPAddr.new(p_host).include?(addr)
+            rescue IPAddr::InvalidAddressError
+              next
+            end
+          end
+        end
+      }
+      true
+    end
+  end
+end

--- a/lib/bundler/vendor/uri/lib/uri/http.rb
+++ b/lib/bundler/vendor/uri/lib/uri/http.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: false
+# = uri/http.rb
+#
+# Author:: Akira Yamada <akira@ruby-lang.org>
+# License:: You can redistribute it and/or modify it under the same term as Ruby.
+# Revision:: $Id$
+#
+# See Bundler::URI for general documentation
+#
+
+require_relative 'generic'
+
+module Bundler::URI
+
+  #
+  # The syntax of HTTP URIs is defined in RFC1738 section 3.3.
+  #
+  # Note that the Ruby Bundler::URI library allows HTTP URLs containing usernames and
+  # passwords. This is not legal as per the RFC, but used to be
+  # supported in Internet Explorer 5 and 6, before the MS04-004 security
+  # update. See <URL:http://support.microsoft.com/kb/834489>.
+  #
+  class HTTP < Generic
+    # A Default port of 80 for Bundler::URI::HTTP.
+    DEFAULT_PORT = 80
+
+    # An Array of the available components for Bundler::URI::HTTP.
+    COMPONENT = %i[
+      scheme
+      userinfo host port
+      path
+      query
+      fragment
+    ].freeze
+
+    #
+    # == Description
+    #
+    # Creates a new Bundler::URI::HTTP object from components, with syntax checking.
+    #
+    # The components accepted are userinfo, host, port, path, query, and
+    # fragment.
+    #
+    # The components should be provided either as an Array, or as a Hash
+    # with keys formed by preceding the component names with a colon.
+    #
+    # If an Array is used, the components must be passed in the
+    # order <code>[userinfo, host, port, path, query, fragment]</code>.
+    #
+    # Example:
+    #
+    #     uri = Bundler::URI::HTTP.build(host: 'www.example.com', path: '/foo/bar')
+    #
+    #     uri = Bundler::URI::HTTP.build([nil, "www.example.com", nil, "/path",
+    #       "query", 'fragment'])
+    #
+    # Currently, if passed userinfo components this method generates
+    # invalid HTTP URIs as per RFC 1738.
+    #
+    def self.build(args)
+      tmp = Util.make_components_hash(self, args)
+      super(tmp)
+    end
+
+    #
+    # == Description
+    #
+    # Returns the full path for an HTTP request, as required by Net::HTTP::Get.
+    #
+    # If the Bundler::URI contains a query, the full path is Bundler::URI#path + '?' + Bundler::URI#query.
+    # Otherwise, the path is simply Bundler::URI#path.
+    #
+    # Example:
+    #
+    #     uri = Bundler::URI::HTTP.build(path: '/foo/bar', query: 'test=true')
+    #     uri.request_uri #  => "/foo/bar?test=true"
+    #
+    def request_uri
+      return unless @path
+
+      url = @query ? "#@path?#@query" : @path.dup
+      url.start_with?(?/.freeze) ? url : ?/ + url
+    end
+  end
+
+  @@schemes['HTTP'] = HTTP
+
+end

--- a/lib/bundler/vendor/uri/lib/uri/https.rb
+++ b/lib/bundler/vendor/uri/lib/uri/https.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: false
+# = uri/https.rb
+#
+# Author:: Akira Yamada <akira@ruby-lang.org>
+# License:: You can redistribute it and/or modify it under the same term as Ruby.
+# Revision:: $Id$
+#
+# See Bundler::URI for general documentation
+#
+
+require_relative 'http'
+
+module Bundler::URI
+
+  # The default port for HTTPS URIs is 443, and the scheme is 'https:' rather
+  # than 'http:'. Other than that, HTTPS URIs are identical to HTTP URIs;
+  # see Bundler::URI::HTTP.
+  class HTTPS < HTTP
+    # A Default port of 443 for Bundler::URI::HTTPS
+    DEFAULT_PORT = 443
+  end
+  @@schemes['HTTPS'] = HTTPS
+end

--- a/lib/bundler/vendor/uri/lib/uri/ldap.rb
+++ b/lib/bundler/vendor/uri/lib/uri/ldap.rb
@@ -1,0 +1,261 @@
+# frozen_string_literal: false
+# = uri/ldap.rb
+#
+# Author::
+#  Takaaki Tateishi <ttate@jaist.ac.jp>
+#  Akira Yamada <akira@ruby-lang.org>
+# License::
+#   Bundler::URI::LDAP is copyrighted free software by Takaaki Tateishi and Akira Yamada.
+#   You can redistribute it and/or modify it under the same term as Ruby.
+# Revision:: $Id$
+#
+# See Bundler::URI for general documentation
+#
+
+require_relative 'generic'
+
+module Bundler::URI
+
+  #
+  # LDAP Bundler::URI SCHEMA (described in RFC2255).
+  #--
+  # ldap://<host>/<dn>[?<attrs>[?<scope>[?<filter>[?<extensions>]]]]
+  #++
+  class LDAP < Generic
+
+    # A Default port of 389 for Bundler::URI::LDAP.
+    DEFAULT_PORT = 389
+
+    # An Array of the available components for Bundler::URI::LDAP.
+    COMPONENT = [
+      :scheme,
+      :host, :port,
+      :dn,
+      :attributes,
+      :scope,
+      :filter,
+      :extensions,
+    ].freeze
+
+    # Scopes available for the starting point.
+    #
+    # * SCOPE_BASE - the Base DN
+    # * SCOPE_ONE  - one level under the Base DN, not including the base DN and
+    #   not including any entries under this
+    # * SCOPE_SUB  - subtrees, all entries at all levels
+    #
+    SCOPE = [
+      SCOPE_ONE = 'one',
+      SCOPE_SUB = 'sub',
+      SCOPE_BASE = 'base',
+    ].freeze
+
+    #
+    # == Description
+    #
+    # Creates a new Bundler::URI::LDAP object from components, with syntax checking.
+    #
+    # The components accepted are host, port, dn, attributes,
+    # scope, filter, and extensions.
+    #
+    # The components should be provided either as an Array, or as a Hash
+    # with keys formed by preceding the component names with a colon.
+    #
+    # If an Array is used, the components must be passed in the
+    # order <code>[host, port, dn, attributes, scope, filter, extensions]</code>.
+    #
+    # Example:
+    #
+    #     uri = Bundler::URI::LDAP.build({:host => 'ldap.example.com',
+    #       :dn => '/dc=example'})
+    #
+    #     uri = Bundler::URI::LDAP.build(["ldap.example.com", nil,
+    #       "/dc=example;dc=com", "query", nil, nil, nil])
+    #
+    def self.build(args)
+      tmp = Util::make_components_hash(self, args)
+
+      if tmp[:dn]
+        tmp[:path] = tmp[:dn]
+      end
+
+      query = []
+      [:extensions, :filter, :scope, :attributes].collect do |x|
+        next if !tmp[x] && query.size == 0
+        query.unshift(tmp[x])
+      end
+
+      tmp[:query] = query.join('?')
+
+      return super(tmp)
+    end
+
+    #
+    # == Description
+    #
+    # Creates a new Bundler::URI::LDAP object from generic Bundler::URI components as per
+    # RFC 2396. No LDAP-specific syntax checking is performed.
+    #
+    # Arguments are +scheme+, +userinfo+, +host+, +port+, +registry+, +path+,
+    # +opaque+, +query+, and +fragment+, in that order.
+    #
+    # Example:
+    #
+    #     uri = Bundler::URI::LDAP.new("ldap", nil, "ldap.example.com", nil, nil,
+    #       "/dc=example;dc=com", nil, "query", nil)
+    #
+    # See also Bundler::URI::Generic.new.
+    #
+    def initialize(*arg)
+      super(*arg)
+
+      if @fragment
+        raise InvalidURIError, 'bad LDAP URL'
+      end
+
+      parse_dn
+      parse_query
+    end
+
+    # Private method to cleanup +dn+ from using the +path+ component attribute.
+    def parse_dn
+      @dn = @path[1..-1]
+    end
+    private :parse_dn
+
+    # Private method to cleanup +attributes+, +scope+, +filter+, and +extensions+
+    # from using the +query+ component attribute.
+    def parse_query
+      @attributes = nil
+      @scope      = nil
+      @filter     = nil
+      @extensions = nil
+
+      if @query
+        attrs, scope, filter, extensions = @query.split('?')
+
+        @attributes = attrs if attrs && attrs.size > 0
+        @scope      = scope if scope && scope.size > 0
+        @filter     = filter if filter && filter.size > 0
+        @extensions = extensions if extensions && extensions.size > 0
+      end
+    end
+    private :parse_query
+
+    # Private method to assemble +query+ from +attributes+, +scope+, +filter+, and +extensions+.
+    def build_path_query
+      @path = '/' + @dn
+
+      query = []
+      [@extensions, @filter, @scope, @attributes].each do |x|
+        next if !x && query.size == 0
+        query.unshift(x)
+      end
+      @query = query.join('?')
+    end
+    private :build_path_query
+
+    # Returns dn.
+    def dn
+      @dn
+    end
+
+    # Private setter for dn +val+.
+    def set_dn(val)
+      @dn = val
+      build_path_query
+      @dn
+    end
+    protected :set_dn
+
+    # Setter for dn +val+.
+    def dn=(val)
+      set_dn(val)
+      val
+    end
+
+    # Returns attributes.
+    def attributes
+      @attributes
+    end
+
+    # Private setter for attributes +val+.
+    def set_attributes(val)
+      @attributes = val
+      build_path_query
+      @attributes
+    end
+    protected :set_attributes
+
+    # Setter for attributes +val+.
+    def attributes=(val)
+      set_attributes(val)
+      val
+    end
+
+    # Returns scope.
+    def scope
+      @scope
+    end
+
+    # Private setter for scope +val+.
+    def set_scope(val)
+      @scope = val
+      build_path_query
+      @scope
+    end
+    protected :set_scope
+
+    # Setter for scope +val+.
+    def scope=(val)
+      set_scope(val)
+      val
+    end
+
+    # Returns filter.
+    def filter
+      @filter
+    end
+
+    # Private setter for filter +val+.
+    def set_filter(val)
+      @filter = val
+      build_path_query
+      @filter
+    end
+    protected :set_filter
+
+    # Setter for filter +val+.
+    def filter=(val)
+      set_filter(val)
+      val
+    end
+
+    # Returns extensions.
+    def extensions
+      @extensions
+    end
+
+    # Private setter for extensions +val+.
+    def set_extensions(val)
+      @extensions = val
+      build_path_query
+      @extensions
+    end
+    protected :set_extensions
+
+    # Setter for extensions +val+.
+    def extensions=(val)
+      set_extensions(val)
+      val
+    end
+
+    # Checks if Bundler::URI has a path.
+    # For Bundler::URI::LDAP this will return +false+.
+    def hierarchical?
+      false
+    end
+  end
+
+  @@schemes['LDAP'] = LDAP
+end

--- a/lib/bundler/vendor/uri/lib/uri/ldaps.rb
+++ b/lib/bundler/vendor/uri/lib/uri/ldaps.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: false
+# = uri/ldap.rb
+#
+# License:: You can redistribute it and/or modify it under the same term as Ruby.
+#
+# See Bundler::URI for general documentation
+#
+
+require_relative 'ldap'
+
+module Bundler::URI
+
+  # The default port for LDAPS URIs is 636, and the scheme is 'ldaps:' rather
+  # than 'ldap:'. Other than that, LDAPS URIs are identical to LDAP URIs;
+  # see Bundler::URI::LDAP.
+  class LDAPS < LDAP
+    # A Default port of 636 for Bundler::URI::LDAPS
+    DEFAULT_PORT = 636
+  end
+  @@schemes['LDAPS'] = LDAPS
+end

--- a/lib/bundler/vendor/uri/lib/uri/mailto.rb
+++ b/lib/bundler/vendor/uri/lib/uri/mailto.rb
@@ -1,0 +1,294 @@
+# frozen_string_literal: false
+# = uri/mailto.rb
+#
+# Author:: Akira Yamada <akira@ruby-lang.org>
+# License:: You can redistribute it and/or modify it under the same term as Ruby.
+# Revision:: $Id$
+#
+# See Bundler::URI for general documentation
+#
+
+require_relative 'generic'
+
+module Bundler::URI
+
+  #
+  # RFC6068, the mailto URL scheme.
+  #
+  class MailTo < Generic
+    include REGEXP
+
+    # A Default port of nil for Bundler::URI::MailTo.
+    DEFAULT_PORT = nil
+
+    # An Array of the available components for Bundler::URI::MailTo.
+    COMPONENT = [ :scheme, :to, :headers ].freeze
+
+    # :stopdoc:
+    #  "hname" and "hvalue" are encodings of an RFC 822 header name and
+    #  value, respectively. As with "to", all URL reserved characters must
+    #  be encoded.
+    #
+    #  "#mailbox" is as specified in RFC 822 [RFC822]. This means that it
+    #  consists of zero or more comma-separated mail addresses, possibly
+    #  including "phrase" and "comment" components. Note that all URL
+    #  reserved characters in "to" must be encoded: in particular,
+    #  parentheses, commas, and the percent sign ("%"), which commonly occur
+    #  in the "mailbox" syntax.
+    #
+    #  Within mailto URLs, the characters "?", "=", "&" are reserved.
+
+    # ; RFC 6068
+    # hfields      = "?" hfield *( "&" hfield )
+    # hfield       = hfname "=" hfvalue
+    # hfname       = *qchar
+    # hfvalue      = *qchar
+    # qchar        = unreserved / pct-encoded / some-delims
+    # some-delims  = "!" / "$" / "'" / "(" / ")" / "*"
+    #              / "+" / "," / ";" / ":" / "@"
+    #
+    # ; RFC3986
+    # unreserved   = ALPHA / DIGIT / "-" / "." / "_" / "~"
+    # pct-encoded  = "%" HEXDIG HEXDIG
+    HEADER_REGEXP  = /\A(?<hfield>(?:%\h\h|[!$'-.0-;@-Z_a-z~])*=(?:%\h\h|[!$'-.0-;@-Z_a-z~])*)(?:&\g<hfield>)*\z/
+    # practical regexp for email address
+    # https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
+    EMAIL_REGEXP = /\A[a-zA-Z0-9.!\#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\z/
+    # :startdoc:
+
+    #
+    # == Description
+    #
+    # Creates a new Bundler::URI::MailTo object from components, with syntax checking.
+    #
+    # Components can be provided as an Array or Hash. If an Array is used,
+    # the components must be supplied as <code>[to, headers]</code>.
+    #
+    # If a Hash is used, the keys are the component names preceded by colons.
+    #
+    # The headers can be supplied as a pre-encoded string, such as
+    # <code>"subject=subscribe&cc=address"</code>, or as an Array of Arrays
+    # like <code>[['subject', 'subscribe'], ['cc', 'address']]</code>.
+    #
+    # Examples:
+    #
+    #    require 'bundler/vendor/uri/lib/uri'
+    #
+    #    m1 = Bundler::URI::MailTo.build(['joe@example.com', 'subject=Ruby'])
+    #    m1.to_s  # => "mailto:joe@example.com?subject=Ruby"
+    #
+    #    m2 = Bundler::URI::MailTo.build(['john@example.com', [['Subject', 'Ruby'], ['Cc', 'jack@example.com']]])
+    #    m2.to_s  # => "mailto:john@example.com?Subject=Ruby&Cc=jack@example.com"
+    #
+    #    m3 = Bundler::URI::MailTo.build({:to => 'listman@example.com', :headers => [['subject', 'subscribe']]})
+    #    m3.to_s  # => "mailto:listman@example.com?subject=subscribe"
+    #
+    def self.build(args)
+      tmp = Util.make_components_hash(self, args)
+
+      case tmp[:to]
+      when Array
+        tmp[:opaque] = tmp[:to].join(',')
+      when String
+        tmp[:opaque] = tmp[:to].dup
+      else
+        tmp[:opaque] = ''
+      end
+
+      if tmp[:headers]
+        query =
+          case tmp[:headers]
+          when Array
+            tmp[:headers].collect { |x|
+              if x.kind_of?(Array)
+                x[0] + '=' + x[1..-1].join
+              else
+                x.to_s
+              end
+            }.join('&')
+          when Hash
+            tmp[:headers].collect { |h,v|
+              h + '=' + v
+            }.join('&')
+          else
+            tmp[:headers].to_s
+          end
+        unless query.empty?
+          tmp[:opaque] << '?' << query
+        end
+      end
+
+      super(tmp)
+    end
+
+    #
+    # == Description
+    #
+    # Creates a new Bundler::URI::MailTo object from generic URL components with
+    # no syntax checking.
+    #
+    # This method is usually called from Bundler::URI::parse, which checks
+    # the validity of each component.
+    #
+    def initialize(*arg)
+      super(*arg)
+
+      @to = nil
+      @headers = []
+
+      # The RFC3986 parser does not normally populate opaque
+      @opaque = "?#{@query}" if @query && !@opaque
+
+      unless @opaque
+        raise InvalidComponentError,
+          "missing opaque part for mailto URL"
+      end
+      to, header = @opaque.split('?', 2)
+      # allow semicolon as a addr-spec separator
+      # http://support.microsoft.com/kb/820868
+      unless /\A(?:[^@,;]+@[^@,;]+(?:\z|[,;]))*\z/ =~ to
+        raise InvalidComponentError,
+          "unrecognised opaque part for mailtoURL: #{@opaque}"
+      end
+
+      if arg[10] # arg_check
+        self.to = to
+        self.headers = header
+      else
+        set_to(to)
+        set_headers(header)
+      end
+    end
+
+    # The primary e-mail address of the URL, as a String.
+    attr_reader :to
+
+    # E-mail headers set by the URL, as an Array of Arrays.
+    attr_reader :headers
+
+    # Checks the to +v+ component.
+    def check_to(v)
+      return true unless v
+      return true if v.size == 0
+
+      v.split(/[,;]/).each do |addr|
+        # check url safety as path-rootless
+        if /\A(?:%\h\h|[!$&-.0-;=@-Z_a-z~])*\z/ !~ addr
+          raise InvalidComponentError,
+            "an address in 'to' is invalid as Bundler::URI #{addr.dump}"
+        end
+
+        # check addr-spec
+        # don't s/\+/ /g
+        addr.gsub!(/%\h\h/, Bundler::URI::TBLDECWWWCOMP_)
+        if EMAIL_REGEXP !~ addr
+          raise InvalidComponentError,
+            "an address in 'to' is invalid as uri-escaped addr-spec #{addr.dump}"
+        end
+      end
+
+      true
+    end
+    private :check_to
+
+    # Private setter for to +v+.
+    def set_to(v)
+      @to = v
+    end
+    protected :set_to
+
+    # Setter for to +v+.
+    def to=(v)
+      check_to(v)
+      set_to(v)
+      v
+    end
+
+    # Checks the headers +v+ component against either
+    # * HEADER_REGEXP
+    def check_headers(v)
+      return true unless v
+      return true if v.size == 0
+      if HEADER_REGEXP !~ v
+        raise InvalidComponentError,
+          "bad component(expected opaque component): #{v}"
+      end
+
+      true
+    end
+    private :check_headers
+
+    # Private setter for headers +v+.
+    def set_headers(v)
+      @headers = []
+      if v
+        v.split('&').each do |x|
+          @headers << x.split(/=/, 2)
+        end
+      end
+    end
+    protected :set_headers
+
+    # Setter for headers +v+.
+    def headers=(v)
+      check_headers(v)
+      set_headers(v)
+      v
+    end
+
+    # Constructs String from Bundler::URI.
+    def to_s
+      @scheme + ':' +
+        if @to
+          @to
+        else
+          ''
+        end +
+        if @headers.size > 0
+          '?' + @headers.collect{|x| x.join('=')}.join('&')
+        else
+          ''
+        end +
+        if @fragment
+          '#' + @fragment
+        else
+          ''
+        end
+    end
+
+    # Returns the RFC822 e-mail text equivalent of the URL, as a String.
+    #
+    # Example:
+    #
+    #   require 'bundler/vendor/uri/lib/uri'
+    #
+    #   uri = Bundler::URI.parse("mailto:ruby-list@ruby-lang.org?Subject=subscribe&cc=myaddr")
+    #   uri.to_mailtext
+    #   # => "To: ruby-list@ruby-lang.org\nSubject: subscribe\nCc: myaddr\n\n\n"
+    #
+    def to_mailtext
+      to = Bundler::URI.decode_www_form_component(@to)
+      head = ''
+      body = ''
+      @headers.each do |x|
+        case x[0]
+        when 'body'
+          body = Bundler::URI.decode_www_form_component(x[1])
+        when 'to'
+          to << ', ' + Bundler::URI.decode_www_form_component(x[1])
+        else
+          head << Bundler::URI.decode_www_form_component(x[0]).capitalize + ': ' +
+            Bundler::URI.decode_www_form_component(x[1])  + "\n"
+        end
+      end
+
+      "To: #{to}
+#{head}
+#{body}
+"
+    end
+    alias to_rfc822text to_mailtext
+  end
+
+  @@schemes['MAILTO'] = MailTo
+end

--- a/lib/bundler/vendor/uri/lib/uri/rfc2396_parser.rb
+++ b/lib/bundler/vendor/uri/lib/uri/rfc2396_parser.rb
@@ -1,0 +1,546 @@
+# frozen_string_literal: false
+#--
+# = uri/common.rb
+#
+# Author:: Akira Yamada <akira@ruby-lang.org>
+# Revision:: $Id$
+# License::
+#   You can redistribute it and/or modify it under the same term as Ruby.
+#
+# See Bundler::URI for general documentation
+#
+
+module Bundler::URI
+  #
+  # Includes Bundler::URI::REGEXP::PATTERN
+  #
+  module RFC2396_REGEXP
+    #
+    # Patterns used to parse Bundler::URI's
+    #
+    module PATTERN
+      # :stopdoc:
+
+      # RFC 2396 (Bundler::URI Generic Syntax)
+      # RFC 2732 (IPv6 Literal Addresses in URL's)
+      # RFC 2373 (IPv6 Addressing Architecture)
+
+      # alpha         = lowalpha | upalpha
+      ALPHA = "a-zA-Z"
+      # alphanum      = alpha | digit
+      ALNUM = "#{ALPHA}\\d"
+
+      # hex           = digit | "A" | "B" | "C" | "D" | "E" | "F" |
+      #                         "a" | "b" | "c" | "d" | "e" | "f"
+      HEX     = "a-fA-F\\d"
+      # escaped       = "%" hex hex
+      ESCAPED = "%[#{HEX}]{2}"
+      # mark          = "-" | "_" | "." | "!" | "~" | "*" | "'" |
+      #                 "(" | ")"
+      # unreserved    = alphanum | mark
+      UNRESERVED = "\\-_.!~*'()#{ALNUM}"
+      # reserved      = ";" | "/" | "?" | ":" | "@" | "&" | "=" | "+" |
+      #                 "$" | ","
+      # reserved      = ";" | "/" | "?" | ":" | "@" | "&" | "=" | "+" |
+      #                 "$" | "," | "[" | "]" (RFC 2732)
+      RESERVED = ";/?:@&=+$,\\[\\]"
+
+      # domainlabel   = alphanum | alphanum *( alphanum | "-" ) alphanum
+      DOMLABEL = "(?:[#{ALNUM}](?:[-#{ALNUM}]*[#{ALNUM}])?)"
+      # toplabel      = alpha | alpha *( alphanum | "-" ) alphanum
+      TOPLABEL = "(?:[#{ALPHA}](?:[-#{ALNUM}]*[#{ALNUM}])?)"
+      # hostname      = *( domainlabel "." ) toplabel [ "." ]
+      HOSTNAME = "(?:#{DOMLABEL}\\.)*#{TOPLABEL}\\.?"
+
+      # :startdoc:
+    end # PATTERN
+
+    # :startdoc:
+  end # REGEXP
+
+  # Class that parses String's into Bundler::URI's.
+  #
+  # It contains a Hash set of patterns and Regexp's that match and validate.
+  #
+  class RFC2396_Parser
+    include RFC2396_REGEXP
+
+    #
+    # == Synopsis
+    #
+    #   Bundler::URI::Parser.new([opts])
+    #
+    # == Args
+    #
+    # The constructor accepts a hash as options for parser.
+    # Keys of options are pattern names of Bundler::URI components
+    # and values of options are pattern strings.
+    # The constructor generates set of regexps for parsing URIs.
+    #
+    # You can use the following keys:
+    #
+    #   * :ESCAPED (Bundler::URI::PATTERN::ESCAPED in default)
+    #   * :UNRESERVED (Bundler::URI::PATTERN::UNRESERVED in default)
+    #   * :DOMLABEL (Bundler::URI::PATTERN::DOMLABEL in default)
+    #   * :TOPLABEL (Bundler::URI::PATTERN::TOPLABEL in default)
+    #   * :HOSTNAME (Bundler::URI::PATTERN::HOSTNAME in default)
+    #
+    # == Examples
+    #
+    #   p = Bundler::URI::Parser.new(:ESCAPED => "(?:%[a-fA-F0-9]{2}|%u[a-fA-F0-9]{4})")
+    #   u = p.parse("http://example.jp/%uABCD") #=> #<Bundler::URI::HTTP http://example.jp/%uABCD>
+    #   Bundler::URI.parse(u.to_s) #=> raises Bundler::URI::InvalidURIError
+    #
+    #   s = "http://example.com/ABCD"
+    #   u1 = p.parse(s) #=> #<Bundler::URI::HTTP http://example.com/ABCD>
+    #   u2 = Bundler::URI.parse(s) #=> #<Bundler::URI::HTTP http://example.com/ABCD>
+    #   u1 == u2 #=> true
+    #   u1.eql?(u2) #=> false
+    #
+    def initialize(opts = {})
+      @pattern = initialize_pattern(opts)
+      @pattern.each_value(&:freeze)
+      @pattern.freeze
+
+      @regexp = initialize_regexp(@pattern)
+      @regexp.each_value(&:freeze)
+      @regexp.freeze
+    end
+
+    # The Hash of patterns.
+    #
+    # See also Bundler::URI::Parser.initialize_pattern.
+    attr_reader :pattern
+
+    # The Hash of Regexp.
+    #
+    # See also Bundler::URI::Parser.initialize_regexp.
+    attr_reader :regexp
+
+    # Returns a split Bundler::URI against regexp[:ABS_URI].
+    def split(uri)
+      case uri
+      when ''
+        # null uri
+
+      when @regexp[:ABS_URI]
+        scheme, opaque, userinfo, host, port,
+          registry, path, query, fragment = $~[1..-1]
+
+        # Bundler::URI-reference = [ absoluteURI | relativeURI ] [ "#" fragment ]
+
+        # absoluteURI   = scheme ":" ( hier_part | opaque_part )
+        # hier_part     = ( net_path | abs_path ) [ "?" query ]
+        # opaque_part   = uric_no_slash *uric
+
+        # abs_path      = "/"  path_segments
+        # net_path      = "//" authority [ abs_path ]
+
+        # authority     = server | reg_name
+        # server        = [ [ userinfo "@" ] hostport ]
+
+        if !scheme
+          raise InvalidURIError,
+            "bad Bundler::URI(absolute but no scheme): #{uri}"
+        end
+        if !opaque && (!path && (!host && !registry))
+          raise InvalidURIError,
+            "bad Bundler::URI(absolute but no path): #{uri}"
+        end
+
+      when @regexp[:REL_URI]
+        scheme = nil
+        opaque = nil
+
+        userinfo, host, port, registry,
+          rel_segment, abs_path, query, fragment = $~[1..-1]
+        if rel_segment && abs_path
+          path = rel_segment + abs_path
+        elsif rel_segment
+          path = rel_segment
+        elsif abs_path
+          path = abs_path
+        end
+
+        # Bundler::URI-reference = [ absoluteURI | relativeURI ] [ "#" fragment ]
+
+        # relativeURI   = ( net_path | abs_path | rel_path ) [ "?" query ]
+
+        # net_path      = "//" authority [ abs_path ]
+        # abs_path      = "/"  path_segments
+        # rel_path      = rel_segment [ abs_path ]
+
+        # authority     = server | reg_name
+        # server        = [ [ userinfo "@" ] hostport ]
+
+      else
+        raise InvalidURIError, "bad Bundler::URI(is not Bundler::URI?): #{uri}"
+      end
+
+      path = '' if !path && !opaque # (see RFC2396 Section 5.2)
+      ret = [
+        scheme,
+        userinfo, host, port,         # X
+        registry,                     # X
+        path,                         # Y
+        opaque,                       # Y
+        query,
+        fragment
+      ]
+      return ret
+    end
+
+    #
+    # == Args
+    #
+    # +uri+::
+    #    String
+    #
+    # == Description
+    #
+    # Parses +uri+ and constructs either matching Bundler::URI scheme object
+    # (File, FTP, HTTP, HTTPS, LDAP, LDAPS, or MailTo) or Bundler::URI::Generic.
+    #
+    # == Usage
+    #
+    #   p = Bundler::URI::Parser.new
+    #   p.parse("ldap://ldap.example.com/dc=example?user=john")
+    #   #=> #<Bundler::URI::LDAP ldap://ldap.example.com/dc=example?user=john>
+    #
+    def parse(uri)
+      scheme, userinfo, host, port,
+        registry, path, opaque, query, fragment = self.split(uri)
+
+      if scheme && Bundler::URI.scheme_list.include?(scheme.upcase)
+        Bundler::URI.scheme_list[scheme.upcase].new(scheme, userinfo, host, port,
+                                           registry, path, opaque, query,
+                                           fragment, self)
+      else
+        Generic.new(scheme, userinfo, host, port,
+                    registry, path, opaque, query,
+                    fragment, self)
+      end
+    end
+
+
+    #
+    # == Args
+    #
+    # +uris+::
+    #    an Array of Strings
+    #
+    # == Description
+    #
+    # Attempts to parse and merge a set of URIs.
+    #
+    def join(*uris)
+      uris[0] = convert_to_uri(uris[0])
+      uris.inject :merge
+    end
+
+    #
+    # :call-seq:
+    #   extract( str )
+    #   extract( str, schemes )
+    #   extract( str, schemes ) {|item| block }
+    #
+    # == Args
+    #
+    # +str+::
+    #    String to search
+    # +schemes+::
+    #    Patterns to apply to +str+
+    #
+    # == Description
+    #
+    # Attempts to parse and merge a set of URIs.
+    # If no +block+ given, then returns the result,
+    # else it calls +block+ for each element in result.
+    #
+    # See also Bundler::URI::Parser.make_regexp.
+    #
+    def extract(str, schemes = nil)
+      if block_given?
+        str.scan(make_regexp(schemes)) { yield $& }
+        nil
+      else
+        result = []
+        str.scan(make_regexp(schemes)) { result.push $& }
+        result
+      end
+    end
+
+    # Returns Regexp that is default self.regexp[:ABS_URI_REF],
+    # unless +schemes+ is provided. Then it is a Regexp.union with self.pattern[:X_ABS_URI].
+    def make_regexp(schemes = nil)
+      unless schemes
+        @regexp[:ABS_URI_REF]
+      else
+        /(?=#{Regexp.union(*schemes)}:)#{@pattern[:X_ABS_URI]}/x
+      end
+    end
+
+    #
+    # :call-seq:
+    #   escape( str )
+    #   escape( str, unsafe )
+    #
+    # == Args
+    #
+    # +str+::
+    #    String to make safe
+    # +unsafe+::
+    #    Regexp to apply. Defaults to self.regexp[:UNSAFE]
+    #
+    # == Description
+    #
+    # Constructs a safe String from +str+, removing unsafe characters,
+    # replacing them with codes.
+    #
+    def escape(str, unsafe = @regexp[:UNSAFE])
+      unless unsafe.kind_of?(Regexp)
+        # perhaps unsafe is String object
+        unsafe = Regexp.new("[#{Regexp.quote(unsafe)}]", false)
+      end
+      str.gsub(unsafe) do
+        us = $&
+        tmp = ''
+        us.each_byte do |uc|
+          tmp << sprintf('%%%02X', uc)
+        end
+        tmp
+      end.force_encoding(Encoding::US_ASCII)
+    end
+
+    #
+    # :call-seq:
+    #   unescape( str )
+    #   unescape( str, escaped )
+    #
+    # == Args
+    #
+    # +str+::
+    #    String to remove escapes from
+    # +escaped+::
+    #    Regexp to apply. Defaults to self.regexp[:ESCAPED]
+    #
+    # == Description
+    #
+    # Removes escapes from +str+.
+    #
+    def unescape(str, escaped = @regexp[:ESCAPED])
+      enc = str.encoding
+      enc = Encoding::UTF_8 if enc == Encoding::US_ASCII
+      str.gsub(escaped) { [$&[1, 2]].pack('H2').force_encoding(enc) }
+    end
+
+    @@to_s = Kernel.instance_method(:to_s)
+    def inspect
+      @@to_s.bind_call(self)
+    end
+
+    private
+
+    # Constructs the default Hash of patterns.
+    def initialize_pattern(opts = {})
+      ret = {}
+      ret[:ESCAPED] = escaped = (opts.delete(:ESCAPED) || PATTERN::ESCAPED)
+      ret[:UNRESERVED] = unreserved = opts.delete(:UNRESERVED) || PATTERN::UNRESERVED
+      ret[:RESERVED] = reserved = opts.delete(:RESERVED) || PATTERN::RESERVED
+      ret[:DOMLABEL] = opts.delete(:DOMLABEL) || PATTERN::DOMLABEL
+      ret[:TOPLABEL] = opts.delete(:TOPLABEL) || PATTERN::TOPLABEL
+      ret[:HOSTNAME] = hostname = opts.delete(:HOSTNAME)
+
+      # RFC 2396 (Bundler::URI Generic Syntax)
+      # RFC 2732 (IPv6 Literal Addresses in URL's)
+      # RFC 2373 (IPv6 Addressing Architecture)
+
+      # uric          = reserved | unreserved | escaped
+      ret[:URIC] = uric = "(?:[#{unreserved}#{reserved}]|#{escaped})"
+      # uric_no_slash = unreserved | escaped | ";" | "?" | ":" | "@" |
+      #                 "&" | "=" | "+" | "$" | ","
+      ret[:URIC_NO_SLASH] = uric_no_slash = "(?:[#{unreserved};?:@&=+$,]|#{escaped})"
+      # query         = *uric
+      ret[:QUERY] = query = "#{uric}*"
+      # fragment      = *uric
+      ret[:FRAGMENT] = fragment = "#{uric}*"
+
+      # hostname      = *( domainlabel "." ) toplabel [ "." ]
+      # reg-name      = *( unreserved / pct-encoded / sub-delims ) # RFC3986
+      unless hostname
+        ret[:HOSTNAME] = hostname = "(?:[a-zA-Z0-9\\-.]|%\\h\\h)+"
+      end
+
+      # RFC 2373, APPENDIX B:
+      # IPv6address = hexpart [ ":" IPv4address ]
+      # IPv4address   = 1*3DIGIT "." 1*3DIGIT "." 1*3DIGIT "." 1*3DIGIT
+      # hexpart = hexseq | hexseq "::" [ hexseq ] | "::" [ hexseq ]
+      # hexseq  = hex4 *( ":" hex4)
+      # hex4    = 1*4HEXDIG
+      #
+      # XXX: This definition has a flaw. "::" + IPv4address must be
+      # allowed too.  Here is a replacement.
+      #
+      # IPv4address = 1*3DIGIT "." 1*3DIGIT "." 1*3DIGIT "." 1*3DIGIT
+      ret[:IPV4ADDR] = ipv4addr = "\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
+      # hex4     = 1*4HEXDIG
+      hex4 = "[#{PATTERN::HEX}]{1,4}"
+      # lastpart = hex4 | IPv4address
+      lastpart = "(?:#{hex4}|#{ipv4addr})"
+      # hexseq1  = *( hex4 ":" ) hex4
+      hexseq1 = "(?:#{hex4}:)*#{hex4}"
+      # hexseq2  = *( hex4 ":" ) lastpart
+      hexseq2 = "(?:#{hex4}:)*#{lastpart}"
+      # IPv6address = hexseq2 | [ hexseq1 ] "::" [ hexseq2 ]
+      ret[:IPV6ADDR] = ipv6addr = "(?:#{hexseq2}|(?:#{hexseq1})?::(?:#{hexseq2})?)"
+
+      # IPv6prefix  = ( hexseq1 | [ hexseq1 ] "::" [ hexseq1 ] ) "/" 1*2DIGIT
+      # unused
+
+      # ipv6reference = "[" IPv6address "]" (RFC 2732)
+      ret[:IPV6REF] = ipv6ref = "\\[#{ipv6addr}\\]"
+
+      # host          = hostname | IPv4address
+      # host          = hostname | IPv4address | IPv6reference (RFC 2732)
+      ret[:HOST] = host = "(?:#{hostname}|#{ipv4addr}|#{ipv6ref})"
+      # port          = *digit
+      ret[:PORT] = port = '\d*'
+      # hostport      = host [ ":" port ]
+      ret[:HOSTPORT] = hostport = "#{host}(?::#{port})?"
+
+      # userinfo      = *( unreserved | escaped |
+      #                    ";" | ":" | "&" | "=" | "+" | "$" | "," )
+      ret[:USERINFO] = userinfo = "(?:[#{unreserved};:&=+$,]|#{escaped})*"
+
+      # pchar         = unreserved | escaped |
+      #                 ":" | "@" | "&" | "=" | "+" | "$" | ","
+      pchar = "(?:[#{unreserved}:@&=+$,]|#{escaped})"
+      # param         = *pchar
+      param = "#{pchar}*"
+      # segment       = *pchar *( ";" param )
+      segment = "#{pchar}*(?:;#{param})*"
+      # path_segments = segment *( "/" segment )
+      ret[:PATH_SEGMENTS] = path_segments = "#{segment}(?:/#{segment})*"
+
+      # server        = [ [ userinfo "@" ] hostport ]
+      server = "(?:#{userinfo}@)?#{hostport}"
+      # reg_name      = 1*( unreserved | escaped | "$" | "," |
+      #                     ";" | ":" | "@" | "&" | "=" | "+" )
+      ret[:REG_NAME] = reg_name = "(?:[#{unreserved}$,;:@&=+]|#{escaped})+"
+      # authority     = server | reg_name
+      authority = "(?:#{server}|#{reg_name})"
+
+      # rel_segment   = 1*( unreserved | escaped |
+      #                     ";" | "@" | "&" | "=" | "+" | "$" | "," )
+      ret[:REL_SEGMENT] = rel_segment = "(?:[#{unreserved};@&=+$,]|#{escaped})+"
+
+      # scheme        = alpha *( alpha | digit | "+" | "-" | "." )
+      ret[:SCHEME] = scheme = "[#{PATTERN::ALPHA}][\\-+.#{PATTERN::ALPHA}\\d]*"
+
+      # abs_path      = "/"  path_segments
+      ret[:ABS_PATH] = abs_path = "/#{path_segments}"
+      # rel_path      = rel_segment [ abs_path ]
+      ret[:REL_PATH] = rel_path = "#{rel_segment}(?:#{abs_path})?"
+      # net_path      = "//" authority [ abs_path ]
+      ret[:NET_PATH] = net_path = "//#{authority}(?:#{abs_path})?"
+
+      # hier_part     = ( net_path | abs_path ) [ "?" query ]
+      ret[:HIER_PART] = hier_part = "(?:#{net_path}|#{abs_path})(?:\\?(?:#{query}))?"
+      # opaque_part   = uric_no_slash *uric
+      ret[:OPAQUE_PART] = opaque_part = "#{uric_no_slash}#{uric}*"
+
+      # absoluteURI   = scheme ":" ( hier_part | opaque_part )
+      ret[:ABS_URI] = abs_uri = "#{scheme}:(?:#{hier_part}|#{opaque_part})"
+      # relativeURI   = ( net_path | abs_path | rel_path ) [ "?" query ]
+      ret[:REL_URI] = rel_uri = "(?:#{net_path}|#{abs_path}|#{rel_path})(?:\\?#{query})?"
+
+      # Bundler::URI-reference = [ absoluteURI | relativeURI ] [ "#" fragment ]
+      ret[:URI_REF] = "(?:#{abs_uri}|#{rel_uri})?(?:##{fragment})?"
+
+      ret[:X_ABS_URI] = "
+        (#{scheme}):                           (?# 1: scheme)
+        (?:
+           (#{opaque_part})                    (?# 2: opaque)
+        |
+           (?:(?:
+             //(?:
+                 (?:(?:(#{userinfo})@)?        (?# 3: userinfo)
+                   (?:(#{host})(?::(\\d*))?))? (?# 4: host, 5: port)
+               |
+                 (#{reg_name})                 (?# 6: registry)
+               )
+             |
+             (?!//))                           (?# XXX: '//' is the mark for hostport)
+             (#{abs_path})?                    (?# 7: path)
+           )(?:\\?(#{query}))?                 (?# 8: query)
+        )
+        (?:\\#(#{fragment}))?                  (?# 9: fragment)
+      "
+
+      ret[:X_REL_URI] = "
+        (?:
+          (?:
+            //
+            (?:
+              (?:(#{userinfo})@)?       (?# 1: userinfo)
+                (#{host})?(?::(\\d*))?  (?# 2: host, 3: port)
+            |
+              (#{reg_name})             (?# 4: registry)
+            )
+          )
+        |
+          (#{rel_segment})              (?# 5: rel_segment)
+        )?
+        (#{abs_path})?                  (?# 6: abs_path)
+        (?:\\?(#{query}))?              (?# 7: query)
+        (?:\\#(#{fragment}))?           (?# 8: fragment)
+      "
+
+      ret
+    end
+
+    # Constructs the default Hash of Regexp's.
+    def initialize_regexp(pattern)
+      ret = {}
+
+      # for Bundler::URI::split
+      ret[:ABS_URI] = Regexp.new('\A\s*' + pattern[:X_ABS_URI] + '\s*\z', Regexp::EXTENDED)
+      ret[:REL_URI] = Regexp.new('\A\s*' + pattern[:X_REL_URI] + '\s*\z', Regexp::EXTENDED)
+
+      # for Bundler::URI::extract
+      ret[:URI_REF]     = Regexp.new(pattern[:URI_REF])
+      ret[:ABS_URI_REF] = Regexp.new(pattern[:X_ABS_URI], Regexp::EXTENDED)
+      ret[:REL_URI_REF] = Regexp.new(pattern[:X_REL_URI], Regexp::EXTENDED)
+
+      # for Bundler::URI::escape/unescape
+      ret[:ESCAPED] = Regexp.new(pattern[:ESCAPED])
+      ret[:UNSAFE]  = Regexp.new("[^#{pattern[:UNRESERVED]}#{pattern[:RESERVED]}]")
+
+      # for Generic#initialize
+      ret[:SCHEME]   = Regexp.new("\\A#{pattern[:SCHEME]}\\z")
+      ret[:USERINFO] = Regexp.new("\\A#{pattern[:USERINFO]}\\z")
+      ret[:HOST]     = Regexp.new("\\A#{pattern[:HOST]}\\z")
+      ret[:PORT]     = Regexp.new("\\A#{pattern[:PORT]}\\z")
+      ret[:OPAQUE]   = Regexp.new("\\A#{pattern[:OPAQUE_PART]}\\z")
+      ret[:REGISTRY] = Regexp.new("\\A#{pattern[:REG_NAME]}\\z")
+      ret[:ABS_PATH] = Regexp.new("\\A#{pattern[:ABS_PATH]}\\z")
+      ret[:REL_PATH] = Regexp.new("\\A#{pattern[:REL_PATH]}\\z")
+      ret[:QUERY]    = Regexp.new("\\A#{pattern[:QUERY]}\\z")
+      ret[:FRAGMENT] = Regexp.new("\\A#{pattern[:FRAGMENT]}\\z")
+
+      ret
+    end
+
+    def convert_to_uri(uri)
+      if uri.is_a?(Bundler::URI::Generic)
+        uri
+      elsif uri = String.try_convert(uri)
+        parse(uri)
+      else
+        raise ArgumentError,
+          "bad argument (expected Bundler::URI object or Bundler::URI string)"
+      end
+    end
+
+  end # class Parser
+end # module Bundler::URI

--- a/lib/bundler/vendor/uri/lib/uri/rfc3986_parser.rb
+++ b/lib/bundler/vendor/uri/lib/uri/rfc3986_parser.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: false
+module Bundler::URI
+  class RFC3986_Parser # :nodoc:
+    # Bundler::URI defined in RFC3986
+    # this regexp is modified not to host is not empty string
+    RFC3986_URI = /\A(?<Bundler::URI>(?<scheme>[A-Za-z][+\-.0-9A-Za-z]*):(?<hier-part>\/\/(?<authority>(?:(?<userinfo>(?:%\h\h|[!$&-.0-;=A-Z_a-z~])*)@)?(?<host>(?<IP-literal>\[(?:(?<IPv6address>(?:\h{1,4}:){6}(?<ls32>\h{1,4}:\h{1,4}|(?<IPv4address>(?<dec-octet>[1-9]\d|1\d{2}|2[0-4]\d|25[0-5]|\d)\.\g<dec-octet>\.\g<dec-octet>\.\g<dec-octet>))|::(?:\h{1,4}:){5}\g<ls32>|\h{1,4}?::(?:\h{1,4}:){4}\g<ls32>|(?:(?:\h{1,4}:)?\h{1,4})?::(?:\h{1,4}:){3}\g<ls32>|(?:(?:\h{1,4}:){,2}\h{1,4})?::(?:\h{1,4}:){2}\g<ls32>|(?:(?:\h{1,4}:){,3}\h{1,4})?::\h{1,4}:\g<ls32>|(?:(?:\h{1,4}:){,4}\h{1,4})?::\g<ls32>|(?:(?:\h{1,4}:){,5}\h{1,4})?::\h{1,4}|(?:(?:\h{1,4}:){,6}\h{1,4})?::)|(?<IPvFuture>v\h+\.[!$&-.0-;=A-Z_a-z~]+))\])|\g<IPv4address>|(?<reg-name>(?:%\h\h|[!$&-.0-9;=A-Z_a-z~])+))?(?::(?<port>\d*))?)(?<path-abempty>(?:\/(?<segment>(?:%\h\h|[!$&-.0-;=@-Z_a-z~])*))*)|(?<path-absolute>\/(?:(?<segment-nz>(?:%\h\h|[!$&-.0-;=@-Z_a-z~])+)(?:\/\g<segment>)*)?)|(?<path-rootless>\g<segment-nz>(?:\/\g<segment>)*)|(?<path-empty>))(?:\?(?<query>[^#]*))?(?:\#(?<fragment>(?:%\h\h|[!$&-.0-;=@-Z_a-z~\/?])*))?)\z/
+    RFC3986_relative_ref = /\A(?<relative-ref>(?<relative-part>\/\/(?<authority>(?:(?<userinfo>(?:%\h\h|[!$&-.0-;=A-Z_a-z~])*)@)?(?<host>(?<IP-literal>\[(?<IPv6address>(?:\h{1,4}:){6}(?<ls32>\h{1,4}:\h{1,4}|(?<IPv4address>(?<dec-octet>[1-9]\d|1\d{2}|2[0-4]\d|25[0-5]|\d)\.\g<dec-octet>\.\g<dec-octet>\.\g<dec-octet>))|::(?:\h{1,4}:){5}\g<ls32>|\h{1,4}?::(?:\h{1,4}:){4}\g<ls32>|(?:(?:\h{1,4}:){,1}\h{1,4})?::(?:\h{1,4}:){3}\g<ls32>|(?:(?:\h{1,4}:){,2}\h{1,4})?::(?:\h{1,4}:){2}\g<ls32>|(?:(?:\h{1,4}:){,3}\h{1,4})?::\h{1,4}:\g<ls32>|(?:(?:\h{1,4}:){,4}\h{1,4})?::\g<ls32>|(?:(?:\h{1,4}:){,5}\h{1,4})?::\h{1,4}|(?:(?:\h{1,4}:){,6}\h{1,4})?::)|(?<IPvFuture>v\h+\.[!$&-.0-;=A-Z_a-z~]+)\])|\g<IPv4address>|(?<reg-name>(?:%\h\h|[!$&-.0-9;=A-Z_a-z~])+))?(?::(?<port>\d*))?)(?<path-abempty>(?:\/(?<segment>(?:%\h\h|[!$&-.0-;=@-Z_a-z~])*))*)|(?<path-absolute>\/(?:(?<segment-nz>(?:%\h\h|[!$&-.0-;=@-Z_a-z~])+)(?:\/\g<segment>)*)?)|(?<path-noscheme>(?<segment-nz-nc>(?:%\h\h|[!$&-.0-9;=@-Z_a-z~])+)(?:\/\g<segment>)*)|(?<path-empty>))(?:\?(?<query>[^#]*))?(?:\#(?<fragment>(?:%\h\h|[!$&-.0-;=@-Z_a-z~\/?])*))?)\z/
+    attr_reader :regexp
+
+    def initialize
+      @regexp = default_regexp.each_value(&:freeze).freeze
+    end
+
+    def split(uri) #:nodoc:
+      begin
+        uri = uri.to_str
+      rescue NoMethodError
+        raise InvalidURIError, "bad Bundler::URI(is not Bundler::URI?): #{uri.inspect}"
+      end
+      uri.ascii_only? or
+        raise InvalidURIError, "Bundler::URI must be ascii only #{uri.dump}"
+      if m = RFC3986_URI.match(uri)
+        query = m["query".freeze]
+        scheme = m["scheme".freeze]
+        opaque = m["path-rootless".freeze]
+        if opaque
+          opaque << "?#{query}" if query
+          [ scheme,
+            nil, # userinfo
+            nil, # host
+            nil, # port
+            nil, # registry
+            nil, # path
+            opaque,
+            nil, # query
+            m["fragment".freeze]
+          ]
+        else # normal
+          [ scheme,
+            m["userinfo".freeze],
+            m["host".freeze],
+            m["port".freeze],
+            nil, # registry
+            (m["path-abempty".freeze] ||
+             m["path-absolute".freeze] ||
+             m["path-empty".freeze]),
+            nil, # opaque
+            query,
+            m["fragment".freeze]
+          ]
+        end
+      elsif m = RFC3986_relative_ref.match(uri)
+        [ nil, # scheme
+          m["userinfo".freeze],
+          m["host".freeze],
+          m["port".freeze],
+          nil, # registry,
+          (m["path-abempty".freeze] ||
+           m["path-absolute".freeze] ||
+           m["path-noscheme".freeze] ||
+           m["path-empty".freeze]),
+          nil, # opaque
+          m["query".freeze],
+          m["fragment".freeze]
+        ]
+      else
+        raise InvalidURIError, "bad Bundler::URI(is not Bundler::URI?): #{uri.inspect}"
+      end
+    end
+
+    def parse(uri) # :nodoc:
+      scheme, userinfo, host, port,
+        registry, path, opaque, query, fragment = self.split(uri)
+      scheme_list = Bundler::URI.scheme_list
+      if scheme && scheme_list.include?(uc = scheme.upcase)
+        scheme_list[uc].new(scheme, userinfo, host, port,
+                            registry, path, opaque, query,
+                            fragment, self)
+      else
+        Generic.new(scheme, userinfo, host, port,
+                    registry, path, opaque, query,
+                    fragment, self)
+      end
+    end
+
+
+    def join(*uris) # :nodoc:
+      uris[0] = convert_to_uri(uris[0])
+      uris.inject :merge
+    end
+
+    @@to_s = Kernel.instance_method(:to_s)
+    def inspect
+      @@to_s.bind_call(self)
+    end
+
+    private
+
+    def default_regexp # :nodoc:
+      {
+        SCHEME: /\A[A-Za-z][A-Za-z0-9+\-.]*\z/,
+        USERINFO: /\A(?:%\h\h|[!$&-.0-;=A-Z_a-z~])*\z/,
+        HOST: /\A(?:(?<IP-literal>\[(?:(?<IPv6address>(?:\h{1,4}:){6}(?<ls32>\h{1,4}:\h{1,4}|(?<IPv4address>(?<dec-octet>[1-9]\d|1\d{2}|2[0-4]\d|25[0-5]|\d)\.\g<dec-octet>\.\g<dec-octet>\.\g<dec-octet>))|::(?:\h{1,4}:){5}\g<ls32>|\h{,4}::(?:\h{1,4}:){4}\g<ls32>|(?:(?:\h{1,4}:)?\h{1,4})?::(?:\h{1,4}:){3}\g<ls32>|(?:(?:\h{1,4}:){,2}\h{1,4})?::(?:\h{1,4}:){2}\g<ls32>|(?:(?:\h{1,4}:){,3}\h{1,4})?::\h{1,4}:\g<ls32>|(?:(?:\h{1,4}:){,4}\h{1,4})?::\g<ls32>|(?:(?:\h{1,4}:){,5}\h{1,4})?::\h{1,4}|(?:(?:\h{1,4}:){,6}\h{1,4})?::)|(?<IPvFuture>v\h+\.[!$&-.0-;=A-Z_a-z~]+))\])|\g<IPv4address>|(?<reg-name>(?:%\h\h|[!$&-.0-9;=A-Z_a-z~])*))\z/,
+        ABS_PATH: /\A\/(?:%\h\h|[!$&-.0-;=@-Z_a-z~])*(?:\/(?:%\h\h|[!$&-.0-;=@-Z_a-z~])*)*\z/,
+        REL_PATH: /\A(?:%\h\h|[!$&-.0-;=@-Z_a-z~])+(?:\/(?:%\h\h|[!$&-.0-;=@-Z_a-z~])*)*\z/,
+        QUERY: /\A(?:%\h\h|[!$&-.0-;=@-Z_a-z~\/?])*\z/,
+        FRAGMENT: /\A(?:%\h\h|[!$&-.0-;=@-Z_a-z~\/?])*\z/,
+        OPAQUE: /\A(?:[^\/].*)?\z/,
+        PORT: /\A[\x09\x0a\x0c\x0d ]*\d*[\x09\x0a\x0c\x0d ]*\z/,
+      }
+    end
+
+    def convert_to_uri(uri)
+      if uri.is_a?(Bundler::URI::Generic)
+        uri
+      elsif uri = String.try_convert(uri)
+        parse(uri)
+      else
+        raise ArgumentError,
+          "bad argument (expected Bundler::URI object or Bundler::URI string)"
+      end
+    end
+
+  end # class Parser
+end # module Bundler::URI

--- a/lib/bundler/vendor/uri/lib/uri/version.rb
+++ b/lib/bundler/vendor/uri/lib/uri/version.rb
@@ -1,0 +1,6 @@
+module Bundler::URI
+  # :stopdoc:
+  VERSION_CODE = '001000'.freeze
+  VERSION = VERSION_CODE.scan(/../).collect{|n| n.to_i}.join('.').freeze
+  # :startdoc:
+end

--- a/lib/bundler/vendored_uri.rb
+++ b/lib/bundler/vendored_uri.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module Bundler; end
+require_relative "vendor/uri/lib/uri"

--- a/spec/bundler/fetcher/base_spec.rb
+++ b/spec/bundler/fetcher/base_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Bundler::Fetcher::Base do
   end
 
   describe "#fetch_uri" do
-    let(:remote_uri_obj) { URI("http://rubygems.org") }
+    let(:remote_uri_obj) { Bundler::URI("http://rubygems.org") }
 
     before { allow(subject).to receive(:remote_uri).and_return(remote_uri_obj) }
 
@@ -49,10 +49,10 @@ RSpec.describe Bundler::Fetcher::Base do
     end
 
     context "when the remote uri's host is not rubygems.org" do
-      let(:remote_uri_obj) { URI("http://otherhost.org") }
+      let(:remote_uri_obj) { Bundler::URI("http://otherhost.org") }
 
       it "should return the remote uri" do
-        expect(subject.fetch_uri).to eq(URI("http://otherhost.org"))
+        expect(subject.fetch_uri).to eq(Bundler::URI("http://otherhost.org"))
       end
     end
 

--- a/spec/bundler/fetcher/compact_index_spec.rb
+++ b/spec/bundler/fetcher/compact_index_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Bundler::Fetcher::CompactIndex do
   let(:downloader)  { double(:downloader) }
-  let(:display_uri) { URI("http://sampleuri.com") }
+  let(:display_uri) { Bundler::URI("http://sampleuri.com") }
   let(:remote)      { double(:remote, :cache_slug => "lsjdf", :uri => display_uri) }
   let(:compact_index) { described_class.new(downloader, remote, display_uri) }
 

--- a/spec/bundler/fetcher/dependency_spec.rb
+++ b/spec/bundler/fetcher/dependency_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Bundler::Fetcher::Dependency do
   let(:downloader)  { double(:downloader) }
-  let(:remote)      { double(:remote, :uri => URI("http://localhost:5000")) }
+  let(:remote)      { double(:remote, :uri => Bundler::URI("http://localhost:5000")) }
   let(:display_uri) { "http://sample_uri.com" }
 
   subject { described_class.new(downloader, remote, display_uri) }
@@ -258,7 +258,7 @@ RSpec.describe Bundler::Fetcher::Dependency do
   end
 
   describe "#dependency_api_uri" do
-    let(:uri) { URI("http://gem-api.com") }
+    let(:uri) { Bundler::URI("http://gem-api.com") }
 
     context "with gem names" do
       let(:gem_names) { %w[foo bar bundler rubocop] }

--- a/spec/bundler/fetcher/downloader_spec.rb
+++ b/spec/bundler/fetcher/downloader_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Bundler::Fetcher::Downloader do
   let(:connection)     { double(:connection) }
   let(:redirect_limit) { 5 }
-  let(:uri)            { URI("http://www.uri-to-fetch.com/api/v2/endpoint") }
+  let(:uri)            { Bundler::URI("http://www.uri-to-fetch.com/api/v2/endpoint") }
   let(:options)        { double(:options) }
 
   subject { described_class.new(connection, redirect_limit) }
@@ -41,19 +41,19 @@ RSpec.describe Bundler::Fetcher::Downloader do
       before { http_response["location"] = "http://www.redirect-uri.com/api/v2/endpoint" }
 
       it "should try to fetch the redirect uri and iterate the # requests counter" do
-        expect(subject).to receive(:fetch).with(URI("http://www.uri-to-fetch.com/api/v2/endpoint"), options, 0).and_call_original
-        expect(subject).to receive(:fetch).with(URI("http://www.redirect-uri.com/api/v2/endpoint"), options, 1)
+        expect(subject).to receive(:fetch).with(Bundler::URI("http://www.uri-to-fetch.com/api/v2/endpoint"), options, 0).and_call_original
+        expect(subject).to receive(:fetch).with(Bundler::URI("http://www.redirect-uri.com/api/v2/endpoint"), options, 1)
         subject.fetch(uri, options, counter)
       end
 
       context "when the redirect uri and original uri are the same" do
-        let(:uri) { URI("ssh://username:password@www.uri-to-fetch.com/api/v2/endpoint") }
+        let(:uri) { Bundler::URI("ssh://username:password@www.uri-to-fetch.com/api/v2/endpoint") }
 
         before { http_response["location"] = "ssh://www.uri-to-fetch.com/api/v1/endpoint" }
 
         it "should set the same user and password for the redirect uri" do
-          expect(subject).to receive(:fetch).with(URI("ssh://username:password@www.uri-to-fetch.com/api/v2/endpoint"), options, 0).and_call_original
-          expect(subject).to receive(:fetch).with(URI("ssh://username:password@www.uri-to-fetch.com/api/v1/endpoint"), options, 1)
+          expect(subject).to receive(:fetch).with(Bundler::URI("ssh://username:password@www.uri-to-fetch.com/api/v2/endpoint"), options, 0).and_call_original
+          expect(subject).to receive(:fetch).with(Bundler::URI("ssh://username:password@www.uri-to-fetch.com/api/v1/endpoint"), options, 1)
           subject.fetch(uri, options, counter)
         end
       end
@@ -84,7 +84,7 @@ RSpec.describe Bundler::Fetcher::Downloader do
       end
 
       context "when the there are credentials provided in the request" do
-        let(:uri) { URI("http://user:password@www.uri-to-fetch.com") }
+        let(:uri) { Bundler::URI("http://user:password@www.uri-to-fetch.com") }
 
         it "should raise a Bundler::Fetcher::BadAuthenticationError that doesn't contain the password" do
           expect { subject.fetch(uri, options, counter) }.
@@ -102,7 +102,7 @@ RSpec.describe Bundler::Fetcher::Downloader do
       end
 
       context "when the there are credentials provided in the request" do
-        let(:uri) { URI("http://username:password@www.uri-to-fetch.com/api/v2/endpoint") }
+        let(:uri) { Bundler::URI("http://username:password@www.uri-to-fetch.com/api/v2/endpoint") }
 
         it "should raise a Bundler::Fetcher::FallbackError that doesn't contain the password" do
           expect { subject.fetch(uri, options, counter) }.
@@ -137,7 +137,7 @@ RSpec.describe Bundler::Fetcher::Downloader do
     context "when there is a user provided in the request" do
       context "and there is also a password provided" do
         context "that contains cgi escaped characters" do
-          let(:uri) { URI("http://username:password%24@www.uri-to-fetch.com/api/v2/endpoint") }
+          let(:uri) { Bundler::URI("http://username:password%24@www.uri-to-fetch.com/api/v2/endpoint") }
 
           it "should request basic authentication with the username and password" do
             expect(net_http_get).to receive(:basic_auth).with("username", "password$")
@@ -146,7 +146,7 @@ RSpec.describe Bundler::Fetcher::Downloader do
         end
 
         context "that is all unescaped characters" do
-          let(:uri) { URI("http://username:password@www.uri-to-fetch.com/api/v2/endpoint") }
+          let(:uri) { Bundler::URI("http://username:password@www.uri-to-fetch.com/api/v2/endpoint") }
           it "should request basic authentication with the username and proper cgi compliant password" do
             expect(net_http_get).to receive(:basic_auth).with("username", "password")
             subject.request(uri, options)
@@ -155,7 +155,7 @@ RSpec.describe Bundler::Fetcher::Downloader do
       end
 
       context "and there is no password provided" do
-        let(:uri) { URI("http://username@www.uri-to-fetch.com/api/v2/endpoint") }
+        let(:uri) { Bundler::URI("http://username@www.uri-to-fetch.com/api/v2/endpoint") }
 
         it "should request basic authentication with just the user" do
           expect(net_http_get).to receive(:basic_auth).with("username", nil)
@@ -164,7 +164,7 @@ RSpec.describe Bundler::Fetcher::Downloader do
       end
 
       context "that contains cgi escaped characters" do
-        let(:uri) { URI("http://username%24@www.uri-to-fetch.com/api/v2/endpoint") }
+        let(:uri) { Bundler::URI("http://username%24@www.uri-to-fetch.com/api/v2/endpoint") }
 
         it "should request basic authentication with the proper cgi compliant password user" do
           expect(net_http_get).to receive(:basic_auth).with("username$", nil)
@@ -244,7 +244,7 @@ RSpec.describe Bundler::Fetcher::Downloader do
         end
 
         context "when the there are credentials provided in the request" do
-          let(:uri) { URI("http://username:password@www.uri-to-fetch.com/api/v2/endpoint") }
+          let(:uri) { Bundler::URI("http://username:password@www.uri-to-fetch.com/api/v2/endpoint") }
           before do
             allow(net_http_get).to receive(:basic_auth).with("username", "password")
           end

--- a/spec/bundler/fetcher/index_spec.rb
+++ b/spec/bundler/fetcher/index_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Bundler::Fetcher::Index do
 
   context "error handling" do
     shared_examples_for "the error is properly handled" do
-      let(:remote_uri) { URI("http://remote-uri.org") }
+      let(:remote_uri) { Bundler::URI("http://remote-uri.org") }
       before do
         allow(subject).to receive(:remote_uri).and_return(remote_uri)
       end

--- a/spec/bundler/fetcher_spec.rb
+++ b/spec/bundler/fetcher_spec.rb
@@ -3,7 +3,7 @@
 require "bundler/fetcher"
 
 RSpec.describe Bundler::Fetcher do
-  let(:uri) { URI("https://example.com") }
+  let(:uri) { Bundler::URI("https://example.com") }
   let(:remote) { double("remote", :uri => uri, :original_uri => nil) }
 
   subject(:fetcher) { Bundler::Fetcher.new(remote) }
@@ -45,7 +45,7 @@ RSpec.describe Bundler::Fetcher do
     end
 
     context "when a rubygems source mirror is set" do
-      let(:orig_uri) { URI("http://zombo.com") }
+      let(:orig_uri) { Bundler::URI("http://zombo.com") }
       let(:remote_with_mirror) do
         double("remote", :uri => uri, :original_uri => orig_uri, :anonymized_uri => uri)
       end

--- a/spec/bundler/mirror_spec.rb
+++ b/spec/bundler/mirror_spec.rb
@@ -36,12 +36,12 @@ RSpec.describe Bundler::Settings::Mirror do
 
   it "takes a string for the uri but returns an uri object" do
     mirror.uri = "http://localhost:9292"
-    expect(mirror.uri).to eq(URI("http://localhost:9292"))
+    expect(mirror.uri).to eq(Bundler::URI("http://localhost:9292"))
   end
 
   it "takes an uri object for the uri" do
-    mirror.uri = URI("http://localhost:9293")
-    expect(mirror.uri).to eq(URI("http://localhost:9293"))
+    mirror.uri = Bundler::URI("http://localhost:9293")
+    expect(mirror.uri).to eq(Bundler::URI("http://localhost:9293"))
   end
 
   context "without a uri" do
@@ -145,7 +145,7 @@ RSpec.describe Bundler::Settings::Mirror do
 end
 
 RSpec.describe Bundler::Settings::Mirrors do
-  let(:localhost_uri) { URI("http://localhost:9292") }
+  let(:localhost_uri) { Bundler::URI("http://localhost:9292") }
 
   context "with a just created mirror" do
     let(:mirrors) do
@@ -260,7 +260,7 @@ RSpec.describe Bundler::Settings::Mirrors do
         before { mirrors.parse("mirror.all.fallback_timeout", "true") }
 
         it "returns the source uri, not localhost" do
-          expect(mirrors.for("http://whatever.com").uri).to eq(URI("http://whatever.com/"))
+          expect(mirrors.for("http://whatever.com").uri).to eq(Bundler::URI("http://whatever.com/"))
         end
       end
     end
@@ -270,7 +270,7 @@ RSpec.describe Bundler::Settings::Mirrors do
 
       context "without a fallback timeout" do
         it "returns the uri that is not mirrored" do
-          expect(mirrors.for("http://whatever.com").uri).to eq(URI("http://whatever.com/"))
+          expect(mirrors.for("http://whatever.com").uri).to eq(Bundler::URI("http://whatever.com/"))
         end
 
         it "returns localhost for rubygems.org" do
@@ -282,11 +282,11 @@ RSpec.describe Bundler::Settings::Mirrors do
         before { mirrors.parse("mirror.http://rubygems.org/.fallback_timeout", "true") }
 
         it "returns the uri that is not mirrored" do
-          expect(mirrors.for("http://whatever.com").uri).to eq(URI("http://whatever.com/"))
+          expect(mirrors.for("http://whatever.com").uri).to eq(Bundler::URI("http://whatever.com/"))
         end
 
         it "returns rubygems.org for rubygems.org" do
-          expect(mirrors.for("http://rubygems.org/").uri).to eq(URI("http://rubygems.org/"))
+          expect(mirrors.for("http://rubygems.org/").uri).to eq(Bundler::URI("http://rubygems.org/"))
         end
       end
     end

--- a/spec/bundler/rubygems_integration_spec.rb
+++ b/spec/bundler/rubygems_integration_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Bundler::RubygemsIntegration do
   describe "#download_gem" do
     let(:bundler_retry) { double(Bundler::Retry) }
     let(:retry) { double("Bundler::Retry") }
-    let(:uri) {  URI.parse("https://foo.bar") }
+    let(:uri) {  Bundler::URI.parse("https://foo.bar") }
     let(:path) { Gem.path.first }
     let(:spec) do
       spec = Bundler::RemoteSpecification.new("Foo", Gem::Version.new("2.5.2"),
@@ -73,7 +73,7 @@ RSpec.describe Bundler::RubygemsIntegration do
     let(:prerelease_specs_response) { Marshal.dump(["prerelease_specs"]) }
 
     context "when a rubygems source mirror is set" do
-      let(:orig_uri) { URI("http://zombo.com") }
+      let(:orig_uri) { Bundler::URI("http://zombo.com") }
       let(:remote_with_mirror) { double("remote", :uri => uri, :original_uri => orig_uri) }
 
       it "sets the 'X-Gemfile-Source' header containing the original source" do

--- a/spec/bundler/settings_spec.rb
+++ b/spec/bundler/settings_spec.rb
@@ -180,7 +180,7 @@ that would suck --ehhh=oh geez it looks like i might have broken bundler somehow
   end
 
   describe "#mirror_for" do
-    let(:uri) { URI("https://rubygems.org/") }
+    let(:uri) { Bundler::URI("https://rubygems.org/") }
 
     context "with no configured mirror" do
       it "returns the original URI" do
@@ -193,7 +193,7 @@ that would suck --ehhh=oh geez it looks like i might have broken bundler somehow
     end
 
     context "with a configured mirror" do
-      let(:mirror_uri) { URI("https://rubygems-mirror.org/") }
+      let(:mirror_uri) { Bundler::URI("https://rubygems-mirror.org/") }
 
       before { settings.set_local "mirror.https://rubygems.org/", mirror_uri.to_s }
 
@@ -214,7 +214,7 @@ that would suck --ehhh=oh geez it looks like i might have broken bundler somehow
       end
 
       context "with a file URI" do
-        let(:mirror_uri) { URI("file:/foo/BAR/baz/qUx/") }
+        let(:mirror_uri) { Bundler::URI("file:/foo/BAR/baz/qUx/") }
 
         it "returns the mirror URI" do
           expect(settings.mirror_for(uri)).to eq(mirror_uri)
@@ -232,7 +232,7 @@ that would suck --ehhh=oh geez it looks like i might have broken bundler somehow
   end
 
   describe "#credentials_for" do
-    let(:uri) { URI("https://gemserver.example.org/") }
+    let(:uri) { Bundler::URI("https://gemserver.example.org/") }
     let(:credentials) { "username:password" }
 
     context "with no configured credentials" do
@@ -292,7 +292,7 @@ that would suck --ehhh=oh geez it looks like i might have broken bundler somehow
     it "reads older keys without trailing slashes" do
       settings.set_local "mirror.https://rubygems.org", "http://rubygems-mirror.org"
       expect(settings.mirror_for("https://rubygems.org/")).to eq(
-        URI("http://rubygems-mirror.org/")
+        Bundler::URI("http://rubygems-mirror.org/")
       )
     end
 

--- a/spec/bundler/source/rubygems/remote_spec.rb
+++ b/spec/bundler/source/rubygems/remote_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Bundler::Source::Rubygems::Remote do
     allow(Digest(:MD5)).to receive(:hexdigest).with(duck_type(:to_s)) {|string| "MD5HEX(#{string})" }
   end
 
-  let(:uri_no_auth) { URI("https://gems.example.com") }
-  let(:uri_with_auth) { URI("https://#{credentials}@gems.example.com") }
+  let(:uri_no_auth) { Bundler::URI("https://gems.example.com") }
+  let(:uri_with_auth) { Bundler::URI("https://#{credentials}@gems.example.com") }
   let(:credentials) { "username:password" }
 
   context "when the original URI has no credentials" do
@@ -89,11 +89,11 @@ RSpec.describe Bundler::Source::Rubygems::Remote do
   end
 
   context "when the original URI has only a username" do
-    let(:uri) { URI("https://SeCrEt-ToKeN@gem.fury.io/me/") }
+    let(:uri) { Bundler::URI("https://SeCrEt-ToKeN@gem.fury.io/me/") }
 
     describe "#anonymized_uri" do
       it "returns the URI without username and password" do
-        expect(remote(uri).anonymized_uri).to eq(URI("https://gem.fury.io/me/"))
+        expect(remote(uri).anonymized_uri).to eq(Bundler::URI("https://gem.fury.io/me/"))
       end
     end
 
@@ -105,9 +105,9 @@ RSpec.describe Bundler::Source::Rubygems::Remote do
   end
 
   context "when a mirror with inline credentials is configured for the URI" do
-    let(:uri) { URI("https://rubygems.org/") }
-    let(:mirror_uri_with_auth) { URI("https://username:password@rubygems-mirror.org/") }
-    let(:mirror_uri_no_auth) { URI("https://rubygems-mirror.org/") }
+    let(:uri) { Bundler::URI("https://rubygems.org/") }
+    let(:mirror_uri_with_auth) { Bundler::URI("https://username:password@rubygems-mirror.org/") }
+    let(:mirror_uri_no_auth) { Bundler::URI("https://rubygems-mirror.org/") }
 
     before { Bundler.settings.temporary("mirror.https://rubygems.org/" => mirror_uri_with_auth.to_s) }
 
@@ -131,9 +131,9 @@ RSpec.describe Bundler::Source::Rubygems::Remote do
   end
 
   context "when a mirror with configured credentials is configured for the URI" do
-    let(:uri) { URI("https://rubygems.org/") }
-    let(:mirror_uri_with_auth) { URI("https://#{credentials}@rubygems-mirror.org/") }
-    let(:mirror_uri_no_auth) { URI("https://rubygems-mirror.org/") }
+    let(:uri) { Bundler::URI("https://rubygems.org/") }
+    let(:mirror_uri_with_auth) { Bundler::URI("https://#{credentials}@rubygems-mirror.org/") }
+    let(:mirror_uri_no_auth) { Bundler::URI("https://rubygems-mirror.org/") }
 
     before do
       Bundler.settings.temporary("mirror.https://rubygems.org/" => mirror_uri_no_auth.to_s)

--- a/spec/bundler/source_list_spec.rb
+++ b/spec/bundler/source_list_spec.rb
@@ -125,8 +125,8 @@ RSpec.describe Bundler::SourceList do
       it "adds the provided remote to the beginning of the aggregate source" do
         source_list.add_rubygems_remote("https://othersource.org")
         expect(returned_source.remotes).to eq [
-          URI("https://othersource.org/"),
-          URI("https://rubygems.org/"),
+          Bundler::URI("https://othersource.org/"),
+          Bundler::URI("https://rubygems.org/"),
         ]
       end
     end

--- a/spec/bundler/uri_credentials_filter_spec.rb
+++ b/spec/bundler/uri_credentials_filter_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Bundler::URICredentialsFilter do
           let(:credentials) { "oauth_token:x-oauth-basic@" }
 
           it "returns the uri without the oauth token" do
-            expect(subject.credential_filtered_uri(uri).to_s).to eq(URI("https://x-oauth-basic@github.com/company/private-repo").to_s)
+            expect(subject.credential_filtered_uri(uri).to_s).to eq(Bundler::URI("https://x-oauth-basic@github.com/company/private-repo").to_s)
           end
 
           it_behaves_like "original type of uri is maintained"
@@ -26,7 +26,7 @@ RSpec.describe Bundler::URICredentialsFilter do
           let(:credentials) { "oauth_token:x@" }
 
           it "returns the uri without the oauth token" do
-            expect(subject.credential_filtered_uri(uri).to_s).to eq(URI("https://x@github.com/company/private-repo").to_s)
+            expect(subject.credential_filtered_uri(uri).to_s).to eq(Bundler::URI("https://x@github.com/company/private-repo").to_s)
           end
 
           it_behaves_like "original type of uri is maintained"
@@ -37,7 +37,7 @@ RSpec.describe Bundler::URICredentialsFilter do
         let(:credentials) { "username1:hunter3@" }
 
         it "returns the uri without the password" do
-          expect(subject.credential_filtered_uri(uri).to_s).to eq(URI("https://username1@github.com/company/private-repo").to_s)
+          expect(subject.credential_filtered_uri(uri).to_s).to eq(Bundler::URI("https://username1@github.com/company/private-repo").to_s)
         end
 
         it_behaves_like "original type of uri is maintained"
@@ -55,7 +55,7 @@ RSpec.describe Bundler::URICredentialsFilter do
     end
 
     context "uri is a uri object" do
-      let(:uri) { URI("https://#{credentials}github.com/company/private-repo") }
+      let(:uri) { Bundler::URI("https://#{credentials}github.com/company/private-repo") }
 
       it_behaves_like "sensitive credentials in uri are filtered out"
     end
@@ -90,7 +90,7 @@ RSpec.describe Bundler::URICredentialsFilter do
   describe "#credential_filtered_string" do
     let(:str_to_filter) { "This is a git message containing a uri #{uri}!" }
     let(:credentials)   { "" }
-    let(:uri)           { URI("https://#{credentials}github.com/company/private-repo") }
+    let(:uri)           { Bundler::URI("https://#{credentials}github.com/company/private-repo") }
 
     context "with a uri that contains credentials" do
       let(:credentials) { "oauth_token:x-oauth-basic@" }

--- a/spec/bundler/vendored_persistent_spec.rb
+++ b/spec/bundler/vendored_persistent_spec.rb
@@ -23,14 +23,14 @@ RSpec.describe Bundler::PersistentHTTP do
     shared_examples_for "does not warn" do
       it "does not warn" do
         allow(Bundler.ui).to receive(:warn).never
-        subject.warn_old_tls_version_rubygems_connection(URI(uri), connection)
+        subject.warn_old_tls_version_rubygems_connection(Bundler::URI(uri), connection)
       end
     end
 
     shared_examples_for "does warn" do |*expected|
       it "warns" do
         expect(Bundler.ui).to receive(:warn).with(*expected)
-        subject.warn_old_tls_version_rubygems_connection(URI(uri), connection)
+        subject.warn_old_tls_version_rubygems_connection(Bundler::URI(uri), connection)
       end
     end
 

--- a/spec/realworld/edgecases_spec.rb
+++ b/spec/realworld/edgecases_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "real world edgecases", :realworld => true, :sometimes => true do
       require "#{lib_dir}/bundler/source/rubygems/remote"
       require "#{lib_dir}/bundler/fetcher"
       rubygem = Bundler.ui.silence do
-        source = Bundler::Source::Rubygems::Remote.new(URI("https://rubygems.org"))
+        source = Bundler::Source::Rubygems::Remote.new(Bundler::URI("https://rubygems.org"))
         fetcher = Bundler::Fetcher.new(source)
         index = fetcher.specs([#{name.dump}], nil)
         index.search(Gem::Dependency.new(#{name.dump}, #{requirement.dump})).last

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,7 @@ $:.unshift Spec::Path.lib_dir.to_s
 
 require "bundler/psyched_yaml"
 require "bundler/vendored_fileutils"
-require "uri"
+require "bundler/vendored_uri"
 require "digest"
 
 if File.expand_path(__FILE__) =~ %r{([^\w/\.:\-])}

--- a/spec/support/path.rb
+++ b/spec/support/path.rb
@@ -100,8 +100,6 @@ module Spec
       protocol = "file://"
       root = Gem.win_platform? ? "/" : ""
 
-      return protocol + "localhost" + root + path.to_s if RUBY_VERSION < "2.5"
-
       protocol + root + path.to_s
     end
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that after the gemification of the `uri` library (which will happen in ruby 2.7), `bundler` will activate the default version of the new library inside its own `bundler/setup` code. That means users won't be able to specify the version of the library they want/need to use in their own Gemfiles.

### What was your diagnosis of the problem?

My diagnosis was that we should avoid using `uri` inside `bundler/setup` code.

### What is your fix for the problem, implemented in this PR?

My fix is to vendor the `uri` library, like we did with `fileutils`.