### PR TITLE
Delay appending `ruby/<ABI_VERSION>` to `$BUNDLE_PATH`

### DIFF
--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -36,6 +36,7 @@ module Bundler
     settings_flag(:deployment_means_frozen) { bundler_3_mode? }
     settings_flag(:disable_multisource) { bundler_3_mode? }
     settings_flag(:forget_cli_options) { bundler_3_mode? }
+    settings_flag(:global_path_appends_ruby_scope) { bundler_3_mode? }
     settings_flag(:global_gem_cache) { bundler_3_mode? }
     settings_flag(:only_update_to_newer_versions) { bundler_3_mode? }
     settings_flag(:path_relative_to_cwd) { bundler_3_mode? }

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -210,17 +210,17 @@ module Bundler
       key  = key_for(:path)
       path = ENV[key] || @global_config[key]
       if path && !@temporary.key?(key) && !@local_config.key?(key)
-        return Path.new(path, false, false)
+        return Path.new(path, true, false, false)
       end
 
       system_path = self["path.system"] || (self[:disable_shared_gems] == false)
-      Path.new(self[:path], system_path, Bundler.feature_flag.default_install_uses_path?)
+      Path.new(self[:path], true, system_path, Bundler.feature_flag.default_install_uses_path?)
     end
 
-    Path = Struct.new(:explicit_path, :system_path, :default_install_uses_path) do
+    Path = Struct.new(:explicit_path, :append_ruby_scope, :system_path, :default_install_uses_path) do
       def path
         path = base_path
-        path = File.join(path, Bundler.ruby_scope) unless use_system_gems?
+        path = File.join(path, Bundler.ruby_scope) if append_ruby_scope && !use_system_gems?
         path
       end
 

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -30,6 +30,7 @@ module Bundler
       frozen
       gem.coc
       gem.mit
+      global_path_appends_ruby_scope
       global_gem_cache
       ignore_messages
       init_gems_rb
@@ -205,12 +206,13 @@ module Bundler
       locations
     end
 
-    # for legacy reasons, in Bundler 2, we do not respect :disable_shared_gems
+    # for legacy reasons, in Bundler 2, the ruby scope isnt appended when the setting comes from ENV or the global config,
+    # nor do we respect :disable_shared_gems
     def path
       key  = key_for(:path)
       path = ENV[key] || @global_config[key]
       if path && !@temporary.key?(key) && !@local_config.key?(key)
-        return Path.new(path, true, false, false)
+        return Path.new(path, Bundler.feature_flag.global_path_appends_ruby_scope?, false, false)
       end
 
       system_path = self["path.system"] || (self[:disable_shared_gems] == false)

--- a/man/bundle-config.1
+++ b/man/bundle-config.1
@@ -211,6 +211,9 @@ The following is a list of all configuration keys and their purpose\. You can le
 \fBglobal_gem_cache\fR (\fBBUNDLE_GLOBAL_GEM_CACHE\fR): Whether Bundler should cache all gems globally, rather than locally to the installing Ruby installation\.
 .
 .IP "\(bu" 4
+\fBglobal_path_appends_ruby_scope\fR (\fBBUNDLE_GLOBAL_PATH_APPENDS_RUBY_SCOPE\fR): Whether Bundler should append the Ruby scope (e\.g\. engine and ABI version) to a globally\-configured path\.
+.
+.IP "\(bu" 4
 \fBignore_messages\fR (\fBBUNDLE_IGNORE_MESSAGES\fR): When set, no post install messages will be printed\. To silence a single gem, use dot notation like \fBignore_messages\.httparty true\fR\.
 .
 .IP "\(bu" 4

--- a/man/bundle-config.1
+++ b/man/bundle-config.1
@@ -211,9 +211,6 @@ The following is a list of all configuration keys and their purpose\. You can le
 \fBglobal_gem_cache\fR (\fBBUNDLE_GLOBAL_GEM_CACHE\fR): Whether Bundler should cache all gems globally, rather than locally to the installing Ruby installation\.
 .
 .IP "\(bu" 4
-\fBglobal_path_appends_ruby_scope\fR (\fBBUNDLE_GLOBAL_PATH_APPENDS_RUBY_SCOPE\fR): Whether Bundler should append the Ruby scope (e\.g\. engine and ABI version) to a globally\-configured path\.
-.
-.IP "\(bu" 4
 \fBignore_messages\fR (\fBBUNDLE_IGNORE_MESSAGES\fR): When set, no post install messages will be printed\. To silence a single gem, use dot notation like \fBignore_messages\.httparty true\fR\.
 .
 .IP "\(bu" 4
@@ -313,6 +310,13 @@ In general, you should set these settings per\-application by using the applicab
 .
 .P
 You can set them globally either via environment variables or \fBbundle config\fR, whichever is preferable for your setup\. If you use both, environment variables will take preference over global settings\.
+.
+.SH "LIST OF EARLY OPT\-IN CONFIGURATION KEYS"
+The following is a list of configuration keys meant to only be used to early opt into bug fixes that are deemed to be too disruptive to be shipped on a non\-major release of Bundler\. The functionality they enable will be the default and only behavior in future versions of bundler\. Only set these settings to true\.
+.
+.TP
+\fBglobal_path_appends_ruby_scope\fR (\fBBUNDLE_GLOBAL_PATH_APPENDS_RUBY_SCOPE\fR)
+Whether Bundler should append the Ruby scope (e\.g\. engine and ABI version) to a globally\-configured path\.
 .
 .SH "LOCAL GIT REPOS"
 Bundler also allows you to work against a git repository locally instead of using the remote version\. This can be achieved by setting up a local override:

--- a/man/bundle-config.1.txt
+++ b/man/bundle-config.1.txt
@@ -247,89 +247,84 @@ LIST OF AVAILABLE KEYS
 	   cache all gems globally, rather than locally to the installing Ruby
 	   installation.
 
-       o   global_path_appends_ruby_scope				 (BUN-
-	   DLE_GLOBAL_PATH_APPENDS_RUBY_SCOPE): Whether Bundler should	append
-	   the	Ruby scope (e.g. engine and ABI version) to a globally-config-
-	   ured path.
-
        o   ignore_messages (BUNDLE_IGNORE_MESSAGES): When set, no post install
 	   messages will be printed. To silence a single gem, use dot notation
 	   like ignore_messages.httparty true.
 
