### PR TITLE
Document running tests in parallel inside a dev environment

### DIFF
--- a/doc/development/SETUP.md
+++ b/doc/development/SETUP.md
@@ -24,6 +24,10 @@ Bundler doesn't use a Gemfile to list development dependencies, because when we 
 
         $ bin/rake spec
 
+6. Optionally, you can run the test suite in parallel:
+
+        $ bin/parallel_rspec spec
+
 6. Set up a shell alias to run Bundler from your clone, e.g. a Bash alias ([follow these instructions](https://www.moncefbelyamani.com/create-aliases-in-bash-profile-to-assign-shortcuts-for-common-terminal-commands/) for adding aliases to your `~/.bashrc` profile):
 
         $ alias dbundle='/path/to/bundler/repo/bin/bundle'

--- a/doc/development/SETUP.md
+++ b/doc/development/SETUP.md
@@ -28,7 +28,7 @@ Bundler doesn't use a Gemfile to list development dependencies, because when we 
 
         $ bin/parallel_rspec spec
 
-6. Set up a shell alias to run Bundler from your clone, e.g. a Bash alias ([follow these instructions](https://www.moncefbelyamani.com/create-aliases-in-bash-profile-to-assign-shortcuts-for-common-terminal-commands/) for adding aliases to your `~/.bashrc` profile):
+7. Set up a shell alias to run Bundler from your clone, e.g. a Bash alias ([follow these instructions](https://www.moncefbelyamani.com/create-aliases-in-bash-profile-to-assign-shortcuts-for-common-terminal-commands/) for adding aliases to your `~/.bashrc` profile):
 
         $ alias dbundle='/path/to/bundler/repo/bin/bundle'
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

We do not have any documentation for running the test suite in parallel. Developers working on Bundler may be unaware that the test suite can be executed in parallel to help speed up the time needed to run tests.

### What is your fix for the problem, implemented in this PR?

Document how to run the parallel Bundler test suit in the Contributing docs.
