### PR TITLE
Revert "Write & read dummy gems binarily"

### DIFF
--- a/spec/install/redownload_spec.rb
+++ b/spec/install/redownload_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "bundle install" do
       bundle! :install, flag => true
 
       expect(out).to include "Installing rack 1.0.0"
-      expect(rack_lib.binread).to eq("RACK = '1.0.0'\n")
+      expect(rack_lib.open(&:read)).to eq("RACK = '1.0.0'\n")
       expect(the_bundle).to include_gems "rack 1.0.0"
     end
 

--- a/spec/support/builders.rb
+++ b/spec/support/builders.rb
@@ -632,7 +632,7 @@ module Spec
         @files.each do |file, source|
           file = Pathname.new(path).join(file)
           FileUtils.mkdir_p(file.dirname)
-          File.open(file, "wb") {|f| f.puts source }
+          File.open(file, "w") {|f| f.puts source }
         end
         @spec.files = @files.keys
         path


### PR DESCRIPTION
This reverts commit f11c4757a17bea029e1a83ad67c425ccf16133ff.


### What was the end-user problem that led to this PR?

The problem was that since #7451, azure logs are flooded with messages like

```
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in foo.gemspec.
```

This makes it hard to scan for other potential errors.

### What was your diagnosis of the problem?

My diagnosis was that some commit in that PR introduced this warnings.

### What is your fix for the problem, implemented in this PR?

My fix is to revert the offending commit.