### PR TITLE
Remove unnecessary CI steps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,17 @@ script: bin/rake spec:travis
 before_script:
   - travis_retry gem install rake:"~> 12.0"
   - travis_retry bin/rake override_version
-  - travis_retry bin/rake spec:travis:deps
+  - travis_retry bin/rake spec:deps
   - bin/rake man:check
+  - if [ "$BUNDLER_SPEC_SUB_VERSION" = "" ];
+    then
+      sudo apt-get install graphviz -y;
+    fi
+  - if [ "$TRAVIS_RUBY_VERSION" = "2.3.8" ];
+    then
+      sudo sed -i 's/1000::/1000:Travis:/g' /etc/passwd;
+      sudo sed -i '/secure_path/d' /etc/sudoers;
+    fi
 
 branches:
   only:

--- a/Rakefile
+++ b/Rakefile
@@ -109,7 +109,7 @@ task :check_rvm_integration do
   # The rubygems-bundler gem is installed by RVM by default and it could easily
   # break when we change bundler. Make sure that binstubs still run with it
   # installed.
-  sh("bin/rake install && gem install rubygems-bundler && rake -T")
+  sh("gem install rubygems-bundler && RUBYOPT=-Ilib rake -T")
 end
 
 namespace :man do

--- a/Rakefile
+++ b/Rakefile
@@ -36,20 +36,6 @@ namespace :spec do
     Spec::Rubygems.dev_setup
   end
 
-  namespace :travis do
-    task :deps do
-      # Give the travis user a name so that git won't fatally error
-      system "sudo sed -i 's/1000::/1000:Travis:/g' /etc/passwd"
-      # Strip secure_path so that RVM paths transmit through sudo -E
-      system "sudo sed -i '/secure_path/d' /etc/sudoers"
-      # Install graphviz so that the viz specs can run
-      sh "sudo apt-get install graphviz -y"
-
-      # Install the other gem deps, etc
-      Rake::Task["spec:deps"].invoke
-    end
-  end
-
   task :clean do
     rm_rf "tmp"
   end

--- a/Rakefile
+++ b/Rakefile
@@ -42,10 +42,6 @@ namespace :spec do
       system "sudo sed -i 's/1000::/1000:Travis:/g' /etc/passwd"
       # Strip secure_path so that RVM paths transmit through sudo -E
       system "sudo sed -i '/secure_path/d' /etc/sudoers"
-      # Refresh packages index that the ones we need can be installed
-      sh "sudo apt-get update"
-      # Install groff so ronn can generate man/help pages
-      sh "sudo apt-get install groff-base=1.22.3-10 -y"
       # Install graphviz so that the viz specs can run
       sh "sudo apt-get install graphviz -y"
 

--- a/task/release.rake
+++ b/task/release.rake
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "bundler/gem_tasks"
+require_relative "../lib/bundler/gem_tasks"
 task :build => ["build_metadata"] do
   Rake::Task["build_metadata:clean"].tap(&:reenable).real_invoke
 end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that merging #7505 failed.

### What was your diagnosis of the problem?

My diagnosis was that some `apt` operation installing `graphviz` failed, but installing `graphviz` was unnecessary in the specific job that failed.

### What is your fix for the problem, implemented in this PR?

My fix is to only modifying the OS when strictly necessary.

Also fixed another test issue with the recently added test for integration with the `rubygems-bundler` gem by `rvm`.