### PR TITLE
Use raise instead of flunk

### DIFF
--- a/spec/support/indexes.rb
+++ b/spec/support/indexes.rb
@@ -45,7 +45,7 @@ module Spec
 
     def should_conflict_on(names)
       got = resolve
-      flunk "The resolve succeeded with: #{got.map(&:full_name).sort.inspect}"
+      raise "The resolve succeeded with: #{got.map(&:full_name).sort.inspect}"
     rescue Bundler::VersionConflict => e
       expect(Array(names).sort).to eq(e.conflicts.sort)
     end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

This PR doesn't fix any end-user problem.

This PR fixes a developer problem.

RSpec doesn't provide `flunk` method. It's a method name in test-unit and minitest.

### What was your diagnosis of the problem?

3edfddbf7ebe4b942e1e2b6d693afd582e9a8147 may use `flunk` accidentally.

### What is your fix for the problem, implemented in this PR?

My fix uses `raise` instead of `flunk`.

### Why did you choose this fix out of the possible options?

I don't have another option.