### PR TITLE
Fix another silent rubygems issue

### DIFF
--- a/lib/bundler/cli/exec.rb
+++ b/lib/bundler/cli/exec.rb
@@ -25,12 +25,12 @@ module Bundler
       SharedHelpers.set_bundle_environment
       if bin_path = Bundler.which(cmd)
         if !Bundler.settings[:disable_exec_load] && ruby_shebang?(bin_path)
-          return with_verbose_rubygems { kernel_load(bin_path, *args) }
+          return kernel_load(bin_path, *args)
         end
-        with_verbose_rubygems { kernel_exec(bin_path, *args) }
+        kernel_exec(bin_path, *args)
       else
         # exec using the given command
-        with_verbose_rubygems { kernel_exec(cmd, *args) }
+        kernel_exec(cmd, *args)
       end
     end
 
@@ -88,15 +88,6 @@ module Bundler
 
       first_line = File.open(file, "rb") {|f| f.read(possibilities.map(&:size).max) }
       possibilities.any? {|shebang| first_line.start_with?(shebang) }
-    end
-
-    def with_verbose_rubygems
-      old_ui = Gem::DefaultUserInteraction.ui
-      Gem::DefaultUserInteraction.ui = nil
-
-      yield
-    ensure
-      Gem::DefaultUserInteraction.ui = old_ui
     end
   end
 end

--- a/lib/bundler/setup.rb
+++ b/lib/bundler/setup.rb
@@ -19,4 +19,9 @@ if Bundler::SharedHelpers.in_bundle?
   else
     Bundler.ui.silence { Bundler.setup }
   end
+
+  # We might be in the middle of shelling out to rubygems
+  # (RUBYOPT=-rbundler/setup), so we need to give rubygems the opportunity of
+  # not being silent.
+  Gem::DefaultUserInteraction.ui = nil
 end

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -61,6 +61,12 @@ RSpec.describe "bundle exec" do
     expect(out).to eq(Gem::VERSION)
   end
 
+  it "works when exec'ing to rubygems through sh -c" do
+    install_gemfile 'gem "rack"'
+    bundle "exec sh -c '#{gem_cmd} --version'"
+    expect(out).to eq(Gem::VERSION)
+  end
+
   it "respects custom process title when loading through ruby" do
     script_that_changes_its_own_title_and_checks_if_picked_up_by_ps_unix_utility = <<~'RUBY'
       Process.setproctitle("1-2-3-4-5-6-7-8-9-10-11-12-13-14-15")


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that we still have some issues where using the `gem` script on a `bundler` context is silenced.

### What was your diagnosis of the problem?

My diagnosis was that `bundle exec` adds `-rbundler/setup` to RUBYOPT which silences `rubygems` output, and that we need to reset `rubygems` UI after that so that if we end up shelling out to `gem`, it is not silent. The previous approach worked for loading the `gem` script in-process, but didn't work in other case.

### What is your fix for the problem, implemented in this PR?

My fix is to reset rubygems UI right after `bundler/setup`.

### Why did you choose this fix out of the possible options?

I chose this fix because it fixes the problem independently of the rubygems version being run, but we can probably also fix this more cleanly inside the `gem` script by adding something like `Gem::DefaultUserInteraction.ui = Gem::ConsoleUI.new` at the top of the script.

Fixes #7490.