-       o   init_gems_rb (BUNDLE_INIT_GEMS_RB) Generate a gems.rb instead of  a
+       o   init_gems_rb  (BUNDLE_INIT_GEMS_RB) Generate a gems.rb instead of a
 	   Gemfile when running bundle init.
 
-       o   jobs  (BUNDLE_JOBS): The number of gems Bundler can install in par-
+       o   jobs (BUNDLE_JOBS): The number of gems Bundler can install in  par-
 	   allel. Defaults to 1.
 
-       o   no_install (BUNDLE_NO_INSTALL): Whether bundle package should  skip
+       o   no_install  (BUNDLE_NO_INSTALL): Whether bundle package should skip
 	   installing gems.
 
-       o   no_prune  (BUNDLE_NO_PRUNE):  Whether Bundler should leave outdated
+       o   no_prune (BUNDLE_NO_PRUNE): Whether Bundler should  leave  outdated
 	   gems unpruned when caching.
 
        o   only_update_to_newer_versions     (BUNDLE_ONLY_UPDATE_TO_NEWER_VER-
 	   SIONS): During bundle update, only resolve to newer versions of the
 	   gems in the lockfile.
 
-       o   path (BUNDLE_PATH): The location on disk where  all	gems  in  your
+       o   path  (BUNDLE_PATH):  The  location	on disk where all gems in your
 	   bundle will be located regardless of $GEM_HOME or $GEM_PATH values.
-	   Bundle gems not found in this location will be installed by	bundle
-	   install.  Defaults  to Gem.dir. When --deployment is used, defaults
+	   Bundle  gems not found in this location will be installed by bundle
+	   install. Defaults to Gem.dir. When --deployment is  used,  defaults
 	   to vendor/bundle.
 
-       o   path.system (BUNDLE_PATH__SYSTEM):  Whether	Bundler  will  install
+       o   path.system	(BUNDLE_PATH__SYSTEM):	Whether  Bundler  will install
 	   gems into the default system path (Gem.dir).
 
-       o   path_relative_to_cwd   (BUNDLE_PATH_RELATIVE_TO_CWD)  Makes	--path
+       o   path_relative_to_cwd  (BUNDLE_PATH_RELATIVE_TO_CWD)	Makes	--path
 	   relative to the CWD instead of the Gemfile.
 
        o   plugins (BUNDLE_PLUGINS): Enable Bundler's experimental plugin sys-
 	   tem.
 
-       o   prefer_patch  (BUNDLE_PREFER_PATCH):  Prefer  updating only to next
-	   patch version during updates. Makes bundle update calls  equivalent
+       o   prefer_patch (BUNDLE_PREFER_PATCH): Prefer updating	only  to  next
+	   patch  version during updates. Makes bundle update calls equivalent
 	   to bundler update --patch.
 
-       o   print_only_version_number  (BUNDLE_PRINT_ONLY_VERSION_NUMBER) Print
+       o   print_only_version_number (BUNDLE_PRINT_ONLY_VERSION_NUMBER)  Print
 	   only version number from bundler --version.
 
-       o   redirect (BUNDLE_REDIRECT): The number  of  redirects  allowed  for
+       o   redirect  (BUNDLE_REDIRECT):  The  number  of redirects allowed for
 	   network requests. Defaults to 5.
 
-       o   retry  (BUNDLE_RETRY):  The number of times to retry failed network
+       o   retry (BUNDLE_RETRY): The number of times to retry  failed  network
 	   requests. Defaults to 3.
 
        o   setup_makes_kernel_gem_public   (BUNDLE_SETUP_MAKES_KERNEL_GEM_PUB-
-	   LIC):  Have	Bundler.setup  make the Kernel#gem method public, even
+	   LIC): Have Bundler.setup make the Kernel#gem  method  public,  even
 	   though RubyGems declares it as private.
 
-       o   shebang (BUNDLE_SHEBANG): The program name that should  be  invoked
-	   for	generated  binstubs. Defaults to the ruby install name used to
+       o   shebang  (BUNDLE_SHEBANG):  The program name that should be invoked
+	   for generated binstubs. Defaults to the ruby install name  used  to
 	   generate the binstub.
 
        o   silence_deprecations (BUNDLE_SILENCE_DEPRECATIONS): Whether Bundler
-	   should  silence  deprecation  warnings  for	behavior  that will be
+	   should silence deprecation  warnings  for  behavior	that  will  be
 	   changed in the next major version.
 
-       o   silence_root_warning  (BUNDLE_SILENCE_ROOT_WARNING):  Silence   the
+       o   silence_root_warning   (BUNDLE_SILENCE_ROOT_WARNING):  Silence  the
 	   warning Bundler prints when installing gems as root.
 
        o   skip_default_git_sources (BUNDLE_SKIP_DEFAULT_GIT_SOURCES): Whether
 	   Bundler should skip adding default git source shortcuts to the Gem-
 	   file DSL.
 
-       o   specific_platform   (BUNDLE_SPECIFIC_PLATFORM):  Allow  bundler  to
+       o   specific_platform  (BUNDLE_SPECIFIC_PLATFORM):  Allow  bundler   to
 	   resolve for the specific running platform and store it in the lock-
 	   file, instead of only using a generic platform. A specific platform
-	   is the exact platform triple reported by Gem::Platform.local,  such
-	   as  x86_64-darwin-16  or  universal-java-1.8.  On  the  other hand,
-	   generic platforms are those such as ruby, mswin, or java.  In  this
-	   example,  x86_64-darwin-16 would map to ruby and universal-java-1.8
+	   is  the exact platform triple reported by Gem::Platform.local, such
+	   as x86_64-darwin-16	or  universal-java-1.8.  On  the  other  hand,
+	   generic  platforms  are those such as ruby, mswin, or java. In this
+	   example, x86_64-darwin-16 would map to ruby and  universal-java-1.8
 	   to java.
 
-       o   ssl_ca_cert (BUNDLE_SSL_CA_CERT): Path to a designated CA  certifi-
-	   cate  file  or  folder containing multiple certificates for trusted
+       o   ssl_ca_cert	(BUNDLE_SSL_CA_CERT): Path to a designated CA certifi-
+	   cate file or folder containing multiple  certificates  for  trusted
 	   CAs in PEM format.
 
        o   ssl_client_cert (BUNDLE_SSL_CLIENT_CERT): Path to a designated file
