### PR TITLE
Build local bundler on a "thread-safe folder"

### DIFF
--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -299,11 +299,16 @@ module Spec
     end
 
     def with_built_bundler
-      with_root_gemspec do |gemspec|
-        gem_command! "build #{gemspec}", :dir => root
-      end
+      bundler_path = tmp + "bundler-#{Bundler::VERSION}.gem"
 
-      bundler_path = root + "bundler-#{Bundler::VERSION}.gem"
+      with_root_gemspec do |gemspec|
+        if Gem::Version.new(Gem::VERSION) >= Gem::Version.new("3.0.0")
+          gem_command! "build #{gemspec} --output #{bundler_path}", :dir => root
+        else
+          gem_command! "build #{gemspec}", :dir => root
+          FileUtils.mv root + File.basename(bundler_path), bundler_path
+        end
+      end
 
       begin
         yield(bundler_path)


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

If you're updating documentation, make sure you run `bin/rake man:build` and
squash the result into your changes, so that all documentation formats are
updated.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

### What was the end-user or developer problem that led to this PR?

Sometimes tests that `gem build` to local version of bundler fail.

### What is your fix for the problem, implemented in this PR?

Some tests using `system_gems :bundler` run `gem build bundler.gemspec` to build a local version of the bundler gem and install that to the temporary gem location for tests. After the test finishes, it removes the `bundler*.gem` artifact generated by `gem build` at the root of the repo.

The problem is that if two tests like this run concurrently, they can run into race condtions because they use the same common folder (the root folder). For example, test1 generates the `bundler*.gem` file, test2 (re)generates the `bundler*.gem` file, test1 removes the file after it's done, test2 fails to remove the file because it was already removed by other test.

To fix this issue, we generate this artifact on a "thread specific" folder, so it doesn't interfere with other threads.

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->
