### PR TITLE
Don't rename folders while being inside

### DIFF
--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe "bundle exec" do
       gem "rack", "0.9.1"
     G
 
-    Dir.chdir bundled_app2 do
+    in_app_root2 do
       install_gemfile bundled_app2("Gemfile"), <<-G
         source "#{file_uri_for(gem_repo2)}"
         gem "rack_two", "1.0.0"
@@ -157,7 +157,7 @@ RSpec.describe "bundle exec" do
 
     expect(out).to eq("0.9.1")
 
-    Dir.chdir bundled_app2 do
+    in_app_root2 do
       bundle! "exec rackup"
       expect(out).to eq("1.0.0")
     end
@@ -254,7 +254,7 @@ RSpec.describe "bundle exec" do
       gem "rack", "0.9.1"
     G
 
-    Dir.chdir bundled_app2 do
+    in_app_root2 do
       install_gemfile bundled_app2("Gemfile"), <<-G
         source "#{file_uri_for(gem_repo2)}"
         gem "rack_two", "1.0.0"

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -504,7 +504,7 @@ RSpec.describe "bundle install with gem sources" do
       root_dir = tmp("foo[]bar")
 
       FileUtils.mkdir_p(root_dir)
-      in_app_root_custom(root_dir)
+      Dir.chdir(root_dir)
     end
 
     it "doesn't blow up" do

--- a/spec/commands/show_spec.rb
+++ b/spec/commands/show_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
   context "in a fresh gem in a blank git repo" do
     before :each do
       build_git "foo", :path => lib_path("foo")
-      in_app_root_custom lib_path("foo")
+      Dir.chdir lib_path("foo")
       File.open("Gemfile", "w") {|f| f.puts "gemspec" }
       sys_exec "rm -rf .git && git init"
     end

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -129,6 +129,8 @@ RSpec.describe "bundle install with git sources" do
 
     it "still works after moving the application directory" do
       bundle "install --path vendor/bundle"
+
+      Dir.chdir root
       FileUtils.mv bundled_app, tmp("bundled_app.bck")
 
       Dir.chdir tmp("bundled_app.bck")
@@ -137,6 +139,8 @@ RSpec.describe "bundle install with git sources" do
 
     it "can still install after moving the application directory" do
       bundle "install --path vendor/bundle"
+
+      Dir.chdir root
       FileUtils.mv bundled_app, tmp("bundled_app.bck")
 
       update_git "foo", "1.1", :path => lib_path("foo-1.0")

--- a/spec/install/gemfile_spec.rb
+++ b/spec/install/gemfile_spec.rb
@@ -54,10 +54,6 @@ RSpec.describe "bundle install" do
   end
 
   context "with deprecated features" do
-    before :each do
-      in_app_root
-    end
-
     it "reports that lib is an invalid option" do
       gemfile <<-G
         gem "rack", :lib => "rack"

--- a/spec/install/gems/standalone_spec.rb
+++ b/spec/install/gems/standalone_spec.rb
@@ -29,6 +29,7 @@ RSpec.shared_examples "bundle install --standalone" do
     end
 
     it "works on a different system" do
+      Dir.chdir root
       FileUtils.mv(bundled_app, "#{bundled_app}2")
 
       testrb = String.new <<-RUBY

--- a/spec/install/gems/standalone_spec.rb
+++ b/spec/install/gems/standalone_spec.rb
@@ -40,7 +40,7 @@ RSpec.shared_examples "bundle install --standalone" do
         testrb << "\nrequire \"#{k}\""
         testrb << "\nputs #{k.upcase}"
       end
-      Dir.chdir("#{bundled_app}2") do
+      in_app_root2 do
         ruby testrb, :no_lib => true
       end
 

--- a/spec/install/global_cache_spec.rb
+++ b/spec/install/global_cache_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe "global gem caching" do
         expect(source_global_cache("rack-1.0.0.gem")).to exist
         expect(source_global_cache("activesupport-2.3.5.gem")).to exist
 
