### PR TITLE
Bump RuboCop to 0.77.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,7 +55,7 @@ Lint/DuplicateCaseCondition:
 Lint/DuplicateMethods:
   Enabled: true
 
-Lint/DuplicatedKey:
+Lint/DuplicateHashKey:
   Enabled: true
 
 Lint/EachWithObjectArgument:
@@ -106,7 +106,7 @@ Lint/LiteralInInterpolation:
 Lint/Loop:
   Enabled: true
 
-Lint/MultipleCompare:
+Lint/MultipleComparison:
   Enabled: true
 
 Lint/NestedPercentLiteral:
@@ -171,7 +171,7 @@ Lint/ShadowedArgument:
 Lint/ShadowingOuterLocalVariable:
   Enabled: true
 
-Lint/StringConversionInInterpolation:
+Lint/RedundantStringCoercion:
   Enabled: true
 
 Lint/Syntax:
@@ -213,10 +213,10 @@ Layout/AccessModifierIndentation:
   Enabled: true
   EnforcedStyle: outdent
 
-Layout/AlignArray:
+Layout/ArrayAlignment:
   Enabled: true
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   Enabled: true
   EnforcedStyle: with_fixed_indentation
 
@@ -292,18 +292,18 @@ Layout/EndOfLine:
 Layout/ExtraSpacing:
   Enabled: true
 
-Layout/IndentAssignment:
+Layout/AssignmentIndentation:
   Enabled: true
 
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   Enabled: true
   EnforcedStyle: consistent
 
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   Enabled: true
   EnforcedStyle: special_inside_parentheses
 
-Layout/IndentFirstArgument:
+Layout/FirstArgumentIndentation:
   Enabled: true
 
 Layout/IndentationConsistency:
@@ -315,7 +315,7 @@ Layout/IndentationWidth:
 Layout/InitialIndentation:
   Enabled: true
 
-Layout/LeadingBlankLines:
+Layout/LeadingEmptyLines:
   Enabled: true
 
 Layout/LeadingCommentSpace:
@@ -386,7 +386,7 @@ Layout/SpaceInsideStringInterpolation:
 Layout/Tab:
   Enabled: true
 
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   Enabled: true
 
 Layout/TrailingWhitespace:
@@ -415,7 +415,7 @@ Naming/HeredocDelimiterCase:
 Naming/MethodName:
   Enabled: true
 
-Naming/UncommunicativeBlockParamName:
+Naming/BlockParameterName:
   Enabled: true
 
 Naming/VariableName:

--- a/spec/support/rubygems_ext.rb
+++ b/spec/support/rubygems_ext.rb
@@ -10,7 +10,7 @@ module Spec
       "rake" => "~> 12.0",
       "ronn" => "~> 0.7.3",
       "rspec" => "~> 3.8",
-      "rubocop" => "= 0.76.0",
+      "rubocop" => "= 0.77.0",
       "rubocop-performance" => "= 1.5.1",
     }.freeze
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

RuboCop 0.77.0 has been released.
https://github.com/rubocop-hq/rubocop/releases/tag/v0.77.0

This PR updates the following changes.

```console
% bin/rake rubocop
bin/rubocop --parallel
Error: The `Layout/AlignArray` cop has been renamed to
`Layout/ArrayAlignment`.
(obsolete configuration found in .rubocop.yml, please update it)
The `Layout/AlignParameters` cop has been renamed to
`Layout/ParameterAlignment`.
(obsolete configuration found in .rubocop.yml, please update it)
The `Layout/IndentAssignment` cop has been renamed to
`Layout/AssignmentIndentation`.
(obsolete configuration found in .rubocop.yml, please update it)
The `Layout/IndentFirstArgument` cop has been renamed to
`Layout/FirstArgumentIndentation`.
(obsolete configuration found in .rubocop.yml, please update it)
The `Layout/IndentFirstArrayElement` cop has been renamed to
`Layout/FirstArrayElementIndentation`.
(obsolete configuration found in .rubocop.yml, please update it)
The `Layout/IndentFirstHashElement` cop has been renamed to
`Layout/FirstHashElementIndentation`.
(obsolete configuration found in .rubocop.yml, please update it)
The `Layout/LeadingBlankLines` cop has been renamed to
`Layout/LeadingEmptyLines`.
(obsolete configuration found in .rubocop.yml, please update it)
The `Layout/TrailingBlankLines` cop has been renamed to
`Layout/TrailingEmptyLines`.
(obsolete configuration found in .rubocop.yml, please update it)
The `Lint/DuplicatedKey` cop has been renamed to
`Lint/DuplicateHashKey`.
(obsolete configuration found in .rubocop.yml, please update it)
The `Lint/MultipleCompare` cop has been renamed to
`Lint/MultipleComparison`.
(obsolete configuration found in .rubocop.yml, please update it)
The `Lint/StringConversionInInterpolation` cop has been renamed to
`Lint/RedundantStringCoercion`.
(obsolete configuration found in .rubocop.yml, please update it)
The `Naming/UncommunicativeBlockParamName` cop has been renamed to
`Naming/BlockParameterName`.
(obsolete configuration found in .rubocop.yml, please update it)
rake aborted!
Command failed with status (2): [bin/rubocop --parallel...]
/Users/koic/src/github.com/bundler/bundler/Rakefile:123:in `block in
<top (required)>'
/Users/koic/src/github.com/bundler/bundler/Rakefile:15:in `block in
invoke'
/Users/koic/src/github.com/bundler/bundler/Rakefile:14:in `invoke'
/Users/koic/src/github.com/bundler/bundler/spec/support/rubygems_ext.rb:87:in
`load'
/Users/koic/src/github.com/bundler/bundler/spec/support/rubygems_ext.rb:87:in
`gem_load_and_activate'
/Users/koic/src/github.com/bundler/bundler/spec/support/rubygems_ext.rb:45:in
`gem_load'
Tasks: TOP => rubocop
(See full trace by running task with --trace)
```

### What is your fix for the problem, implemented in this PR?

And this PR has auto-correction of .rubocop.yml using Mry gem.
https://github.com/pocke/mry

```console
% gem i mry
Fetching mry-0.77.0.2.gem
Successfully installed mry-0.77.0.2
1 gem installed
% mry .rubocop.yml
```
