### PR TITLE
Don't spawn a shell when git pushing on release

### DIFF
--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -132,7 +132,6 @@ module Bundler
       cmd = "git push #{options}"
       out, status = sh_with_status(cmd.shellsplit)
       return if status.success?
-      cmd = cmd.shelljoin if cmd.respond_to?(:shelljoin)
       raise "Couldn't git push. `#{cmd}' failed with the following output:\n\n#{out}\n"
     end
 

--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -130,7 +130,7 @@ module Bundler
 
     def perform_git_push(options = "")
       cmd = "git push #{options}"
-      out, status = sh_with_status(cmd)
+      out, status = sh_with_status(cmd.shellsplit)
       return if status.success?
       cmd = cmd.shelljoin if cmd.respond_to?(:shelljoin)
       raise "Couldn't git push. `#{cmd}' failed with the following output:\n\n#{out}\n"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that I almost went crazy when trying to release the last bundler version. `rake release` was hanging and I didn't know why.

### What was your diagnosis of the problem?

Thanks to passing `DEBUG=true` to the task, I noticed that it was `git push` and `git push --tags` commands that were hanging:

```
$ DEBUG=true bin/rake release
["gem", "build", "-V", "/home/deivid/Code/bundler/bundler.gemspec"]
bundler 2.1.2 built to pkg/bundler-2.1.2.gem.
["git", "diff", "--exit-code"]
["git", "diff-index", "--quiet", "--cached", "HEAD"]
["git", "tag"]
["git", "tag", "-m", "Version 2.1.2", "v2.1.2"]
Tagged v2.1.2.
git push git push  --tags
^Crake aborted!
Interrupt: 
/home/deivid/Code/bundler/lib/bundler/gem_helper.rb:198:in `read'
/home/deivid/Code/bundler/lib/bundler/gem_helper.rb:198:in `popen'
/home/deivid/Code/bundler/lib/bundler/gem_helper.rb:198:in `block in sh_with_status'
/home/deivid/Code/bundler/lib/bundler/shared_helpers.rb:52:in `chdir'
/home/deivid/Code/bundler/lib/bundler/shared_helpers.rb:52:in `block in chdir'
/home/deivid/Code/bundler/lib/bundler/shared_helpers.rb:51:in `chdir'
/home/deivid/Code/bundler/lib/bundler/gem_helper.rb:197:in `sh_with_status'
/home/deivid/Code/bundler/lib/bundler/gem_helper.rb:133:in `perform_git_push'
/home/deivid/Code/bundler/lib/bundler/gem_helper.rb:115:in `git_push'
/home/deivid/Code/bundler/lib/bundler/gem_helper.rb:64:in `block (2 levels) in install'
/home/deivid/Code/bundler/lib/bundler/gem_helper.rb:160:in `tag_version'
/home/deivid/Code/bundler/lib/bundler/gem_helper.rb:64:in `block in install'
/home/deivid/Code/bundler/Rakefile:14:in `block in invoke'
/home/deivid/Code/bundler/Rakefile:13:in `invoke'
/home/deivid/Code/bundler/spec/support/rubygems_ext.rb:87:in `load'
/home/deivid/Code/bundler/spec/support/rubygems_ext.rb:87:in `gem_load_and_activate'
/home/deivid/Code/bundler/spec/support/rubygems_ext.rb:45:in `gem_load'
Tasks: TOP => release => release:source_control_push
(See full trace by running task with --trace)
```

The debugging output is very interesting because it also tells us that these commands are the only ones passing Strings to `IO.popen` instead of Arrays. That means these commands are [spawning a new shell](https://ruby-doc.org/core-2.6.5/IO.html#method-c-popen).

That's when I realized that I have [hub](https://github.com/github/hub) installed on my system and `git` aliased to it. So I figure this aliasing was interacting with the subcommand in a bad way.

Indeed, disabling `hub` fixed the issue and let me make the release.

### What is your fix for the problem, implemented in this PR?

I think we can avoid other issues similar to this for people pushing releases by not spawing a shell here, just like we do with all of the other commands.

I think it's a good practice anyways.

### Why did you choose this fix out of the possible options?

I chose this fix because I think it makes the code better. Of course I can disable `hub` every time I release, but I think this is worth doing.