### PR TITLE
Don't create `test_dir` folder in repo root

### DIFF
--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -428,8 +428,8 @@ RSpec.describe Bundler::SharedHelpers do
       let(:file_op_block) { proc {|path| FileUtils.mkdir_p(path) } }
 
       it "performs the operation in the passed block" do
-        subject.filesystem_access("./test_dir", &file_op_block)
-        expect(Pathname.new("test_dir")).to exist
+        subject.filesystem_access(bundled_app("test_dir"), &file_op_block)
+        expect(bundled_app("test_dir")).to exist
       end
     end
 


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

If you're updating documentation, make sure you run `bin/rake man:build` and
squash the result into your changes, so that all documentation formats are
updated.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

### What was the end-user or developer problem that led to this PR?

Running `bin/rspec spec/bundler/shared_helpers_spec.rb` leaves an empty `test_dir` folder at the root of the repo.

### What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

Create the empty `test_dir` folder under `tmp/`.