### PR TITLE
Warn on similar to known rubygem sources

### DIFF
--- a/spec/bundler/source/rubygems_spec.rb
+++ b/spec/bundler/source/rubygems_spec.rb
@@ -29,5 +29,12 @@ RSpec.describe Bundler::Source::Rubygems do
         expect { subject.add_remote("https:rubygems.org") }.to raise_error(ArgumentError)
       end
     end
+
+    context "when the source is too similar to a known host" do
+      it "warns" do
+        expect(Bundler.ui).to receive(:warn).with(/similar/)
+        subject.add_remote("https://rubgems.org")
+      end
+    end
   end
 end


### PR DESCRIPTION
This article got me thinking: http://gavinmiller.io/2020/how-i-mitmd-rubygems-org-kinda/. It's very easy to accidentally make a spelling mistake in the source of a Gemfile. This commit adds a warning if you do to verify that you absolutely do want that behavior.

I thought about throwing an error but I suppose it's possible someone could want that, so we can just let it go through but warn every time.