### PR TITLE
Add `bundle fund` command

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -434,10 +434,12 @@ module Bundler
       Outdated.new(options, gems).run
     end
 
-    desc "fund", "Lists information about gems seeking funding assistance"
-    def fund(*gems)
+    desc "fund [OPTIONS]", "Lists information about gems seeking funding assistance"
+    method_option "group", :aliases => "-g", :type => :array, :banner =>
+      "Fetch funding information for a specific group"
+    def fund
       require_relative "cli/fund"
-      Fund.new(gems).run
+      Fund.new(options).run
     end
 
     desc "cache [OPTIONS]", "Locks and then caches all of the gems into vendor/cache"

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -434,6 +434,12 @@ module Bundler
       Outdated.new(options, gems).run
     end
 
+    desc "fund", "Lists information about gems seeking funding assistance"
+    def fund(*gems)
+      require_relative "cli/fund"
+      Fund.new(gems).run
+    end
+
     desc "cache [OPTIONS]", "Locks and then caches all of the gems into vendor/cache"
     unless Bundler.feature_flag.cache_all?
       method_option "all",  :type => :boolean,

--- a/lib/bundler/cli/common.rb
+++ b/lib/bundler/cli/common.rb
@@ -14,11 +14,14 @@ module Bundler
       Bundler.ui.info msg
     end
 
-    def self.output_fund_metadata_summary(funds)
-      gems_seeking_funding = funds.keys.count
-      return if gems_seeking_funding.zero?
+    def self.output_fund_metadata_summary(gems_seeking_funding)
+      gem_names = gems_seeking_funding.keys
+      current_dependencies = Bundler.definition.current_dependencies.map(&:name)
+      direct_gems_seeking_funding = gem_names.reject { |g| !current_dependencies.include?(g) }
+      return if direct_gems_seeking_funding.empty?
 
-      intro = gems_seeking_funding > 1 ? "#{gems_seeking_funding} gems you depend on are" : "#{gems_seeking_funding} gem you depend on is"
+      count = direct_gems_seeking_funding.length
+      intro = count > 1 ? "#{count} gems you depend on are" : "#{count} gem you depend on is"
       message = "#{intro} looking for funding!\n  Run `bundle fund` for details"
       Bundler.ui.info message
     end

--- a/lib/bundler/cli/common.rb
+++ b/lib/bundler/cli/common.rb
@@ -14,6 +14,15 @@ module Bundler
       Bundler.ui.info msg
     end
 
+    def self.output_fund_metadata_summary(funds)
+      gems_seeking_funding = funds.keys.count
+      return if gems_seeking_funding.zero?
+
+      intro = gems_seeking_funding > 1 ? "#{gems_seeking_funding} gems you depend on are" : "#{gems_seeking_funding} gem you depend on is"
+      message = "#{intro} looking for funding!\n  Run `bundle fund` for details"
+      Bundler.ui.info message
+    end
+
     def self.output_without_groups_message(command)
       return if Bundler.settings[:without].empty?
       Bundler.ui.confirm without_groups_message(command)

--- a/lib/bundler/cli/common.rb
+++ b/lib/bundler/cli/common.rb
@@ -17,7 +17,7 @@ module Bundler
     def self.output_fund_metadata_summary(gems_seeking_funding)
       gem_names = gems_seeking_funding.keys
       current_dependencies = Bundler.definition.current_dependencies.map(&:name)
-      direct_gems_seeking_funding = gem_names.reject { |g| !current_dependencies.include?(g) }
+      direct_gems_seeking_funding = gem_names.reject {|g| !current_dependencies.include?(g) }
       return if direct_gems_seeking_funding.empty?
 
       count = direct_gems_seeking_funding.length

--- a/lib/bundler/cli/fund.rb
+++ b/lib/bundler/cli/fund.rb
@@ -26,7 +26,7 @@ module Bundler
         end
       end
 
-      if fund_info.length.zero?
+      if fund_info.empty?
         Bundler.ui.info "None of the gems you depend on are looking for funding!"
       else
         Bundler.ui.info fund_info.join("\n")

