### PR TITLE
Fixed test failures with gem command path on ruby core repo

### DIFF
--- a/spec/bundler/gem_helper_spec.rb
+++ b/spec/bundler/gem_helper_spec.rb
@@ -235,7 +235,7 @@ RSpec.describe Bundler::GemHelper do
           end
 
           it "uses Kernel.system" do
-            expect(Kernel).to receive(:system).with("gem", "push", app_gem_path.to_s, "--host", "http://example.org").and_return(true)
+            expect(Kernel).to receive(:system).with(gem_bin, "push", app_gem_path.to_s, "--host", "http://example.org").and_return(true)
 
             Rake.application["release"].invoke
           end

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "bundle exec" do
 
   it "works when exec'ing to rubygems" do
     install_gemfile 'gem "rack"'
-    bundle "exec gem --version"
+    bundle "exec #{gem_cmd} --version"
     expect(out).to eq(Gem::VERSION)
   end
 

--- a/spec/support/path.rb
+++ b/spec/support/path.rb
@@ -21,8 +21,12 @@ module Spec
       @bindir ||= root.join(ruby_core? ? "libexec" : "exe")
     end
 
+    def gem_cmd
+      @gem_cmd ||= ruby_core? ? root.join("bin/gem") : "gem"
+    end
+
     def gem_bin
-      @gem_bin ||= ruby_core? ? ENV["GEM_COMMAND"] : "#{Gem.ruby} -S gem --backtrace"
+      @gem_bin ||= ruby_core? ? ENV["GEM_COMMAND"] : "gem"
     end
 
     def spec_dir

--- a/spec/support/rubygems_ext.rb
+++ b/spec/support/rubygems_ext.rb
@@ -99,7 +99,7 @@ module Spec
       no_reqs.map!(&:first)
       reqs.map! {|name, req| "'#{name}:#{req}'" }
       deps = reqs.concat(no_reqs).join(" ")
-      gem = Path.gem_bin
+      gem = ENV["GEM_COMMAND"] || "#{Gem.ruby} -S gem --backtrace"
       cmd = "#{gem} install #{deps} --no-document --conservative"
       system(cmd) || raise("Installing gems #{deps} for the tests to use failed!")
     end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Some of the examples failed with ruby-core repository.

### What was your diagnosis of the problem?

The ruby-core repository used `gem` commands under the its repository named `bin/gem` directory. But the current examples points `gem` command with a global path.

### What is your fix for the problem, implemented in this PR?

I fixed them used by `ruby_core?` helper methods.