-        Dir.chdir bundled_app2 do
+        in_app_root2 do
           create_file bundled_app2("gems.rb"), <<-G
             source "#{source}"
             gem "activesupport"

--- a/spec/quality_es_spec.rb
+++ b/spec/quality_es_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "La biblioteca si misma" do
   it "mantiene la calidad de lenguaje de la documentación" do
     included = /ronn/
     error_messages = []
-    Dir.chdir(root) do
+    in_repo_root do
       `git ls-files -z -- man`.split("\x0").each do |filename|
         next unless filename =~ included
         error_messages << check_for_expendable_words(filename)
@@ -53,7 +53,7 @@ RSpec.describe "La biblioteca si misma" do
   it "mantiene la calidad de lenguaje de oraciones usadas en el código fuente" do
     error_messages = []
     exempt = /vendor/
-    Dir.chdir(root) do
+    in_repo_root do
       lib_tracked_files.split("\x0").each do |filename|
         next if filename =~ exempt
         error_messages << check_for_expendable_words(filename)

--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe "The library itself" do
   it "has no malformed whitespace" do
     exempt = /\.gitmodules|fixtures|vendor|LICENSE|vcr_cassettes|rbreadline\.diff|\.txt$/
     error_messages = []
-    Dir.chdir(root) do
+    in_repo_root do
       tracked_files.split("\x0").each do |filename|
         next if filename =~ exempt
         error_messages << check_for_tab_characters(filename)
@@ -120,7 +120,7 @@ RSpec.describe "The library itself" do
   it "has no estraneous quotes" do
     exempt = /vendor|vcr_cassettes|LICENSE|rbreadline\.diff/
     error_messages = []
-    Dir.chdir(root) do
+    in_repo_root do
       tracked_files.split("\x0").each do |filename|
         next if filename =~ exempt
         error_messages << check_for_straneous_quotes(filename)
@@ -132,7 +132,7 @@ RSpec.describe "The library itself" do
   it "does not include any leftover debugging or development mechanisms" do
     exempt = %r{quality_spec.rb|support/helpers|vcr_cassettes|\.md|\.ronn|\.txt|\.5|\.1}
     error_messages = []
-    Dir.chdir(root) do
+    in_repo_root do
       tracked_files.split("\x0").each do |filename|
         next if filename =~ exempt
         error_messages << check_for_debugging_mechanisms(filename)
@@ -144,7 +144,7 @@ RSpec.describe "The library itself" do
   it "does not include any unresolved merge conflicts" do
     error_messages = []
     exempt = %r{lock/lockfile_spec|quality_spec|vcr_cassettes|\.ronn|lockfile_parser\.rb}
-    Dir.chdir(root) do
+    in_repo_root do
       tracked_files.split("\x0").each do |filename|
         next if filename =~ exempt
         error_messages << check_for_git_merge_conflicts(filename)
@@ -156,7 +156,7 @@ RSpec.describe "The library itself" do
   it "maintains language quality of the documentation" do
     included = /ronn/
     error_messages = []
-    Dir.chdir(root) do
+    in_repo_root do
       `git ls-files -z -- man`.split("\x0").each do |filename|
         next unless filename =~ included
         error_messages << check_for_expendable_words(filename)
@@ -169,7 +169,7 @@ RSpec.describe "The library itself" do
   it "maintains language quality of sentences used in source code" do
     error_messages = []
     exempt = /vendor|vcr_cassettes/
-    Dir.chdir(root) do
+    in_repo_root do
       lib_tracked_files.split("\x0").each do |filename|
         next if filename =~ exempt
         error_messages << check_for_expendable_words(filename)
@@ -197,7 +197,7 @@ RSpec.describe "The library itself" do
     Bundler::Settings::NUMBER_KEYS.each {|k| all_settings[k] << "in Bundler::Settings::NUMBER_KEYS" }
     Bundler::Settings::ARRAY_KEYS.each {|k| all_settings[k] << "in Bundler::Settings::ARRAY_KEYS" }
 