--- a/lib/bundler/cli/fund.rb
+++ b/lib/bundler/cli/fund.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Bundler
+  class CLI::Fund
+    attr_reader :options
+
+    def initialize(options)
+      @options = options
+    end
+
+    def run
+      Bundler.definition.validate_runtime!
+
+      groups  = Array(options[:group]).map(&:to_sym)
+
+      deps = if groups.any?
+               Bundler.definition.current_dependencies.select { |d| (d.groups & groups).any? }
+             else
+               Bundler.definition.current_dependencies
+             end
+
+      fund_info = deps.each_with_object([]) do |dep, arr|
+        spec = Bundler.definition.specs[dep.name].first
+        if spec.metadata.key?("funding_uri")
+          arr << "* #{spec.name} (#{spec.version})\n  Funding: #{spec.metadata['funding_uri']}"
+        end
+      end
+
+      if fund_info.length.zero?
+        Bundler.ui.info "None of the gems you depend on are looking for funding!"
+      else
+        Bundler.ui.info fund_info.join("\n")
+      end
+    end
+  end
+end

--- a/lib/bundler/cli/fund.rb
+++ b/lib/bundler/cli/fund.rb
@@ -11,18 +11,18 @@ module Bundler
     def run
       Bundler.definition.validate_runtime!
 
-      groups  = Array(options[:group]).map(&:to_sym)
+      groups = Array(options[:group]).map(&:to_sym)
 
       deps = if groups.any?
-               Bundler.definition.current_dependencies.select { |d| (d.groups & groups).any? }
-             else
-               Bundler.definition.current_dependencies
-             end
+        Bundler.definition.current_dependencies.select {|d| (d.groups & groups).any? }
+      else
+        Bundler.definition.current_dependencies
+      end
 
       fund_info = deps.each_with_object([]) do |dep, arr|
         spec = Bundler.definition.specs[dep.name].first
         if spec.metadata.key?("funding_uri")
-          arr << "* #{spec.name} (#{spec.version})\n  Funding: #{spec.metadata['funding_uri']}"
+          arr << "* #{spec.name} (#{spec.version})\n  Funding: #{spec.metadata["funding_uri"]}"
         end
       end
 

--- a/lib/bundler/cli/info.rb
+++ b/lib/bundler/cli/info.rb
@@ -57,6 +57,7 @@ module Bundler
       gem_info << "\tHomepage: #{spec.homepage}\n" if spec.homepage
       gem_info << "\tDocumentation: #{metadata["documentation_uri"]}\n" if metadata.key?("documentation_uri")
       gem_info << "\tSource Code: #{metadata["source_code_uri"]}\n" if metadata.key?("source_code_uri")
+      gem_info << "\tFunding: #{metadata["funding_uri"]}\n" if metadata.key?("funding_uri")
       gem_info << "\tWiki: #{metadata["wiki_uri"]}\n" if metadata.key?("wiki_uri")
       gem_info << "\tChangelog: #{metadata["changelog_uri"]}\n" if metadata.key?("changelog_uri")
       gem_info << "\tBug Tracker: #{metadata["bug_tracker_uri"]}\n" if metadata.key?("bug_tracker_uri")

--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -84,6 +84,8 @@ module Bundler
         require_relative "clean"
         Bundler::CLI::Clean.new(options).run
       end
+
+      Bundler::CLI::Common.output_fund_metadata_summary installer.fund_metadata
     rescue GemNotFound, VersionConflict => e
       if options[:local] && Bundler.app_cache.exist?
         Bundler.ui.warn "Some gems seem to be missing from your #{Bundler.settings.app_cache_path} directory."

--- a/lib/bundler/cli/update.rb
+++ b/lib/bundler/cli/update.rb
@@ -106,6 +106,8 @@ module Bundler
       Bundler.ui.confirm "Bundle updated!"
       Bundler::CLI::Common.output_without_groups_message(:update)
       Bundler::CLI::Common.output_post_install_messages installer.post_install_messages
+
+      Bundler::CLI::Common.output_fund_metadata_summary installer.fund_metadata
     end
   end
 end

--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -15,7 +15,7 @@ module Bundler
       Installer.ambiguous_gems = []
     end
 
-    attr_reader :post_install_messages
+    attr_reader :post_install_messages, :fund_metadata
 
     # Begins the installation process for Bundler.
     # For more information see the #run method on this class.
@@ -31,6 +31,7 @@ module Bundler
       @root = root
       @definition = definition
       @post_install_messages = {}
+      @fund_metadata = {}
     end
 
     # Runs the install procedures for a specific Gemfile.
@@ -282,6 +283,7 @@ module Bundler
       spec_installations = ParallelInstaller.call(self, @definition.specs, size, standalone, force)
       spec_installations.each do |installation|
         post_install_messages[installation.name] = installation.post_install_message if installation.has_post_install_message?
+        fund_metadata[installation.name] = installation.fund_metadata if installation.has_fund_metadata?
       end
     end
 

