### PR TITLE
Remove optional require net-http-pipeline from vendored net-http-persistent.

### DIFF
--- a/lib/bundler/vendor/net-http-persistent/lib/net/http/persistent.rb
+++ b/lib/bundler/vendor/net-http-persistent/lib/net/http/persistent.rb
@@ -3,11 +3,6 @@ require_relative '../../../../uri/lib/uri'
 require 'cgi' # for escaping
 require_relative '../../../../connection_pool/lib/connection_pool'
 
-begin
-  require 'net/http/pipeline'
-rescue LoadError
-end
-
 autoload :OpenSSL, 'openssl'
 
 ##
@@ -771,23 +766,6 @@ class Bundler::Persistent::Net::HTTP::Persistent
 
   def normalize_uri uri
     (uri =~ /^https?:/) ? uri : "http://#{uri}"
-  end
-
-  ##
-  # Pipelines +requests+ to the HTTP server at +uri+ yielding responses if a
-  # block is given.  Returns all responses received.
-  #
-  # See
-  # Net::HTTP::Pipeline[http://docs.seattlerb.org/net-http-pipeline/Net/HTTP/Pipeline.html]
-  # for further details.
-  #
-  # Only if <tt>net-http-pipeline</tt> was required before
-  # <tt>net-http-persistent</tt> #pipeline will be present.
-
-  def pipeline uri, requests, &block # :yields: responses
-    connection_for uri do |connection|
-      connection.http.pipeline requests, &block
-    end
   end
 
   ##

--- a/spec/commands/pristine_spec.rb
+++ b/spec/commands/pristine_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe "bundle pristine", :ruby_repo do
 
     it "reinstall gemspec dependency" do
       spec = Bundler.definition.specs["baz-dev"].first
-      changed_file = Pathname.new(spec.full_gem_path).join("lib/baz-dev.rb")
+      changed_file = Pathname.new(spec.full_gem_path).join("lib/baz/dev.rb")
       diff = "#Pristine spec changes"
 
       File.open(changed_file, "a") {|f| f.puts "#Pristine spec changes" }

--- a/spec/install/gemfile/gemspec_spec.rb
+++ b/spec/install/gemfile/gemspec_spec.rb
@@ -210,7 +210,7 @@ RSpec.describe "bundle install from an existing gemspec" do
     build_lib("foo", :path => bundled_app)
     gemspec = bundled_app("foo.gemspec").read
     bundled_app("foo.gemspec").open("w") do |f|
-      f.write "#{gemspec.strip}.tap { gem 'rack-obama'; require 'rack-obama' }"
+      f.write "#{gemspec.strip}.tap { gem 'rack-obama'; require 'rack/obama' }"
     end
 
     install_gemfile! <<-G

--- a/spec/plugins/source/example_spec.rb
+++ b/spec/plugins/source/example_spec.rb
@@ -125,14 +125,14 @@ RSpec.describe "real source plugins" do
     end
 
     it "installs the gem executables" do
-      build_lib "gem-with-bin" do |s|
+      build_lib "gem_with_bin" do |s|
         s.executables = ["foo"]
       end
 
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}" # plugin source
-        source "#{lib_path("gem-with-bin-1.0")}", :type => :mpath do
-          gem "gem-with-bin"
+        source "#{lib_path("gem_with_bin-1.0")}", :type => :mpath do
+          gem "gem_with_bin"
         end
       G
 
@@ -451,7 +451,7 @@ RSpec.describe "real source plugins" do
         bundle "install"
 
         run <<-RUBY
-          require 'ma-gitp-gem'
+          require 'ma/gitp/gem'
           puts "WIN" unless defined?(MAGITPGEM_PREV_REF)
         RUBY
         expect(out).to eq("WIN")
@@ -462,7 +462,7 @@ RSpec.describe "real source plugins" do
         bundle "update ma-gitp-gem"
 
         run <<-RUBY
-          require 'ma-gitp-gem'
+          require 'ma/gitp/gem'
           puts "WIN" if defined?(MAGITPGEM_PREV_REF)
         RUBY
         expect(out).to eq("WIN")

--- a/spec/runtime/require_spec.rb
+++ b/spec/runtime/require_spec.rb
@@ -168,7 +168,6 @@ RSpec.describe "Bundler.require" do
       build_lib "jquery-rails", "1.0.0" do |s|
         s.write "lib/jquery/rails.rb", "puts 'jquery/rails'"
       end
-      lib_path("jquery-rails-1.0.0/lib/jquery-rails.rb").rmtree
     end
 
     it "requires gem names that are namespaced" do
@@ -241,7 +240,6 @@ RSpec.describe "Bundler.require" do
       build_lib "load-fuuu", "1.0.0" do |s|
         s.write "lib/load/fuuu.rb", "raise LoadError.new(\"cannot load such file -- load-bar\")"
       end
