### PR TITLE
Fix flaky test failures

### DIFF
--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -109,7 +109,8 @@ RSpec.describe Bundler::SharedHelpers do
 
     shared_examples_for "correctly determines whether to return a Gemfile path" do
       context "currently in directory with a Gemfile" do
-        before { File.new("Gemfile", "w") }
+        before { FileUtils.touch("Gemfile") }
+        after { FileUtils.rm("Gemfile") }
 
         it "returns path of the bundle Gemfile" do
           expect(subject.in_bundle?).to eq("#{bundled_app}/Gemfile")


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was `SharedHelpers#in_bundle?` specs could fail depending on the run order.

### What was your diagnosis of the problem?

My diagnosis was that the test Gemfile needs to be removed after the test because other specs rely on it being missing.

### What is your fix for the problem, implemented in this PR?

My fix is to remove the `Gemfile` after the test.

Closes #6891.