### PR TITLE
Fix `bundle exec rake install` failing

### DIFF
--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -86,8 +86,8 @@ module Bundler
       built_gem_path ||= build_gem
       cmd = "#{gem_command} install #{built_gem_path}"
       cmd += " --local" if local
-      out, status = sh_with_status(cmd.shellsplit)
-      unless status.success? && out[/Successfully installed/]
+      _, status = sh_with_status(cmd.shellsplit)
+      unless status.success?
         raise "Couldn't install gem, run `gem install #{built_gem_path}' for more detailed output"
       end
       Bundler.ui.confirm "#{name} (#{version}) installed."

--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -98,13 +98,13 @@ module Bundler
   protected
 
     def rubygem_push(path)
-      gem_command = %W[gem push #{path}]
-      gem_command << "--key" << gem_key if gem_key
-      gem_command << "--host" << allowed_push_host if allowed_push_host
+      cmd = %W[gem push #{path}]
+      cmd << "--key" << gem_key if gem_key
+      cmd << "--host" << allowed_push_host if allowed_push_host
       unless allowed_push_host || Bundler.user_home.join(".gem/credentials").file?
         raise "Your rubygems.org credentials aren't set. Run `gem push` to set them."
       end
-      sh_with_input(gem_command)
+      sh_with_input(cmd)
       Bundler.ui.confirm "Pushed #{name} #{version} to #{gem_push_host}"
     end
 

--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -73,8 +73,7 @@ module Bundler
 
     def build_gem
       file_name = nil
-      gem = ENV["GEM_COMMAND"] ? ENV["GEM_COMMAND"] : "gem"
-      sh("#{gem} build -V #{spec_path}".shellsplit) do
+      sh("#{gem_command} build -V #{spec_path}".shellsplit) do
         file_name = File.basename(built_gem_path)
         SharedHelpers.filesystem_access(File.join(base, "pkg")) {|p| FileUtils.mkdir_p(p) }
         FileUtils.mv(built_gem_path, "pkg")
@@ -85,8 +84,7 @@ module Bundler
 
     def install_gem(built_gem_path = nil, local = false)
       built_gem_path ||= build_gem
-      gem = ENV["GEM_COMMAND"] ? ENV["GEM_COMMAND"] : "gem"
-      cmd = "#{gem} install #{built_gem_path}"
+      cmd = "#{gem_command} install #{built_gem_path}"
       cmd += " --local" if local
       out, status = sh_with_status(cmd.shellsplit)
       unless status.success? && out[/Successfully installed/]
@@ -98,7 +96,7 @@ module Bundler
   protected
 
     def rubygem_push(path)
-      cmd = %W[gem push #{path}]
+      cmd = %W[#{gem_command} push #{path}]
       cmd << "--key" << gem_key if gem_key
       cmd << "--host" << allowed_push_host if allowed_push_host
       unless allowed_push_host || Bundler.user_home.join(".gem/credentials").file?
@@ -210,6 +208,10 @@ module Bundler
 
     def gem_push?
       !%w[n no nil false off 0].include?(ENV["gem_push"].to_s.downcase)
+    end
+
+    def gem_command
+      ENV["GEM_COMMAND"] ? ENV["GEM_COMMAND"] : "gem"
     end
   end
 end

--- a/spec/commands/clean_spec.rb
+++ b/spec/commands/clean_spec.rb
@@ -782,7 +782,7 @@ RSpec.describe "bundle clean" do
     expect(vendored_gems("bundler/gems/very_simple_git_binary-1.0-#{revision[0..11]}")).to exist
 
     bundle! :clean
-    expect(out).to eq("")
+    expect(out).to be_empty
 
     expect(vendored_gems("bundler/gems/extensions")).to exist
     expect(vendored_gems("bundler/gems/very_simple_git_binary-1.0-#{revision[0..11]}")).to exist

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe "bundle exec" do
     install_gemfile ""
     sys_exec "#{Gem.ruby} #{command.path}"
 
-    expect(out).to eq("")
+    expect(out).to be_empty
     expect(err).to be_empty
   end
 

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -324,7 +324,7 @@ RSpec.describe "bundle outdated" do
     context "and no gems are outdated" do
       it "has empty output" do
         subject
-        expect(out).to eq("")
+        expect(out).to be_empty
       end
     end
   end

--- a/spec/runtime/gem_tasks_spec.rb
+++ b/spec/runtime/gem_tasks_spec.rb
@@ -6,15 +6,25 @@ RSpec.describe "require 'bundler/gem_tasks'" do
       f.write <<-GEMSPEC
         Gem::Specification.new do |s|
           s.name = "foo"
+          s.version = "1.0"
+          s.summary = "dummy"
+          s.author = "Perry Mason"
         end
       GEMSPEC
     end
+
     bundled_app("Rakefile").open("w") do |f|
       f.write <<-RAKEFILE
         $:.unshift("#{lib_dir}")
         require "bundler/gem_tasks"
       RAKEFILE
     end
+
+    install_gemfile! <<-G
+      source "#{file_uri_for(gem_repo1)}"
+
+      gem "rake"
+    G
   end
 
   it "includes the relevant tasks" do
@@ -33,6 +43,18 @@ RSpec.describe "require 'bundler/gem_tasks'" do
     tasks = out.lines.to_a.map {|s| s.split("#").first.strip }
     expect(tasks & expected_tasks).to eq(expected_tasks)
     expect(exitstatus).to eq(0) if exitstatus
+  end
+
+  it "defines a working `rake install` task" do
+    with_gem_path_as(Spec::Path.base_system_gems.to_s) do
+      sys_exec "#{rake} install", "RUBYOPT" => "-I#{lib_dir}"
+    end
+
+    expect(err).to be_empty
+
+    bundle! "exec rake install"
+
+    expect(err).to be_empty
   end
 
   it "adds 'pkg' to rake/clean's CLOBBER" do

--- a/spec/runtime/gem_tasks_spec.rb
+++ b/spec/runtime/gem_tasks_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "require 'bundler/gem_tasks'" do
       sys_exec "#{rake} -T", "RUBYOPT" => "-I#{lib_dir}"
     end
 
-    expect(err).to eq("")
+    expect(err).to be_empty
     expected_tasks = [
       "rake build",
       "rake clean",

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe "Bundler.setup" do
       load_path = out.split("\n")
       rack_load_order = load_path.index {|path| path.include?("rack") }
 
-      expect(err).to eq("")
+      expect(err).to be_empty
       expect(load_path).to include(a_string_ending_with("dash_i_dir"), "rubylib_dir")
       expect(rack_load_order).to be > 0
     end
@@ -1042,7 +1042,7 @@ end
       RUBY
 
       expect(err).to be_empty
-      expect(out).to eq("")
+      expect(out).to be_empty
     end
   end
 
@@ -1098,8 +1098,8 @@ end
       it "does not change the lock or warn" do
         lockfile lock_with(Bundler::VERSION.succ)
         ruby "require '#{lib_dir}/bundler/setup'"
-        expect(out).to eq("")
-        expect(err).to eq("")
+        expect(out).to be_empty
+        expect(err).to be_empty
         lockfile_should_be lock_with(Bundler::VERSION.succ)
       end
     end
@@ -1162,8 +1162,8 @@ end
       let(:ruby_version) { "5.5.5" }
       it "does not change the lock or warn" do
         expect { ruby! "require '#{lib_dir}/bundler/setup'" }.not_to change { lockfile }
-        expect(out).to eq("")
-        expect(err).to eq("")
+        expect(out).to be_empty
+        expect(err).to be_empty
       end
     end
 

--- a/spec/support/path.rb
+++ b/spec/support/path.rb
@@ -22,7 +22,7 @@ module Spec
     end
 
     def gem_bin
-      @gem_bin ||= ruby_core? ? ENV["GEM_COMMAND"] : "#{Gem.ruby} -I#{spec_dir}/rubygems -S gem --backtrace"
+      @gem_bin ||= ruby_core? ? ENV["GEM_COMMAND"] : "#{Gem.ruby} -S gem --backtrace"
     end
 
     def spec_dir


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that I noticed `bundle exec rake install` was failing on my gem using the latest prerelease of bundler.

### What was your diagnosis of the problem?

My diagnosis was that `bundler` silences output of rubygems by default, and in a `bundle exec` context, `bundler/setup` is always required by subprocesses. So, the `rake install` task is silencing rubygems, but it requires it to not be silent:

https://github.com/bundler/bundler/blob/bada03dd6d4d15828fb5b2cf7f744948e88a69a3/lib/bundler/gem_helper.rb#L91-L92

### What is your fix for the problem, implemented in this PR?

My fix is to wrap the execution of the rubygems subprocess with `Bundler.with_original_env` so that the `gem` command runs without `bundler` involved.
