### PR TITLE
Set parallel_tests to output progress in the same format as regular RSpec

### DIFF
--- a/.rspec_parallel
+++ b/.rspec_parallel
@@ -1,3 +1,4 @@
+--format progress
 --format ParallelTests::RSpec::RuntimeLogger --out tmp/parallel_runtime_rspec.log
 --require spec_helper
 --require support/parallel.rb


### PR DESCRIPTION
# What was the end-user problem that led to this PR?

When running tests using the `parallel_test` tool, there will be no output on the terminal to show the progress or result of the test suit.

```
$ ./bin/parallel_rspec spec         
8 processes for 162 specs, ~ 20 specs per process

Took 576 seconds (9:36)
```

You have to go diving into a file that's located in `tmp/parallel_runtime_rspec.log`.

It would be better to have the output that we get from the regular `./bin/rspec` and show the progress/result of the test suit.

### What was your diagnosis of the problem?

Run the parallel test suit using `./bin/parallel_rspec spec`

### What is your fix for the problem, implemented in this PR?

Add the additional `progress` formatter to the parallel rspec configuration