@@ -339,41 +334,52 @@ LIST OF AVAILABLE KEYS
 	   Bundler uses when making HTTPS requests. Defaults to verify peer.
 
        o   suppress_install_using_messages (BUNDLE_SUPPRESS_INSTALL_USING_MES-
-	   SAGES):  Avoid printing Using ... messages during installation when
+	   SAGES): Avoid printing Using ... messages during installation  when
 	   the version of a gem has not changed.
 
-       o   system_bindir (BUNDLE_SYSTEM_BINDIR): The location  where  RubyGems
+       o   system_bindir  (BUNDLE_SYSTEM_BINDIR):  The location where RubyGems
 	   installs binstubs. Defaults to Gem.bindir.
 
        o   timeout (BUNDLE_TIMEOUT): The seconds allowed before timing out for
 	   network requests. Defaults to 10.
 
        o   unlock_source_unlocks_spec	  (BUNDLE_UNLOCK_SOURCE_UNLOCKS_SPEC):
-	   Whether  running bundle update --source NAME unlocks a gem with the
+	   Whether running bundle update --source NAME unlocks a gem with  the
 	   given name. Defaults to true.
 
-       o   update_requires_all_flag (BUNDLE_UPDATE_REQUIRES_ALL_FLAG)  Require
-	   passing  --all  to bundle update when everything should be updated,
+       o   update_requires_all_flag  (BUNDLE_UPDATE_REQUIRES_ALL_FLAG) Require
+	   passing --all to bundle update when everything should  be  updated,
 	   and disallow passing no options to bundle update.
 
-       o   user_agent (BUNDLE_USER_AGENT):  The  custom  user  agent  fragment
+       o   user_agent  (BUNDLE_USER_AGENT):  The  custom  user	agent fragment
 	   Bundler includes in API requests.
 
        o   with (BUNDLE_WITH): A :-separated list of groups whose gems bundler
 	   should install.
 
-       o   without (BUNDLE_WITHOUT): A :-separated list of groups  whose  gems
+       o   without  (BUNDLE_WITHOUT):  A :-separated list of groups whose gems
 	   bundler should not install.
 
 
 
-       In  general, you should set these settings per-application by using the
-       applicable flag to the bundle install(1) bundle-install.1.html or  bun-
+       In general, you should set these settings per-application by using  the
+       applicable  flag to the bundle install(1) bundle-install.1.html or bun-
        dle package(1) bundle-package.1.html command.
 
-       You  can  set  them globally either via environment variables or bundle
-       config, whichever is preferable for your setup. If you use both,  envi-
+       You can set them globally either via environment  variables  or	bundle
+       config,	whichever is preferable for your setup. If you use both, envi-
        ronment variables will take preference over global settings.
+
+LIST OF EARLY OPT-IN CONFIGURATION KEYS
+       The following is a list of configuration keys meant to only be used  to
+       early  opt  into  bug  fixes that are deemed to be too disruptive to be
+       shipped on a non-major  release	of  Bundler.  The  functionality  they
+       enable  will  be  the  default  and only behavior in future versions of
+       bundler. Only set these settings to true.
+
+       global_path_appends_ruby_scope (BUNDLE_GLOBAL_PATH_APPENDS_RUBY_SCOPE)
+	      Whether Bundler should append the Ruby scope  (e.g.  engine  and
+	      ABI version) to a globally-configured path.
 
 LOCAL GIT REPOS
        Bundler	also  allows  you  to  work  against  a git repository locally

--- a/man/bundle-config.1.txt
+++ b/man/bundle-config.1.txt
@@ -247,84 +247,89 @@ LIST OF AVAILABLE KEYS
 	   cache all gems globally, rather than locally to the installing Ruby
 	   installation.
 
+       o   global_path_appends_ruby_scope				 (BUN-
+	   DLE_GLOBAL_PATH_APPENDS_RUBY_SCOPE): Whether Bundler should	append
+	   the	Ruby scope (e.g. engine and ABI version) to a globally-config-
+	   ured path.
+
        o   ignore_messages (BUNDLE_IGNORE_MESSAGES): When set, no post install
 	   messages will be printed. To silence a single gem, use dot notation
 	   like ignore_messages.httparty true.
 
-       o   init_gems_rb  (BUNDLE_INIT_GEMS_RB) Generate a gems.rb instead of a
+       o   init_gems_rb (BUNDLE_INIT_GEMS_RB) Generate a gems.rb instead of  a
 	   Gemfile when running bundle init.
 
-       o   jobs (BUNDLE_JOBS): The number of gems Bundler can install in  par-
+       o   jobs  (BUNDLE_JOBS): The number of gems Bundler can install in par-
 	   allel. Defaults to 1.
 
-       o   no_install  (BUNDLE_NO_INSTALL): Whether bundle package should skip
+       o   no_install (BUNDLE_NO_INSTALL): Whether bundle package should  skip
 	   installing gems.
 
-       o   no_prune (BUNDLE_NO_PRUNE): Whether Bundler should  leave  outdated
+       o   no_prune  (BUNDLE_NO_PRUNE):  Whether Bundler should leave outdated
 	   gems unpruned when caching.
 
        o   only_update_to_newer_versions     (BUNDLE_ONLY_UPDATE_TO_NEWER_VER-
 	   SIONS): During bundle update, only resolve to newer versions of the
 	   gems in the lockfile.
 
-       o   path  (BUNDLE_PATH):  The  location	on disk where all gems in your
+       o   path (BUNDLE_PATH): The location on disk where  all	gems  in  your
 	   bundle will be located regardless of $GEM_HOME or $GEM_PATH values.
-	   Bundle  gems not found in this location will be installed by bundle
-	   install. Defaults to Gem.dir. When --deployment is  used,  defaults
+	   Bundle gems not found in this location will be installed by	bundle
+	   install.  Defaults  to Gem.dir. When --deployment is used, defaults
 	   to vendor/bundle.
 
-       o   path.system	(BUNDLE_PATH__SYSTEM):	Whether  Bundler  will install
+       o   path.system (BUNDLE_PATH__SYSTEM):  Whether	Bundler  will  install
 	   gems into the default system path (Gem.dir).
 