--- a/lib/bundler/installer/parallel_installer.rb
+++ b/lib/bundler/installer/parallel_installer.rb
@@ -6,12 +6,13 @@ require_relative "gem_installer"
 module Bundler
   class ParallelInstaller
     class SpecInstallation
-      attr_accessor :spec, :name, :post_install_message, :state, :error
+      attr_accessor :spec, :name, :post_install_message, :fund_metadata, :state, :error
       def initialize(spec)
         @spec = spec
         @name = spec.name
         @state = :none
         @post_install_message = ""
+        @fund_metadata = {}
         @error = nil
       end
 
@@ -38,6 +39,10 @@ module Bundler
 
       def has_post_install_message?
         !post_install_message.empty?
+      end
+
+      def has_fund_metadata?
+        !fund_metadata.empty?
       end
 
       def ignorable_dependency?(dep)
@@ -164,6 +169,7 @@ module Bundler
       if success
         spec_install.state = :installed
         spec_install.post_install_message = message unless message.nil?
+        spec_install.fund_metadata = { version: spec_install.spec.version, uri: spec_install.spec.metadata["funding_uri"] } if spec_install.spec.metadata.key?("funding_uri")
       else
         spec_install.state = :failed
         spec_install.error = "#{message}\n\n#{require_tree_for_spec(spec_install.spec)}"

--- a/lib/bundler/installer/parallel_installer.rb
+++ b/lib/bundler/installer/parallel_installer.rb
@@ -169,7 +169,7 @@ module Bundler
       if success
         spec_install.state = :installed
         spec_install.post_install_message = message unless message.nil?
-        spec_install.fund_metadata = { version: spec_install.spec.version, uri: spec_install.spec.metadata["funding_uri"] } if spec_install.spec.metadata.key?("funding_uri")
+        spec_install.fund_metadata = spec_install.spec.metadata["funding_uri"] if spec_install.spec.metadata.key?("funding_uri")
       else
         spec_install.state = :failed
         spec_install.error = "#{message}\n\n#{require_tree_for_spec(spec_install.spec)}"

--- a/spec/commands/fund_spec.rb
+++ b/spec/commands/fund_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe "bundle fund" do
 
     bundle "fund"
 
-    expect(out).to include("* has_metadata (1.0)\n  Funding: https://example.com/bestgemever/funding")
-    expect(out).to include("* has_funding (1.2.3)\n  Funding: https://example.com/somewildgem/funding")
+    expect(out).to include("* has_metadata (1.0)\n  Funding: https://example.com/has_metadata/funding")
+    expect(out).to include("* has_funding (1.2.3)\n  Funding: https://example.com/has_funding/funding")
     expect(out).to_not include("rack-obama")
   end
 
@@ -24,7 +24,7 @@ RSpec.describe "bundle fund" do
 
     bundle "fund"
 
-    expect(out).to_not include("* has_funding (1.2.3)\n  Funding: https://example.com/somewildgem/funding")
+    expect(out).to_not include("* has_funding (1.2.3)\n  Funding: https://example.com/has_funding/funding")
     expect(out).to_not include("gem_with_dependent_funding")
   end
 
@@ -48,8 +48,8 @@ RSpec.describe "bundle fund" do
       G
 
       bundle "fund --group development"
-      expect(out).to include("* has_metadata (1.0)\n  Funding: https://example.com/bestgemever/funding")
-      expect(out).to_not include("* has_funding (1.2.3)\n  Funding: https://example.com/somewildgem/funding")
+      expect(out).to include("* has_metadata (1.0)\n  Funding: https://example.com/has_metadata/funding")
+      expect(out).to_not include("* has_funding (1.2.3)\n  Funding: https://example.com/has_funding/funding")
     end
   end
 end

