### PR TITLE
Do `require "rubygems"` only when needed

### DIFF
--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "rubygems"
+require "rubygems" unless defined?(Gem)
 
 module Bundler
   class RubygemsIntegration


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The require causes circular require.  See https://github.com/bundler/bundler/pull/7505#issuecomment-568832933

```
$ touch empty_file

$ RUBYGEMS_GEMDEPS=empty_file ./local/bin/ruby -w -e ''
/home/mame/work/ruby/local/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92: warning: /home/mame/work/ruby/local/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92: warning: loading in progress, circular require considered harmful - /home/mame/work/ruby/local/lib/ruby/2.7.0/rubygems.rb
	from <internal:gem_prelude>:1:in  `<internal:gem_prelude>'
	from <internal:gem_prelude>:1:in  `require'
	from /home/mame/work/ruby/local/lib/ruby/2.7.0/rubygems.rb:1417:in  `<top (required)>'
	from /home/mame/work/ruby/local/lib/ruby/2.7.0/rubygems.rb:1203:in  `use_gemdeps'
	from /home/mame/work/ruby/local/lib/ruby/2.7.0/rubygems/user_interaction.rb:47:in  `use_ui'
	from /home/mame/work/ruby/local/lib/ruby/2.7.0/rubygems.rb:1204:in  `block in use_gemdeps'
	from /home/mame/work/ruby/local/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in  `require'
	from /home/mame/work/ruby/local/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in  `require'
	from /home/mame/work/ruby/local/lib/ruby/2.7.0/bundler.rb:11:in  `<top (required)>'
	from /home/mame/work/ruby/local/lib/ruby/2.7.0/bundler.rb:11:in  `require_relative'
	from /home/mame/work/ruby/local/lib/ruby/2.7.0/bundler/rubygems_integration.rb:3:in  `<top (required)>'
	from /home/mame/work/ruby/local/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in  `require'
	from /home/mame/work/ruby/local/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in  `require'
```

### What was your diagnosis of the problem?

Do not `require "rubygems"` blindly.

### What is your fix for the problem, implemented in this PR?

Add `unless defined?(Gem)` to make sure it does `require "rubygems"` only when rubygems is not required.

### Why did you choose this fix out of the possible options?

This is needed to release Ruby 2.7.0 so I chose the simplest fix.