-       o   path_relative_to_cwd  (BUNDLE_PATH_RELATIVE_TO_CWD)	Makes	--path
+       o   path_relative_to_cwd   (BUNDLE_PATH_RELATIVE_TO_CWD)  Makes	--path
 	   relative to the CWD instead of the Gemfile.
 
        o   plugins (BUNDLE_PLUGINS): Enable Bundler's experimental plugin sys-
 	   tem.
 
-       o   prefer_patch (BUNDLE_PREFER_PATCH): Prefer updating	only  to  next
-	   patch  version during updates. Makes bundle update calls equivalent
+       o   prefer_patch  (BUNDLE_PREFER_PATCH):  Prefer  updating only to next
+	   patch version during updates. Makes bundle update calls  equivalent
 	   to bundler update --patch.
 
-       o   print_only_version_number (BUNDLE_PRINT_ONLY_VERSION_NUMBER)  Print
+       o   print_only_version_number  (BUNDLE_PRINT_ONLY_VERSION_NUMBER) Print
 	   only version number from bundler --version.
 
-       o   redirect  (BUNDLE_REDIRECT):  The  number  of redirects allowed for
+       o   redirect (BUNDLE_REDIRECT): The number  of  redirects  allowed  for
 	   network requests. Defaults to 5.
 
-       o   retry (BUNDLE_RETRY): The number of times to retry  failed  network
+       o   retry  (BUNDLE_RETRY):  The number of times to retry failed network
 	   requests. Defaults to 3.
 
        o   setup_makes_kernel_gem_public   (BUNDLE_SETUP_MAKES_KERNEL_GEM_PUB-
-	   LIC): Have Bundler.setup make the Kernel#gem  method  public,  even
+	   LIC):  Have	Bundler.setup  make the Kernel#gem method public, even
 	   though RubyGems declares it as private.
 
-       o   shebang  (BUNDLE_SHEBANG):  The program name that should be invoked
-	   for generated binstubs. Defaults to the ruby install name  used  to
+       o   shebang (BUNDLE_SHEBANG): The program name that should  be  invoked
+	   for	generated  binstubs. Defaults to the ruby install name used to
 	   generate the binstub.
 
        o   silence_deprecations (BUNDLE_SILENCE_DEPRECATIONS): Whether Bundler
-	   should silence deprecation  warnings  for  behavior	that  will  be
+	   should  silence  deprecation  warnings  for	behavior  that will be
 	   changed in the next major version.
 
-       o   silence_root_warning   (BUNDLE_SILENCE_ROOT_WARNING):  Silence  the
+       o   silence_root_warning  (BUNDLE_SILENCE_ROOT_WARNING):  Silence   the
 	   warning Bundler prints when installing gems as root.
 
        o   skip_default_git_sources (BUNDLE_SKIP_DEFAULT_GIT_SOURCES): Whether
 	   Bundler should skip adding default git source shortcuts to the Gem-
 	   file DSL.
 
-       o   specific_platform  (BUNDLE_SPECIFIC_PLATFORM):  Allow  bundler   to
+       o   specific_platform   (BUNDLE_SPECIFIC_PLATFORM):  Allow  bundler  to
 	   resolve for the specific running platform and store it in the lock-
 	   file, instead of only using a generic platform. A specific platform
-	   is  the exact platform triple reported by Gem::Platform.local, such
-	   as x86_64-darwin-16	or  universal-java-1.8.  On  the  other  hand,
-	   generic  platforms  are those such as ruby, mswin, or java. In this
-	   example, x86_64-darwin-16 would map to ruby and  universal-java-1.8
+	   is the exact platform triple reported by Gem::Platform.local,  such
+	   as  x86_64-darwin-16  or  universal-java-1.8.  On  the  other hand,
+	   generic platforms are those such as ruby, mswin, or java.  In  this
+	   example,  x86_64-darwin-16 would map to ruby and universal-java-1.8
 	   to java.
 
-       o   ssl_ca_cert	(BUNDLE_SSL_CA_CERT): Path to a designated CA certifi-
-	   cate file or folder containing multiple  certificates  for  trusted
+       o   ssl_ca_cert (BUNDLE_SSL_CA_CERT): Path to a designated CA  certifi-
+	   cate  file  or  folder containing multiple certificates for trusted
 	   CAs in PEM format.
 
        o   ssl_client_cert (BUNDLE_SSL_CLIENT_CERT): Path to a designated file
@@ -334,44 +339,44 @@ LIST OF AVAILABLE KEYS
 	   Bundler uses when making HTTPS requests. Defaults to verify peer.
 
        o   suppress_install_using_messages (BUNDLE_SUPPRESS_INSTALL_USING_MES-
-	   SAGES): Avoid printing Using ... messages during installation  when
+	   SAGES):  Avoid printing Using ... messages during installation when
 	   the version of a gem has not changed.
 
-       o   system_bindir  (BUNDLE_SYSTEM_BINDIR):  The location where RubyGems
+       o   system_bindir (BUNDLE_SYSTEM_BINDIR): The location  where  RubyGems
 	   installs binstubs. Defaults to Gem.bindir.
 
        o   timeout (BUNDLE_TIMEOUT): The seconds allowed before timing out for
 	   network requests. Defaults to 10.
 
        o   unlock_source_unlocks_spec	  (BUNDLE_UNLOCK_SOURCE_UNLOCKS_SPEC):
-	   Whether running bundle update --source NAME unlocks a gem with  the
+	   Whether  running bundle update --source NAME unlocks a gem with the
 	   given name. Defaults to true.
 
-       o   update_requires_all_flag  (BUNDLE_UPDATE_REQUIRES_ALL_FLAG) Require
-	   passing --all to bundle update when everything should  be  updated,
+       o   update_requires_all_flag (BUNDLE_UPDATE_REQUIRES_ALL_FLAG)  Require
+	   passing  --all  to bundle update when everything should be updated,
 	   and disallow passing no options to bundle update.
 
-       o   user_agent  (BUNDLE_USER_AGENT):  The  custom  user	agent fragment
+       o   user_agent (BUNDLE_USER_AGENT):  The  custom  user  agent  fragment
 	   Bundler includes in API requests.
 
        o   with (BUNDLE_WITH): A :-separated list of groups whose gems bundler
 	   should install.
 
-       o   without  (BUNDLE_WITHOUT):  A :-separated list of groups whose gems
+       o   without (BUNDLE_WITHOUT): A :-separated list of groups  whose  gems
 	   bundler should not install.
 
 
 