-      lib_path("load-fuuu-1.0.0/lib/load-fuuu.rb").rmtree
 
       gemfile <<-G
         path "#{lib_path}" do

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -1263,6 +1263,27 @@ end
         expect(out).to eq("{}")
       end
 
+      it "does not load net-http-pipeline too early" do
+        build_repo4 do
+          build_gem "net-http-pipeline", "1.0.1"
+        end
+
+        system_gems "net-http-pipeline-1.0.1", :gem_repo => gem_repo4 do
+          gemfile <<-G
+            source "#{file_uri_for(gem_repo4)}"
+            gem "net-http-pipeline", "1.0.1"
+          G
+
+          bundle "config set --local path vendor/bundle"
+
+          bundle! :install
+
+          bundle! :check
+
+          expect(out).to eq("The Gemfile's dependencies are satisfied")
+        end
+      end
+
       Gem::Specification.select(&:default_gem?).map(&:name).each do |g|
         it "activates newer versions of #{g}" do
           skip if exemptions.include?(g)

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -899,17 +899,17 @@ end
 
   describe "with git gems that don't have gemspecs" do
     before :each do
-      build_git "no-gemspec", :gemspec => false
+      build_git "no_gemspec", :gemspec => false
 
       install_gemfile <<-G
-        gem "no-gemspec", "1.0", :git => "#{lib_path("no-gemspec-1.0")}"
+        gem "no_gemspec", "1.0", :git => "#{lib_path("no_gemspec-1.0")}"
       G
     end
 
     it "loads the library via a virtual spec" do
       run <<-R
-        require 'no-gemspec'
-        puts NOGEMSPEC
+        require 'no_gemspec'
+        puts NO_GEMSPEC
       R
 
       expect(out).to eq("1.0")

--- a/spec/support/builders.rb
+++ b/spec/support/builders.rb
@@ -623,7 +623,7 @@ module Spec
         unless options[:no_default]
           gem_source = options[:source] || "path@#{path}"
           @files = _default_files.
-                   merge("lib/#{name}/source.rb" => "#{Builders.constantize(name)}_SOURCE = #{gem_source.to_s.dump}").
+                   merge("lib/#{entrypoint}/source.rb" => "#{Builders.constantize(name)}_SOURCE = #{gem_source.to_s.dump}").
                    merge(@files)
         end
 
@@ -639,14 +639,19 @@ module Spec
       end
 
       def _default_files
-        @_default_files ||= begin
-          platform_string = " #{@spec.platform}" unless @spec.platform == Gem::Platform::RUBY
-          { "lib/#{name}.rb" => "#{Builders.constantize(name)} = '#{version}#{platform_string}'" }
-        end
+        @_default_files ||= { "lib/#{entrypoint}.rb" => "#{Builders.constantize(name)} = '#{version}#{platform_string}'" }
+      end
+
+      def entrypoint
+        name.tr("-", "/")
       end
 
       def _default_path
         @context.tmp("libs", @spec.full_name)
+      end
+
+      def platform_string
+        " #{@spec.platform}" unless @spec.platform == Gem::Platform::RUBY
       end
     end
 
@@ -767,7 +772,10 @@ module Spec
 
     class PluginBuilder < GemBuilder
       def _default_files
-        @_default_files ||= super.merge("plugins.rb" => "")
+        @_default_files ||= {
+          "lib/#{name}.rb" => "#{Builders.constantize(name)} = '#{version}#{platform_string}'",
+          "plugins.rb" => "",
+        }
       end
     end
 

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -128,7 +128,7 @@ module Spec
         groups << opts
         @errors = names.map do |name|
           name, version, platform = name.split(/\s+/)
-          require_path = name == "bundler" ? "#{lib_dir}/bundler" : name
+          require_path = name == "bundler" ? "#{lib_dir}/bundler" : name.tr("-", "/")
           version_const = name == "bundler" ? "Bundler::VERSION" : Spec::Builders.constantize(name)
           begin
             run! "require '#{require_path}.rb'; puts #{version_const}", *groups
@@ -145,7 +145,7 @@ module Spec
           next unless source
           begin
             source_const = "#{Spec::Builders.constantize(name)}_SOURCE"
-            run! "require '#{name}/source'; puts #{source_const}", *groups
+            run! "require '#{require_path}/source'; puts #{source_const}", *groups
           rescue StandardError
             next "#{name} does not have a source defined:\n#{indent(e)}"
           end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

See issue https://github.com/bundler/bundler/issues/7521.

### What was your diagnosis of the problem?

My diagnosis was If you have net-http-pipeline gem installed bundler loads it and you can't vendor it.

### What is your fix for the problem, implemented in this PR?

My fix is remove the optional require of net-http-pipeline.

### Why did you choose this fix out of the possible options?

I chose this fix because was a recommendation in the issue by @deivid-rodriguez 

Fixes #7521.
