### PR TITLE
Fix CI failure with mustermann 1.1.0

### DIFF
--- a/spec/support/artifice/endpoint.rb
+++ b/spec/support/artifice/endpoint.rb
@@ -4,7 +4,7 @@ require_relative "../path"
 require Spec::Path.lib_dir.join("bundler/deprecate")
 include Spec::Path
 
-$LOAD_PATH.unshift(*Dir[Spec::Path.base_system_gems.join("gems/{artifice,mustermann,rack,tilt,sinatra}-*/lib")].map(&:to_s))
+$LOAD_PATH.unshift(*Dir[Spec::Path.base_system_gems.join("gems/{artifice,mustermann,rack,tilt,sinatra,ruby2_keywords}-*/lib")].map(&:to_s))
 
 require "artifice"
 require "sinatra/base"

--- a/spec/support/artifice/endpoint_500.rb
+++ b/spec/support/artifice/endpoint_500.rb
@@ -3,7 +3,7 @@
 require_relative "../path"
 include Spec::Path
 
-$LOAD_PATH.unshift(*Dir[Spec::Path.base_system_gems.join("gems/{artifice,mustermann,rack,tilt,sinatra}-*/lib")].map(&:to_s))
+$LOAD_PATH.unshift(*Dir[Spec::Path.base_system_gems.join("gems/{artifice,mustermann,rack,tilt,sinatra,ruby2_keywords}-*/lib")].map(&:to_s))
 
 require "artifice"
 require "sinatra/base"

--- a/spec/support/artifice/windows.rb
+++ b/spec/support/artifice/windows.rb
@@ -3,7 +3,7 @@
 require_relative "../path"
 include Spec::Path
 
-$LOAD_PATH.unshift(*Dir[Spec::Path.base_system_gems.join("gems/{artifice,mustermann,rack,tilt,sinatra}-*/lib")].map(&:to_s))
+$LOAD_PATH.unshift(*Dir[Spec::Path.base_system_gems.join("gems/{artifice,mustermann,rack,tilt,sinatra,ruby2_keywords}-*/lib")].map(&:to_s))
 
 require "artifice"
 require "sinatra/base"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

This PR doesn't fix any end-user problem.

This PR fixes a developer problem. Our CI is failed with mustermann 1.1.0.

### What was your diagnosis of the problem?

This is caused because mustermann 1.1.0 starts depending on ruby2_keyword gem but our test script doesn't add a load path for ruby2_keyword gem yet.

See also:

  * The PR that adds ruby2_keyword gem dependency to mustermann: https://github.com/sinatra/mustermann/pull/97
  * Error message on CI: https://github.com/bundler/bundler/pull/7523#issuecomment-569736683

### What is your fix for the problem, implemented in this PR?

My fix adds a load path for ruby2_keywrod gem installed in `tmp/1/gems/`.

### Why did you choose this fix out of the possible options?

I don't have another option.
