### PR TITLE
Fix `rake build` when path has spaces on it

### DIFF
--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -73,7 +73,7 @@ module Bundler
 
     def build_gem
       file_name = nil
-      sh("#{gem_command} build -V #{spec_path}".shellsplit) do
+      sh("#{gem_command} build -V #{spec_path.shellescape}".shellsplit) do
         file_name = File.basename(built_gem_path)
         SharedHelpers.filesystem_access(File.join(base, "pkg")) {|p| FileUtils.mkdir_p(p) }
         FileUtils.mv(built_gem_path, "pkg")

--- a/spec/runtime/gem_tasks_spec.rb
+++ b/spec/runtime/gem_tasks_spec.rb
@@ -57,6 +57,20 @@ RSpec.describe "require 'bundler/gem_tasks'" do
     expect(err).to be_empty
   end
 
+  context "rake build when path has spaces" do
+    before do
+      spaced_bundled_app = tmp.join("bundled app")
+      FileUtils.mv bundled_app, spaced_bundled_app
+      Dir.chdir(spaced_bundled_app)
+    end
+
+    it "still runs successfully" do
+      bundle! "exec rake build"
+
+      expect(err).to be_empty
+    end
+  end
+
   it "adds 'pkg' to rake/clean's CLOBBER" do
     with_gem_path_as(Spec::Path.base_system_gems.to_s) do
       sys_exec! %(#{rake} -e 'load "Rakefile"; puts CLOBBER.inspect')


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that `rake build` can no longer be run from a path that has spaces on it.

### What was your diagnosis of the problem?

My diagnosis was that we need to escape the path for the shell somewhere.

### What is your fix for the problem, implemented in this PR?

My fix is to add `.shellescape` at the right place.

### Why did you choose this fix out of the possible options?

I chose this fix because it fixes the problem.

Fixes #7512.