-       In general, you should set these settings per-application by using  the
-       applicable  flag to the bundle install(1) bundle-install.1.html or bun-
+       In  general, you should set these settings per-application by using the
+       applicable flag to the bundle install(1) bundle-install.1.html or  bun-
        dle package(1) bundle-package.1.html command.
 
-       You can set them globally either via environment  variables  or	bundle
-       config,	whichever is preferable for your setup. If you use both, envi-
+       You  can  set  them globally either via environment variables or bundle
+       config, whichever is preferable for your setup. If you use both,  envi-
        ronment variables will take preference over global settings.
 
 LOCAL GIT REPOS
-       Bundler also allows you	to  work  against  a  git  repository  locally
+       Bundler	also  allows  you  to  work  against  a git repository locally
        instead of using the remote version. This can be achieved by setting up
        a local override:
 
@@ -390,30 +395,30 @@ LOCAL GIT REPOS
 
 
 
-       Now  instead of checking out the remote git repository, the local over-
-       ride will be used. Similar to a path source, every time the  local  git
-       repository  change, changes will be automatically picked up by Bundler.
-       This means a commit in the local git repo will update the  revision  in
+       Now instead of checking out the remote git repository, the local  over-
+       ride  will  be used. Similar to a path source, every time the local git
+       repository change, changes will be automatically picked up by  Bundler.
+       This  means  a commit in the local git repo will update the revision in
        the Gemfile.lock to the local git repo revision. This requires the same
-       attention as git submodules. Before pushing to the remote, you need  to
+       attention  as git submodules. Before pushing to the remote, you need to
        ensure the local override was pushed, otherwise you may point to a com-
-       mit that only exists in your local machine. You'll  also  need  to  CGI
+       mit  that  only	exists	in your local machine. You'll also need to CGI
        escape your usernames and passwords as well.
 
-       Bundler	does many checks to ensure a developer won't work with invalid
-       references. Particularly, we force a developer to specify a  branch  in
-       the  Gemfile  in  order to use this feature. If the branch specified in
-       the Gemfile and the current branch in the local git repository  do  not
-       match,  Bundler	will  abort.  This  ensures that a developer is always
-       working against the correct branches, and prevents  accidental  locking
+       Bundler does many checks to ensure a developer won't work with  invalid
+       references.  Particularly,  we force a developer to specify a branch in
+       the Gemfile in order to use this feature. If the  branch  specified  in
+       the  Gemfile  and the current branch in the local git repository do not
+       match, Bundler will abort. This ensures	that  a  developer  is	always
+       working	against  the correct branches, and prevents accidental locking
        to a different branch.
 
-       Finally,  Bundler  also	ensures  that the current revision in the Gem-
-       file.lock exists in the local git repository. By  doing	this,  Bundler
+       Finally, Bundler also ensures that the current  revision  in  the  Gem-
+       file.lock  exists  in  the local git repository. By doing this, Bundler
        forces you to fetch the latest changes in the remotes.
 
 MIRRORS OF GEM SOURCES
-       Bundler	supports  overriding gem sources with mirrors. This allows you
+       Bundler supports overriding gem sources with mirrors. This  allows  you
        to configure rubygems.org as the gem source in your Gemfile while still
        using your mirror to fetch gems.
 
@@ -423,7 +428,7 @@ MIRRORS OF GEM SOURCES
 
 
 
-       For  example,  to  use a mirror of rubygems.org hosted at rubygems-mir-
+       For example, to use a mirror of rubygems.org  hosted  at  rubygems-mir-
        ror.org:
 
 
@@ -432,8 +437,8 @@ MIRRORS OF GEM SOURCES
 
 
 
-       Each mirror also provides a fallback timeout  setting.  If  the	mirror
-       does  not  respond within the fallback timeout, Bundler will try to use
+       Each  mirror  also  provides  a fallback timeout setting. If the mirror
+       does not respond within the fallback timeout, Bundler will try  to  use
        the original server instead of the mirror.
 
 
@@ -450,11 +455,11 @@ MIRRORS OF GEM SOURCES
 
 
 
-       The default fallback timeout is 0.1 seconds, but the setting  can  cur-
+       The  default  fallback timeout is 0.1 seconds, but the setting can cur-
        rently only accept whole seconds (for example, 1, 15, or 30).
 
 CREDENTIALS FOR GEM SOURCES
-       Bundler	allows	you to configure credentials for any gem source, which
+       Bundler allows you to configure credentials for any gem	source,  which
        allows you to avoid putting secrets into your Gemfile.
 
 
@@ -463,7 +468,7 @@ CREDENTIALS FOR GEM SOURCES
 
 
 
-       For example, to save the credentials of	user  claudette  for  the  gem
+       For  example,  to  save	the  credentials of user claudette for the gem
        source at gems.longerous.com, you would run:
 
 
@@ -497,7 +502,7 @@ CREDENTIALS FOR GEM SOURCES
 
 
 
-       This is especially useful for private repositories  on  hosts  such  as
+       This  is  especially  useful  for private repositories on hosts such as
        Github, where you can use personal OAuth tokens:
 
 
@@ -507,9 +512,9 @@ CREDENTIALS FOR GEM SOURCES
 
 
 CONFIGURE BUNDLER DIRECTORIES
-       Bundler's  home,  config,  cache  and plugin directories are able to be
-       configured through environment  variables.  The	default  location  for
-       Bundler's  home	directory  is ~/.bundle, which all directories inherit
+       Bundler's home, config, cache and plugin directories  are  able	to  be
+       configured  through  environment  variables.  The  default location for
+       Bundler's home directory is ~/.bundle, which  all  directories  inherit
        from by default. The following outlines the available environment vari-
        ables and their default values
 

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -205,6 +205,9 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
 * `global_gem_cache` (`BUNDLE_GLOBAL_GEM_CACHE`):
    Whether Bundler should cache all gems globally, rather than locally to the
    installing Ruby installation.
+* `global_path_appends_ruby_scope` (`BUNDLE_GLOBAL_PATH_APPENDS_RUBY_SCOPE`):
+   Whether Bundler should append the Ruby scope (e.g. engine and ABI version)
+   to a globally-configured path.
 * `ignore_messages` (`BUNDLE_IGNORE_MESSAGES`): When set, no post install
    messages will be printed. To silence a single gem, use dot notation like
    `ignore_messages.httparty true`.

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -205,9 +205,6 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
 * `global_gem_cache` (`BUNDLE_GLOBAL_GEM_CACHE`):
    Whether Bundler should cache all gems globally, rather than locally to the
    installing Ruby installation.
