### PR TITLE
Vendor fileutils 1.4.1

### DIFF
--- a/lib/bundler/vendor/fileutils/lib/fileutils.rb
+++ b/lib/bundler/vendor/fileutils/lib/fileutils.rb
@@ -6,8 +6,6 @@ rescue LoadError
   # for make mjit-headers
 end
 
-require_relative "fileutils/version"
-
 #
 # = fileutils.rb
 #
@@ -104,6 +102,7 @@ require_relative "fileutils/version"
 # <tt>:verbose</tt> flags to methods in Bundler::FileUtils.
 #
 module Bundler::FileUtils
+  VERSION = "1.4.1"
 
   def self.private_module_function(name)   #:nodoc:
     module_function name
@@ -1300,7 +1299,8 @@ module Bundler::FileUtils
            .reject {|n| n == '.' or n == '..' }
       end
 
-      files.map {|n| Entry_.new(prefix(), join(rel(), n.tap{|x| x.untaint if RUBY_VERSION < "2.7" })) }
+      untaint = RUBY_VERSION < '2.7'
+      files.map {|n| Entry_.new(prefix(), join(rel(), untaint ? n.untaint : n)) }
     end
 
     def stat

--- a/lib/bundler/vendor/fileutils/lib/fileutils/version.rb
+++ b/lib/bundler/vendor/fileutils/lib/fileutils/version.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-module Bundler::FileUtils
-  VERSION = "1.3.0"
-end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was no big deal. Just a discrepancy between the fileutils version we're vendoring and the one that will ship with ruby 2.7. This doesn't cause any issues, but I prefer that they match.

### What is your fix for the problem, implemented in this PR?

My fix is to `bin/rake vendor:fileutils[v1.4.1]` and commit the result.
