### PR TITLE
Move `bin/rake man:check` to `linting` phase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,13 +54,7 @@ env:
 jobs:
   include:
     - rvm: 2.6.5
-      script: bin/rake rubocop
-      stage: linting
-    - rvm: 2.6.5
-      script: bin/rake check_rvm_integration
-      stage: linting
-    - rvm: 2.6.5
-      script: bin/rake man:check
+      script: bin/rake rubocop check_rvm_integration man:check
       stage: linting
     # Ruby 2.3 also tested in 2.x mode
     - rvm: 2.3.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ before_script:
   - travis_retry gem install rake:"~> 12.0"
   - travis_retry bin/rake override_version
   - travis_retry bin/rake spec:deps
-  - bin/rake man:check
   - if [ "$BUNDLER_SPEC_SUB_VERSION" = "" ];
     then
       travis_retry sudo apt-get install graphviz -y;
@@ -59,6 +58,9 @@ jobs:
       stage: linting
     - rvm: 2.6.5
       script: bin/rake check_rvm_integration
+      stage: linting
+    - rvm: 2.6.5
+      script: bin/rake man:check
       stage: linting
     # Ruby 2.3 also tested in 2.x mode
     - rvm: 2.3.8


### PR DESCRIPTION
So that it's only run once.

### What was the end-user problem that led to this PR?

The problem was that `bin/rake man:check` is run for every CI matrix entry and that's useless.

### What was your diagnosis of the problem?

My diagnosis was that we should move the check to the linting phase and run it only once, like we did for `rubocop` at https://github.com/bundler/bundler/pull/6830.

### What is your fix for the problem, implemented in this PR?

My fix is to do that.