### PR TITLE
Ignore tests needing file permissions on Windows

### DIFF
--- a/spec/commands/clean_spec.rb
+++ b/spec/commands/clean_spec.rb
@@ -536,7 +536,7 @@ RSpec.describe "bundle clean" do
     expect(out).to include("rack (1.0.0)")
   end
 
-  describe "when missing permissions" do
+  describe "when missing permissions", :permissions do
     before { ENV["BUNDLE_PATH__SYSTEM"] = "true" }
     let(:system_cache_path) { system_gem_path("cache") }
     after do

--- a/spec/commands/doctor_spec.rb
+++ b/spec/commands/doctor_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe "bundle doctor" do
       expect(@stdout.string).not_to include("No issues")
     end
 
-    context "when home contains files that are not owned by the current process" do
+    context "when home contains files that are not owned by the current process", :permissions do
       before(:each) do
         allow(@stat).to receive(:uid) { 0o0000 }
       end

--- a/spec/support/filters.rb
+++ b/spec/support/filters.rb
@@ -40,6 +40,7 @@ RSpec.configure do |config|
   config.filter_run_excluding :bundler => RequirementChecker.against(Bundler::VERSION.split(".")[0])
   config.filter_run_excluding :ruby_repo => !ENV["GEM_COMMAND"].nil?
   config.filter_run_excluding :no_color_tty => Gem.win_platform? || !ENV["GITHUB_ACTION"].nil?
+  config.filter_run_excluding :permissions => Gem.win_platform?
 
   config.filter_run_when_matching :focus unless ENV["CI"]
 end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that some specs fail under Windows because permissions are not supported the way they are supported on Unix.

### What is your fix for the problem, implemented in this PR?

My fix is to exclude this tests on Windows.

### Why did you choose this fix out of the possible options?

I chose this fix because it was proposed at https://github.com/bundler/bundler/issues/6897 and makes sense to me.

Closes #6897.