-* `global_path_appends_ruby_scope` (`BUNDLE_GLOBAL_PATH_APPENDS_RUBY_SCOPE`):
-   Whether Bundler should append the Ruby scope (e.g. engine and ABI version)
-   to a globally-configured path.
 * `ignore_messages` (`BUNDLE_IGNORE_MESSAGES`): When set, no post install
    messages will be printed. To silence a single gem, use dot notation like
    `ignore_messages.httparty true`.
@@ -298,6 +295,17 @@ flag to the [bundle install(1)](bundle-install.1.html) or [bundle package(1)](bu
 You can set them globally either via environment variables or `bundle config`,
 whichever is preferable for your setup. If you use both, environment variables
 will take preference over global settings.
+
+## LIST OF EARLY OPT-IN CONFIGURATION KEYS
+
+The following is a list of configuration keys meant to only be used to early opt
+into bug fixes that are deemed to be too disruptive to be shipped on a non-major
+release of Bundler. The functionality they enable will be the default and only
+behavior in future versions of bundler. Only set these settings to true.
+
+* `global_path_appends_ruby_scope` (`BUNDLE_GLOBAL_PATH_APPENDS_RUBY_SCOPE`):
+   Whether Bundler should append the Ruby scope (e.g. engine and ABI version)
+   to a globally-configured path.
 
 ## LOCAL GIT REPOS
 

--- a/spec/commands/clean_spec.rb
+++ b/spec/commands/clean_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe "bundle clean" do
       gem "foo"
     G
 
-    bundle "config set path vendor/bundle"
-    bundle "config set clean false"
+    bundle "config --local path vendor/bundle"
+    bundle "config --local clean false"
     bundle! "install"
 
     gemfile <<-G
@@ -54,8 +54,8 @@ RSpec.describe "bundle clean" do
       gem "foo"
     G
 
-    bundle "config set path vendor/bundle"
-    bundle "config set clean false"
+    bundle "config --local path vendor/bundle"
+    bundle "config --local clean false"
     bundle "install"
 
     gemfile <<-G
@@ -84,8 +84,8 @@ RSpec.describe "bundle clean" do
       gem "foo"
     G
 
-    bundle "config set path vendor/bundle"
-    bundle "config set clean false"
+    bundle "config set --local path vendor/bundle"
+    bundle "config set --local clean false"
     bundle! "install"
 
     gemfile <<-G
@@ -117,9 +117,9 @@ RSpec.describe "bundle clean" do
       end
     G
 
-    bundle "config set path vendor/bundle"
+    bundle "config set --local path vendor/bundle"
     bundle "install"
-    bundle "config set without test_group"
+    bundle "config set --local without test_group"
     bundle "install"
     bundle :clean
 
@@ -145,7 +145,7 @@ RSpec.describe "bundle clean" do
       end
     G
 
-    bundle "config set path vendor/bundle"
+    bundle "config set --local path vendor/bundle"
     bundle "install"
 
     bundle :clean
@@ -169,7 +169,7 @@ RSpec.describe "bundle clean" do
       end
     G
 
-    bundle "config set path vendor/bundle"
+    bundle "config set --local path vendor/bundle"
     bundle "install"
 
     gemfile <<-G
@@ -210,7 +210,7 @@ RSpec.describe "bundle clean" do
     FileUtils.mkdir_p(bundled_app("real-path"))
     FileUtils.ln_sf(bundled_app("real-path"), bundled_app("symlink-path"))
 
-    bundle "config set path #{bundled_app("symlink-path")}"
+    bundle "config set --local path #{bundled_app("symlink-path")}"
     bundle "install"
 
     bundle :clean
@@ -233,7 +233,7 @@ RSpec.describe "bundle clean" do
       end
     G
 
-    bundle "config set path vendor/bundle"
+    bundle "config set --local path vendor/bundle"
     bundle! "install"
 
     update_git "foo", :path => lib_path("foo-bar")
@@ -264,7 +264,7 @@ RSpec.describe "bundle clean" do
       gem "activesupport", :git => "#{lib_path("rails")}", :ref => '#{revision}'
     G
 
-    bundle "config set path vendor/bundle"
+    bundle "config set --local path vendor/bundle"
     bundle "install"
     bundle :clean
     expect(out).to include("")
@@ -287,8 +287,8 @@ RSpec.describe "bundle clean" do
         end
       end
     G
-    bundle "config set path vendor/bundle"
-    bundle "config set without test"
+    bundle "config set --local path vendor/bundle"
+    bundle "config set --local without test"
     bundle "install"
 
     bundle :clean
@@ -310,8 +310,8 @@ RSpec.describe "bundle clean" do
       end
     G
 
-    bundle "config set path vendor/bundle"
-    bundle "config set without development"
+    bundle "config set --local path vendor/bundle"
+    bundle "config set --local without development"
     bundle "install"
 
     bundle :clean
@@ -341,7 +341,7 @@ RSpec.describe "bundle clean" do
       gem "foo"
     G
 
-    bundle "config set path vendor/bundle"
+    bundle "config set --local path vendor/bundle"
     bundle "install"
 
     gemfile <<-G
@@ -390,9 +390,9 @@ RSpec.describe "bundle clean" do
       gem "thin"
       gem "rack"
     G
-    bundle "config set path vendor/bundle"
-    bundle "config set clean false"
-    bundle "install --clean true"
+    bundle "config set --local path vendor/bundle"
+    bundle "config set --local clean true"
+    bundle "install"
 
     gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -413,9 +413,9 @@ RSpec.describe "bundle clean" do
 
       gem "foo"
     G
-    bundle "config set path vendor/bundle"
-    bundle "config set clean false"
-    bundle "install --clean true"
+    bundle "config set --local path vendor/bundle"
+    bundle "config set --local clean true"
+    bundle! "install"
 
     update_repo2 do
       build_gem "foo", "1.0.1"
@@ -458,7 +458,7 @@ RSpec.describe "bundle clean" do
       gem "thin"
       gem "rack"
     G
-    bundle "config set path vendor/bundle"
+    bundle "config set --local path vendor/bundle"
     bundle "install"
 
     gemfile <<-G
@@ -479,7 +479,7 @@ RSpec.describe "bundle clean" do
 
       gem "foo"
     G
-    bundle "config set path vendor/bundle"
+    bundle "config set --local path vendor/bundle"
     bundle! "install"
 
     update_repo2 do
@@ -581,7 +581,7 @@ RSpec.describe "bundle clean" do
       gem "foo", :git => "#{lib_path("foo-1.0")}"
     G
 
-    bundle "config set path vendor/bundle"
+    bundle "config set --local path vendor/bundle"
     bundle "install"
 
     # mimic 7 length git revisions in Gemfile.lock
@@ -591,7 +591,7 @@ RSpec.describe "bundle clean" do
     end
     lockfile(bundled_app("Gemfile.lock"), gemfile_lock.join("\n"))
 
-    bundle "config set path vendor/bundle"
+    bundle "config set --local path vendor/bundle"
     bundle "install"
 
     bundle :clean
@@ -642,7 +642,7 @@ RSpec.describe "bundle clean" do
       gem "bar", "1.0", :path => "#{relative_path}"
     G
 
-    bundle "config set path vendor/bundle"
+    bundle "config set --local path vendor/bundle"
     bundle "install"
     bundle! :clean
   end
@@ -655,8 +655,8 @@ RSpec.describe "bundle clean" do
       gem "foo"
     G
 
-    bundle "config set path vendor/bundle"
-    bundle "config set clean false"
+    bundle "config set --local path vendor/bundle"
+    bundle "config set --local clean false"
     bundle "install"
 
     gemfile <<-G
@@ -685,8 +685,8 @@ RSpec.describe "bundle clean" do
       gem "foo"
     G
 
-    bundle "config set path vendor/bundle"
-    bundle "config set clean false"
+    bundle "config set --local path vendor/bundle"
+    bundle "config set --local clean false"
     bundle "install"
 
     gemfile <<-G
@@ -715,8 +715,8 @@ RSpec.describe "bundle clean" do
       gem "foo"
     G
 
-    bundle "config set path vendor/bundle"
-    bundle "config set clean false"
+    bundle "config set --local path vendor/bundle"
+    bundle "config set --local clean false"
     bundle "install"
     bundle "config set dry_run false"
 
@@ -747,8 +747,8 @@ RSpec.describe "bundle clean" do
       gem "foo"
     G
 
-    bundle "config set path vendor/bundle"
-    bundle "config set clean false"
+    bundle "config set --local path vendor/bundle"
+    bundle "config set --local clean false"
     bundle! "install"
 
     gemfile <<-G
@@ -776,7 +776,7 @@ RSpec.describe "bundle clean" do
       gem "very_simple_git_binary", :git => "#{lib_path("very_simple_git_binary-1.0")}", :ref => "#{revision}"
     G
 
-    bundle "config set path vendor/bundle"
+    bundle "config set --local path vendor/bundle"
     bundle! "install"
     expect(vendored_gems("bundler/gems/extensions")).to exist
     expect(vendored_gems("bundler/gems/very_simple_git_binary-1.0-#{revision[0..11]}")).to exist
@@ -797,7 +797,7 @@ RSpec.describe "bundle clean" do
       gem "simple_binary"
     G
 
-    bundle "config set path vendor/bundle"
+    bundle "config set --local path vendor/bundle"
     bundle! "install"
 
     very_simple_binary_extensions_dir =
@@ -837,7 +837,7 @@ RSpec.describe "bundle clean" do
       gem "very_simple_git_binary", :git => "#{lib_path("very_simple_git_binary-1.0")}", :ref => "#{revision}"
     G
 
-    bundle "config set path vendor/bundle"
+    bundle "config set --local path vendor/bundle"
     bundle! "install"
 
     very_simple_binary_extensions_dir =

--- a/spec/install/bundler_spec.rb
+++ b/spec/install/bundler_spec.rb
@@ -146,6 +146,7 @@ RSpec.describe "bundle install" do
 
     it "can install dependencies with newer bundler version with a local path" do
       bundle! "config set path .bundle"
+      bundle! "config set global_path_appends_ruby_scope true"
       install_gemfile! <<-G
         source "#{file_uri_for(gem_repo2)}"
         gem "rails", "3.0"

--- a/spec/install/gems/sudo_spec.rb
+++ b/spec/install/gems/sudo_spec.rb
@@ -59,6 +59,8 @@ RSpec.describe "when using sudo", :sudo => true do
     end
 
     it "installs when BUNDLE_PATH is owned by root" do
+      bundle! "config set global_path_appends_ruby_scope false" # consistency in tests between 2.x and 3.x modes
+
       bundle_path = tmp("owned_by_root")
       FileUtils.mkdir_p bundle_path
       sudo "chown -R root #{bundle_path}"
@@ -69,12 +71,14 @@ RSpec.describe "when using sudo", :sudo => true do
         gem "rack", '1.0'
       G
 
-      expect(bundle_path.join(Bundler.ruby_scope, "gems/rack-1.0.0")).to exist
-      expect(bundle_path.join(Bundler.ruby_scope, "gems/rack-1.0.0").stat.uid).to eq(0)
+      expect(bundle_path.join("gems/rack-1.0.0")).to exist
+      expect(bundle_path.join("gems/rack-1.0.0").stat.uid).to eq(0)
       expect(the_bundle).to include_gems "rack 1.0"
     end
 
     it "installs when BUNDLE_PATH does not exist" do
+      bundle! "config set global_path_appends_ruby_scope false" # consistency in tests between 2.x and 3.x modes
+
       root_path = tmp("owned_by_root")
       FileUtils.mkdir_p root_path
       sudo "chown -R root #{root_path}"
@@ -86,8 +90,8 @@ RSpec.describe "when using sudo", :sudo => true do
         gem "rack", '1.0'
       G
 
-      expect(bundle_path.join(Bundler.ruby_scope, "gems/rack-1.0.0")).to exist
-      expect(bundle_path.join(Bundler.ruby_scope, "gems/rack-1.0.0").stat.uid).to eq(0)
+      expect(bundle_path.join("gems/rack-1.0.0")).to exist
+      expect(bundle_path.join("gems/rack-1.0.0").stat.uid).to eq(0)
       expect(the_bundle).to include_gems "rack 1.0"
     end
 

--- a/spec/install/path_spec.rb
+++ b/spec/install/path_spec.rb
@@ -113,36 +113,71 @@ RSpec.describe "bundle install" do
           expect(the_bundle).to include_gems "rack 1.0.0"
         end
 
-        it "installs gems to ." do
-          set_bundle_path(type, ".")
-          bundle! "config set --global disable_shared_gems true"
+        context "with global_path_appends_ruby_scope set", :bundler => "3" do
+          it "installs gems to ." do
+            set_bundle_path(type, ".")
+            bundle! "config set --global disable_shared_gems true"
 
-          bundle! :install
-
-          paths_to_exist = %w[cache/rack-1.0.0.gem gems/rack-1.0.0 specifications/rack-1.0.0.gemspec].map {|path| bundled_app(Bundler.ruby_scope, path) }
-          expect(paths_to_exist).to all exist
-          expect(the_bundle).to include_gems "rack 1.0.0"
-        end
-
-        it "installs gems to the path" do
-          set_bundle_path(type, bundled_app("vendor").to_s)
-
-          bundle! :install
-
-          expect(bundled_app("vendor", Bundler.ruby_scope, "gems/rack-1.0.0")).to be_directory
-          expect(the_bundle).to include_gems "rack 1.0.0"
-        end
-
-        it "installs gems to the path relative to root when relative" do
-          set_bundle_path(type, "vendor")
-
-          FileUtils.mkdir_p bundled_app("lol")
-          Dir.chdir(bundled_app("lol")) do
             bundle! :install
+
+            paths_to_exist = %w[cache/rack-1.0.0.gem gems/rack-1.0.0 specifications/rack-1.0.0.gemspec].map {|path| bundled_app(Bundler.ruby_scope, path) }
+            expect(paths_to_exist).to all exist
+            expect(the_bundle).to include_gems "rack 1.0.0"
           end
 
-          expect(bundled_app("vendor", Bundler.ruby_scope, "gems/rack-1.0.0")).to be_directory
-          expect(the_bundle).to include_gems "rack 1.0.0"
+          it "installs gems to the path" do
+            set_bundle_path(type, bundled_app("vendor").to_s)
+
+            bundle! :install
+
+            expect(bundled_app("vendor", Bundler.ruby_scope, "gems/rack-1.0.0")).to be_directory
+            expect(the_bundle).to include_gems "rack 1.0.0"
+          end
+
+          it "installs gems to the path relative to root when relative" do
+            set_bundle_path(type, "vendor")
+
+            FileUtils.mkdir_p bundled_app("lol")
+            Dir.chdir(bundled_app("lol")) do
+              bundle! :install
+            end
+
+            expect(bundled_app("vendor", Bundler.ruby_scope, "gems/rack-1.0.0")).to be_directory
+            expect(the_bundle).to include_gems "rack 1.0.0"
+          end
+        end
+
+        context "with global_path_appends_ruby_scope unset", :bundler => "< 3" do
+          it "installs gems to ." do
+            set_bundle_path(type, ".")
+            bundle! "config set --global disable_shared_gems true"
+
+            bundle! :install
+
+            expect([bundled_app("cache/rack-1.0.0.gem"), bundled_app("gems/rack-1.0.0"), bundled_app("specifications/rack-1.0.0.gemspec")]).to all exist
+            expect(the_bundle).to include_gems "rack 1.0.0"
+          end
+
+          it "installs gems to BUNDLE_PATH with #{type}" do
+            set_bundle_path(type, bundled_app("vendor").to_s)
+
+            bundle :install
+
+            expect(bundled_app("vendor/gems/rack-1.0.0")).to be_directory
+            expect(the_bundle).to include_gems "rack 1.0.0"
+          end
+
+          it "installs gems to BUNDLE_PATH relative to root when relative" do
+            set_bundle_path(type, "vendor")
+
+            FileUtils.mkdir_p bundled_app("lol")
+            Dir.chdir(bundled_app("lol")) do
+              bundle :install
+            end
+
+            expect(bundled_app("vendor/gems/rack-1.0.0")).to be_directory
+            expect(the_bundle).to include_gems "rack 1.0.0"
+          end
         end
       end
     end

--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -192,6 +192,7 @@ RSpec.describe "The library itself" do
 
     all_settings = Hash.new {|h, k| h[k] = [] }
     documented_settings = []
+    documented_setting_sections = []
 
     Bundler::Settings::BOOL_KEYS.each {|k| all_settings[k] << "in Bundler::Settings::BOOL_KEYS" }
     Bundler::Settings::NUMBER_KEYS.each {|k| all_settings[k] << "in Bundler::Settings::NUMBER_KEYS" }
@@ -204,7 +205,8 @@ RSpec.describe "The library itself" do
           line.scan(/Bundler\.settings\[:#{key_pattern}\]/).flatten.each {|s| all_settings[s] << "referenced at `#{filename}:#{number.succ}`" }
         end
       end
-      documented_settings = File.read("man/bundle-config.ronn")[/LIST OF AVAILABLE KEYS.*/m].scan(/^\* `#{key_pattern}`/).flatten
+      documented_setting_sections = File.read("man/bundle-config.ronn").split(/LIST OF .* KEYS/)[1..-1].map {|section| section.scan(/^\* `#{key_pattern}`/).flatten }
+      documented_settings = documented_setting_sections.flatten
     end
 
     documented_settings.each do |s|
@@ -221,7 +223,9 @@ RSpec.describe "The library itself" do
 
     expect(error_messages.sort).to be_well_formed
 
-    expect(documented_settings).to be_sorted
+    documented_setting_sections.each do |documented_setting_section|
+      expect(documented_setting_section).to be_sorted
+    end
   end
 
   it "can still be built" do


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that https://github.com/bundler/bundler/pull/7163 broke several things regarding official docker ruby images.

### What was your diagnosis of the problem?

My diagnosis was that appending `ruby/<ABI_VERSION>` to `$BUNDLE_PATH` break things there because gems nor executables are no longer installed at a location that `rubygems` now about.

### What is your fix for the problem, implemented in this PR?

My fix is to revert the offending PR for the time being.

### Why did you choose this fix out of the possible options?

I chose this fix because it's quick.

I think the better fix would be to get `BUNDLE_PATH__SYSTEM=true` working as expected and upstream that change to the docker images, because I think that's exactly the use case for the docker images. But I need more time for that, and I want to restore working behavior.

/cc @indirect Sorry, you were right about this being dangerous :flushed:

Closes #7197.
Closes #7494.