### PR TITLE
Add `travis_retry` to apt-get operation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_script:
   - bin/rake man:check
   - if [ "$BUNDLER_SPEC_SUB_VERSION" = "" ];
     then
-      sudo apt-get install graphviz -y;
+      travis_retry sudo apt-get install graphviz -y;
     fi
   - if [ "$TRAVIS_RUBY_VERSION" = "2.3.8" ];
     then


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was another failed build due to [apt-get install failing](https://travis-ci.org/bundler/bundler/jobs/627348743).

### What was your diagnosis of the problem?

My diagnosis was TravisCI networking is unstable at the moment.

### What is your fix for the problem, implemented in this PR?

Not a permanent fix, since that doesn't depend on us, but using `travis_retry` should increase reliability.