### PR TITLE
Add ruby 2.7 and rubygems 3.1.2 to CI matrix

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [ '2.4.x', '2.5.x', '2.6.x' ]
+        ruby: [ '2.4.x', '2.5.x', '2.6.x', '2.7.x' ]
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,6 +19,12 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
+      - uses: actions/checkout@v2
+        with:
+          repository: deivid-rodriguez/parallel_tests
+          ref: fix_fetch_issue
+          path: parallel_tests
+
       - name: Setup ruby
         uses: actions/setup-ruby@v1
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -35,5 +35,5 @@ jobs:
         shell: bash
 
       - name: Run specs
-        run: bin/parallel_rspec spec
+        run: parallel_tests/bin/parallel_rspec spec
         shell: bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ script:
   - BUNDLER_SPEC_PRE_RECORDED=1 bin/rake spec:realworld
 
 before_script:
-  - travis_retry gem install rake:"~> 12.0"
   - travis_retry bin/rake override_version
   - travis_retry bin/rake spec:parallel_deps
   - if [ "$BUNDLER_SPEC_SUB_VERSION" = "" ];

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ notifications:
       - secure: JxBi7DDJGkIF/7f/FSN/HUHpvV4EKfQccZHTPd1b2pNJn3GXo6u+tNVbAw2WjxYzPyPQI3ZcYBCU9SEXp/i7VmG8uMzh8Kyildw+miSKYKVb90uYqcsXWzbxwyNBgJLvyDkzST45H5lgnyAicee3WkFes/WDZikIajbH7ztdb04=
 
 rvm:
+  - 2.7.0
   - 2.6.5
   - 2.5.7
   - 2.4.9
@@ -52,12 +53,12 @@ env:
   - RGV=master BUNDLER_SPEC_SUB_VERSION=3.0.0
   - RGV=master
   # Test the latest rubygems release with all of our supported rubies
-  - RGV=v3.0.6 BUNDLER_SPEC_SUB_VERSION=3.0.0
-  - RGV=v3.0.6
+  - RGV=v3.1.2 BUNDLER_SPEC_SUB_VERSION=3.0.0
+  - RGV=v3.1.2
 
 jobs:
   include:
-    - rvm: 2.6.5
+    - rvm: 2.7.0
       script: bin/rake rubocop check_rvm_integration man:check
       stage: linting
     # Ruby 2.3 also tested in 2.x mode
@@ -65,6 +66,10 @@ jobs:
       env: RGV=master
       stage: test
     - rvm: 2.3.8
+      env: RGV=v3.1.2
+      stage: test
+    # Ruby 2.6, Rubygems 3.0
+    - rvm: 2.6.5
       env: RGV=v3.0.6
       stage: test
     # Ruby 2.5, Rubygems 2.7

--- a/bin/parallel_rspec
+++ b/bin/parallel_rspec
@@ -1,6 +1,4 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require_relative "../spec/support/rubygems_ext"
-
-Spec::Rubygems.gem_load("parallel_tests", "parallel_rspec")
+load File.expand_path("../parallel_tests/bin/parallel_rspec", __dir__)

--- a/bin/parallel_rspec
+++ b/bin/parallel_rspec
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-load File.expand_path("../parallel_tests/bin/parallel_rspec", __dir__)
+require_relative "../spec/support/rubygems_ext"
+
+Spec::Rubygems.gem_load("parallel_tests", "parallel_rspec")

--- a/lib/bundler/build_metadata.rb
+++ b/lib/bundler/build_metadata.rb
@@ -29,15 +29,15 @@ module Bundler
       # commit instance variable then we can't determine its commits SHA.
       git_dir = File.join(File.expand_path("../../..", __FILE__), ".git")
       if File.directory?(git_dir)
-        return @git_commit_sha = Dir.chdir(git_dir) { `git rev-parse --short HEAD`.strip.freeze }
+        require "open3"
+        return @git_commit_sha = Open3.capture2e("git", "rev-parse", "--short", "HEAD", :chdir => git_dir)[0].strip.freeze
       end
 
       # If Bundler is a submodule in RubyGems, get the submodule commit
       git_sub_dir = File.join(File.expand_path("../../../..", __FILE__), ".git")
       if File.directory?(git_sub_dir)
-        return @git_commit_sha = Dir.chdir(git_sub_dir) do
-          `git ls-tree --abbrev=8 HEAD bundler`.split(/\s/).fetch(2, "").strip.freeze
-        end
+        require "open3"
+        return @git_commit_sha = Open3.capture2e("git", "ls-tree", "--abbrev=8", "HEAD", "bundler", :chdir => git_sub_dir)[0].split(/\s/).fetch(2, "").strip.freeze
       end
 
       @git_commit_sha ||= "unknown"

--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -166,10 +166,9 @@ module Bundler
 
       if Bundler.git_present? && options[:git]
         Bundler.ui.info "Initializing git repo in #{target}"
-        Dir.chdir(target) do
-          `git init`
-          `git add .`
-        end
+        require "open3"
+        Open3.capture2e("git", "init", :chdir => target)
+        Open3.capture2e("git", "add", ".", :chdir => target)
       end
 
       # Open gemspec in editor

--- a/lib/bundler/cli/open.rb
+++ b/lib/bundler/cli/open.rb
@@ -18,12 +18,10 @@ module Bundler
         Bundler.ui.info "Unable to open #{name} because it's a default gem, so the directory it would normally be installed to does not exist."
       else
         path = spec.full_gem_path
-        Dir.chdir(path) do
-          command = Shellwords.split(editor) + [path]
-          Bundler.with_original_env do
-            system(*command)
-          end || Bundler.ui.info("Could not run '#{command.join(" ")}'")
-        end
+        command = Shellwords.split(editor) + [path]
+        Bundler.with_original_env do
+          system(*command, :chdir => path)
+        end || Bundler.ui.info("Could not run '#{command.join(" ")}'")
       end
     end
   end

--- a/spec/support/rubygems_ext.rb
+++ b/spec/support/rubygems_ext.rb
@@ -7,7 +7,6 @@ module Spec
     DEV_DEPS = {
       "automatiek" => "~> 0.3.0",
       "parallel_tests" => "~> 2.29",
-      "rake" => "~> 12.0",
       "ronn" => "~> 0.7.3",
       "rspec" => "~> 3.8",
       "rubocop" => "= 0.77.0",


### PR DESCRIPTION
Closes #7585.

<!--
Thanks so much for the contribution!

If you're updating documentation, make sure you run `bin/rake man:build` and
squash the result into your changes, so that all documentation formats are
updated.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

### What was the end-user or developer problem that led to this PR?

As a developer, I want to make sure that bundler works against the latest versions of ruby and rubygems.

### What is your fix for the problem, implemented in this PR?

My fix is to add those to the CI matrix.