### PR TITLE
Make `bundle config deployment true` equivalent to `bundle install --deployment` in regards to configuration

### DIFF
--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -38,7 +38,8 @@ module Bundler
         if Bundler.feature_flag.deployment_means_frozen?
           Bundler.settings.set_command_option :deployment, true
         else
-          Bundler.settings.set_command_option :frozen, true
+          Bundler.settings.set_command_option :deployment, true if options[:deployment]
+          Bundler.settings.set_command_option :frozen, true if options[:frozen]
         end
       end
 
@@ -169,7 +170,7 @@ module Bundler
     def normalize_settings
       Bundler.settings.set_command_option :path, nil if options[:system]
       Bundler.settings.temporary(:path_relative_to_cwd => false) do
-        Bundler.settings.set_command_option :path, "vendor/bundle" if options[:deployment]
+        Bundler.settings.set_command_option :path, "vendor/bundle" if Bundler.settings[:deployment] && Bundler.settings[:path].nil?
       end
       Bundler.settings.set_command_option_if_given :path, options[:path]
       Bundler.settings.temporary(:path_relative_to_cwd => false) do

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -553,7 +553,7 @@ RSpec.describe "bundle outdated" do
       expect(err).to include("You are trying to check outdated gems in deployment mode.")
       expect(err).to include("Run `bundle outdated` elsewhere.")
       expect(err).to include("If this is a development machine, remove the ")
-      expect(err).to include("Gemfile freeze\nby running `bundle install --no-deployment`.")
+      expect(err).to include("Gemfile freeze\nby running `bundle config unset deployment`.")
     end
   end
 

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -286,7 +286,7 @@ RSpec.describe "bundle update" do
 
       expect(last_command).to be_failure
       expect(err).to match(/You are trying to install in deployment mode after changing.your Gemfile/m)
-      expect(err).to match(/freeze \nby running `bundle install --no-deployment`./m)
+      expect(err).to match(/freeze \nby running `bundle config unset deployment`./m)
     end
 
     it "should suggest different command when frozen is set globally", :bundler => "< 3" do

--- a/spec/install/deploy_spec.rb
+++ b/spec/install/deploy_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "install with --deployment or --frozen" do
       expect(exitstatus).to eq(15) if exitstatus
     end
 
-    it "works after you try to deploy without a lock" do
+    it "doesn't mess up a subsequent `bundle install` after you try to deploy without a lock" do
       bundle "install --deployment"
       bundle! :install
       expect(the_bundle).to include_gems "rack 1.0"

--- a/spec/install/deploy_spec.rb
+++ b/spec/install/deploy_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "install with --deployment or --frozen" do
   end
 
   it "still works if you are not in the app directory and specify --gemfile" do
-    bundle "install"
+    bundle! "install"
     Dir.chdir tmp do
       simulate_new_machine
       bundle! :install,
@@ -60,12 +60,12 @@ RSpec.describe "install with --deployment or --frozen" do
         gem "foo", :git => "#{lib_path("foo-1.0")}"
       end
     G
-    bundle :install
+    bundle! :install
     bundle! :install, forgotten_command_line_options(:deployment => true, :without => "test")
   end
 
   it "works when you bundle exec bundle" do
-    bundle :install
+    bundle! :install
     bundle "install --deployment"
     bundle! "exec bundle check"
   end
@@ -106,7 +106,7 @@ RSpec.describe "install with --deployment or --frozen" do
 
   describe "with an existing lockfile" do
     before do
-      bundle "install"
+      bundle! "install"
     end
 
     it "works with the --deployment flag if you didn't change anything", :bundler => "< 3" do
@@ -317,7 +317,7 @@ RSpec.describe "install with --deployment or --frozen" do
         before { bundle! "config set allow_deployment_source_credential_changes true" }
 
         it "allows the replace" do