--- a/spec/commands/fund_spec.rb
+++ b/spec/commands/fund_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+RSpec.describe "bundle fund" do
+  it "prints fund information for all gems in the bundle" do
+    install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
+      gem 'has_metadata'
+      gem 'has_funding'
+      gem 'rack-obama'
+    G
+
+    bundle "fund"
+
+    expect(out).to include("* has_metadata (1.0)\n  Funding: https://example.com/bestgemever/funding")
+    expect(out).to include("* has_funding (1.2.3)\n  Funding: https://example.com/somewildgem/funding")
+    expect(out).to_not include("rack-obama")
+  end
+
+  it "does not consider fund information for gem dependencies" do
+    install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
+      gem 'gem_with_dependent_funding'
+    G
+
+    bundle "fund"
+
+    expect(out).to_not include("* has_funding (1.2.3)\n  Funding: https://example.com/somewildgem/funding")
+    expect(out).to_not include("gem_with_dependent_funding")
+  end
+
+  it "prints message if none of the gems have fund information" do
+    install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
+      gem 'rack-obama'
+    G
+
+    bundle "fund"
+
+    expect(out).to include("None of the gems you depend on are looking for funding!")
+  end
+
+  describe "with --group option" do
+    it "should print fund message for only specified group gems" do
+      install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
+        gem 'has_metadata', :group => :development
+        gem 'has_funding'
+      G
+
+      bundle "fund --group development"
+      expect(out).to include("* has_metadata (1.0)\n  Funding: https://example.com/bestgemever/funding")
+      expect(out).to_not include("* has_funding (1.2.3)\n  Funding: https://example.com/somewildgem/funding")
+    end
+  end
+end

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe "bundle info" do
 \tHomepage: http://example.com
 \tDocumentation: https://www.example.info/gems/bestgemever/0.0.1
 \tSource Code: https://example.com/user/bestgemever
+\tFunding: https://example.com/bestgemever/funding
 \tWiki: https://example.com/user/bestgemever/wiki
 \tChangelog: https://example.com/user/bestgemever/CHANGELOG.md
 \tBug Tracker: https://example.com/user/bestgemever/issues

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "bundle info" do
 \tHomepage: http://example.com
 \tDocumentation: https://www.example.info/gems/bestgemever/0.0.1
 \tSource Code: https://example.com/user/bestgemever
-\tFunding: https://example.com/bestgemever/funding
+\tFunding: https://example.com/has_metadata/funding
 \tWiki: https://example.com/user/bestgemever/wiki
 \tChangelog: https://example.com/user/bestgemever/CHANGELOG.md
 \tBug Tracker: https://example.com/user/bestgemever/issues

--- a/spec/install/gems/fund_spec.rb
+++ b/spec/install/gems/fund_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+RSpec.describe "bundle install" do
+  context "with gem sources" do
+    context "when gems include a fund URI" do
+      it "should display the plural fund message after installing" do
+        gemfile <<-G
+          source "#{file_uri_for(gem_repo1)}"
+          gem 'has_metadata'
+          gem 'has_funding'
+          gem 'rack-obama'
+        G
+
+        bundle :install
+        expect(out).to include("2 gems you depend on are looking for funding!")
+      end
+
+      it "should display the singular fund message after installing" do
+        gemfile <<-G
+          source "#{file_uri_for(gem_repo1)}"
+          gem 'has_funding'
+          gem 'rack-obama'
+        G
+
+        bundle :install
+        expect(out).to include("1 gem you depend on is looking for funding!")
+      end
+    end
+
+    context "when gems do not include fund messages" do
+      it "should not display any fund messages" do
+        gemfile <<-G
+          source "#{file_uri_for(gem_repo1)}"
+          gem "activesupport"
+        G
+
+        bundle :install
+        expect(out).not_to include("gem you depend on")
+      end
+    end
+
+    context "when a dependecy includes a fund message" do
+      it "should not display the fund message" do
+        gemfile <<-G
+          source "#{file_uri_for(gem_repo1)}"
+          gem 'gem_with_dependent_funding'
+        G
+
+        bundle :install
+        expect(out).not_to include("gem you depend on")
+      end
+    end
+  end
+
+  context "with git sources" do
+    context "when gems include fund URI" do
+      it "should display the fund URI after installing" do
+        build_git "also_has_funding" do |s|
+          s.metadata = {
+            "funding_uri" => "https://example.com/also_has_funding/funding",
+          }
+        end
+        gemfile <<-G
+          source "#{file_uri_for(gem_repo1)}"
+          gem 'also_has_funding', :git => '#{lib_path("also_has_funding-1.0")}'
+        G
+
+        bundle :install
+        expect(out).to include("1 gem you depend on is looking for funding")
+      end
+
+      it "should display the fund URI if repo is updated" do
+        build_git "also_has_funding" do |s|
+          s.metadata = {
+            "funding_uri" => "https://example.com/also_has_funding/funding",
+          }
+        end
+        gemfile <<-G
+          source "#{file_uri_for(gem_repo1)}"
+          gem 'also_has_funding', :git => '#{lib_path("also_has_funding-1.0")}'
+        G
+        bundle :install
+
+        build_git "also_has_funding", "1.1" do |s|
+          s.metadata = {
+            "funding_uri" => "https://example.com/also_has_funding/funding",
+          }
+        end
+        gemfile <<-G
+          source "#{file_uri_for(gem_repo1)}"
+          gem 'also_has_funding', :git => '#{lib_path("also_has_funding-1.1")}'
+        G
+        bundle :install
+
+        expect(out).to include("1 gem you depend on is looking for funding")
+      end
+
+      it "should still display the fund URI if repo is not updated" do
+        build_git "also_has_funding" do |s|
+          s.metadata = {
+            "funding_uri" => "https://example.com/also_has_funding/funding",
+          }
+        end
+        gemfile <<-G
+          source "#{file_uri_for(gem_repo1)}"
+          gem 'also_has_funding', :git => '#{lib_path("also_has_funding-1.0")}'
+        G
+
+        bundle :install
+        expect(out).to include("1 gem you depend on is looking for funding")
+
+        bundle :install
+        expect(out).to include("1 gem you depend on is looking for funding")
+      end
+    end
+  end
+end

