### PR TITLE
Add compatibility methods for `rubygems-bundler` gem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,9 @@ jobs:
     - rvm: 2.6.5
       script: bin/rake rubocop
       stage: linting
+    - rvm: 2.6.5
+      script: bin/rake check_rvm_integration
+      stage: linting
     # Ruby 2.3 also tested in 2.x mode
     - rvm: 2.3.8
       env: RGV=master

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-$:.unshift File.expand_path("../lib", __FILE__)
 require "benchmark"
 
 require_relative "spec/support/rubygems_ext"

--- a/Rakefile
+++ b/Rakefile
@@ -122,6 +122,14 @@ task :rubocop do
   sh("bin/rubocop --parallel")
 end
 
+desc "Check RVM integration"
+task :check_rvm_integration do
+  # The rubygems-bundler gem is installed by RVM by default and it could easily
+  # break when we change bundler. Make sure that binstubs still run with it
+  # installed.
+  sh("bin/rake install && gem install rubygems-bundler && rake -T")
+end
+
 namespace :man do
   if RUBY_ENGINE == "jruby"
     task(:build) {}

--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -496,6 +496,14 @@ module Bundler
       end
     end
 
+    def plain_specs
+      Gem::Specification._all
+    end
+
+    def plain_specs=(specs)
+      Gem::Specification.all = specs
+    end
+
     def fetch_specs(remote, name)
       path = remote.uri.to_s + "#{name}.#{Gem.marshal_version}.gz"
       fetcher = gem_remote_fetcher


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that `bundler install` on a `ruby` installation using `rvm` is broken by default.

### What was your diagnosis of the problem?

My diagnosis was that during 2.1.0 development phase I removed some stuff I thought it was internal and nobody would be using.

### What is your fix for the problem, implemented in this PR?

My fix is to restore a minimal compatibility layer so that this stuff works again.

### Why did you choose this fix out of the possible options?

I chose this fix because I think this is the minimum set of additions that gets stuff working again.

Fixes #7488.