### PR TITLE
Make test platform independent

### DIFF
--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -192,6 +192,7 @@ RSpec.describe Bundler::Dsl do
       let(:platform) { "ruby" }
 
       it "keeps track of the ruby platforms in the dependency" do
+        allow(Gem::Platform).to receive(:local).and_return(rb)
         subject.gemspec
         expect(subject.dependencies.last.platforms).to eq(Bundler::Dependency::REVERSE_PLATFORM_MAP[Gem::Platform::RUBY])
       end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that a test for the `gemspec` DSL is failing on Windows.

### What was your diagnosis of the problem?

My diagnosis was that the test uses local platforms (that change between OS) but asserts for ruby platforms.

### What is your fix for the problem, implemented in this PR?

My fix is to add a proper stub.

### Why did you choose this fix out of the possible options?

I chose this fix because it was suggested in https://github.com/bundler/bundler/issues/6887 by @janpio and looks good.

Closes #6687.
