### PR TITLE
Set master's version to 2.2.0.dev

### DIFF
--- a/lib/bundler/version.rb
+++ b/lib/bundler/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: false
 
 module Bundler
-  VERSION = "2.1.2".freeze
+  VERSION = "2.2.0.dev".freeze
 
   def self.bundler_major_version
     @bundler_major_version ||= VERSION.split(".").first.to_i


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that master version is set to the latest patch level release, but the code in master doesn't really match the latest patch level release.

### What is your fix for the problem, implemented in this PR?

My fix is to use 2.2.0.dev to name master's development version.