### PR TITLE
Make sure to `require "rubygems"` explicitly

### DIFF
--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "rubygems"
+
 module Bundler
   class RubygemsIntegration
     if defined?(Gem::Ext::Builder::CHDIR_MONITOR)

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -1344,5 +1344,11 @@ end
       expect(last_command.stdboth).not_to include "FAIL"
       expect(err).to include "private method `require'"
     end
+
+    it "takes care of requiring rubygems" do
+      sys_exec("#{Gem.ruby} -I#{lib_dir} -e \"puts require('bundler/setup')\"", "RUBYOPT" => "--disable=gems")
+
+      expect(last_command.stdboth).to eq("true")
+    end
   end
 end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was some setups have `--disable=gem` in `RUBYOPT`, and sometimes use `bundler` without modifying that env.

### What was your diagnosis of the problem?

My diagnosis was that we shouldn't break those setups just to save a `require`.

### What is your fix for the problem, implemented in this PR?

My fix is to add a `require "rubygems"` on top of the file that needs it.

Fixes #7487.