--- a/spec/support/builders.rb
+++ b/spec/support/builders.rb
@@ -310,9 +310,20 @@ module Spec
             "documentation_uri" => "https://www.example.info/gems/bestgemever/0.0.1",
             "homepage_uri"      => "https://bestgemever.example.io",
             "mailing_list_uri"  => "https://groups.example.com/bestgemever",
+            "funding_uri"       => "https://example.com/bestgemever/funding",
             "source_code_uri"   => "https://example.com/user/bestgemever",
             "wiki_uri"          => "https://example.com/user/bestgemever/wiki",
           }
+        end
+
+        build_gem "has_funding", "1.2.3" do |s|
+          s.metadata = {
+            "funding_uri"       => "https://example.com/somewildgem/funding",
+          }
+        end
+
+        build_gem "gem_with_dependent_funding", "1.0" do |s|
+          s.add_dependency "has_funding"
         end
       end
     end

--- a/spec/support/builders.rb
+++ b/spec/support/builders.rb
@@ -310,7 +310,7 @@ module Spec
             "documentation_uri" => "https://www.example.info/gems/bestgemever/0.0.1",
             "homepage_uri"      => "https://bestgemever.example.io",
             "mailing_list_uri"  => "https://groups.example.com/bestgemever",
-            "funding_uri"       => "https://example.com/bestgemever/funding",
+            "funding_uri"       => "https://example.com/has_metadata/funding",
             "source_code_uri"   => "https://example.com/user/bestgemever",
             "wiki_uri"          => "https://example.com/user/bestgemever/wiki",
           }
@@ -318,7 +318,7 @@ module Spec
 
         build_gem "has_funding", "1.2.3" do |s|
           s.metadata = {
-            "funding_uri"       => "https://example.com/somewildgem/funding",
+            "funding_uri"       => "https://example.com/has_funding/funding",
           }
         end
 

--- a/spec/update/gems/fund_spec.rb
+++ b/spec/update/gems/fund_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe "bundle update" do
+  let(:config) {}
+
+  before do
+    gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
+      gem 'has_metadata'
+      gem 'has_funding', '< 2.0'
+    G
+
+    bundle! "config set #{config}" if config
+
+    bundle! :install
+  end
+
+  shared_examples "a fund message outputter" do
+    it "should display fund message for updated gems" do
+      expect(out).to include("2 gems you depend on are looking for funding!")
+    end
+  end
+
+  context "when listed gem is updated" do
+    before do
+      gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gem 'has_metadata'
+        gem 'has_funding'
+      G
+
+      bundle! :update, :all => true
+    end
+
+    it_behaves_like "a fund message outputter"
+  end
+end


### PR DESCRIPTION
### What was the end-user or developer problem that led to this PR?

This PR implements the `bundle fund` proposal in [this accepted RFC](https://github.com/rubygems/rfcs/blob/aa031d3774a4ce6cb06d317ab03ea5cd161da498/text/0000-add-funding-uri.md).

### What is your fix for the problem, implemented in this PR?

The rationale and technical details for the `bundle fund` command are explained in the RFC, but roughly:

* A new `metadata` key, `funding_uri`, can be specified, that points to a funding page for a gem
* On a successful `bundle install` or `bundle update`, a message will be printed out that indicates gems which require support: `4 gems you depend on are looking for funding`
* `bundle fund` will list out all those gems, with their funding links
* `bundle info` will include the `funding_uri` in its printout
* You can restrict `bundle fund` to only list information for a specific group
* Dependencies of dependencies are currently _not_ listed in `bundle fund`; this is [by design](https://github.com/rubygems/rfcs/blob/aa031d3774a4ce6cb06d317ab03ea5cd161da498/text/0000-add-funding-uri.md#unresolved-questions) 