-    Dir.chdir(root) do
+    in_repo_root do
       key_pattern = /([a-z\._-]+)/i
       lib_tracked_files.split("\x0").each do |filename|
         each_line(filename) do |line, number|
@@ -231,7 +231,7 @@ RSpec.describe "The library itself" do
   end
 
   it "ships the correct set of files" do
-    Dir.chdir(root) do
+    in_repo_root do
       git_list = shipped_files.split("\x0")
 
       gem_list = Gem::Specification.load(gemspec.to_s).files
@@ -241,7 +241,7 @@ RSpec.describe "The library itself" do
   end
 
   it "does not contain any warnings" do
-    Dir.chdir(root) do
+    in_repo_root do
       exclusions = %w[
         lib/bundler/capistrano.rb
         lib/bundler/deployment.rb
@@ -267,7 +267,7 @@ RSpec.describe "The library itself" do
   end
 
   it "does not use require internally, but require_relative" do
-    Dir.chdir(root) do
+    in_repo_root do
       exempt = %r{templates/|vendor/}
       all_bad_requires = []
       lib_tracked_files.split("\x0").each do |filename|

--- a/spec/runtime/gem_tasks_spec.rb
+++ b/spec/runtime/gem_tasks_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe "require 'bundler/gem_tasks'" do
 
   context "rake build when path has spaces" do
     before do
+      Dir.chdir(root)
       spaced_bundled_app = tmp.join("bundled app")
       FileUtils.mv bundled_app, spaced_bundled_app
       Dir.chdir(spaced_bundled_app)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -105,7 +105,9 @@ RSpec.configure do |config|
     ENV.replace(original_env)
     reset!
     system_gems []
-    in_app_root
+
+    Dir.chdir(bundled_app)
+
     @command_executions = []
 
     Bundler.ui.silence { example.run }

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -67,10 +67,6 @@ module Spec
       Dir.chdir(bundled_app2, &blk)
     end
 
-    def in_app_root_custom(root, &blk)
-      Dir.chdir(root, &blk)
-    end
-
     def run(cmd, *args)
       opts = args.last.is_a?(Hash) ? args.pop : {}
       groups = args.map(&:inspect).join(", ")

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -297,7 +297,7 @@ module Spec
 
     def with_built_bundler
       with_root_gemspec do |gemspec|
-        Dir.chdir(root) { gem_command! :build, gemspec.to_s }
+        in_repo_root { gem_command! :build, gemspec.to_s }
       end
 
       bundler_path = root + "bundler-#{Bundler::VERSION}.gem"

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -59,14 +59,6 @@ module Spec
       last_command.exitstatus
     end
 
-    def in_app_root(&blk)
-      Dir.chdir(bundled_app, &blk)
-    end
-
-    def in_app_root2(&blk)
-      Dir.chdir(bundled_app2, &blk)
-    end
-
     def run(cmd, *args)
       opts = args.last.is_a?(Hash) ? args.pop : {}
       groups = args.map(&:inspect).join(", ")

--- a/spec/support/path.rb
+++ b/spec/support/path.rb
@@ -180,16 +180,16 @@ module Spec
       end
     end
 
-    def in_app_root(&blk)
-      Dir.chdir(bundled_app, &blk)
+    def in_app_root
+      Dir.chdir(bundled_app) { yield }
     end
 
-    def in_app_root2(&blk)
-      Dir.chdir(bundled_app2, &blk)
+    def in_app_root2
+      Dir.chdir(bundled_app2) { yield }
     end
 
-    def in_repo_root(&blk)
-      Dir.chdir(root, &blk)
+    def in_repo_root
+      Dir.chdir(root) { yield }
     end
 
     extend self

--- a/spec/support/path.rb
+++ b/spec/support/path.rb
@@ -158,8 +158,8 @@ module Spec
     def with_root_gemspec
       if ruby_core?
         root_gemspec = root.join("bundler.gemspec")
-        # Dir.chdir(root) for Dir.glob in gemspec
-        spec = Dir.chdir(root) { Gem::Specification.load(gemspec.to_s) }
+        # `in_repo_root` for Dir.glob in gemspec
+        spec = in_repo_root { Gem::Specification.load(gemspec.to_s) }
         spec.bindir = "libexec"
         File.open(root_gemspec.to_s, "w") {|f| f.write spec.to_ruby }
         yield(root_gemspec)
@@ -186,6 +186,10 @@ module Spec
 
     def in_app_root2(&blk)
       Dir.chdir(bundled_app2, &blk)
+    end
+
+    def in_repo_root(&blk)
+      Dir.chdir(root, &blk)
     end
 
     extend self

--- a/spec/support/path.rb
+++ b/spec/support/path.rb
@@ -180,6 +180,14 @@ module Spec
       end
     end
 
+    def in_app_root(&blk)
+      Dir.chdir(bundled_app, &blk)
+    end
+
+    def in_app_root2(&blk)
+      Dir.chdir(bundled_app2, &blk)
+    end
+
     extend self
 
   private


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that some specs were failing under Windows, with error messages like the following:

```
Permission denied @ rb_file_s_rename - (D:/a/1/s/tmp/1/bundled_app, D:/a/1/s/tmp/1/bundled_app2)

Failure/Error: FileUtils.mv(bundled_app, "#{bundled_app}2")

Errno::EACCES:
  Permission denied @ rb_file_s_rename - (D:/a/1/s/tmp/1/bundled_app, D:/a/1/s/tmp/1/bundled_app2)

  Commands:
  $ C:/hostedtoolcache/windows/Ruby/2.6.3/x64/bin/ruby.exe -ID:/a/1/s/lib\;D:/a/1/s/spec -rsupport/hax \
    -rsupport/artifice/fail D:/a/1/s/exe/bundle install --path D:/a/1/s/tmp/1/bundled_app/bundle \
    --standalone
  Fetching d:/a/1/s/tmp/1/libs/devise-1.0
  Fetching source index from file:///D:/a/1/s/tmp/1/gems/remote1/
  Resolving dependencies...
  Fetching rake 12.3.2
  Installing rake 12.3.2
  Fetching activesupport 2.3.2
  Installing activesupport 2.3.2
  Fetching actionmailer 2.3.2
  Installing actionmailer 2.3.2
  Fetching actionpack 2.3.2
  Installing actionpack 2.3.2
  Fetching activerecord 2.3.2
  Installing activerecord 2.3.2
  Fetching activeresource 2.3.2
  Installing activeresource 2.3.2
  Using bundler 2.2.0.dev
  Using devise 1.0 from d:/a/1/s/tmp/1/libs/devise-1.0 (at master@1cdf130)
  Fetching rails 2.3.2
  Installing rails 2.3.2
  Bundle complete! 2 Gemfile dependencies, 9 gems now installed.
  Bundled gems are installed into `./bundle`
  [DEPRECATED] The `--path` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set path 'D:/a/1/s/tmp/1/bundled_app/bundle'`, and stop using this flag
  # $? => 0
Shared Example Group: "common functionality" called from ./spec/install/gems/standalone_spec.rb:136
Shared Example Group: "bundle install --standalone" called from ./spec/install/gems/standalone_spec.rb:328
./spec/install/gems/standalone_spec.rb:32:in `block (3 levels) in <top (required)>'
./spec/spec_helper.rb:111:in `block (3 levels) in <top (required)>'
./spec/spec_helper.rb:111:in `block (2 levels) in <top (required)>'
./spec/spec_helper.rb:78:in `block (2 levels) in <top (required)>'
./spec/support/rubygems_ext.rb:87:in `load'
./spec/support/rubygems_ext.rb:87:in `gem_load_and_activate'
./spec/support/rubygems_ext.rb:45:in `gem_load'
```

### What was your diagnosis of the problem?

My diagnosis was that Windows doesn't like renaming folders while being inside them.

### What is your fix for the problem, implemented in this PR?

My fix is to move away from the folder to the root of the repo before renaming it.

### Why did you choose this fix out of the possible options?

I chose this fix because it fixes the failures under Windows while still achieving the same thing.