### PR TITLE
Delegate should be supported now

### DIFF
--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -1203,7 +1203,7 @@ end
     describe "default gem activation" do
       let(:exemptions) do
         if Gem::Version.new(Gem::VERSION) >= Gem::Version.new("2.7")
-          %w[delegate did_you_mean]
+          %w[did_you_mean]
         else
           %w[io-console openssl]
         end << "bundler"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that delegate is now supported since `did_you_mean` drop its dependency on it at https://github.com/ruby/ruby/commit/e2708068ad65f7f9986adf4fb3a4fa660f430a5a.

### What was your diagnosis of the problem?

My diagnosis was that we can test that arbitrary `delegate` versions can be included in Gemfiles again.

### What is your fix for the problem, implemented in this PR?

My fix removes `delegate` from the exemptions.