### PR TITLE
Drop ruby 2.3 and rubygems 2.5 support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ require: rubocop-performance
 
 AllCops:
   DisabledByDefault: true
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
   Exclude:
     - tmp/**/*
     - lib/bundler/vendor/**/*
@@ -445,9 +445,6 @@ Performance/EndWith:
   Enabled: true
 
 Performance/FixedSize:
-  Enabled: true
-
-Performance/RegexpMatch:
   Enabled: true
 
 Performance/ReverseEach:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,6 @@ before_script:
     then
       travis_retry sudo apt-get install graphviz -y;
     fi
-  - if [ "$TRAVIS_RUBY_VERSION" = "2.3.8" ];
-    then
-      sudo sed -i 's/1000::/1000:Travis:/g' /etc/passwd;
-      sudo sed -i '/secure_path/d' /etc/sudoers;
-    fi
 
 branches:
   only:
@@ -61,13 +56,6 @@ jobs:
     - rvm: 2.6.5
       script: bin/rake rubocop check_rvm_integration man:check
       stage: linting
-    # Ruby 2.3 also tested in 2.x mode
-    - rvm: 2.3.8
-      env: RGV=master
-      stage: test
-    - rvm: 2.3.8
-      env: RGV=v3.0.6
-      stage: test
     # Ruby 2.5, Rubygems 2.7
     - rvm: 2.5.7
       env: RGV=v2.7.10
@@ -75,10 +63,6 @@ jobs:
     # Ruby 2.4, Rubygems 2.6
     - rvm: 2.4.9
       env: RGV=v2.6.14
-      stage: test
-    # Ruby 2.3, Rubygems 2.5
-    - rvm: 2.3.8
-      env: RGV=v2.5.2
       stage: test
     # Ruby-head (we want to know how we're doing, but not fail the build)
     - rvm: ruby-head

--- a/bundler.gemspec
+++ b/bundler.gemspec
@@ -31,8 +31,8 @@ Gem::Specification.new do |s|
     }
   end
 
-  s.required_ruby_version     = ">= 2.3.0"
-  s.required_rubygems_version = ">= 2.5.2"
+  s.required_ruby_version     = ">= 2.4.0"
+  s.required_rubygems_version = ">= 2.6.14"
 
   s.files = Dir.glob("{lib,man,exe}/**/*", File::FNM_DOTMATCH).reject {|f| File.directory?(f) }
 

--- a/doc/POLICIES.md
+++ b/doc/POLICIES.md
@@ -17,7 +17,7 @@ Bundler tries for perfect backwards compatibility. That means that if something 
 
 Bundler will provide features and bugfixes to older versions on a schedule similar to Ruby itself. For example, when Bundler 4.x is the current version, Bundler 4 will be eligible for new features and bugfixes. Bundler 3 will be eligible for bugfixes only. Bundler 2 will be eligible for security bugfixes only. Bundler 1 will be unsupported.
 
-Bundler 2 and above will support Ruby and RubyGems versions for the same amount of time as the Ruby core team supports them. As of February 2018, that means no support for Bundler running on Ruby 2.2, security fixes only for Bundler running on Ruby 2.3, and full support (including new features and bugfixes) for Bundler running on Ruby 2.4 and 2.5. Unsupported Ruby versions will be dropped in the first Bundler minor release after support ends.
+Bundler 2 supports Ruby and RubyGems versions for the same amount of time as the Ruby core team supports them. As of February 2020, that means no support for Bundler running on Ruby 2.3, security fixes only for Bundler running on Ruby 2.4, and full support (including new features and bugfixes) for Bundler running on Ruby 2.5, 2.6 and 2.7. Unsupported Ruby versions will be dropped in the first Bundler minor release after support ends.
 
 These policies are not a guarantee that any particular fix will be backported. Instead, this is a way for us to set an upper limit on the versions of Ruby, RubyGems, and Bundler that we have to consider while making changes. Without the limit, the number of versions grows exponentially over time and quickly becomes overwhelming, which leads to maintainer burnout. We want to avoid that.
 

--- a/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
 <%- if config[:mit] -%>
   spec.license       = "MIT"
 <%- end -%>
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.4.0")
 
   spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
 


### PR DESCRIPTION
Closes #7586. 

### What was the end-user problem that led to this PR?

The problem was that ruby 2.3 reached its end of life almost a year ago and we still support it.

### What was your diagnosis of the problem?

My diagnosis was that we should drop support.

### What is your fix for the problem, implemented in this PR?

My fix is to drop support.

### Why did you choose this fix out of the possible options?

I chose this fix because it's part of our ruby support policy. 
