### PR TITLE
Fix rspec stuck problem for large stderr external command

### DIFF
--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -210,8 +210,10 @@ module Spec
         yield stdin, stdout, wait_thr if block_given?
         stdin.close
 
-        command_execution.stdout = Thread.new { stdout.read }.value.strip
-        command_execution.stderr = Thread.new { stderr.read }.value.strip
+        stdout_read_thread = Thread.new { stdout.read }
+        stderr_read_thread = Thread.new { stderr.read }
+        command_execution.stdout = stdout_read_thread.value.strip
+        command_execution.stderr = stderr_read_thread.value.strip
         command_execution.exitstatus = wait_thr && wait_thr.value.exitstatus
       end
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

This PR doesn't fix any end-user problem.

This PR just fixes a developer problem.

Some specs runs external commands by `sys_exec` in `spec/support/helpers.rb`. They may be stuck when they outputs many text to its stderr.

### What was your diagnosis of the problem?

`sys_exec` uses `open3`. It uses pipe to communicate an external command. If `rspec` process doesn't read stderr of the external command, the external command is stuck when the external command writes many text to its stderr. Because the external command can't write to pipe infinitely.

### What is your fix for the problem, implemented in this PR?

The current `sys_exec` tries to fix this situation but it's incomplete:

```ruby
        command_execution.stdout = Thread.new { stdout.read }.value.strip
        command_execution.stderr = Thread.new { stderr.read }.value.strip
```

`Thread.new { stderr.read ` isn't started until `Thread.new { stdout.read }.value` is finished. Normally, it's finished when the external command is finished. It's late. We should read stderr of the external command while the external command is alive.

### Why did you choose this fix out of the possible options?

I don't have another option.
