### PR TITLE
Reset `Gemfile` to the empty string after bundler/inline

### DIFF
--- a/lib/bundler/inline.rb
+++ b/lib/bundler/inline.rb
@@ -78,7 +78,7 @@ def gemfile(install = false, options = {}, &gemfile)
     if old_gemfile
       ENV["BUNDLE_GEMFILE"] = old_gemfile
     else
-      ENV.delete("BUNDLE_GEMFILE")
+      ENV["BUNDLE_GEMFILE"] = ""
     end
   end
 end

--- a/spec/runtime/inline_spec.rb
+++ b/spec/runtime/inline_spec.rb
@@ -333,4 +333,21 @@ RSpec.describe "bundler/inline#gemfile" do
     expect(last_command).to be_success
     expect(out).to include("BUNDLE_GEMFILE is empty")
   end
+
+  it "resets BUNDLE_GEMFILE to the empty string if it wasn't set previously" do
+    ENV["BUNDLE_GEMFILE"] = nil
+    script <<-RUBY
+      gemfile do
+        source "#{file_uri_for(gem_repo1)}"
+        gem "rack"
+      end
+
+      puts "BUNDLE_GEMFILE is empty" if ENV["BUNDLE_GEMFILE"].empty?
+      system("#{Gem.ruby} -w -e '42'") # this should see original value of BUNDLE_GEMFILE
+      exit $?.exitstatus
+    RUBY
+
+    expect(last_command).to be_success
+    expect(out).to include("BUNDLE_GEMFILE is empty")
+  end
 end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that if `BUNDLE_GEMFILE` is not set before requiring `bundler/inline`, we're removing it back again. That means that when requiring gems after that, `bundler` will go through the "Gemfile resolution" logic again and fail if a Gemfile is not found in the filesystem.

### What was your diagnosis of the problem?

My diagnosis was that the file resolution logic should be skipped after requiring `bundler/inline`, since we want to use the "inline bundle".

### What is your fix for the problem, implemented in this PR?

My fix is to instead reset `BUNDLE_GEMFILE` to the empty string if it had no previous value, since that skips searching the filesystem for a `Gemfile`.

### Why did you choose this fix out of the possible options?

I chose this fix because it seems to fix the issue.

Fixes #7536.