### PR TITLE
Skip `did_you_mean` and `delegate` failures on MRI 2.7

### DIFF
--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -1203,7 +1203,7 @@ end
     describe "default gem activation" do
       let(:exemptions) do
         if Gem::Version.new(Gem::VERSION) >= Gem::Version.new("2.7")
-          []
+          %w[delegate did_you_mean]
         else
           %w[io-console openssl]
         end << "bundler"


### PR DESCRIPTION
# What was the end-user problem that led to this PR?

`ruby-head` build [is broken again](https://travis-ci.org/bundler/bundler/jobs/624581155).

### What was your diagnosis of the problem?

Ruby 2.7 will turn `did_you_mean` into a default gem. That means that bundler tests that make sure that an arbritary version of default gems can be specified in the `Gemfile` will now run against `did_you_mean`. And this doesn't work because `did_you_mean` is activated in ruby's `prelude.rb`, way before `bundler/setup` is required, so the latest version will always be activated, regardless of what the user specifies. If these versions are not the same, a gem activation conflict error will happen.

Note that this problem is not specific to ruby 2.7, it simply gets triggered by the change of making it a default gem, but it would also happen on older versions if the user `did_you_mean` version specified in the `Gemfile` does not match the latest version installed on her system.

As a consequence of this, we also get activation trouble because `did_you_mean` depends on `delegate` which is also a default gem on ruby 2.7. This problem _is_ specific to ruby 2.7 because `delegate` was not gemified before that, but can probably be workarounded by removing the `delegate` dependendcy from `did_you_mean`.

### What is your fix for the problem, implemented in this PR?

My "fix" allow these failures, because there's not much we can do about this at the moment. However, I'd like to ping @yuki24 and ask how difficult would be to remove the dependency on `delegate` from `did_you_mean`, because that would fix the issue with the `delegate` gem.
