### PR TITLE
Adapt `Bundler#which` test to Windows

### DIFF
--- a/spec/bundler/bundler_spec.rb
+++ b/spec/bundler/bundler_spec.rb
@@ -124,7 +124,15 @@ RSpec.describe Bundler do
 
   describe "#which" do
     let(:executable) { "executable" }
-    let(:path) { %w[/a /b c ../d /e] }
+
+    let(:path) do
+      if Gem.win_platform?
+        %w[C:/a C:/b C:/c C:/../d C:/e]
+      else
+        %w[/a /b c ../d /e]
+      end
+    end
+
     let(:expected) { "executable" }
 
     before do
@@ -149,7 +157,13 @@ RSpec.describe Bundler do
     it_behaves_like "it returns the correct executable"
 
     context "when the executable in inside a quoted path" do
-      let(:expected) { "/e/executable" }
+      let(:expected) do
+        if Gem.win_platform?
+          "C:/e/executable"
+        else
+          "/e/executable"
+        end
+      end
       it_behaves_like "it returns the correct executable"
     end
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that this spec was failing under Windows.

### What was your diagnosis of the problem?

My diagnosis was that the test needs Windows specific paths.

### What is your fix for the problem, implemented in this PR?

My fix is to separate the test per OS.

### Why did you choose this fix out of the possible options?

I chose this fix because it was discussed and considered the better fix at https://github.com/bundler/bundler/issues/6875.

Closes https://github.com/bundler/bundler/issues/6875.
