### PR TITLE
Improve rubygems switcher

### DIFF
--- a/spec/rubygems/rubygems.rb
+++ b/spec/rubygems/rubygems.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-require_relative "../support/rubygems_version_manager"
-
-RubygemsVersionManager.new(ENV["RGV"]).switch
-
-$:.delete("#{Spec::Path.spec_dir}/rubygems")
-
-require "rubygems"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -82,7 +82,7 @@ RSpec.configure do |config|
   config.before :suite do
     require_relative "support/rubygems_ext"
     Spec::Rubygems.setup
-    ENV["RUBYOPT"] = "#{ENV["RUBYOPT"]} -I#{Spec::Path.spec_dir}/rubygems -r#{Spec::Path.spec_dir}/support/hax.rb"
+    ENV["RUBYOPT"] = "#{ENV["RUBYOPT"]} -r#{Spec::Path.spec_dir}/support/hax.rb"
     ENV["BUNDLE_SPEC_RUN"] = "true"
     ENV["BUNDLE_USER_CONFIG"] = ENV["BUNDLE_USER_CACHE"] = ENV["BUNDLE_USER_PLUGIN"] = nil
     ENV["GEMRC"] = nil

--- a/spec/support/rubygems_ext.rb
+++ b/spec/support/rubygems_ext.rb
@@ -39,7 +39,9 @@ module Spec
     end
 
     def gem_load(gem_name, bin_container)
-      require_relative "../rubygems/rubygems"
+      require_relative "rubygems_version_manager"
+      RubygemsVersionManager.new(ENV["RGV"]).switch
+
       gem_load_and_activate(gem_name, bin_container)
     end
 

--- a/spec/support/rubygems_version_manager.rb
+++ b/spec/support/rubygems_version_manager.rb
@@ -8,8 +8,8 @@ class RubygemsVersionManager
   include Spec::Helpers
   include Spec::Path
 
-  def initialize(env_version)
-    @env_version = env_version
+  def initialize(source)
+    @source = source
   end
 
   def switch
@@ -23,7 +23,7 @@ class RubygemsVersionManager
 private
 
   def use_system?
-    @env_version.nil?
+    @source.nil?
   end
 
   def unrequire_rubygems_if_needed
@@ -57,7 +57,7 @@ private
   end
 
   def local_copy_switch_needed?
-    !env_version_is_path? && target_tag != local_copy_tag
+    !source_is_path? && target_tag != local_copy_tag
   end
 
   def target_tag
@@ -75,7 +75,7 @@ private
   end
 
   def resolve_local_copy_path
-    return expanded_env_version if env_version_is_path?
+    return expanded_source if source_is_path?
 
     rubygems_path = root.join("tmp/rubygems")
 
@@ -87,17 +87,17 @@ private
     rubygems_path
   end
 
-  def env_version_is_path?
-    expanded_env_version.directory?
+  def source_is_path?
+    expanded_source.directory?
   end
 
-  def expanded_env_version
-    @expanded_env_version ||= Pathname.new(@env_version).expand_path(root)
+  def expanded_source
+    @expanded_source ||= Pathname.new(@source).expand_path(root)
   end
 
   def resolve_target_tag
-    return "v#{@env_version}" if @env_version.match(/^\d/)
+    return "v#{@source}" if @source.match(/^\d/)
 
-    @env_version
+    @source
   end
 end

--- a/spec/support/rubygems_version_manager.rb
+++ b/spec/support/rubygems_version_manager.rb
@@ -46,7 +46,7 @@ private
 
     Dir.chdir(local_copy_path) do
       sys_exec!("git remote update")
-      sys_exec!("git checkout #{target_tag_version} --quiet")
+      sys_exec!("git checkout #{target_tag} --quiet")
     end
 
     ENV["RGV"] = local_copy_path.to_s
@@ -57,11 +57,11 @@ private
   end
 
   def local_copy_switch_needed?
-    !env_version_is_path? && target_tag_version != local_copy_tag
+    !env_version_is_path? && target_tag != local_copy_tag
   end
 
-  def target_tag_version
-    @target_tag_version ||= resolve_target_tag_version
+  def target_tag
+    @target_tag ||= resolve_target_tag
   end
 
   def local_copy_tag
@@ -95,7 +95,7 @@ private
     @expanded_env_version ||= Pathname.new(@env_version).expand_path(root)
   end
 
-  def resolve_target_tag_version
+  def resolve_target_tag
     return "v#{@env_version}" if @env_version.match(/^\d/)
 
     @env_version

--- a/spec/support/rubygems_version_manager.rb
+++ b/spec/support/rubygems_version_manager.rb
@@ -17,7 +17,7 @@ class RubygemsVersionManager
 
     switch_local_copy_if_needed
 
-    unrequire_rubygems_if_needed
+    reexec_if_needed
   end
 
 private
@@ -26,7 +26,7 @@ private
     @source.nil?
   end
 
-  def unrequire_rubygems_if_needed
+  def reexec_if_needed
     return unless rubygems_unrequire_needed?
 
     require "rbconfig"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was we have some code in our tests to make sure that the `ENV["RGV"]` variable we use to set the rubygems version we want to test bundler against is always respected, including every subprocess our tests start. However:

* The code was overly complicated.
* It didn't support custom branches, for example, `RGV=lazily_load_uri`. This is a feature I find very useful when a PR you're working on also need some changes in the rubygems side, like it happened to me at #7460.

### What was your diagnosis of the problem?

My diagnosis was that all the code needs to do is:

* Set up the location of the rubygems code we'll test bundler against, be it a path, a branch, or a released version.
* Modify `RUBYOPT` to include that location in the LOAD_PATH, so that `rubygems` is always loaded from there instead of the system's version.

### What is your fix for the problem, implemented in this PR?

My fix is to do just that, remove all the stuff that wasn't needed, and do a bit of renaming to improve readability.