### PR TITLE
Delay deprecation of `bundle config` and `bundle update` without args

### DIFF
--- a/lib/bundler/cli/config.rb
+++ b/lib/bundler/cli/config.rb
@@ -25,7 +25,7 @@ module Bundler
           ["config", "get", ARGV[1]]
         end
 
-      SharedHelpers.major_deprecation 2,
+      SharedHelpers.major_deprecation 3,
         "Using the `config` command without a subcommand [list, get, set, unset] is deprecated and will be removed in the future. Use `bundle #{new_args.join(" ")}` instead."
 
       Base.new(options, name, value, self).run

--- a/lib/bundler/cli/update.rb
+++ b/lib/bundler/cli/update.rb
@@ -22,7 +22,7 @@ module Bundler
         if Bundler.feature_flag.update_requires_all_flag?
           raise InvalidOption, "To update everything, pass the `--all` flag."
         end
-        SharedHelpers.major_deprecation 2, "Pass --all to `bundle update` to update everything"
+        SharedHelpers.major_deprecation 3, "Pass --all to `bundle update` to update everything"
       elsif !full_update && options[:all]
         raise InvalidOption, "Cannot specify --all along with specific options."
       end

--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -46,7 +46,7 @@ module Bundler
     settings_flag(:specific_platform) { bundler_3_mode? }
     settings_flag(:suppress_install_using_messages) { bundler_3_mode? }
     settings_flag(:unlock_source_unlocks_spec) { !bundler_3_mode? }
-    settings_flag(:update_requires_all_flag) { bundler_3_mode? }
+    settings_flag(:update_requires_all_flag) { bundler_4_mode? }
     settings_flag(:use_gem_version_promoter_for_major_updates) { bundler_3_mode? }
 
     settings_option(:default_cli_command) { bundler_3_mode? ? :cli_help : :install }

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe "major deprecations" do
         bundle! "config"
       end
 
-      it "warns", :bundler => "2" do
+      it "warns", :bundler => "3" do
         expect(deprecations).to include("Using the `config` command without a subcommand [list, get, set, unset] is deprecated and will be removed in the future. Use `bundle config list` instead.")
       end
 
@@ -139,7 +139,7 @@ RSpec.describe "major deprecations" do
         bundle! "config waka"
       end
 
-      it "warns", :bundler => "2" do
+      it "warns", :bundler => "3" do
         expect(deprecations).to include("Using the `config` command without a subcommand [list, get, set, unset] is deprecated and will be removed in the future. Use `bundle config get waka` instead.")
       end
 
@@ -151,7 +151,7 @@ RSpec.describe "major deprecations" do
         bundle! "config waka wakapun"
       end
 
-      it "warns", :bundler => "2" do
+      it "warns", :bundler => "3" do
         expect(deprecations).to include("Using the `config` command without a subcommand [list, get, set, unset] is deprecated and will be removed in the future. Use `bundle config set waka wakapun` instead.")
       end
 
@@ -163,7 +163,7 @@ RSpec.describe "major deprecations" do
         bundle! "config --local waka wakapun"
       end
 
-      it "warns", :bundler => "2" do
+      it "warns", :bundler => "3" do
         expect(deprecations).to include("Using the `config` command without a subcommand [list, get, set, unset] is deprecated and will be removed in the future. Use `bundle config set --local waka wakapun` instead.")
       end
 
@@ -175,7 +175,7 @@ RSpec.describe "major deprecations" do
         bundle! "config --global waka wakapun"
       end
 
-      it "warns", :bundler => "2" do
+      it "warns", :bundler => "3" do
         expect(deprecations).to include("Using the `config` command without a subcommand [list, get, set, unset] is deprecated and will be removed in the future. Use `bundle config set --global waka wakapun` instead.")
       end
 
@@ -187,7 +187,7 @@ RSpec.describe "major deprecations" do
         bundle! "config --delete waka"
       end
 
-      it "warns", :bundler => "2" do
+      it "warns", :bundler => "3" do
         expect(deprecations).to include("Using the `config` command without a subcommand [list, get, set, unset] is deprecated and will be removed in the future. Use `bundle config unset waka` instead.")
       end
 
@@ -199,7 +199,7 @@ RSpec.describe "major deprecations" do
         bundle! "config --delete --local waka"
       end
 
-      it "warns", :bundler => "2" do
+      it "warns", :bundler => "3" do
         expect(deprecations).to include("Using the `config` command without a subcommand [list, get, set, unset] is deprecated and will be removed in the future. Use `bundle config unset --local waka` instead.")
       end
 
@@ -211,7 +211,7 @@ RSpec.describe "major deprecations" do
         bundle! "config --delete --global waka"
       end
 
-      it "warns", :bundler => "2" do
+      it "warns", :bundler => "3" do
         expect(deprecations).to include("Using the `config` command without a subcommand [list, get, set, unset] is deprecated and will be removed in the future. Use `bundle config unset --global waka` instead.")
       end
 
@@ -227,7 +227,7 @@ RSpec.describe "major deprecations" do
       G
     end
 
-    it "warns when no options are given", :bundler => "2" do
+    it "warns when no options are given", :bundler => "3" do
       bundle! "update"
       expect(deprecations).to include("Pass --all to `bundle update` to update everything")
     end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem I was thinking about the upcoming release of bundler 2.1.0, and I'm not convinced about these two deprecations.

I'm not necessarily against them, but these command are very common IMO, and we'll be making them harder to run. Again, maybe for good reasons, but still. That will be combined with the fact that:

* In this same release, we'll be enabling all of the other deprecations.
* Ruby 2.7 will include bundler 2.1 and ruby 2.7 will also come with a lot of warnings about keyword arguments. 

### What was your diagnosis of the problem?

My diagnosis was that I think it's better to postpone these two deprecations for now. Get the other deprecations going and get user feedback about them, and then worry about these two later.

### What is your fix for the problem, implemented in this PR?

My fix is to delay both deprecations.

### Why did you choose this fix out of the possible options?

I chose this fix because I don't want to be too annoying to users at this moment.
