### PR TITLE
Add new option to `bundle gem` for choosing a CI sevice

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -570,6 +570,7 @@ module Bundler
     method_option :rubocop, :type => :boolean, :desc => "Add rubocop to the generated Rakefile and gemspec. Set a default with `bundle config set gem.rubocop true`."
     method_option :test, :type => :string, :lazy_default => "rspec", :aliases => "-t", :banner => "rspec",
                          :desc => "Generate a test directory for your library, either rspec, minitest or test-unit. Set a default with `bundle config set gem.test rspec`."
+    method_option :ci,   :type => :string, :desc => "Generate CI configuration, either Github Actions, Travis CI, Gitlab CI or Circle CI. Set a default with `bundle config set gem.ci (github|travis|gitlab|circle)`"
     def gem(name)
     end
 

--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -107,23 +107,16 @@ module Bundler
         end
       end
 
-      if ci_template = ask_and_set_ci
-        config[:ci] = ci_template
-
-        case ci_template
-        when "github"
-          templates.merge!(".github/workflows/main.yml.tt" => ".github/workflows/main.yml")
-          config[:ci] = "github"
-        when "travis"
-          templates.merge!("travis.yml.tt" => ".travis.yml")
-          config[:ci] = "travis"
-        when "gitlab"
-          templates.merge!(".gitlab-ci.yml.tt" => ".gitlab-ci.yml")
-          config[:ci] = "gitlab"
-        when "circle"
-          templates.merge!(".circleci/config.yml.tt" => ".circleci/config.yml")
-          config[:ci] = "circleci"
-        end
+      config[:ci] = ask_and_set_ci
+      case config[:ci]
+      when "github"
+        templates.merge!(".github/workflows/main.yml.tt" => ".github/workflows/main.yml")
+      when "travis"
+        templates.merge!("travis.yml.tt" => ".travis.yml")
+      when "gitlab"
+        templates.merge!(".gitlab-ci.yml.tt" => ".gitlab-ci.yml")
+      when "circle"
+        templates.merge!(".circleci/config.yml.tt" => ".circleci/config.yml")
       end
 
       if ask_and_set(:mit, "Do you want to license your code permissively under the MIT license?",
@@ -252,16 +245,16 @@ module Bundler
       ci_template = options[:ci] || Bundler.settings["gem.ci"]
 
       if ci_template.nil?
-        Bundler.ui.confirm "Do you want to add Continuous Integration to your gem? " \
-        "Adding a CI service to your project helps ensure your project is well tested " \
-        "before shipping your gem to users. Bundler recommends several different services for testing "\
-        "your code. For more information about each service, see:\n" \
-        "* Travis CI:      https://travis-ci.org/\n" \
-        "* Github Actions: https://github.com/features/actions\n" \
-        "* Circle CI:      https://circleci.com/\n" \
-        "* Gitlab CI:      https://docs.gitlab.com/ee/ci/\n\n"
+        Bundler.ui.confirm "Do you want to set up automated testing for your gem? " \
+          "Continuous integration services make it easy to see if pull requests have passing tests " \
+          "before you merge them. Bundler supports these services:"\
+          "* Circle CI:      https://circleci.com/\n" \
+          "* Github Actions: https://github.com/features/actions\n" \
+          "* Gitlab CI:      https://docs.gitlab.com/ee/ci/\n" \
+          "* Travis CI:      https://travis-ci.org/\n" \
+          "\n"
 
-        result = Bundler.ui.ask "Type 'github', 'travis', 'gitlab' or 'circle' to generate the CI configuration now and " \
+        result = Bundler.ui.ask "Enter a service name to generate a CI configuration now and " \
           "in the future. github/travis/gitlab/circle/(none):"
         if result =~ /github|travis|gitlab|circle/
           ci_template = result

--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -261,7 +261,7 @@ module Bundler
         "* Circle CI:      https://circleci.com/\n" \
         "* Gitlab CI:      https://docs.gitlab.com/ee/ci/\n\n"
 
-        result = Bundler.ui.ask "Type 'github', 'travis', 'gitlab' or 'circle' to generate those test files now and " \
+        result = Bundler.ui.ask "Type 'github', 'travis', 'gitlab' or 'circle' to generate the CI configuration now and " \
           "in the future. github/travis/gitlab/circle/(none):"
         if result =~ /github|travis|gitlab|circle/
           ci_template = result

--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -84,8 +84,6 @@ module Bundler
         config[:test] = test_framework
         config[:test_framework_version] = TEST_FRAMEWORK_VERSIONS[test_framework]
 
-        templates.merge!("travis.yml.tt" => ".travis.yml")
-
         case test_framework
         when "rspec"
           templates.merge!(
@@ -106,6 +104,25 @@ module Bundler
             "test/test-unit/newgem_test.rb.tt" => "test/#{namespaced_path}_test.rb"
           )
           config[:test_task] = :test
+        end
+      end
+
+      if ci_template = ask_and_set_ci
+        config[:ci] = ci_template
+
+        case ci_template
+        when "github"
+          templates.merge!(".github/workflows/main.yml.tt" => ".github/workflows/main.yml")
+          config[:ci] = "github"
+        when "travis"
+          templates.merge!("travis.yml.tt" => ".travis.yml")
+          config[:ci] = "travis"
+        when "gitlab"
+          templates.merge!(".gitlab-ci.yml.tt" => ".gitlab-ci.yml")
+          config[:ci] = "gitlab"
+        when "circle"
+          templates.merge!(".circleci/config.yml.tt" => ".circleci/config.yml")
+          config[:ci] = "circleci"
         end
       end
 
@@ -229,6 +246,35 @@ module Bundler
       end
 
       test_framework
+    end
+
+    def ask_and_set_ci
+      ci_template = options[:ci] || Bundler.settings["gem.ci"]
+
+      if ci_template.nil?
+        Bundler.ui.confirm "Do you want to add Continuous Integration to your gem? " \
+        "Adding a CI service to your project helps ensure your project is well tested " \
+        "before shipping your gem to users. Bundler recommends several different services for testing "\
+        "your code. For more information about each service, see:\n" \
+        "* Travis CI:      https://travis-ci.org/\n" \
+        "* Github Actions: https://github.com/features/actions\n" \
+        "* Circle CI:      https://circleci.com/\n" \
+        "* Gitlab CI:      https://docs.gitlab.com/ee/ci/\n\n"
+
+        result = Bundler.ui.ask "Type 'github', 'travis', 'gitlab' or 'circle' to generate those test files now and " \
+          "in the future. github/travis/gitlab/circle/(none):"
+        if result =~ /github|travis|gitlab|circle/
+          ci_template = result
+        else
+          ci_template = false
+        end
+      end
+
+      if Bundler.settings["gem.ci"].nil?
+        Bundler.settings.set_global("gem.ci", ci_template)
+      end
+
+      ci_template
     end
 
     def bundler_dependency_version

--- a/lib/bundler/templates/newgem/.circleci/config.yml.tt
+++ b/lib/bundler/templates/newgem/.circleci/config.yml.tt
@@ -1,0 +1,13 @@
+version: 2.1
+jobs:
+  build:
+    docker:
+      - image: ruby:<%= RUBY_VERSION %>
+    steps:
+      - checkout
+      - run:
+          name: Run tests
+          command: |
+            gem install bundler -v <%= Bundler::Version %>
+            bundle install
+            bundle exec rake test

--- a/lib/bundler/templates/newgem/.github/workflows/main.yml.tt
+++ b/lib/bundler/templates/newgem/.github/workflows/main.yml.tt
@@ -1,0 +1,18 @@
+name: Ruby
+
+on: [push,pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby <%= ::Gem::Version.new(RUBY_VERSION).segments[0..1].join(".") %>
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: <%= ::Gem::Version.new(RUBY_VERSION).segments[0..1].join(".") %>.x
+    - name: Build and test with Rake
+      run: |
+        gem install bundler -v <%= Bundler::VERSION %>
+        bundle install --jobs 4 --retry 3
+        bundle exec rake

--- a/lib/bundler/templates/newgem/.gitlab-ci.yml.tt
+++ b/lib/bundler/templates/newgem/.gitlab-ci.yml.tt
@@ -1,0 +1,9 @@
+image: ruby:<%= RUBY_VERSION %>
+
+before_script:
+  - gem install bundler
+  - bundle install -v <%= Bundler::VERSION %>
+
+test:
+  script:
+    - bundle exec rake test

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -558,6 +558,94 @@ RSpec.describe "bundle gem" do
       end
     end
 
+    context "--ci with no arugment" do
+      it "does not generate any CI config" do
+        bundle "gem #{gem_name}"
+
+        expect(bundled_app("#{gem_name}/.github/workflows/main.yml")).to_not exist
+        expect(bundled_app("#{gem_name}/.travis.yml")).to_not exist
+        expect(bundled_app("#{gem_name}/.gitlab-ci.yml")).to_not exist
+        expect(bundled_app("#{gem_name}/.circleci/config.yml")).to_not exist
+      end
+    end
+
+    context "--ci set to github" do
+      it "generates a Github Actions config file" do
+        bundle "gem #{gem_name} --ci=github"
+
+        expect(bundled_app("#{gem_name}/.github/workflows/main.yml")).to exist
+      end
+    end
+
+    context "--ci set to gitlab" do
+      it "generates a Gitlab Ci config file" do
+        bundle "gem #{gem_name} --ci=gitlab"
+
+        expect(bundled_app("#{gem_name}/.gitlab-ci.yml")).to exist
+      end
+    end
+
+    context "--ci set to circle" do
+      it "generates a Circle Ci config file" do
+        bundle "gem #{gem_name} --ci=circle"
+
+        expect(bundled_app("#{gem_name}/.circleci/config.yml")).to exist
+      end
+    end
+
+    context "--ci set to travis" do
+      it "generates a Travis Ci config file" do
+        bundle "gem #{gem_name} --ci=travis"
+
+        expect(bundled_app("#{gem_name}/.travis.yml")).to exist
+      end
+    end
+
+    context "gem.ci setting set to none" do
+      it "doesnt generate any CI config" do
+        expect(bundled_app("#{gem_name}/.github/workflows/main.yml")).to_not exist
+        expect(bundled_app("#{gem_name}/.travis.yml")).to_not exist
+        expect(bundled_app("#{gem_name}/.gitlab-ci.yml")).to_not exist
+        expect(bundled_app("#{gem_name}/.circleci/config.yml")).to_not exist
+      end
+    end
+
+    context "gem.ci setting set to github" do
+      it "generates a Github Actions config file" do
+        bundle "config set gem.ci github"
+        bundle "gem #{gem_name}"
+
+        expect(bundled_app("#{gem_name}/.github/workflows/main.yml")).to exist
+      end
+    end
+
+    context "gem.ci setting set to travis" do
+      it "generates a Travis config file" do
+        bundle "config set gem.ci travis"
+        bundle "gem #{gem_name}"
+
+        expect(bundled_app("#{gem_name}/.travis.yml")).to exist
+      end
+    end
+
+    context "gem.ci setting set to gitlab" do
+      it "generates a Gitlab config file" do
+        bundle "config set gem.ci gitlab"
+        bundle "gem #{gem_name}"
+
+        expect(bundled_app("#{gem_name}/.gitlab-ci.yml")).to exist
+      end
+    end
+
+    context "gem.ci setting set to circleci" do
+      it "generates a CircleCI config file" do
+        bundle "config set gem.ci circle"
+        bundle "gem #{gem_name}"
+
+        expect(bundled_app("#{gem_name}/.circleci/config.yml")).to exist
+      end
+    end
+
     context "gem.test setting set to test-unit" do
       before do
         bundle "config set gem.test test-unit"
@@ -590,10 +678,6 @@ RSpec.describe "bundle gem" do
       it "defaults to rspec" do
         expect(bundled_app("#{gem_name}/spec/spec_helper.rb")).to exist
         expect(bundled_app("#{gem_name}/test/test_helper.rb")).to_not exist
-      end
-
-      it "creates a .travis.yml file to test the library against the current Ruby version on Travis CI" do
-        expect(bundled_app("#{gem_name}/.travis.yml").read).to match(/- #{RUBY_VERSION}/)
       end
     end
 
@@ -806,8 +890,18 @@ Usage: "bundle gem NAME [OPTIONS]"
       expect(bundled_app("foobar/Gemfile").read).to include('gem "rspec"')
     end
 
+    it "asks about CI service" do
+      global_config "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__MIT" => "false", "BUNDLE_GEM__COC" => "false", "BUNDLE_GEM__RUBOCOP" => "false"
+
+      bundle! "gem foobar" do |input, _, _|
+        input.puts "github"
+      end
+
+      expect(bundled_app("foobar/.github/workflows/main.yml")).to exist
+    end
+
     it "asks about MIT license" do
-      global_config "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__COC" => "false"
+      global_config "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__COC" => "false", "BUNDLE_GEM__CI" => "false", "BUNDLE_GEM__RUBOCOP" => "false"
 
       bundle "config list"
 
@@ -819,7 +913,7 @@ Usage: "bundle gem NAME [OPTIONS]"
     end
 
     it "asks about CoC" do
-      global_config "BUNDLE_GEM__MIT" => "false", "BUNDLE_GEM__TEST" => "false"
+      global_config "BUNDLE_GEM__MIT" => "false", "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__CI" => "false", "BUNDLE_GEM__RUBOCOP" => "false"
 
       bundle! "gem foobar" do |input, _, _|
         input.puts "yes"


### PR DESCRIPTION
### Context

At the moment, every gem created with `bundle gem` will have configuration generated for Travis CI regardless of if you want to or not. When this change was introduced, Travis CI was a clear recommendation for most open source projects to use for testing their projects with. But this is no longer true, there are now lots of different CI services and Travis CI is no longer the clear recommendation it once was.

### Changes

This PR introduces a new option to `bundle gem` for choosing a CI service or just not generating one at all.

```
Creating gem 'test'...
Do you want to add Continuous Integration to your gem? Adding a CI service to your project helps ensure your project is well tested before shipping your gem to users. Bundler recommends several different services for testing your code. For more information about each service, see:
* Travis CI:      https://travis-ci.org/
* Github Actions: https://github.com/features/actions
* Circle CI:      https://circleci.com/
* Gitlab CI:      https://docs.gitlab.com/ee/ci/

Type 'github', 'travis', 'gitlab' or 'circle' to generate those test files now and in the future. github/travis/gitlab/circle/(none):
```

I decided to add Github Actions, Gitlab, Circle CI along with Travis CI, which i think covers most services most people will typically go with.

Each service will generate it's own configuration which is ready to use out the box.
 