### PR TITLE
Fix escaping of some subprocesses during specs

### DIFF
--- a/spec/runtime/require_spec.rb
+++ b/spec/runtime/require_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe "Bundler.require" do
       begin
         Bundler.require
       rescue LoadError => e
-        $stderr.puts "ZOMG LOAD ERROR: \#{e.message}"
+        warn "ZOMG LOAD ERROR: \#{e.message}"
       end
     RUBY
     run(cmd)
@@ -228,7 +228,7 @@ RSpec.describe "Bundler.require" do
         begin
           Bundler.require
         rescue LoadError => e
-          $stderr.puts "ZOMG LOAD ERROR" if e.message.include?("Could not open library 'libfuuu-1.0'")
+          warn "ZOMG LOAD ERROR" if e.message.include?("Could not open library 'libfuuu-1.0'")
         end
       RUBY
       run(cmd)
@@ -251,7 +251,7 @@ RSpec.describe "Bundler.require" do
         begin
           Bundler.require
         rescue LoadError => e
-          $stderr.puts "ZOMG LOAD ERROR: \#{e.message}"
+          warn "ZOMG LOAD ERROR: \#{e.message}"
         end
       RUBY
       run(cmd)

--- a/spec/support/command_execution.rb
+++ b/spec/support/command_execution.rb
@@ -3,18 +3,7 @@
 module Spec
   CommandExecution = Struct.new(:command, :working_directory, :exitstatus, :stdout, :stderr) do
     def to_s
-      c = Shellwords.shellsplit(command.strip).map {|s| s.include?("\n") ? " \\\n  <<EOS\n#{s.gsub(/^/, "  ").chomp}\nEOS" : Shellwords.shellescape(s) }
-      c = c.reduce("") do |acc, elem|
-        concat = acc + " " + elem
-
-        last_line = concat.match(/.*\z/)[0]
-        if last_line.size >= 100
-          acc + " \\\n  " + elem
-        else
-          concat
-        end
-      end
-      "$ #{c.strip}"
+      "$ #{command}"
     end
     alias_method :inspect, :to_s
 

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -167,7 +167,7 @@ module Spec
         begin
           #{ruby}
         rescue LoadError => e
-          $stderr.puts "ZOMG LOAD ERROR"# if e.message.include?("-- #{name}")
+          $stderr.puts "ZOMG LOAD ERROR" if e.message.include?("-- #{name}")
         end
       R
     end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -72,7 +72,7 @@ module Spec
         begin
           #{ruby}
         rescue LoadError => e
-          $stderr.puts "ZOMG LOAD ERROR" if e.message.include?("-- #{name}")
+          warn "ZOMG LOAD ERROR" if e.message.include?("-- #{name}")
         end
       RUBY
       opts = args.last.is_a?(Hash) ? args.pop : {}
@@ -167,7 +167,7 @@ module Spec
         begin
           #{ruby}
         rescue LoadError => e
-          $stderr.puts "ZOMG LOAD ERROR" if e.message.include?("-- #{name}")
+          warn "ZOMG LOAD ERROR" if e.message.include?("-- #{name}")
         end
       R
     end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -156,9 +156,8 @@ module Spec
 
     def ruby(ruby, options = {})
       env = options.delete(:env) || {}
-      ruby = ruby.gsub(/["`]/) {|m| "\\#{m}" }
       lib_option = options[:no_lib] ? "" : " -I#{lib_dir}"
-      sys_exec(%(#{Gem.ruby}#{lib_option} -w -e "#{ruby}"), env)
+      sys_exec(%(#{Gem.ruby}#{lib_option} -w -e #{ruby.shellescape}), env)
     end
     bang :ruby
 

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -156,7 +156,7 @@ module Spec
 
     def ruby(ruby, options = {})
       env = options.delete(:env) || {}
-      ruby = ruby.gsub(/["`\$]/) {|m| "\\#{m}" }
+      ruby = ruby.gsub(/["`]/) {|m| "\\#{m}" }
       lib_option = options[:no_lib] ? "" : " -I#{lib_dir}"
       sys_exec(%(#{Gem.ruby}#{lib_option} -w -e "#{ruby}"), env)
     end
@@ -194,7 +194,8 @@ module Spec
       command_execution = CommandExecution.new(cmd.to_s, Dir.pwd)
 
       require "open3"
-      Open3.popen3(env, cmd.to_s) do |stdin, stdout, stderr, wait_thr|
+      require "shellwords"
+      Open3.popen3(env, *cmd.shellsplit) do |stdin, stdout, stderr, wait_thr|
         yield stdin, stdout, wait_thr if block_given?
         stdin.close
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that some specs are failing on Windows due to commands like the following failing:

```
$ C:/hostedtoolcache/windows/Ruby/2.6.3/x64/bin/ruby.exe -Id:/a/bundler/bundler/lib -w -e  \
  <<EOS
            begin
               $:.unshift File.expand_path("bundle")
               require "bundler/setup"
     
               require "actionpack"
               puts ACTIONPACK
               require "spec"
          
            rescue LoadError => e
               $stderr.puts "ZOMG LOAD ERROR"# if e.message.include?("-- spec")
            end
   EOS
   -e:2: syntax error, unexpected backslash
                       \$:.unshift File.expand_path("...
                       ^
   -e:10: syntax error, unexpected backslash
             \$stderr.puts "ZOMG LOAD ERROR...
             ^
# $? => 1
```

### What was your diagnosis of the problem?

My diagnosis was that if the code being run via `ruby -e` in a subprocess include "$", it was not being properly escaped under Windows.

### What is your fix for the problem, implemented in this PR?

My fix is to use `shellsplit` and `shellescape`.

### Why did you choose this fix out of the possible options?

I chose this fix because after a bit of testing it seemed to do the trick.
