### PR TITLE
Improve error message when not logged in

### DIFF
--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -100,7 +100,7 @@ module Bundler
       cmd << "--key" << gem_key if gem_key
       cmd << "--host" << allowed_push_host if allowed_push_host
       unless allowed_push_host || Bundler.user_home.join(".gem/credentials").file?
-        raise "Your rubygems.org credentials aren't set. Run `gem push` to set them."
+        raise "Your rubygems.org credentials aren't set. Run `gem signin` to set them."
       end
       sh_with_input(cmd)
       Bundler.ui.confirm "Pushed #{name} #{version} to #{gem_push_host}"


### PR DESCRIPTION
`gem push` makes you add other parameters, and is awkward to figure out the details. `gem signin` is a more direct way of doing this.