-          bundle :install
+          bundle! :install
 
           expect(out).to match(/#{success_message}/)
         end

--- a/spec/install/deploy_spec.rb
+++ b/spec/install/deploy_spec.rb
@@ -281,10 +281,6 @@ RSpec.describe "install with --deployment or --frozen" do
     end
 
     context "when replacing a host with the same host with credentials" do
-      let(:success_message) do
-        "Bundle complete!"
-      end
-
       before do
         gemfile <<-G
         source "http://user_name:password@localgemserver.test/"
@@ -319,7 +315,7 @@ RSpec.describe "install with --deployment or --frozen" do
         it "allows the replace" do
           bundle! :install
 
-          expect(out).to match(/#{success_message}/)
+          expect(out).to match(/Bundle complete!/)
         end
       end
 
@@ -339,7 +335,7 @@ RSpec.describe "install with --deployment or --frozen" do
         it "allows the replace" do
           bundle :install
 
-          expect(out).to match(/#{success_message}/)
+          expect(out).to match(/Bundle complete!/)
         end
       end
 

--- a/spec/install/deploy_spec.rb
+++ b/spec/install/deploy_spec.rb
@@ -286,7 +286,7 @@ RSpec.describe "install with --deployment or --frozen" do
       end
 
       before do
-        install_gemfile <<-G
+        gemfile <<-G
         source "http://user_name:password@localgemserver.test/"
         gem "rack"
         G

--- a/spec/install/deploy_spec.rb
+++ b/spec/install/deploy_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe "install with --deployment or --frozen" do
 
   context "when replacing a host with the same host with credentials" do
     before do
-      bundle! "install"
+      bundle! "install", forgotten_command_line_options(:path => "vendor/bundle")
       gemfile <<-G
       source "http://user_name:password@localgemserver.test/"
       gem "rack"
@@ -276,6 +276,19 @@ RSpec.describe "install with --deployment or --frozen" do
       expect(err).to include("* rack-obama")
       expect(err).not_to include("You have deleted from the Gemfile")
       expect(err).not_to include("You have changed in the Gemfile")
+    end
+
+    it "installs gems by default to vendor/bundle when `--deployment` is set via an environment variable", :bundler => "< 3" do
+      ENV["BUNDLE_DEPLOYMENT"] = "true"
+      bundle "install"
+      expect(out).to include("vendor/bundle")
+    end
+
+    it "installs gems to custom path when deployment mode is set via an environment variable ", :bundler => "< 3" do
+      ENV["BUNDLE_DEPLOYMENT"] = "true"
+      ENV["BUNDLE_PATH"] = "vendor/bundle2"
+      bundle "install"
+      expect(out).to include("vendor/bundle2")
     end
 
     it "can have --frozen set to false via an environment variable" do

--- a/spec/install/deploy_spec.rb
+++ b/spec/install/deploy_spec.rb
@@ -180,6 +180,16 @@ RSpec.describe "install with --deployment or --frozen" do
       bundle! "install"
     end
 
+    it "installs gems by default to vendor/bundle", :bundler => "< 3" do
+      bundle! "install --deployment"
+      expect(out).to include("vendor/bundle")
+    end
+
+    it "installs gems to custom path if specified", :bundler => "< 3" do
+      bundle! "install --path vendor/bundle2 --deployment"
+      expect(out).to include("vendor/bundle2")
+    end
+
     it "works with the --deployment flag if you didn't change anything", :bundler => "< 3" do
       bundle! "install --deployment"
     end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that while addressing comments for https://github.com/docker-library/official-images/pull/7188, I noticed that the alternative we're recommending for `bundle install --deployment`, i.e., `bundle config set deployment true`, is not equivalent to it.

### What was your diagnosis of the problem?

My diagnosis was that whereas `bundle install --deployment` configures bundler to be frozen AND to install gems to `vendor/bundle`, `bundle config deployment true` only configures bundler to be frozen.

### What is your fix for the problem, implemented in this PR?

My fix is to make `bundle config deployment true`  behave just like `bundle install --deployment` in regards to configuration. 

### Why did you choose this fix out of the possible options?

I chose this fix because all the commands we're suggesting as alternatives for deprecations should be actual alternatives that work exactly in the same way.

Also, note that there's a change scheduled for bundler 3 where the `deployment` configuration will only mean `frozen`. But for now, we should focus on making sure that people moves away from CLI flags in favor of configuration, so we might want to delay that change to make things less confusing.
